### PR TITLE
OpenTelemetry Update for Jaeger

### DIFF
--- a/environments/docker/infrastructure/observability/docker-compose.yml
+++ b/environments/docker/infrastructure/observability/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   opentelemetry-collector:
-    image: otel/opentelemetry-collector-contrib:0.75.0
+    image: otel/opentelemetry-collector-contrib:0.78.0
     restart: unless-stopped
     command: --config=/etc/otel-collector-config.yaml
     ports:
@@ -40,6 +40,7 @@ services:
       ES_SERVER_URLS: http://search-engine-elasticsearch-1:9200
       METRICS_STORAGE_TYPE: prometheus
       PROMETHEUS_SERVER_URL: http://observability-prometheus-1:9090
+      PROMETHEUS_QUERY_SUPPORT_SPANMETRICS_CONNECTOR: true
       # Necessary as elasticsearch doesn't work with version 8 yet https://github.com/jaegertracing/jaeger/issues/3571
       #ES_VERSION: 7
       #ES_CREATE_INDEX_TEMPLATES: false

--- a/environments/docker/infrastructure/observability/otel-collector-config.yaml
+++ b/environments/docker/infrastructure/observability/otel-collector-config.yaml
@@ -1,13 +1,13 @@
 receivers:
+  jaeger:
+    protocols:
+      thrift_http:
+        endpoint: observability-opentelemetry-collector-1:14278
+
   otlp:
     protocols:
       grpc:
       http:
-
-processors:
-  batch:
-  spanmetrics:
-    metrics_exporter: prometheus
 
 exporters:
   jaeger:
@@ -18,6 +18,13 @@ exporters:
   prometheus:
     endpoint: observability-opentelemetry-collector-1:8889
 
+connectors:
+  spanmetrics:
+    metrics_exporter: prometheus
+
+processors:
+  batch:
+
 extensions:
   health_check:
 
@@ -25,10 +32,13 @@ service:
   extensions: [health_check]
   pipelines:
     traces:
-      receivers: [otlp]
-      processors: [batch, spanmetrics]
-      exporters: [jaeger]
-    metrics:
-      receivers: [otlp]
+      receivers: [otlp, jaeger]
       processors: [batch]
+      exporters: [spanmetrics, jaeger]
+    metrics/spanmetrics:
+      receivers: [spanmetrics]
       exporters: [prometheus]
+    # metrics:
+    #   receivers: [otlp]
+    #   processors: [batch]
+    #   exporters: [prometheus]


### PR DESCRIPTION
Do not merge before Jaeger has released an update with the changes from https://github.com/jaegertracing/jaeger/pull/4452.