### PR TITLE
Update GITHUB_TOKEN in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -30,7 +30,7 @@ jobs:
       - id: auto-merge
         uses: "pascalgn/automerge-action@v0.15.6"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.CUSTOM_TOKEN }}"
           MERGE_LABELS: ""
           MERGE_METHOD: "squash"
           MERGE_RETRIES: 120


### PR DESCRIPTION
This pull request updates the GITHUB_TOKEN in the auto-merge workflow to use the CUSTOM_TOKEN secret instead. This change ensures that the correct token is used for authentication.