### PR TITLE
Fix pull request label synchronization

### DIFF
--- a/.github/workflows/require-labels.yaml
+++ b/.github/workflows/require-labels.yaml
@@ -1,7 +1,7 @@
 name: Require Pull Request Labels
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR updates the pull request label synchronization workflow to include the "reopened" event type. This ensures that labels are synchronized correctly when a pull request is reopened.