### PR TITLE
Fix block pool name

### DIFF
--- a/k8s/environments/talos/infrastructure/ceph-cluster.yaml
+++ b/k8s/environments/talos/infrastructure/ceph-cluster.yaml
@@ -47,7 +47,7 @@ spec:
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
-  name: rook-ceph-mgr
+  name: rook-ceph-block-pool
   namespace: rook-ceph # namespace:cluster
 spec:
   name: .mgr
@@ -64,7 +64,7 @@ metadata:
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
   clusterID: rook-ceph
-  pool: replicapool
+  pool: rook-ceph-block-pool
   imageFormat: "2"
   imageFeatures: layering
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner


### PR DESCRIPTION
This pull request fixes the block pool name in the CephBlockPool resource. The name has been updated from "rook-ceph-mgr" to "rook-ceph-block-pool". This change ensures consistency and clarity in the naming convention used for block pools.