### PR TITLE
Add Local AI and K8sGPT Operator

### DIFF
--- a/k8s/clusters/homelab-ksail/variables/variables.yaml
+++ b/k8s/clusters/homelab-ksail/variables/variables.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: flux-system
 data:
   harbor_persistent_volume_access_mode: ReadWriteOnce
+  local_ai_persistence_access_mode: ReadWriteOnce
   oauth2_proxy_client_id: Ov23liTxrJtJ081Hiq35

--- a/k8s/manifests/apps/kustomization.yaml
+++ b/k8s/manifests/apps/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - homepage
+  - local-ai
   - plantuml
 
 patches:

--- a/k8s/manifests/apps/local-ai/kustomization.yaml
+++ b/k8s/manifests/apps/local-ai/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - local-ai.yaml
+  - namespace.yaml

--- a/k8s/manifests/apps/local-ai/local-ai.yaml
+++ b/k8s/manifests/apps/local-ai/local-ai.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: local-ai
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: local-ai
+  sourceRef:
+    kind: OCIRepository
+    name: oci-artifacts
+  path: local-ai
+  prune: true
+  wait: true
+  patches:
+    - target:
+        name: local-ai
+        kind: HelmRelease
+      patch: |-
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: local-ai
+        spec:
+          values:
+            ingress:
+              annotations:
+                traefik.ingress.kubernetes.io/router.middlewares: traefik-traefik-forward-auth@kubernetescrd

--- a/k8s/manifests/apps/local-ai/namespace.yaml
+++ b/k8s/manifests/apps/local-ai/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-ai

--- a/k8s/manifests/infrastructure/k8sgpt-operator/k8sgpt-operator.yaml
+++ b/k8s/manifests/infrastructure/k8sgpt-operator/k8sgpt-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: k8sgpt-operator
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: k8sgpt-operator
+  sourceRef:
+    kind: OCIRepository
+    name: oci-artifacts
+  path: k8sgpt-operator
+  prune: true
+  wait: true

--- a/k8s/manifests/infrastructure/k8sgpt-operator/kustomization.yaml
+++ b/k8s/manifests/infrastructure/k8sgpt-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - k8sgpt-operator.yaml

--- a/k8s/manifests/infrastructure/k8sgpt-operator/namespace.yaml
+++ b/k8s/manifests/infrastructure/k8sgpt-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8sgpt-operator

--- a/k8s/manifests/infrastructure/kustomization.yaml
+++ b/k8s/manifests/infrastructure/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - gha-runner-scale-set-controller
   - goldilocks
   - harbor
+  - k8sgpt-operator
   - metrics-server
   - oauth2-proxy
   - traefik

--- a/k8s/manifests/repositories/oci-artifacts.yaml
+++ b/k8s/manifests/repositories/oci-artifacts.yaml
@@ -7,4 +7,4 @@ spec:
   interval: 1m
   url: oci://ghcr.io/devantler/oci-artifacts/manifests
   ref:
-    tag: v1.2.7
+    tag: v1.2.8


### PR DESCRIPTION
This pull request adds support for Local AI and K8sGPT Operator. It includes the necessary files and configurations to deploy these components in the Kubernetes cluster. Additionally, the dependency on `ghcr.io/devantler/oci-artifacts` has been updated to version 1.2.8.