### PR TITLE
Update oci-artifacts.yaml to use tag v1.4.4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,19 +23,8 @@ env:
   KSAIL_CLUSTER_NAME: homelab-local
 
 jobs:
-  homelab-status:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check Homelab is up
-        uses: LASER-Yi/workflow-status@v0.0.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: deploy.yaml
-          event: push
-          branch: main
   test:
     runs-on: homelab
-    needs: homelab-status
     env:
       KSAIL_CLUSTER_NAME: homelab-local
     if: github.event.pull_request.draft == false

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ ksail up homelab-local
 
 ## Stack
 
+- [Cluster API Operator](https://cluster-api.sigs.k8s.io/) - To manage the lifecycle of tenant clusters.
 - [Cert Manager](https://cert-manager.io/docs/) - For managing certificates in the cluster.
 - [Cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) - To tunnel all traffic through Cloudflare, and to keep my network private.
 - [GitHub Actions Runner Scale Sets](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller) - To run GitHub Actions in the cluster.

--- a/k8s/repositories/oci-artifacts.yaml
+++ b/k8s/repositories/oci-artifacts.yaml
@@ -7,4 +7,4 @@ spec:
   interval: 1m
   url: oci://ghcr.io/devantler/oci-artifacts/manifests
   ref:
-    tag: latest
+    tag: v1.4.4


### PR DESCRIPTION
This pull request updates the `oci-artifacts.yaml` file to use the tag `v1.4.4` instead of `latest`.