### PR TITLE
Update Helm release gha-runner-scale-set-controller to use eventual update strategy

### DIFF
--- a/k8s/shared/infrastructure/controllers/gha-runner-scale-set-controller/helm-release.yaml
+++ b/k8s/shared/infrastructure/controllers/gha-runner-scale-set-controller/helm-release.yaml
@@ -16,4 +16,6 @@ spec:
         kind: HelmRepository
         name: gha-runner-scale-set-controller
   # https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/values.yaml
-  values: {}
+  values:
+    flags:
+      updateStrategy: "eventual"


### PR DESCRIPTION
This pull request updates the Helm release `gha-runner-scale-set-controller` to use the eventual update strategy. The `values.yaml` file is modified to include the `updateStrategy` flag with a value of "eventual". This change ensures that the all kubernetes resources are completely drained before starting a new job.