### PR TITLE
fix(cd): pass OMNI_SERVICE_ACCOUNT_KEY to ksail steps

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -69,6 +69,9 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.prod.yaml workload reconcile
+        env:
+          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
## Description

The CD workflow fails with:

```
failed to create Talos provisioner: create Omni provider: omni service account key is not set: environment variable OMNI_SERVICE_ACCOUNT_KEY is not set
```

The `ksail.prod.yaml` uses `provider: Omni`, which requires the `OMNI_SERVICE_ACCOUNT_KEY` environment variable. The org secret exists (`OMNI_SERVICE_ACCOUNT_KEY`, updated 4 days ago), but the workflow never exposes it to the `ksail` steps.

## Changes

- Added `OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}` to the env of both the "Push manifests to GHCR" and "Trigger Flux reconciliation" steps.