### PR TITLE
fix: add GITHUB_TOKEN and GITHUB_ACTOR to workflow reconcile steps

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -99,5 +99,7 @@ jobs:
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.prod.yaml workload reconcile
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,5 +175,7 @@ jobs:
         run: ksail --config ksail.dev.yaml workload reconcile
         continue-on-error: true
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
## Summary

Adds missing `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables to the `workload reconcile` steps in both `cd.yaml` and `ci.yaml` (deploy-dev job). KSail needs these to resolve the GHCR registry URL from the config.

## Changes

- **`.github/workflows/cd.yaml`** — Added `GITHUB_ACTOR` and `GITHUB_TOKEN` to the "🔁 Trigger Flux reconciliation" step env block
- **`.github/workflows/ci.yaml`** — Added `GITHUB_ACTOR` and `GITHUB_TOKEN` to the "🔁 Trigger Flux reconciliation" step env block in the deploy-dev job

Fixes #1343