### PR TITLE
fix: set dev cluster to 3 control-plane nodes

### DIFF
--- a/ksail.dev.yaml
+++ b/ksail.dev.yaml
@@ -13,6 +13,8 @@ spec:
     provider: Omni
     cni: Cilium
     gitOpsEngine: Flux
+    talos:
+      controlPlanes: 3
     omni:
       endpoint: "https://devantler.na-west-1.omni.siderolabs.io:443"
     localRegistry:


### PR DESCRIPTION
The dev cluster was running with only 1 control-plane node because `ksail.dev.yaml` did not specify `talos.controlPlanes`, defaulting to 1. The dev environment is expected to use 3 control-plane nodes for HA.

Adds `talos.controlPlanes: 3` to the dev KSail config so the next `ksail cluster update` via CI scales the Omni-managed dev cluster to 3 control planes.

## Type of change

- [x] 🪲 Bug fix