### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,7 +173,6 @@ jobs:
       # Kustomization cannot converge without valid cloud provider secrets.
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.dev.yaml workload reconcile
-        continue-on-error: true
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,10 +167,6 @@ jobs:
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
-      # TODO: Remove continue-on-error once dev cluster secrets are fully
-      # configured (Hetzner API token, Cloudflare tunnel token, etc.).
-      # The reconciliation times out because infrastructure-controllers
-      # Kustomization cannot converge without valid cloud provider secrets.
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.dev.yaml workload reconcile
         env:


### PR DESCRIPTION
This pull request makes a small but important change to the CI workflow configuration. The `continue-on-error: true` flag has been removed from the Flux reconciliation job step, which means that if this step fails, the workflow will now stop instead of continuing.

- CI workflow behavior:
  * Removed `continue-on-error: true` from the "🔁 Trigger Flux reconciliation" step in `.github/workflows/ci.yaml`, causing the workflow to fail if this step fails instead of proceeding.