### PR TITLE
fix: use long-lived PAT for GHCR auth and remove stale workarounds

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,7 @@ Production uses **Talos + Omni** (managed by Sidero Omni SaaS). The cluster is p
 **Key differences from local:**
 - No `ksail cluster create/delete` — Omni manages cluster lifecycle externally
 - OCI artifacts pushed to GHCR (not a local registry)
-- Kubeconfig is fetched dynamically via `omnictl kubeconfig` from the Omni API
+- Kubeconfig is managed by KSail via the Omni API
 - SPIRE mutual auth is enabled (unlike local Docker clusters)
 - Omni endpoint: `https://devantler.omni.siderolabs.io:443`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,9 +114,8 @@ Production uses **Talos + Omni** (managed by Sidero Omni SaaS). The cluster is p
 - **`cd.yaml`**: Runs on `v*` tags. Deploys to production Omni cluster using `ksail --config ksail.prod.yaml`. The prod config has `kustomizationFile: clusters/prod` so no file rewriting is needed — KSail/Flux automatically uses the correct entry point.
 
 **Required GitHub Secrets:**
-- `KUBE_CONFIG` — kubeconfig for the production Omni cluster
+- `GHCR_PAT` — long-lived PAT with `write:packages` scope, used for GHCR push/pull authentication
 - `SOPS_AGE_KEY` — Age private key for SOPS secret decryption
-- `GITHUB_TOKEN` — automatically provided, used for GHCR authentication
 
 ### Working with Secrets
 This platform uses SOPS with Age encryption for all secrets:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,7 +114,7 @@ Production uses **Talos + Omni** (managed by Sidero Omni SaaS). The cluster is p
 - **`cd.yaml`**: Runs on `v*` tags. Deploys to production Omni cluster using `ksail --config ksail.prod.yaml`. The prod config has `kustomizationFile: clusters/prod` so no file rewriting is needed — KSail/Flux automatically uses the correct entry point.
 
 **Required GitHub Secrets:**
-- `GHCR_PAT` — long-lived PAT (owner: `devantler`) with `write:packages` scope, used for GHCR push/pull authentication
+- `GHCR_TOKEN` — long-lived PAT (owner: `devantler`) with `write:packages` scope, used for GHCR push/pull authentication
 - `SOPS_AGE_KEY` — Age private key for SOPS secret decryption
 - `OMNI_SERVICE_ACCOUNT_KEY` — Omni service account key for cluster access (dev/prod)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,7 @@ Production uses **Talos + Omni** (managed by Sidero Omni SaaS). The cluster is p
 **Key differences from local:**
 - No `ksail cluster create/delete` — Omni manages cluster lifecycle externally
 - OCI artifacts pushed to GHCR (not a local registry)
-- `KUBE_CONFIG` secret provides kubeconfig for the Omni cluster
+- Kubeconfig is fetched dynamically via `omnictl kubeconfig` from the Omni API
 - SPIRE mutual auth is enabled (unlike local Docker clusters)
 - Omni endpoint: `https://devantler.omni.siderolabs.io:443`
 
@@ -114,8 +114,12 @@ Production uses **Talos + Omni** (managed by Sidero Omni SaaS). The cluster is p
 - **`cd.yaml`**: Runs on `v*` tags. Deploys to production Omni cluster using `ksail --config ksail.prod.yaml`. The prod config has `kustomizationFile: clusters/prod` so no file rewriting is needed — KSail/Flux automatically uses the correct entry point.
 
 **Required GitHub Secrets:**
-- `GHCR_PAT` — long-lived PAT with `write:packages` scope, used for GHCR push/pull authentication
+- `GHCR_PAT` — long-lived PAT (owner: `devantler`) with `write:packages` scope, used for GHCR push/pull authentication
 - `SOPS_AGE_KEY` — Age private key for SOPS secret decryption
+- `OMNI_SERVICE_ACCOUNT_KEY` — Omni service account key for cluster access (dev/prod)
+
+**Required GitHub Variables:**
+- `OMNI_ENDPOINT` — Omni API endpoint URL (per-environment)
 
 ### Working with Secrets
 This platform uses SOPS with Age encryption for all secrets:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,7 @@ Production uses **Talos + Omni** (managed by Sidero Omni SaaS). The cluster is p
 **Key differences from local:**
 - No `ksail cluster create/delete` — Omni manages cluster lifecycle externally
 - OCI artifacts pushed to GHCR (not a local registry)
-- Kubeconfig is managed by KSail via the Omni API
+- Kubeconfig is fetched via `omnictl kubeconfig` in CI/CD workflows (workaround until KSail handles this natively)
 - SPIRE mutual auth is enabled (unlike local Docker clusters)
 - Omni endpoint: `https://devantler.omni.siderolabs.io:443`
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -83,7 +83,6 @@ jobs:
             ksail --config ksail.prod.yaml cluster create
           fi
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
@@ -101,7 +100,6 @@ jobs:
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.prod.yaml workload push
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
@@ -109,7 +107,6 @@ jobs:
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.prod.yaml workload reconcile
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -81,7 +81,7 @@ jobs:
             ksail --config ksail.prod.yaml cluster create
           fi
         env:
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
@@ -89,7 +89,7 @@ jobs:
         run: ksail --config ksail.prod.yaml workload push
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
@@ -97,6 +97,6 @@ jobs:
         run: ksail --config ksail.prod.yaml workload reconcile
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,19 +33,6 @@ jobs:
       - name: ⚙️ Setup KSail
         uses: devantler-tech/actions/setup-ksail-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
 
-      - name: ⚙️ Setup omnictl
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TMP_DIR="$(mktemp -d)"
-          trap 'rm -rf "$TMP_DIR"' EXIT
-          gh release download v1.6.5 --repo siderolabs/omni \
-            --pattern "omnictl-linux-amd64" --dir "$TMP_DIR"
-          gh release download v1.6.5 --repo siderolabs/omni \
-            --pattern "sha256sum.txt" --dir "$TMP_DIR"
-          (cd "$TMP_DIR" && grep " omnictl-linux-amd64$" sha256sum.txt | sha256sum -c -)
-          install -m 0755 "$TMP_DIR/omnictl-linux-amd64" /usr/local/bin/omnictl
-
       - name: 🔐 Create SOPS Age key
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
@@ -54,26 +41,6 @@ jobs:
           umask 077
           echo "${SOPS_AGE_KEY}" > ~/.config/sops/age/keys.txt
           chmod 600 ~/.config/sops/age/keys.txt
-
-      # Fetch a fresh kubeconfig from the Omni API so cluster update
-      # always has valid credentials, even after cluster recreation.
-      # Allowed to fail when the cluster does not yet exist (cluster
-      # create will fetch the kubeconfig itself).
-      # TODO: Remove once https://github.com/devantler-tech/ksail/issues/3922
-      # is resolved (cluster update should refresh kubeconfig itself).
-      - name: 🔐 Setup kubeconfig
-        continue-on-error: true
-        run: |
-          omnictl kubeconfig --cluster devantler-prod --force \
-            --service-account --user github-actions \
-            --force-context-name devantler-prod
-          CTX=$(kubectl config current-context 2>/dev/null || true)
-          if [[ -n "$CTX" && "$CTX" != "devantler-prod" ]]; then
-            kubectl config rename-context "$CTX" "devantler-prod"
-          fi
-        env:
-          OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
-          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
       - name: 🔄 Create or update cluster
         run: |
@@ -86,16 +53,6 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
-
-      # Workaround: ksail cluster update does not update the
-      # FluxInstance sync.ref from the cluster name to "latest".
-      # TODO: Remove once https://github.com/devantler-tech/ksail/issues/3933
-      # is resolved.
-      - name: 🔧 Fix FluxInstance OCI tag
-        continue-on-error: true
-        run: |
-          kubectl --context devantler-prod patch fluxinstance flux -n flux-system --type=merge \
-            -p '{"spec":{"sync":{"ref":"latest"}}}'
 
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.prod.yaml workload push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -55,6 +55,26 @@ jobs:
           echo "${SOPS_AGE_KEY}" > ~/.config/sops/age/keys.txt
           chmod 600 ~/.config/sops/age/keys.txt
 
+      # Fetch a fresh kubeconfig from the Omni API so cluster update
+      # always has valid credentials, even after cluster recreation.
+      # Allowed to fail when the cluster does not yet exist (cluster
+      # create will fetch the kubeconfig itself).
+      # TODO: Remove once https://github.com/devantler-tech/ksail/issues/3922
+      # is resolved (cluster update should refresh kubeconfig itself).
+      - name: 🔐 Setup kubeconfig
+        continue-on-error: true
+        run: |
+          omnictl kubeconfig --cluster devantler-prod --force \
+            --service-account --user github-actions \
+            --force-context-name devantler-prod
+          CTX=$(kubectl config current-context 2>/dev/null || true)
+          if [[ -n "$CTX" && "$CTX" != "devantler-prod" ]]; then
+            kubectl config rename-context "$CTX" "devantler-prod"
+          fi
+        env:
+          OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
+          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
+
       - name: 🔄 Create or update cluster
         run: |
           if ksail --config ksail.prod.yaml cluster info > /dev/null 2>&1; then
@@ -64,15 +84,25 @@ jobs:
           fi
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
+
+      # Workaround: ksail cluster update does not update the
+      # FluxInstance sync.ref from the cluster name to "latest".
+      # TODO: Remove once https://github.com/devantler-tech/ksail/issues/3933
+      # is resolved.
+      - name: 🔧 Fix FluxInstance OCI tag
+        continue-on-error: true
+        run: |
+          kubectl patch fluxinstance flux -n flux-system --type=merge \
+            -p '{"spec":{"sync":{"ref":"latest"}}}'
 
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.prod.yaml workload push
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
@@ -80,6 +110,6 @@ jobs:
         run: ksail --config ksail.prod.yaml workload reconcile
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,6 +33,19 @@ jobs:
       - name: ⚙️ Setup KSail
         uses: devantler-tech/actions/setup-ksail-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
 
+      - name: ⚙️ Setup omnictl
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TMP_DIR="$(mktemp -d)"
+          trap 'rm -rf "$TMP_DIR"' EXIT
+          gh release download v1.6.5 --repo siderolabs/omni \
+            --pattern "omnictl-linux-amd64" --dir "$TMP_DIR"
+          gh release download v1.6.5 --repo siderolabs/omni \
+            --pattern "sha256sum.txt" --dir "$TMP_DIR"
+          (cd "$TMP_DIR" && grep " omnictl-linux-amd64$" sha256sum.txt | sha256sum -c -)
+          install -m 0755 "$TMP_DIR/omnictl-linux-amd64" /usr/local/bin/omnictl
+
       - name: 🔐 Create SOPS Age key
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
@@ -41,6 +54,24 @@ jobs:
           umask 077
           echo "${SOPS_AGE_KEY}" > ~/.config/sops/age/keys.txt
           chmod 600 ~/.config/sops/age/keys.txt
+
+      # Workaround: ksail cluster update does not fetch kubeconfig from
+      # Omni, so we fetch it manually via omnictl.
+      # TODO: Remove once ksail natively fetches kubeconfig during
+      # cluster update for the Omni provider.
+      - name: 🔐 Setup kubeconfig
+        continue-on-error: true
+        run: |
+          omnictl kubeconfig --cluster devantler-prod --force \
+            --service-account --user github-actions \
+            --force-context-name devantler-prod
+          CTX=$(kubectl config current-context 2>/dev/null || true)
+          if [[ -n "$CTX" && "$CTX" != "devantler-prod" ]]; then
+            kubectl config rename-context "$CTX" "devantler-prod"
+          fi
+        env:
+          OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
+          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
       - name: 🔄 Create or update cluster
         run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -94,12 +94,13 @@ jobs:
       - name: 🔧 Fix FluxInstance OCI tag
         continue-on-error: true
         run: |
-          kubectl patch fluxinstance flux -n flux-system --type=merge \
+          kubectl --context devantler-prod patch fluxinstance flux -n flux-system --type=merge \
             -p '{"spec":{"sync":{"ref":"latest"}}}'
 
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.prod.yaml workload push
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
@@ -107,6 +108,7 @@ jobs:
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.prod.yaml workload reconcile
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,13 +133,8 @@ jobs:
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
-      # TODO: Remove continue-on-error once dev cluster secrets are fully
-      # configured (Hetzner API token, Cloudflare tunnel token, etc.).
-      # The reconciliation times out because infrastructure-controllers
-      # Kustomization cannot converge without valid cloud provider secrets.
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.dev.yaml workload reconcile
-        continue-on-error: true
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,8 +164,12 @@ jobs:
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
+      # TODO: Remove continue-on-error once dev cluster bootstrap is stable
+      # (Talos Hetzner CCM node initialization requires talos-dev patches
+      # for kubelet cloud-provider=external; tracked in a follow-up issue).
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.dev.yaml workload reconcile
+        continue-on-error: true
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,7 +152,7 @@ jobs:
             ksail --config ksail.dev.yaml cluster create
           fi
         env:
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
@@ -160,7 +160,7 @@ jobs:
         run: ksail --config ksail.dev.yaml workload push
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
@@ -168,6 +168,6 @@ jobs:
         run: ksail --config ksail.dev.yaml workload reconcile
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,39 +104,6 @@ jobs:
       - name: ⚙️ Setup KSail
         uses: devantler-tech/actions/setup-ksail-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
 
-      - name: ⚙️ Setup omnictl
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TMP_DIR="$(mktemp -d)"
-          trap 'rm -rf "$TMP_DIR"' EXIT
-          gh release download v1.6.5 --repo siderolabs/omni \
-            --pattern "omnictl-linux-amd64" --dir "$TMP_DIR"
-          gh release download v1.6.5 --repo siderolabs/omni \
-            --pattern "sha256sum.txt" --dir "$TMP_DIR"
-          (cd "$TMP_DIR" && grep " omnictl-linux-amd64$" sha256sum.txt | sha256sum -c -)
-          install -m 0755 "$TMP_DIR/omnictl-linux-amd64" /usr/local/bin/omnictl
-
-      # Fetch a fresh kubeconfig from the Omni API so cluster update
-      # always has valid credentials, even after cluster recreation.
-      # Allowed to fail when the cluster does not yet exist (cluster
-      # create will fetch the kubeconfig itself).
-      # TODO: Remove once https://github.com/devantler-tech/ksail/issues/3922
-      # is resolved (cluster update should refresh kubeconfig itself).
-      - name: 🔐 Setup kubeconfig
-        continue-on-error: true
-        run: |
-          omnictl kubeconfig --cluster devantler-dev --force \
-            --service-account --user github-actions \
-            --force-context-name devantler-dev
-          CTX=$(kubectl config current-context 2>/dev/null || true)
-          if [[ -n "$CTX" && "$CTX" != "devantler-dev" ]]; then
-            kubectl config rename-context "$CTX" "devantler-dev"
-          fi
-        env:
-          OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
-          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
-
       - name: 🔐 Create SOPS Age key
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
@@ -158,16 +125,6 @@ jobs:
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
-      # Workaround: ksail cluster update does not update the
-      # FluxInstance sync.ref from the cluster name to "latest".
-      # TODO: Remove once https://github.com/devantler-tech/ksail/issues/3933
-      # is resolved.
-      - name: 🔧 Fix FluxInstance OCI tag
-        continue-on-error: true
-        run: |
-          kubectl --context devantler-dev patch fluxinstance flux -n flux-system --type=merge \
-            -p '{"spec":{"sync":{"ref":"latest"}}}'
-
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.dev.yaml workload push
         env:
@@ -176,8 +133,13 @@ jobs:
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
+      # TODO: Remove continue-on-error once dev cluster secrets are fully
+      # configured (Hetzner API token, Cloudflare tunnel token, etc.).
+      # The reconciliation times out because infrastructure-controllers
+      # Kustomization cannot converge without valid cloud provider secrets.
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.dev.yaml workload reconcile
+        continue-on-error: true
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,19 @@ jobs:
       - name: ⚙️ Setup KSail
         uses: devantler-tech/actions/setup-ksail-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
 
+      - name: ⚙️ Setup omnictl
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TMP_DIR="$(mktemp -d)"
+          trap 'rm -rf "$TMP_DIR"' EXIT
+          gh release download v1.6.5 --repo siderolabs/omni \
+            --pattern "omnictl-linux-amd64" --dir "$TMP_DIR"
+          gh release download v1.6.5 --repo siderolabs/omni \
+            --pattern "sha256sum.txt" --dir "$TMP_DIR"
+          (cd "$TMP_DIR" && grep " omnictl-linux-amd64$" sha256sum.txt | sha256sum -c -)
+          install -m 0755 "$TMP_DIR/omnictl-linux-amd64" /usr/local/bin/omnictl
+
       - name: 🔐 Create SOPS Age key
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
@@ -112,6 +125,24 @@ jobs:
           umask 077
           echo "${SOPS_AGE_KEY}" > ~/.config/sops/age/keys.txt
           chmod 600 ~/.config/sops/age/keys.txt
+
+      # Workaround: ksail cluster update does not fetch kubeconfig from
+      # Omni, so we fetch it manually via omnictl.
+      # TODO: Remove once ksail natively fetches kubeconfig during
+      # cluster update for the Omni provider.
+      - name: 🔐 Setup kubeconfig
+        continue-on-error: true
+        run: |
+          omnictl kubeconfig --cluster devantler-dev --force \
+            --service-account --user github-actions \
+            --force-context-name devantler-dev
+          CTX=$(kubectl config current-context 2>/dev/null || true)
+          if [[ -n "$CTX" && "$CTX" != "devantler-dev" ]]; then
+            kubectl config rename-context "$CTX" "devantler-dev"
+          fi
+        env:
+          OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
+          OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
       - name: 🔄 Create or update cluster
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,12 +165,13 @@ jobs:
       - name: 🔧 Fix FluxInstance OCI tag
         continue-on-error: true
         run: |
-          kubectl patch fluxinstance flux -n flux-system --type=merge \
+          kubectl --context devantler-dev patch fluxinstance flux -n flux-system --type=merge \
             -p '{"spec":{"sync":{"ref":"latest"}}}'
 
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.dev.yaml workload push
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
@@ -178,6 +179,7 @@ jobs:
       - name: 🔁 Trigger Flux reconciliation
         run: ksail --config ksail.dev.yaml workload reconcile
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,6 @@ jobs:
             ksail --config ksail.dev.yaml cluster create
           fi
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
@@ -172,7 +171,6 @@ jobs:
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.dev.yaml workload push
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
@@ -185,7 +183,6 @@ jobs:
         run: ksail --config ksail.dev.yaml workload reconcile
         continue-on-error: true
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,15 +155,25 @@ jobs:
           fi
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
+
+      # Workaround: ksail cluster update does not update the
+      # FluxInstance sync.ref from the cluster name to "latest".
+      # TODO: Remove once https://github.com/devantler-tech/ksail/issues/3933
+      # is resolved.
+      - name: 🔧 Fix FluxInstance OCI tag
+        continue-on-error: true
+        run: |
+          kubectl patch fluxinstance flux -n flux-system --type=merge \
+            -p '{"spec":{"sync":{"ref":"latest"}}}'
 
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.dev.yaml workload push
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}
 
@@ -176,6 +186,6 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
           OMNI_ENDPOINT: ${{ vars.OMNI_ENDPOINT }}
           OMNI_SERVICE_ACCOUNT_KEY: ${{ secrets.OMNI_SERVICE_ACCOUNT_KEY }}

--- a/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
@@ -7,9 +7,10 @@ stringData:
     cloudflared_tunnel_token: ENC[AES256_GCM,data:dpvl90ylmgrnZDc1wNu81dntH8xwbTjOi4A8Y14EK7xPZIb11Z+rVyTrKB3EMKPN3OtASMHB//jFaiNSuz/kmmhpA/FCXOzP2aYcEpKaTMvEompyN9Hks4koq1CFYRZgDmArTEKnXcdmPUsfZu3TZ7LEwMXU+I5TrROlfugvWYXqlmrWTM2qi/rtGl1/pQFU7c7efjMR2kQnkH8dQAqZdA+2pMp6GbmnCtHOqXM8mAWY13Nr7bhJCQ==,iv:mq4YgSFWvB5Nj1XhvOX67CpNLH+t/C38O+iBH8CwE1E=,tag:y4PVe7opvU0QlQtMphSNVA==,type:str]
     dex_client_secret: ENC[AES256_GCM,data:Jaoos+oHu379R+yjWqsA57hfsM8=,iv:kknhRkcrpgCpYNFeSKlhWEyIk3sDf+N15cXTPXgPSaE=,tag:cYrCAaCJEnW+yITKs18Cng==,type:str]
     github_app_client_secret: ENC[AES256_GCM,data:LIZrinlW1d2PV2MzN95/j5G+1grM4kR6nS5NSkgKfoCJVw3gEMTGCA==,iv:HBmb9tJFRt6U2mL09+nkNaQw/0QP71T7ndeTQvIKKkU=,tag:ACmUEPZZPwV11OOTPsbeKw==,type:str]
-    hcloud_token: ENC[AES256_GCM,data:n16OuYmcvSGSrCEYyY2nV3C58qZSS8Cwv6Rzqz8ZyreMrLHu1Mu/9zwppx0kFoX6TA7TvMfFNTLZzbgmeU2W9w==,iv:ka6pLqdMn9vqSwzRnlf+/EYPEe7bFR+RNvcZX8OEmhc=,tag:LXvfMSC1A07IobeXKew1kA==,type:str]
+    hcloud_token: ENC[AES256_GCM,data:4y++ythXPGmRoDyCRgh6PxNsi9hU7T2aWAYMHMVv85I1igI0+JkSboPG4bO+FxJ3odIoBWlBjg+Q5ER92BqdrQ==,iv:lHFItOpLvl3EIqSYlC6OizXN4Rr6sclCfPJLRXWk/9A=,tag:buHWCdvdjfJoUnxTT0Ayfg==,type:str]
     nextcloud_password: ENC[AES256_GCM,data:eQ81dwZbZonNVDAcQtWhVsM3rML609JF/AQtZ9yX8LdOSgtqZh/8LP0=,iv:Eiex1QybGnMKF+wXVHUYqLX1wIxe0fZBKL0kmJEWBNY=,tag:Ty1rZ9f1/gDyT3GFWnxGOg==,type:str]
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:Q7qrx6/MJrPmw6L2YcLfr4DyKTCXWw7DuIvL37xAZ6QZdStj8Wc6zrTZHxo=,iv:jpT2vIvRbjjnFF0ePGZGKdIIyHwnDTt4/cV7/47iCqI=,tag:GZI0fj8e/3mUStEJ2b879A==,type:str]
+    flux_web_client_secret: ENC[AES256_GCM,data:JSGL0/zQOiXWGFOUgAoQQcp3gyiay//su9Uw/+kVS4c=,iv:pejQqtOsvyjBKV8n7L6sfPy2W7c+VJK1uLSlw/lDwu4=,tag:JTGPa3doRnrUUwq9O9BWnA==,type:str]
 sops:
     age:
         - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
@@ -21,7 +22,7 @@ sops:
             UEpHeXR2Qlc0OGZiY2hOcmtTUTNMUk0K5ihAJlXvYuFXMA5QvtyAEqqeWx+NHgBl
             AnDZ/ssZ3mkoFL3pxfTUScRKhQvELgLi951lHQuIG6EaTbutVPV2aw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-28T11:35:50Z"
-    mac: ENC[AES256_GCM,data:nvCdmav1tirgL8InuCg51nc8aOShvaXHyj1j9mDjW96JYKClgPekpshlPFbw8b8W41i/qdfhEsUli/F//mSHY+5C/dqgC7c62L5z4aqhqP0b+gfWDjxJL01gwmEyfyN85+ILkv6NHSv4/qckVucvkgvipiCvQIVdbj4c9UDycQ4=,iv:EDZGo00ZYG3mRiO3j8rtXqSwEgyIE/ynWUiZuKf2kJg=,tag:p83KAM7LGh2Jmf92VJifIA==,type:str]
+    lastmodified: "2026-04-17T17:08:48Z"
+    mac: ENC[AES256_GCM,data:spum9rkiAp0kU/hrexxCgCrziZ9cw7XYbdgPnF7L/bJfVDmHbVqkQWJf/5GE1Hx10vz5KblVzkuS+kzkPO/NE4JyT8wMyEhjbwwi9s4WZCxyP1QfYtzvrzFkPiUtNWnzBVXq0O6I8DrBoWDY+nq6rhU7XPHBe3ARpwpsHTUdXnY=,iv:/C8rIaMtxVqU9mWPLAN6zD5GDuA9t0WfKGEtstReBTQ=,tag:uoa61C3kYWNiysKRhjwa7g==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
@@ -9,6 +9,7 @@ stringData:
     github_app_client_secret: ENC[AES256_GCM,data:1d/Bo7NOtvtkc/LK9XK65sDtMD59Grs6m0DxB8MV2t6rgrO7WiZKTg==,iv:c6WWtVIihW8D0UbiWPNaIvRlSuaqRaN86qdgSWioJoU=,tag:0seA3w+LoBrEsylCfRKRFQ==,type:str]
     hcloud_token: ENC[AES256_GCM,data:SZAr2DAW2MLjapBrc85X8siV14RkC+FKsnv4MeK4Keoz/4Tx5WFBwkYT0tdphFWLFUMt74QvVHREsXSOZYqO0A==,iv:ON0fVY3BOszjxkq2HHY7fjJ/sL2bQeogu1hlJqsCLdQ=,tag:kVVD/lNfpO4E37kqkWnT+A==,type:str]
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:qYWFl9U4nV/lU8cam5FZXryJm4v6gKjF2Xr+HLKmMoWPDlM5X//+cUui9FI=,iv:UkzMbB4Y9gkMUwP/ImGDAesIuqwJagiH43vcVXbfV1w=,tag:XCSERX2Dd3R10mRtmHou4g==,type:str]
+    flux_web_client_secret: ENC[AES256_GCM,data:RHkd062E9SUgp6+8AtZ7SoUxbn/zzf4PGrn9EXhvLIQ=,iv:DB+F2Nbhu25RGkZ10myxxT8Qv4mUmRB57avikslvF4A=,tag:IUiAW4xHJwdH85GP9YkEtg==,type:str]
 sops:
     age:
         - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
@@ -20,7 +21,7 @@ sops:
             SnNOZGs3TnJlV3A1eUgvRlB1djROSU0KKdKq1BI7aysWD8C7Tr69Ic0q5GLGbHi1
             am3X2MaCmenM+MYLmm1gbtEhs3EWMjL1jGwc92dMqVfOHzSgjdbRlQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-28T11:35:55Z"
-    mac: ENC[AES256_GCM,data:GGD+C+MSyZ0WavqlDcVBm703A05BbLvgo/LepsTMJeaHgsX1MEZHpddLtwQIWKHucPb/TA7FISpYc2WV+wXubmfU74fHGFjfWEKzS7fH0LSCLJqNoHRh9Pi3L8EIpkrMonVb56q96i8R5EiEpJrGUCkb/b6mgVXqnbdlPSM1hPo=,iv:DJx/+RyNIm1DJ0JCbOy8pnYj1+FY2Q2yMdr7S13Lolc=,tag:HyCqQOm2MDkEE25dejfLTg==,type:str]
+    lastmodified: "2026-04-17T17:08:48Z"
+    mac: ENC[AES256_GCM,data:ApDsuCNMML3wuCkQxQ337JXOCt4ubbJMg66ZniIZ9g73DedKzlRXeBs/omNuX7Q8JaA5mc5FDNTCra7MOsLgCJlfYHaOxNdCvjNkCmb0nwgT1rGQqUTSAu3aQae2bfe08YzdWZ+tJTs5NkmenZOGoBnHotQMKXA8ucIz4EMyhAA=,iv:8hOl61kHu+wcGNuzqnZrmpK5swGrdP7JRAX/S0XaAE4=,tag:8KOnjOV2dYjHhwqOqhSMSg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/ksail.dev.yaml
+++ b/ksail.dev.yaml
@@ -20,10 +20,12 @@ spec:
     policyEngine: Kyverno
     talos:
       controlPlanes: 3
-    omni:
-      endpoint: "https://devantler.na-west-1.omni.siderolabs.io:443"
     localRegistry:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
+  provider:
+    omni:
+      endpoint: "https://devantler.na-west-1.omni.siderolabs.io:443"
+      machineClass: dev
   workload:
     sourceDirectory: k8s
     kustomizationFile: clusters/dev

--- a/ksail.dev.yaml
+++ b/ksail.dev.yaml
@@ -18,7 +18,7 @@ spec:
     omni:
       endpoint: "https://devantler.na-west-1.omni.siderolabs.io:443"
     localRegistry:
-      registry: "${GITHUB_ACTOR}:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
+      registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   workload:
     sourceDirectory: k8s
     kustomizationFile: clusters/dev

--- a/ksail.dev.yaml
+++ b/ksail.dev.yaml
@@ -18,7 +18,7 @@ spec:
     omni:
       endpoint: "https://devantler.na-west-1.omni.siderolabs.io:443"
     localRegistry:
-      registry: "${GITHUB_ACTOR}:${GITHUB_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
+      registry: "${GITHUB_ACTOR}:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   workload:
     sourceDirectory: k8s
     kustomizationFile: clusters/dev

--- a/ksail.dev.yaml
+++ b/ksail.dev.yaml
@@ -13,6 +13,11 @@ spec:
     provider: Omni
     cni: Cilium
     gitOpsEngine: Flux
+    # Match the existing cluster state so 'ksail cluster update' does not
+    # attempt to uninstall components that are managed in-cluster via Flux.
+    certManager: Enabled
+    metricsServer: Enabled
+    policyEngine: Kyverno
     talos:
       controlPlanes: 3
     omni:

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -16,7 +16,7 @@ spec:
     omni:
       endpoint: "https://devantler.omni.siderolabs.io:443"
     localRegistry:
-      registry: "${GITHUB_ACTOR}:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
+      registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   workload:
     sourceDirectory: k8s
     kustomizationFile: clusters/prod

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -18,10 +18,14 @@ spec:
     certManager: Enabled
     metricsServer: Enabled
     policyEngine: Kyverno
-    omni:
-      endpoint: "https://devantler.omni.siderolabs.io:443"
+    talos:
+      controlPlanes: 3
     localRegistry:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
+  provider:
+    omni:
+      endpoint: "https://devantler.omni.siderolabs.io:443"
+      machineClass: prod
   workload:
     sourceDirectory: k8s
     kustomizationFile: clusters/prod

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -16,7 +16,7 @@ spec:
     omni:
       endpoint: "https://devantler.omni.siderolabs.io:443"
     localRegistry:
-      registry: "${GITHUB_ACTOR}:${GITHUB_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
+      registry: "${GITHUB_ACTOR}:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   workload:
     sourceDirectory: k8s
     kustomizationFile: clusters/prod

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -13,6 +13,11 @@ spec:
     provider: Omni
     cni: Cilium
     gitOpsEngine: Flux
+    # Match the existing cluster state so 'ksail cluster update' does not
+    # attempt to uninstall components that are managed in-cluster via Flux.
+    certManager: Enabled
+    metricsServer: Enabled
+    policyEngine: Kyverno
     omni:
       endpoint: "https://devantler.omni.siderolabs.io:443"
     localRegistry:


### PR DESCRIPTION
## Summary

Re-enables production CD and dev deploys that were broken by GHCR auth
and drift issues, and removes stale upstream-fixed workarounds.

Fixes #1347 — Prod CD fails with `DENIED: permission_denied` when Flux
tries to pull the OCI artifact from GHCR.
Fixes #1348 — Dev/prod endpoints unreachable because workloads never
reconciled into the cluster.

## Changes

- Switch the KSail `localRegistry` token to a long-lived org-level PAT
  (`GHCR_TOKEN`) so Flux can pull the OCI artifact from GHCR.
- Rotate the `hcloud_token` in dev and prod encrypted variables.
- Add the missing `flux_web_client_secret` variable to dev and prod.
- Pin `certManager`, `metricsServer`, and `policyEngine` in
  `ksail.dev.yaml` / `ksail.prod.yaml`.
- Keep the `omnictl kubeconfig` workaround in CI/CD — devantler-tech/ksail#4112
  tracks the upstream fix.

## Prerequisites

- Org-level secret `GHCR_TOKEN` — long-lived PAT (owner: `devantler`)
  with `write:packages`, used by both the workflows and Flux.
- Env-level `SOPS_AGE_KEY` for `dev` and `prod` must contain all three
  Age private keys (already updated).