### PR TITLE
chore: pin reusable-workflows to v2.2.0 SHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@3273c09293df3e99d4aa9601de31d0f51279120c # v1.33.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     permissions:
       contents: write # create releases and tags
       issues: write # comment on related issues

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   sync-policies:
-    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@3273c09293df3e99d4aa9601de31d0f51279120c # v1.33.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@3273c09293df3e99d4aa9601de31d0f51279120c # v1.33.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     permissions:
       issues: write # create/update TODO issues
     secrets:


### PR DESCRIPTION
## Description

Pins all `devantler-tech/reusable-workflows` callsites to SHA `9ec9792d6c140612f6b5bafa5dc786e751b5ff1a` (v2.2.0).