### PR TITLE
chore: pin actions to v2.1.0 SHA

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup KSail
-        uses: devantler-tech/actions/setup-ksail-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
+        uses: devantler-tech/actions/setup-ksail-cli@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
 
       - name: ⚙️ Setup omnictl
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup KSail
-        uses: devantler-tech/actions/setup-ksail-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
+        uses: devantler-tech/actions/setup-ksail-cli@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
 
       - name: ⚙️ Setup omnictl
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@3273c09293df3e99d4aa9601de31d0f51279120c # v1.33.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     permissions:
       contents: write # create releases and tags
       issues: write # comment on related issues

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   sync-policies:
-    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@3273c09293df3e99d4aa9601de31d0f51279120c # v1.33.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -28,4 +28,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-labels-action@884a9b7321e269351d5fc006d95e0b50b2ddedf6 # v1.9.7
+        uses: devantler-tech/actions/sync-github-labels@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@3273c09293df3e99d4aa9601de31d0f51279120c # v1.33.0
+    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@9ec9792d6c140612f6b5bafa5dc786e751b5ff1a # v2.2.0
     permissions:
       issues: write # create/update TODO issues
     secrets:


### PR DESCRIPTION
Pin all `devantler-tech/actions` workflow callsites to the latest semver release SHA:
`4235593b654b467bb57c2d2f492b1461eab37cba` (`v2.1.0`).

Fixes N/A

## Type of change

EOF- [ ] - [ ] - [ ] - [ ] - [x] 