### PR TITLE
chore(vpa): remove InPlaceOrRecreate feature-gate extraArgs

### DIFF
--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -20,10 +20,3 @@ spec:
   values:
     updater:
       enabled: true
-      # TODO: Remove extraArgs when VPA supports InPlaceOrRecreate by default (GA in VPA 1.6.0+)
-      extraArgs:
-        feature-gates: InPlaceOrRecreate=true
-    admissionController:
-      # TODO: Remove extraArgs when VPA supports InPlaceOrRecreate by default (GA in VPA 1.6.0+)
-      extraArgs:
-        feature-gates: InPlaceOrRecreate=true


### PR DESCRIPTION
## Summary

VPA chart `4.11.0` ships with appVersion `1.6.0`, in which `InPlaceOrRecreate` is GA. The `feature-gates: InPlaceOrRecreate=true` extraArgs for both `updater` and `admissionController` are no longer needed.

## Changes

- Removed `extraArgs.feature-gates: InPlaceOrRecreate=true` from `updater`
- Removed `extraArgs.feature-gates: InPlaceOrRecreate=true` from `admissionController`
- Removed associated TODO comments

Fixes #989