### PR TITLE
fix(cloudflared): migrate to locally-managed tunnels with Cilium Gateway

### DIFF
--- a/k8s/bases/variables/variables-base-secret.enc.yaml
+++ b/k8s/bases/variables/variables-base-secret.enc.yaml
@@ -4,37 +4,37 @@ metadata:
     name: variables-base
     namespace: flux-system
 stringData:
-    cloudflare_api_token: ENC[AES256_GCM,data:bteEJdVogGp5c2LkmByKu/lEHXlW9MrkwJ00rIQjzcFgFIq9/Z5vzA==,iv:asZMNSVoQ/LAHlQ8KcILQNK2cOakNPLujkWiUIkscBc=,tag:3t28xzyOLXO5BqhbpmokTQ==,type:str]
+    cloudflare_api_token: ENC[AES256_GCM,data:ADfRMMzGdOp9oT0wAMLCvlP4QA/3I2S7Ts5LcMF0VZnb4+7nTTFTMLWSwn1k27Fem87bhLA=,iv:narD4cOgsbo8VyEeT4X00wcPFigDSDSHUwAQKjhZABc=,tag:uFKv6ZiBOk03c0YUI2wTbQ==,type:str]
 sops:
     age:
         - recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBR0l6UFQ1K3huVUhjZlJG
-            SHFLU3hSWXN1bmt0eDdUOE1KTGN1QlpNQld3CjVzeFp4MWZ3OVpnaWNEU0hISVc2
-            NFB6aVVFL3IwUTI0dS9PN1hHNVcyVlEKLS0tIFRFOWpDbGdWSGNPUU5CWUtISUFD
-            WjJPRUEvOGJZVzg4ejhlUTJIaXpCcFUKbFKtBvK20m+q7vCdK7/1kamdwEQDhSgJ
-            Bio7NZeyyovOueUit8yCMj8l/Y5tFKtONSyuWl4MF2DQNjvrwa/luw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArWXFZaE4wZHdnRTZNTG9a
+            R2tuNjlxVWVZZkZ1ZlBEaC8xNXVPQXNkUGlRCm50OXhRbE9oaHVZNnJEcTZhd1RD
+            TnBoS2ptWmZKS0d5OUljSHUzUEUvU0UKLS0tIDlnbjdLRjEzQkZYY1FRTXdKWEJQ
+            cnlhTm1SbXBoenBRMGtUL1Z2a0N2c2MKrTlbTvgyx4a+PU8yZ6vUJeeQ7qCIrFP4
+            pC/nbMK1GmFF6NTJKEQPL495PnAVeJ4L7MVeVGkYky9MZVdO4gzsoQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3eCtxc2tiWnhHQkZnQWdy
-            VW5PN0d4Wm9WQW96elFMRXpCM1NTM3ZSb1dRClEvYVptUmRWS1BaQWJucCt0Qkl1
-            SVdmdWtJZ1loVjZUelVQRG1RMUorMmsKLS0tIG5rWExuTG1FbHgyYlZLK0NwVUlW
-            bGpJWlhpaGhRZzFSaDhNRzNGbUkxdFUKCYo8RfZ689ygP7NtJ7+7KVecO9UUKZoI
-            2VOdSpHEPr8l/Ych6d37foJIJHGKrbxkQh9Knaa4LoiLa2YcLUzEww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFWE1aM081a1RBdk1waVdS
+            NDJCUC9SUHdhcGFiTDQ4aFJ0WDRPOUlHRVFjCm1xU3FhenR1YkpZdjc2Q1Jlblh3
+            SUFHSSt5ODZ3VWJYZWdlRWsvM3VTOFkKLS0tIG82VE1PalFCdEd3UERkUzJXRmcx
+            QXgzcTA5MjJkR0dHcEZMSXJBQUZ3SUUK3QiSFp1vw2+9Nqdud5/rGrJbv9BSz80B
+            8b0X8WVPB/60oLgDZEglRv8J+Ktq5UGNdfnIZ3Ckx4WkCTfSi3iYUQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVOGFRWE1tWFRLR0t5S2F0
-            RitHTDcycGluUDhidTUrVUFzVW5WMElkNVVBCi9Hc2k4dTJGdis3UDgyMzZpKzgy
-            UFdQc3YyOE9Hbm1LaFE0eVhXdTdxdE0KLS0tICtpQ3p2eisxZytQb0pkV2llVjBQ
-            Y2pRQXFKbG9ZTGdDR1dQTDZyVlAxSDQKT1SYUmJf1Hqz7qgreB6Bg9OxJbeewLoi
-            yXk9iodMC4ISDiuggKiUJonFdI/ltMAfyST7jDawrOHasbr/rZFIIw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRamdtVks5ancwaFR4aU5S
+            SUR3M2lOMHhsNzlYZytZbCs3a0lmT0RFTTFFCmNUdzZRZW03NGtYbnNhekwxUjRp
+            b0wxUTVEb0N2dUlnakczSXNqa2NOUDgKLS0tIDM4Um9xT0ZqQzVTYnNsWnpGOFR5
+            VURIMUNTaXRVYXBTN3VTVEVQbXhFdkUK8ePnpPhd4qMdBiYz4kC+sNMDUvk9zL3z
+            dV8JyF1+VFTiUPt3D4EZfrZsbKb6PMqo2lhC3lnBSQoJc2OK+emW4g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-05-30T18:17:59Z"
-    mac: ENC[AES256_GCM,data:WYa46ovo7Iu4YarwxczI9IB6XMZEk1478IQ0pPaQ7LX12msmpIWMPq3fiBLVNvLUCHiAO+NfCgWlt6woFw054mUj/iJPazbl78in/L34RjASsksiygFh2dNHhr4/MQtsbSI4edEZhMSendteiGP2jxkVL4i0dRHZ0Ip9YExIGeU=,iv:GzVCckhn7VGoYSp4ZDJkPIIOT9tWjivDDM5axITABw4=,tag:vRVkYFjDA3VNkQZIgdR33w==,type:str]
+    lastmodified: "2026-04-18T18:16:20Z"
+    mac: ENC[AES256_GCM,data:ufa1Prg4dwd79qWTYT/ZU6oq388jVWWGfemc/g6Oim37uJr9afUIxo1H3myPvB5ReQMsjPyia1/Td2K1M/w1PIsznkKTZ55T5Rr2mdJDXc5OD+G2+CsmrrvrKYjS4iVdCWHtyFLeFlY0cij6HPKXAsyMqMDwdCNDiKx9GpK/xUM=,iv:zP1NmW40GjeQJwsiHdAylGSkrHO3afl0HWr9qWmMw4k=,tag:slfuG0J3sHMYxNL2Lv6F0w==,type:str]
     encrypted_regex: ^(data|stringData)$
-    version: 3.10.2
+    version: 3.12.2

--- a/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
@@ -5,7 +5,8 @@ metadata:
   name: variables-cluster
   namespace: flux-system
 data:
-  cloudflared_tunnel_id: feb90d05-6569-4af1-8e79-13ecd147e39a
+  cloudflared_tunnel_id: 16559296-e0ce-4f7d-abef-bc703e0bb319
+  cloudflared_tunnel_name: platform-dev
   domain: dev.platform.devantler.tech
   github_app_client_id: Iv23lidTbdsQoKttGTUI
   issuer_group: cert-manager.k8s.cloudflare.com

--- a/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
@@ -4,25 +4,25 @@ metadata:
     name: variables-cluster
     namespace: flux-system
 stringData:
-    cloudflared_tunnel_token: ENC[AES256_GCM,data:dpvl90ylmgrnZDc1wNu81dntH8xwbTjOi4A8Y14EK7xPZIb11Z+rVyTrKB3EMKPN3OtASMHB//jFaiNSuz/kmmhpA/FCXOzP2aYcEpKaTMvEompyN9Hks4koq1CFYRZgDmArTEKnXcdmPUsfZu3TZ7LEwMXU+I5TrROlfugvWYXqlmrWTM2qi/rtGl1/pQFU7c7efjMR2kQnkH8dQAqZdA+2pMp6GbmnCtHOqXM8mAWY13Nr7bhJCQ==,iv:mq4YgSFWvB5Nj1XhvOX67CpNLH+t/C38O+iBH8CwE1E=,tag:y4PVe7opvU0QlQtMphSNVA==,type:str]
-    dex_client_secret: ENC[AES256_GCM,data:Jaoos+oHu379R+yjWqsA57hfsM8=,iv:kknhRkcrpgCpYNFeSKlhWEyIk3sDf+N15cXTPXgPSaE=,tag:cYrCAaCJEnW+yITKs18Cng==,type:str]
-    github_app_client_secret: ENC[AES256_GCM,data:LIZrinlW1d2PV2MzN95/j5G+1grM4kR6nS5NSkgKfoCJVw3gEMTGCA==,iv:HBmb9tJFRt6U2mL09+nkNaQw/0QP71T7ndeTQvIKKkU=,tag:ACmUEPZZPwV11OOTPsbeKw==,type:str]
-    hcloud_token: ENC[AES256_GCM,data:4y++ythXPGmRoDyCRgh6PxNsi9hU7T2aWAYMHMVv85I1igI0+JkSboPG4bO+FxJ3odIoBWlBjg+Q5ER92BqdrQ==,iv:lHFItOpLvl3EIqSYlC6OizXN4Rr6sclCfPJLRXWk/9A=,tag:buHWCdvdjfJoUnxTT0Ayfg==,type:str]
-    nextcloud_password: ENC[AES256_GCM,data:eQ81dwZbZonNVDAcQtWhVsM3rML609JF/AQtZ9yX8LdOSgtqZh/8LP0=,iv:Eiex1QybGnMKF+wXVHUYqLX1wIxe0fZBKL0kmJEWBNY=,tag:Ty1rZ9f1/gDyT3GFWnxGOg==,type:str]
-    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:Q7qrx6/MJrPmw6L2YcLfr4DyKTCXWw7DuIvL37xAZ6QZdStj8Wc6zrTZHxo=,iv:jpT2vIvRbjjnFF0ePGZGKdIIyHwnDTt4/cV7/47iCqI=,tag:GZI0fj8e/3mUStEJ2b879A==,type:str]
-    flux_web_client_secret: ENC[AES256_GCM,data:JSGL0/zQOiXWGFOUgAoQQcp3gyiay//su9Uw/+kVS4c=,iv:pejQqtOsvyjBKV8n7L6sfPy2W7c+VJK1uLSlw/lDwu4=,tag:JTGPa3doRnrUUwq9O9BWnA==,type:str]
+    cloudflared_tunnel_secret: ENC[AES256_GCM,data:gSy33dkq0LutLIFthPtgELXUz9wDUNe8ayNcxCjWxLzPeVtOm6n8QnHWXAs=,iv:4Sxuu+4asdmGptaF7YCt6edFSxQQwEa/LwFjTqDZpaA=,tag:/l1FNDYLY/FXYL+p6Nfr1Q==,type:str]
+    dex_client_secret: ENC[AES256_GCM,data:hDadjJ9cXtenTzUmwblidFas3k4=,iv:+5j4aSafg0adhoUe4PbF86DV4Kuc3XcYznZyLDFmatE=,tag:g5uk4ifpzg/vb+Dc1ZdOSw==,type:str]
+    github_app_client_secret: ENC[AES256_GCM,data:AG66KZ3fH08LdaH7d+ELdixWT/yV45G8WTVnGjXBxTpKFvmu6bhCjw==,iv:Lvflm6B5atLGxPBl1lPu77+fB4DZW7Hp0PS6qD4hVFc=,tag:iDVnwfFIcKM0YM0nBnfetw==,type:str]
+    hcloud_token: ENC[AES256_GCM,data:XkQPtjhOTNc8UszPjAa3vcOe12vkpGykYyucai1T48U9yiZBskJXwrdtQauaTaV6/kJ0H9OVYhTmFOVH7r2TTg==,iv:U3nIzMa6LuJf5z2VxiPycR0h+irKGfzjhhxbgXGznQQ=,tag:9JPikcMYx4ybBSSDHxCgxA==,type:str]
+    nextcloud_password: ENC[AES256_GCM,data:aOPpRXzSJOAFGPqLc0ilAiKzviv64HePTojAELFsZgLZ3iE9dgdfVoc=,iv:DbYSFKShFKvGlaRp+6KaB+++PCvhMsuo9mJdEFGCYnw=,tag:i0jjE/9sh+3aO7D1qJwIJg==,type:str]
+    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:OPsITgtvzc9OXqgla6i0FH8iWYhv3vMMI/U6wOPcmdvgdDxyPos7tWPnEPQ=,iv:jkH8RVAtaU95JsgX9DATkDN/TWLFG9Q/vIy8DGianuc=,tag:kLp+uGpDO9aHZODfMo8q0A==,type:str]
+    flux_web_client_secret: ENC[AES256_GCM,data:cJYf/pa/wN0Vr3u20JYTkS8Hhla/MNE0pBS87fKYn7c=,iv:v+mIsjLJ7OH/9KNLol41GphlQbhu5adf2hLdIvgawrI=,tag:8kbMhm78JIC1mtnctcjKsQ==,type:str]
 sops:
     age:
         - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyZUtlbTFsSmhDa3NVQU51
-            bTJkQWh2RUJBdFY4UmpjODlQbmt0SW5scWx3Cjg5TlNpbFZjVU1lNEcwYkJIV3k2
-            SHBpWVp4SXViN0FsYmx2OEVpTUptTlEKLS0tICswNWlXay8wQTlNeVRHbGFmNm5m
-            UEpHeXR2Qlc0OGZiY2hOcmtTUTNMUk0K5ihAJlXvYuFXMA5QvtyAEqqeWx+NHgBl
-            AnDZ/ssZ3mkoFL3pxfTUScRKhQvELgLi951lHQuIG6EaTbutVPV2aw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxWHpmZThNMjZlUlg0ajJJ
+            K0NWM1hySkxOU3RibG9JNTNLak9kaUdZL2tVCjJUYVNJcWFmb1FpdG5ROEQyRDlD
+            ZDdZRi9zMTZYUmg2QXlkbUIyalFoQU0KLS0tIElTVmtVSFFqR1lDV0hONTI2aFRr
+            Wkd0QUJpak54NFNNQW0vNitpQUkxY1EKGMC7N4/jcg2qh27v7IdbT8Vpvs6Q260J
+            /RTpDGrcuTmQb9cmJmV9lahq8AKbMfGjs7zKoGY1YodDczJlkPfysA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-17T17:08:48Z"
-    mac: ENC[AES256_GCM,data:spum9rkiAp0kU/hrexxCgCrziZ9cw7XYbdgPnF7L/bJfVDmHbVqkQWJf/5GE1Hx10vz5KblVzkuS+kzkPO/NE4JyT8wMyEhjbwwi9s4WZCxyP1QfYtzvrzFkPiUtNWnzBVXq0O6I8DrBoWDY+nq6rhU7XPHBe3ARpwpsHTUdXnY=,iv:/C8rIaMtxVqU9mWPLAN6zD5GDuA9t0WfKGEtstReBTQ=,tag:uoa61C3kYWNiysKRhjwa7g==,type:str]
+    lastmodified: "2026-04-18T15:50:26Z"
+    mac: ENC[AES256_GCM,data:apWmXuGgSC568vVJyt7bR47cqY5fFLZ80cpqaRwowjtqaBRUwz2QkYHOTpn/C27b1jv+rSMQQ77y7Th6BKiI8gbTbQNrIU9S5z84mpimFTuZnrIXYYIzZvGyt4lkSuakU0uDmLjbZ7fwfaY2MKtCW8uirTJRpY0pnOzkAAbup+g=,iv:TrbcgTfMqHiFtz+8gONGwnMXxh8f8OfxE60jXQCDPW0=,tag:JFVIorSv0wNr62BVF7ZoPQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -5,7 +5,8 @@ metadata:
   name: variables-cluster
   namespace: flux-system
 data:
-  cloudflared_tunnel_id: 18508e52-a9d7-466c-b85e-1fa102b3542e
+  cloudflared_tunnel_id: d3414fbb-2c71-493a-a528-f901204442a3
+  cloudflared_tunnel_name: platform-prod
   domain: platform.devantler.tech
   github_app_client_id: Iv23limfvbk93bAXZI6b
   issuer_group: cert-manager.k8s.cloudflare.com

--- a/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
@@ -4,24 +4,24 @@ metadata:
     name: variables-cluster
     namespace: flux-system
 stringData:
-    cloudflared_tunnel_token: ENC[AES256_GCM,data:LegJqH1JuyPpNYO3L1/dMLRdBrNfkxE0/OYeRhjIrKaBPByKYVpSA3h6XK4AcFHxDLZhHiBpNVi73kFcywXZF12uhaP4oYhFhBuYuYMHaO8PVRZ8HG9cYPvwb9zLs+SRv76oZw2M1+PsIYQU3dncJQmly3MgdGd/Y1rCQG50PI77qUzUgEYCMQIcHNnfhBwugYTj0xTagAtCiipk5Jxq6+E65Dsyig4asceFyx9KP1ZOm8/junMimQ==,iv:sn/VOIjDBgo8/XmU9VudlOrWPKYklxQksa3h7sZ7ego=,tag:pP8vf6V78jx8h10aFVQzoQ==,type:str]
-    dex_client_secret: ENC[AES256_GCM,data:YONU7rnys4Xqgc8sm1OPuiw7j80=,iv:y2RCcxrpLf8hmaAHIbpOGOpx/oo5fHDabuR688CGqfI=,tag:4HyZVcSK2M+UbB/A139Mow==,type:str]
-    github_app_client_secret: ENC[AES256_GCM,data:1d/Bo7NOtvtkc/LK9XK65sDtMD59Grs6m0DxB8MV2t6rgrO7WiZKTg==,iv:c6WWtVIihW8D0UbiWPNaIvRlSuaqRaN86qdgSWioJoU=,tag:0seA3w+LoBrEsylCfRKRFQ==,type:str]
-    hcloud_token: ENC[AES256_GCM,data:SZAr2DAW2MLjapBrc85X8siV14RkC+FKsnv4MeK4Keoz/4Tx5WFBwkYT0tdphFWLFUMt74QvVHREsXSOZYqO0A==,iv:ON0fVY3BOszjxkq2HHY7fjJ/sL2bQeogu1hlJqsCLdQ=,tag:kVVD/lNfpO4E37kqkWnT+A==,type:str]
-    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:qYWFl9U4nV/lU8cam5FZXryJm4v6gKjF2Xr+HLKmMoWPDlM5X//+cUui9FI=,iv:UkzMbB4Y9gkMUwP/ImGDAesIuqwJagiH43vcVXbfV1w=,tag:XCSERX2Dd3R10mRtmHou4g==,type:str]
-    flux_web_client_secret: ENC[AES256_GCM,data:RHkd062E9SUgp6+8AtZ7SoUxbn/zzf4PGrn9EXhvLIQ=,iv:DB+F2Nbhu25RGkZ10myxxT8Qv4mUmRB57avikslvF4A=,tag:IUiAW4xHJwdH85GP9YkEtg==,type:str]
+    cloudflared_tunnel_secret: ENC[AES256_GCM,data:U7cNhEMbJ1eTbTevcbvq/y4vaUcPfseAVIev55k9H4pg2LgsLL8z7ST/ItI=,iv:DxcCKT51pLOZktzPXsc32CDEPpjMDIClVaf1FAYIM9w=,tag:4mcn2ys4Ccbcf8hKWMl7DA==,type:str]
+    dex_client_secret: ENC[AES256_GCM,data:jUnfUyW6LZBY5f3nZ4Y5YWAjvu0=,iv:NcQLre+LOgKtd5gz/tf6FpCL5amZ/gQddvL6/uPty70=,tag:TmHMgMuYkFRWsq5Rojq5BA==,type:str]
+    github_app_client_secret: ENC[AES256_GCM,data:XC7fgGMEYTTtvypdZxIq8CULw3SWkS5t7kGs7jH3gzabZYnWQG9pWw==,iv:ezpPmqh9v53aj5NrqjyEoX2bQww5Mp2f2UVeCUBtF9g=,tag:6CAfQGtgQmPArYBBpU1Hzw==,type:str]
+    hcloud_token: ENC[AES256_GCM,data:xYekiMOjhaxq/dyvslvXZKc8o3Jsp+m1ZgUyOVWBu4kFxGFtr61M7uPHfSd2axHdAiYud9ow3PdoCkF9gJyi4g==,iv:iO+iRnPi2dSgZOrWIPina3COpH0juVkuwAMYnVCvlr0=,tag:lr/7B77Ww1+qVDUK+Dz2gw==,type:str]
+    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:SHzKBurGHhzyaknPyzEy8UO1bDM9PYaCZTMi4vfhjp64Tz8KHyxQwiE5PNg=,iv:Z3KJ+tg7zAPLeJtTTmb0Bwd1wixzBQkFr/rlcMX1bw4=,tag:O6akeH2vZn9rH7kOUv4Eiw==,type:str]
+    flux_web_client_secret: ENC[AES256_GCM,data:HG439eFsbyoURdS9ujcmxoRM1iyWr9S+GSMa4WWHahg=,iv:O7IXV1mvRPUL4XnVLsOcmq5DDprAFv+Shxxyf120jT4=,tag:7PbMQmnENjwOqPVXgmnTZg==,type:str]
 sops:
     age:
         - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1N1VmOVpjZWhGZms4b1I5
-            VmdnTlNjdlc0MWZZMjNFeTg0SUZuQStFREI0CjVjNUpjK1lDWEZYM3o4eGNnU2gv
-            QXF2OXVNZ0N5OVlBVVJYa3lORjc3SEEKLS0tIFBBMTlOUW9lVlBwV0V5ejZHUy9H
-            SnNOZGs3TnJlV3A1eUgvRlB1djROSU0KKdKq1BI7aysWD8C7Tr69Ic0q5GLGbHi1
-            am3X2MaCmenM+MYLmm1gbtEhs3EWMjL1jGwc92dMqVfOHzSgjdbRlQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvQjhVYXcvdWthVDhEN3dB
+            Mm53UktsdHZYckNlTjRuVjdEa3dwN1B6cDJzClI0UU5uYlphRDhLdGVVMTdGVHRL
+            TDRBVGNIYnpqSjJHYTNwZzZHZEM0OGsKLS0tIE9VVmZZWUtwQnBKSXA1VGVrUDAy
+            RU02VGc0L1VxTThKK2ZEaDVMSGQ2cUUK2uCzHaosnnfRtgtFQrb5svaHNstLQZKV
+            znAhCwrhlhGCuCCewEbyVB60FMMUIT1zhZMLmzIKbCTCn/wVlz5+yQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-17T17:08:48Z"
-    mac: ENC[AES256_GCM,data:ApDsuCNMML3wuCkQxQ337JXOCt4ubbJMg66ZniIZ9g73DedKzlRXeBs/omNuX7Q8JaA5mc5FDNTCra7MOsLgCJlfYHaOxNdCvjNkCmb0nwgT1rGQqUTSAu3aQae2bfe08YzdWZ+tJTs5NkmenZOGoBnHotQMKXA8ucIz4EMyhAA=,iv:8hOl61kHu+wcGNuzqnZrmpK5swGrdP7JRAX/S0XaAE4=,tag:8KOnjOV2dYjHhwqOqhSMSg==,type:str]
+    lastmodified: "2026-04-18T15:50:32Z"
+    mac: ENC[AES256_GCM,data:XmTW6zVaSm0Bu4beNFvP42tia71CZMOI0UypasS0cSywdM7oHjF6IeU//WaQZxgflS2+P1aClZYQ8I0mqW1U3WrelLQY6jU8mmGilwJdOUT0TCOS99WNS/oqQ2rhjw6LnsdnLQZpLIK1MMx5m8gqIOG5EMuijhtTGNiHawcWJ1g=,iv:idcb17vEe6MAotnTWOmPtpfW5b+4ogv2hHhK9+NEKEw=,tag:U9A+NxqUlF5sioSxON5IEA==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/README.md
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/README.md
@@ -1,6 +1,8 @@
 # Cloudflared
 
-Cloudflared is a tunneling daemon based on Wireguard that can proxy a local webserver through the Cloudflare network. It is used to make the local Kubernetes cluster available on the internet.
+Cloudflared is a tunneling daemon that proxies traffic through the Cloudflare network. It is used to make the Kubernetes cluster available on the internet.
+
+Tunnels are locally managed — ingress rules are defined declaratively in the Helm release values rather than in the Cloudflare dashboard.
 
 - [Documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
-- [Helm Chart](https://github.com/cloudflare/helm-charts)
+- [Helm Chart](https://github.com/cloudflare/helm-charts/tree/main/charts/cloudflare-tunnel)

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -32,7 +32,7 @@ spec:
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel/values.yaml
   values:
     cloudflare:
-      account: "634e9016d402443e427865dc35457728"
+      account: ${cloudflare_account_id}
       tunnelName: ${cloudflared_tunnel_name}
       tunnelId: ${cloudflared_tunnel_id}
       secret: ${cloudflared_tunnel_secret}

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -10,33 +10,40 @@ spec:
   interval: 2m
   chart:
     spec:
-      chart: cloudflare-tunnel-remote
-      version: 0.1.2
+      chart: cloudflare-tunnel
+      version: 0.3.2
       sourceRef:
         kind: HelmRepository
         name: cloudflared
   # TODO: Remove postRenderers when Cilium supports QUIC protocol for cloudflared (https://github.com/cilium/cilium/issues/37529)
   postRenderers:
-     - kustomize:
-         patches:
-           - target:
-               kind: Deployment
-               name: cloudflared-cloudflare-tunnel-remote
-             patch: |
-               - op: replace
-                 path: /spec/template/spec/containers/0/command
-                 value:
-                   - cloudflared
-                   - tunnel
-                   - --protocol
-                   - http2
-                   - --no-autoupdate
-                   - --metrics
-                   - 0.0.0.0:2000
-                   - run
-  # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel-remote/values.yaml
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: cloudflared-cloudflare-tunnel
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/args/1
+                value: --protocol
+              - op: add
+                path: /spec/template/spec/containers/0/args/2
+                value: http2
+  # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel/values.yaml
   values:
-     cloudflare:
-       tunnel_token: ${cloudflared_tunnel_token}
-     image:
-       pullPolicy: Always
+    cloudflare:
+      account: "634e9016d402443e427865dc35457728"
+      tunnelName: ${cloudflared_tunnel_name}
+      tunnelId: ${cloudflared_tunnel_id}
+      secret: ${cloudflared_tunnel_secret}
+      ingress:
+        - hostname: "*.${domain}"
+          service: https://cilium-gateway-platform.kube-system:443
+          originRequest:
+            noTLSVerify: true
+        - hostname: "${domain}"
+          service: https://cilium-gateway-platform.kube-system:443
+          originRequest:
+            noTLSVerify: true
+    image:
+      pullPolicy: Always


### PR DESCRIPTION
## Summary

Apps on both dev and prod clusters were unreachable via their public domains because Cloudflare tunnels were routing traffic to `traefik.traefik:443` — a service that no longer exists after the Traefik → Cilium Gateway API migration.

## Changes

### Tunnel migration (`cloudflare-tunnel-remote` → `cloudflare-tunnel`)
- **Helm chart**: Switched from `cloudflare-tunnel-remote` (0.1.2) to `cloudflare-tunnel` (0.3.2) for declarative/GitOps-managed ingress rules
- **Ingress rules**: Route `*.${domain}` and `${domain}` to `https://cilium-gateway-platform.kube-system:443` with `noTLSVerify: true`
- **PostRenderers**: Updated patch target from `cloudflared-cloudflare-tunnel-remote` to `cloudflared-cloudflare-tunnel`, adds `--protocol http2` flags (needed until [cilium/cilium#37529](https://github.com/cilium/cilium/issues/37529) is resolved)

### New tunnels & DNS
- Created new locally-managed tunnels: `platform-dev` and `platform-prod`
- Updated DNS CNAME records for `dev.platform.devantler.tech` and `platform.devantler.tech`

### Variables & secrets
- Updated `cloudflared_tunnel_id` and added `cloudflared_tunnel_name` to both dev and prod ConfigMaps
- Replaced `cloudflared_tunnel_token` with `cloudflared_tunnel_secret` in SOPS-encrypted secrets
- Updated `cloudflare_api_token` to new account-owned API token (`cfat_` format)

## Verification

| Endpoint | Status |
|---|---|
| `https://whoami.dev.platform.devantler.tech` | ✅ 200 |
| `https://dev.platform.devantler.tech` | ✅ 401 (OAuth2 — expected) |
| `https://whoami.platform.devantler.tech` | ✅ 200 |
| `https://platform.devantler.tech` | ✅ 401 (OAuth2 — expected) |

## Notes
- The dev cluster has a pre-existing VPA admission controller rollout issue due to CPU resource pressure (unrelated to this PR)
- The prod cluster was newly provisioned via `omnictl cluster template sync` as part of this work
- The `OMNI_SERVICE_ACCOUNT_KEY` has an EdDSA verification failure — Flux/Cilium were bootstrapped manually on prod using interactive auth as a workaround