### PR TITLE
feat: add copilot skills-lock for platform

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "skills": {
+    "copilot-instructions-blueprint-generator": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "find-skills": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "gh-cli": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "gh-stack": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "git-commit": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "github-actions-docs": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "github-issues": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "gitops-cluster-debug": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "gitops-knowledge": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "gitops-repo-audit": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "refactor": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    },
+    "siderolabs": {
+      "source": "devantler-tech/skills",
+      "sourceType": "github"
+    }
+  }
+}


### PR DESCRIPTION
Adds `skills-lock.json` at the repo root so agents and `gh skill install` pull in the curated set of skills relevant to this GitOps platform.

## What

Pins 12 skills sourced from [`devantler-tech/skills`](https://github.com/devantler-tech/skills):

| Skill | Why |
|-------|-----|
| [`siderolabs`](https://github.com/devantler-tech/skills/tree/main/siderolabs) | Talos + Omni are the production distribution. |
| [`git-commit`](https://github.com/devantler-tech/skills/tree/main/git-commit) | Semantic commits are required. |
| [`gh-cli`](https://github.com/devantler-tech/skills/tree/main/gh-cli) | `gh` is used in [Hetzner scripts](hetzner/) and agent flows. |
| [`gh-stack`](https://github.com/devantler-tech/skills/tree/main/gh-stack) | Stacked PRs are required. |
| [`github-issues`](https://github.com/devantler-tech/skills/tree/main/github-issues) | Uses [issue templates](https://github.com/devantler-tech/.github) from `devantler-tech/.github`. |
| [`github-actions-docs`](https://github.com/devantler-tech/skills/tree/main/github-actions-docs) | Maintains [6+ workflows](.github/workflows/). |
| [`copilot-instructions-blueprint-generator`](https://github.com/devantler-tech/skills/tree/main/copilot-instructions-blueprint-generator) | Maintains the large [`copilot-instructions.md`](.github/copilot-instructions.md). |
| [`find-skills`](https://github.com/devantler-tech/skills/tree/main/find-skills) | Skill discovery. |
| [`refactor`](https://github.com/devantler-tech/skills/tree/main/refactor) | YAML/kustomization restructuring. |
| [`gitops-knowledge`](https://github.com/fluxcd/agent-skills/tree/main/skills/gitops-knowledge) | Flux CRD-aware YAML generation. |
| [`gitops-repo-audit`](https://github.com/fluxcd/agent-skills/tree/main/skills/gitops-repo-audit) | Audits the GitOps repo layout. |
| [`gitops-cluster-debug`](https://github.com/fluxcd/agent-skills/tree/main/skills/gitops-cluster-debug) | Debugs live Flux reconciliation. |

## Why

No other third-party skills survey passed the "popular OR from a trusted source" bar for the tools this repo uses (`kubectl`, `kustomize`, `cilium`, `kyverno`, `sops`, `cert-manager`, `traefik`). The only qualifying third-party set was [`fluxcd/agent-skills`](https://github.com/fluxcd/agent-skills), which clears both axes (official FluxCD org, 90–109 installs each on [skills.sh](https://skills.sh)).

Depends on devantler-tech/skills#9, which vendors the three `gitops-*` skills upstream. Merge that first, then this.

## Type of change

- [x] 🚀 New feature