### PR TITLE
ci: add scheduled copilot skills update workflow

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -1,0 +1,86 @@
+name: Update Copilot Skills
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 06:00 UTC
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  update-copilot-skills:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: 📄 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true
+
+      # Ensure gh >= 2.90.0 (required for `gh skill`, introduced in v2.90.0).
+      # The ubuntu-latest runner image currently ships gh 2.89.0, and the
+      # upstream setup-copilot-skills action's in-place /usr/local/bin install
+      # is masked by bash's hash cache, so we prepend a fresh gh to PATH here.
+      - name: 🔧 Install gh >= 2.90.0
+        shell: bash
+        env:
+          GH_VERSION: "2.90.0"
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            x86_64|amd64) arch=amd64 ;;
+            arm64|aarch64) arch=arm64 ;;
+            *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
+          esac
+          tarball="gh_${GH_VERSION}_linux_${arch}.tar.gz"
+          tmp="${RUNNER_TEMP:-/tmp}/gh-${GH_VERSION}"
+          mkdir -p "$tmp"
+          base_url="https://github.com/cli/cli/releases/download/v${GH_VERSION}"
+          curl -fsSL "${base_url}/${tarball}" -o "${tmp}/${tarball}"
+          curl -fsSL "${base_url}/gh_${GH_VERSION}_checksums.txt" -o "${tmp}/gh_${GH_VERSION}_checksums.txt"
+          (
+            cd "$tmp"
+            grep " ${tarball}$" "gh_${GH_VERSION}_checksums.txt" | sha256sum --check --status
+          )
+          tar -xzC "$tmp" -f "${tmp}/${tarball}"
+          echo "${tmp}/gh_${GH_VERSION}_linux_${arch}/bin" >> "$GITHUB_PATH"
+
+      - name: ✅ Verify gh skill is available
+        shell: bash
+        run: |
+          if ! gh skill --help > /dev/null 2>&1; then
+            echo "::error::gh skill command not available — upgrade gh to >= 2.90.0"
+            exit 1
+          fi
+
+      - name: 🔄 Update Copilot skills
+        uses: devantler-tech/actions/setup-copilot-skills@538d7103ed24531647941b3a460393b5ac7ed756 # v2.2.0
+        with:
+          skills-lock: skills-lock.json
+          agent: github-copilot
+          scope: project
+
+      - name: 📦 Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          commit-message: "chore(deps): update copilot skills"
+          title: "chore(deps): update copilot skills"
+          body: |
+            Automated update of skills for GitHub Copilot to their latest versions.
+
+            Updated files:
+            - `skills-lock.json`
+            - `.agents/skills/`
+          branch: deps/copilot-skills-update
+          labels: dependencies,automation
+          delete-branch: true

--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -12,75 +12,11 @@ permissions: {}
 
 jobs:
   update-copilot-skills:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
-      - name: 📄 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: true
-
-      # Ensure gh >= 2.90.0 (required for `gh skill`, introduced in v2.90.0).
-      # The ubuntu-latest runner image currently ships gh 2.89.0, and the
-      # upstream setup-copilot-skills action's in-place /usr/local/bin install
-      # is masked by bash's hash cache, so we prepend a fresh gh to PATH here.
-      - name: 🔧 Install gh >= 2.90.0
-        shell: bash
-        env:
-          GH_VERSION: "2.90.0"
-        run: |
-          set -euo pipefail
-          case "$(uname -m)" in
-            x86_64|amd64) arch=amd64 ;;
-            arm64|aarch64) arch=arm64 ;;
-            *) echo "::error::Unsupported arch: $(uname -m)"; exit 1 ;;
-          esac
-          tarball="gh_${GH_VERSION}_linux_${arch}.tar.gz"
-          tmp="${RUNNER_TEMP:-/tmp}/gh-${GH_VERSION}"
-          mkdir -p "$tmp"
-          base_url="https://github.com/cli/cli/releases/download/v${GH_VERSION}"
-          curl -fsSL "${base_url}/${tarball}" -o "${tmp}/${tarball}"
-          curl -fsSL "${base_url}/gh_${GH_VERSION}_checksums.txt" -o "${tmp}/gh_${GH_VERSION}_checksums.txt"
-          (
-            cd "$tmp"
-            grep " ${tarball}$" "gh_${GH_VERSION}_checksums.txt" | sha256sum --check --status
-          )
-          tar -xzC "$tmp" -f "${tmp}/${tarball}"
-          echo "${tmp}/gh_${GH_VERSION}_linux_${arch}/bin" >> "$GITHUB_PATH"
-
-      - name: ✅ Verify gh skill is available
-        shell: bash
-        run: |
-          if ! gh skill --help > /dev/null 2>&1; then
-            echo "::error::gh skill command not available — upgrade gh to >= 2.90.0"
-            exit 1
-          fi
-
-      - name: 🔄 Update Copilot skills
-        uses: devantler-tech/actions/setup-copilot-skills@538d7103ed24531647941b3a460393b5ac7ed756 # v2.2.0
-        with:
-          skills-lock: skills-lock.json
-          agent: github-copilot
-          scope: project
-
-      - name: 📦 Create pull request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          commit-message: "chore(deps): update copilot skills"
-          title: "chore(deps): update copilot skills"
-          body: |
-            Automated update of skills for GitHub Copilot to their latest versions.
-
-            Updated files:
-            - `skills-lock.json`
-            - `.agents/skills/`
-          branch: deps/copilot-skills-update
-          labels: dependencies,automation
-          delete-branch: true
+    uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@6eea016969bceed84f4fb38c8e79fb04a2cadc31 # main @ 2026-04-18
+    with:
+      skills-lock: skills-lock.json
+      agent: github-copilot
+      scope: project


### PR DESCRIPTION
Follow-up to #1370. Adds the scheduled workflow that installs and keeps the pinned skills in `skills-lock.json` up to date at **project scope** (`.agents/skills/`), so every contributor (and Copilot itself) sees the same skill set.

Delegates to the reusable [`devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/update-copilot-skills.yaml), mirroring [devantler-tech/ksail#4141](https://github.com/devantler-tech/ksail/pull/4141).

## What

- Daily cron at 06:00 UTC + `workflow_dispatch`
- Calls the shared reusable workflow with `scope: project`, `agent: github-copilot`, `skills-lock: skills-lock.json`

The first run (triggerable via `workflow_dispatch` after merge) will open the seed PR vendoring the 12 skills under `.agents/skills/`.

## Type of change

- [x] 🚀 New feature
