### PR TITLE
feat(ha): zero-downtime hardening for the operator tier (stacked on #1376)

### DIFF
--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -25,8 +25,28 @@ spec:
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload
                 value: oidc
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0
   # https://github.com/kubernetes-sigs/headlamp/blob/main/charts/headlamp/values.yaml
   values:
+    replicaCount: ${headlamp_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+      maxUnavailable: null
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: headlamp
+            app.kubernetes.io/instance: headlamp
     config:
       oidc:
         clientID: public-client

--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -25,6 +25,23 @@ spec:
               - op: add
                 path: /metadata/annotations/configmap.reloader.stakater.com~1reload
                 value: homepage
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0
+              - op: add
+                path: /spec/template/spec/topologySpreadConstraints
+                value:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: ScheduleAnyway
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: homepage
+                        app.kubernetes.io/instance: homepage
   # ICONS:
   # https://github.com/walkxcode/dashboard-icons
   # https://simpleicons.org

--- a/k8s/bases/apps/homepage/kustomization.yaml
+++ b/k8s/bases/apps/homepage/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - helm-repository.yaml
   - httproute.yaml
   - namespace.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/apps/homepage/pod-disruption-budget.yaml
+++ b/k8s/bases/apps/homepage/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage
+      app.kubernetes.io/instance: homepage

--- a/k8s/bases/apps/whoami/helm-release.yaml
+++ b/k8s/bases/apps/whoami/helm-release.yaml
@@ -17,5 +17,31 @@ spec:
         name: whoami
   # https://github.com/cowboysysop/charts/blob/master/charts/whoami/values.yaml
   values:
+    replicaCount: ${whoami_replicas:=2}
+    pdb:
+      create: true
+      minAvailable: 1
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: whoami
+            app.kubernetes.io/instance: whoami
     ingress:
       enabled: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: whoami
+            patch: |
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0

--- a/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: oauth2-proxy
 spec:
   replicas: ${auth_proxy_replicas:=2}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: auth-proxy
@@ -17,6 +22,14 @@ spec:
       annotations:
         configmap.reloader.stakater.com/reload: auth-proxy-config
     spec:
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: auth-proxy
       containers:
         - name: traefik
           image: docker.io/library/traefik:v3.6
@@ -37,6 +50,10 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
       volumes:
         - name: config
           configMap:

--- a/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 resources:
   - config-map.yaml
   - deployment.yaml
+  - pod-disruption-budget.yaml
   - reference-grant.yaml
   - service.yaml

--- a/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-proxy
+  namespace: oauth2-proxy
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: auth-proxy

--- a/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
@@ -23,11 +23,57 @@ spec:
   # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   values:
     replicaCount: ${cert_manager_replicas:=2}
-    webhook:
-      replicaCount: ${cert_manager_replicas:=2}
-    cainjector:
-      replicaCount: ${cert_manager_replicas:=2}
     podDisruptionBudget:
       enabled: true
+      minAvailable: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: cert-manager
+            app.kubernetes.io/instance: cert-manager
+    webhook:
+      replicaCount: ${cert_manager_replicas:=2}
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: webhook
+              app.kubernetes.io/instance: cert-manager
+    cainjector:
+      replicaCount: ${cert_manager_replicas:=2}
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cainjector
+              app.kubernetes.io/instance: cert-manager
     crds:
       enabled: true

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -46,10 +46,24 @@ spec:
     hubble:
       relay:
         replicas: ${cilium_replicas:=2}
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
       ui:
         replicas: ${cilium_replicas:=2}
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
     operator:
       replicas: ${cilium_replicas:=2}
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
     clustermesh:
       apiserver:
         replicas: ${cilium_replicas:=2}

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/helm-release.yaml
@@ -19,3 +19,16 @@ spec:
   # https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
   values:
     replicaCount: ${cloudnative_pg_replicas:=2}
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: cloudnative-pg
+            app.kubernetes.io/instance: cloudnative-pg

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - helm-release.yaml
   - helm-repository.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+      app.kubernetes.io/instance: cloudnative-pg

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -19,6 +19,17 @@ spec:
   # https://github.com/dexidp/helm-charts/blob/master/charts/dex/values.yaml
   values:
     replicaCount: ${dex_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: dex
+            app.kubernetes.io/instance: dex
     ingress:
       enabled: false
     envVars:

--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -17,4 +17,22 @@ spec:
         kind: HelmRepository
         name: kyverno
   # https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
-  values: {}
+  values:
+    admissionController:
+      replicas: ${kyverno_admission_replicas:=2}
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: admission-controller
+              app.kubernetes.io/instance: kyverno

--- a/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
@@ -16,4 +16,21 @@ spec:
         kind: HelmRepository
         name: metrics-server
   # https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
-  values: {}
+  values:
+    replicas: ${metrics_server_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: metrics-server
+            app.kubernetes.io/instance: metrics-server

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -21,6 +21,23 @@ spec:
     deploymentAnnotations:
       configmap.reloader.stakater.com/reload: oauth2-proxy
     replicaCount: ${oauth2_proxy_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+      maxUnavailable: null
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: oauth2-proxy
+            app.kubernetes.io/instance: oauth2-proxy
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     config:
       clientID: "${github_app_client_id}"
       clientSecret: "${github_app_client_secret}"

--- a/k8s/bases/infrastructure/controllers/reloader/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/reloader/helm-release.yaml
@@ -19,3 +19,19 @@ spec:
   values:
     reloader:
       reloadStrategy: annotations
+      enableHA: true
+      deployment:
+        replicas: ${reloader_replicas:=2}
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app: reloader-reloader
+        labels:
+          provider: stakater
+          group: com.stakater.platform
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1

--- a/k8s/bases/infrastructure/controllers/trust-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/trust-manager/helm-release.yaml
@@ -25,4 +25,13 @@ spec:
       enabled: true
     podDisruptionBudget:
       enabled: true
+      minAvailable: 1
     replicaCount: ${trust_manager_replicas:=2}
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: trust-manager
+            app.kubernetes.io/instance: trust-manager

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -20,3 +20,7 @@ spec:
   values:
     updater:
       enabled: true
+    admissionController:
+      replicaCount: ${vpa_admission_replicas:=2}
+      podDisruptionBudget:
+        minAvailable: 1

--- a/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
@@ -18,8 +18,8 @@ spec:
       k8s-app: kube-dns
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 1
+      maxSurge: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/k8s/providers/docker/infrastructure/controllers/coredns/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - corefile-config-map.yaml
   - deployment.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/docker/infrastructure/controllers/coredns/pod-disruption-budget.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/pod-disruption-budget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -29,8 +29,26 @@ spec:
               - op: add
                 path: /spec/template/spec/containers/0/args/2
                 value: http2
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0
+              - op: add
+                path: /spec/template/spec/topologySpreadConstraints
+                value:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: ScheduleAnyway
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: cloudflare-tunnel
+                        app.kubernetes.io/instance: cloudflared
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel/values.yaml
   values:
+    replicaCount: ${cloudflared_replicas:=2}
     cloudflare:
       account: ${cloudflare_account_id}
       tunnelName: ${cloudflared_tunnel_name}

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/kustomization.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - helm-release.yaml
   - helm-repository.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/pod-disruption-budget.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflared
+  namespace: cloudflared
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflared

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/helm-release.yaml
@@ -15,3 +15,21 @@ spec:
         kind: HelmRepository
         name: hcloud
   interval: 10m0s
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/chart/values.yaml
+  values:
+    replicaCount: ${hcloud_ccm_replicas:=2}
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: hcloud-cloud-controller-manager
+                  app.kubernetes.io/instance: hcloud-cloud-controller-manager

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/kustomization.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/pod-disruption-budget.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hcloud-cloud-controller-manager
+      app.kubernetes.io/instance: hcloud-cloud-controller-manager

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-csi/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-csi/helm-release.yaml
@@ -21,7 +21,22 @@ spec:
     global:
       enableProvidedByTopology: true
     controller:
+      replicaCount: ${hcloud_csi_controller_replicas:=2}
       hcloudVolumeDefaultLocation: fsn1
+      podDisruptionBudget:
+        create: true
+        minAvailable: 1
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/component: controller
+                    app.kubernetes.io/name: hcloud-csi
+                    app.kubernetes.io/instance: hcloud-csi
     node:
       affinity:
         nodeAffinity:

--- a/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
@@ -13,4 +13,5 @@ spec:
         kind: HelmRepository
         name: origin-ca-issuer
   # https://github.com/cloudflare/origin-ca-issuer/blob/trunk/deploy/charts/origin-ca-issuer/values.yaml
-  values: {}
+  values:
+    replicaCount: ${origin_ca_issuer_replicas:=2}

--- a/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - helm-release.yaml
   - helm-repository.yaml
+  - pod-disruption-budget.yaml
   - https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml
   - https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml

--- a/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/pod-disruption-budget.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: origin-ca-issuer
+  namespace: cert-manager
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: origin-ca-issuer
+      app.kubernetes.io/instance: origin-ca-issuer


### PR DESCRIPTION
**Stacked on #1376** — please merge that one first; this branch's diff against `main` will shrink to just the operator-tier changes once the base PR lands.

This is **PR #2b** of the HA & DR plan: same zero-downtime pattern applied to the operator/control-plane tier so a node drain or rolling Talos upgrade no longer leaves the cluster's day-2 systems with a window of unavailability. PR #2a (#1376) covered the user-facing path; this covers everything that runs the cluster itself.

## What changed

Same pattern as #1376 (`replicaCount=2` variable-driven, PDB `minAvailable=1`, `topologySpreadConstraints` on `kubernetes.io/hostname` with `ScheduleAnyway`, `RollingUpdate` with `maxSurge=1, maxUnavailable=0`).

### Base operators

| Workload | Why it matters | Integration |
|---|---|---|
| `cert-manager` (controller / webhook / cainjector) | Webhook is on the request path — single replica means cert issuance/renewal blocks during a node loss | Native chart values |
| `trust-manager` | Distributes cluster CA bundles | Native chart values |
| `cloudnative-pg` | Operator owns DB StatefulSets; webhook validates `Cluster` CRs | Native values + sibling PDB (chart has none) |
| `reloader` | Picks up Secret/ConfigMap rolls; required `enableHA: true` for leader election | Native chart values |
| `metrics-server` | Powers HPA + VPA + `kubectl top`; was running with empty values (replicas=1, no PDB) | Native chart values |
| `vpa` admission controller | Webhook on request path; recommender + updater stay leader-elected singletons | Native chart values |
| `cilium` operator + hubble relay/ui | Operator manages CRDs/IPAM; PDBs added on top of existing replicas | Native chart values |

### Omni-only operators

| Workload | Notes |
|---|---|
| `hcloud-cloud-controller-manager` | replicas=2 + podAntiAffinity (chart has no `topologySpread`) + sibling PDB |
| `hcloud-csi` controller | replicas=2; chart's native `podDisruptionBudget.create=true, minAvailable=1` |
| `origin-ca-issuer` | replicas=2 + sibling PDB (chart only exposes `replicaCount`) |

### Local Docker provider

- `coredns` (hand-rolled Deployment): sibling PDB + tighter strategy (`maxUnavailable: 0`).

## Intentionally skipped

- **`flux-operator`** — chart does not expose a replica count; recommended deployment is a leader-elected singleton.
- **`kubelet-serving-cert-approver`** — pulls upstream `standalone-install.yaml` by URL; would need restructuring to apply patches. Acceptable singleton (only runs on bootstrap / node join).
- **`goldilocks`** — advisor-tier dashboard, not request-path; chart has no straightforward HA path.
- **`testkube`** — low criticality.
- **DaemonSets** (`cilium-agent`, `hcloud-csi-node`) — chart-managed `updateStrategy.maxUnavailable` defaults are sane.

## Validation

- `kubectl kustomize` succeeds for all 13 component dirs and for `clusters/{local,dev,prod}`.
- Live cluster validation deferred — kustomize builds give high confidence; reviewer can run `ksail cluster create` and assert `kubectl get pdb -A` shows the new PDBs.

## Type of change

- [x] 🚀 New feature

## Notes

- Stacks on `devantler/plan-ha-dr-clusters` (#1376). After that merges, GitHub will retarget this PR onto `main` automatically.
- Next up: PR #3 (Omni etcd backups → R2).
