### PR TITLE
fix(auth-proxy): redirect to oauth2-proxy sign-in on 401

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -25,18 +25,33 @@ data:
             authResponseHeaders:
               - X-Auth-Request-User
               - X-Auth-Request-Email
+        oauth2-signin:
+          errors:
+            status:
+              - "401"
+            service: oauth2-proxy
+            query: "/oauth2/start?rd={url}"
+        oauth2-auth:
+          chain:
+            middlewares:
+              - oauth2-signin
+              - oauth2-forward-auth
       routers:
         homepage:
           rule: "Host(`${domain}`)"
           entryPoints: ["web"]
-          middlewares: ["oauth2-forward-auth"]
+          middlewares: ["oauth2-auth"]
           service: homepage
         goldilocks:
           rule: "Host(`goldilocks.${domain}`)"
           entryPoints: ["web"]
-          middlewares: ["oauth2-forward-auth"]
+          middlewares: ["oauth2-auth"]
           service: goldilocks
       services:
+        oauth2-proxy:
+          loadBalancer:
+            servers:
+              - url: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local:80"
         homepage:
           loadBalancer:
             servers:


### PR DESCRIPTION
Visiting `https://platform.devantler.tech` (or any other host fronted by `auth-proxy`, e.g. `goldilocks.platform.devantler.tech`) showed a bare `Unauthorized` page instead of redirecting to `https://oauth2-proxy.platform.devantler.tech/oauth2/start?...` for sign-in.

Traefik's [`forwardAuth`](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) middleware does not auto-redirect to a sign-in URL on 401 the way nginx-ingress's [`auth-signin`](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/) annotation does — it just propagates the 401 from oauth2-proxy's `/oauth2/auth` endpoint.

This adds a Traefik [`errors`](https://doc.traefik.io/traefik/middlewares/http/errorpages/) middleware that catches `401` responses from the forwardAuth check and fetches `/oauth2/start?rd={url}` from an internal `oauth2-proxy` service. oauth2-proxy returns a `302` to the GitHub OAuth flow, which Traefik passes through to the browser. After login, oauth2-proxy redirects back via the `rd` parameter (allowed by the existing `cookie_domains=[".${domain}"]`).

Routers are switched to a `chain` middleware (`oauth2-auth`) so the errors handler runs before the forwardAuth check. Stakater Reloader will roll the auth-proxy pods automatically when the ConfigMap changes.

No HelmRelease, HTTPRoute, or ReferenceGrant changes are required — the new internal Traefik service stays inside the `oauth2-proxy` namespace.

## Type of change

- [x] 🪲 Bug fix