### PR TITLE
feat(dr): wire R2 bucket + Omni etcd backups (PR #3, stacked on #1377)

### DIFF
--- a/docs/dr/omni-etcd-backups.md
+++ b/docs/dr/omni-etcd-backups.md
@@ -1,0 +1,117 @@
+# Omni etcd backups → Cloudflare R2
+
+Disaster-recovery backup of the Talos/Omni control-plane etcd state for the `dev`
+and `prod` clusters. Configured **inside Omni** (not in this repo) because Omni
+manages cluster lifecycle externally; only the shared R2 bucket and the
+credentials live here, where they are reused by Velero ([PR #4](./velero-cnpg.md))
+and CNPG.
+
+## Why R2
+
+- S3-compatible API → Omni's built-in S3 backup target works as-is
+- **Zero egress fees** — restore from anywhere without a surprise bill
+- ~$0.015/GB/mo storage; etcd snapshots are <100 MB each → ≪ $0.05/mo for the
+  etcd portion. Velero + CNPG share the same bucket under separate prefixes.
+- Already part of the Cloudflare account that fronts the platform
+
+## Bucket layout
+
+One bucket per platform install, multiple prefixes:
+
+```
+devantler-platform-backups/
+├── omni-etcd/<cluster-name>/...   ← this PR
+├── velero/                        ← PR #4
+└── cnpg/<cluster-name>/...        ← PR #4
+```
+
+Bucket name and prefixes are exposed via the shared `variables-base` ConfigMap
+in `k8s/bases/variables/variables-base-config-map.yaml`:
+
+| Key                     | Value                                |
+| ----------------------- | ------------------------------------ |
+| `r2_endpoint`           | `https://<account>.r2.cloudflarestorage.com` |
+| `r2_region`             | `auto`                               |
+| `r2_bucket`             | `devantler-platform-backups`         |
+| `r2_prefix_omni_etcd`   | `omni-etcd`                          |
+| `r2_prefix_velero`      | `velero`                             |
+| `r2_prefix_cnpg`        | `cnpg`                               |
+
+## R2 bucket settings (one-time, in Cloudflare dashboard)
+
+1. Create bucket `devantler-platform-backups` in jurisdiction `default`.
+2. **Object Lock**: enabled, **Compliance** mode disabled, **Governance** mode
+   default retention **30 days**. Prevents an attacker (or `rm -rf` typo) from
+   deleting backups before the retention window.
+3. **Versioning**: enabled. Pairs with object lock and lets restores reach back
+   past an accidental overwrite.
+4. **Lifecycle rules**:
+   - `omni-etcd/`: transition to Infrequent Access after 14 days (still cheap on
+     R2; mostly hygiene); abort incomplete multipart uploads after 1 day.
+   - `velero/`, `cnpg/`: same.
+5. **Server-side encryption**: SSE-S3 (AES-256), which is the R2 default and
+   cannot be disabled. No additional config needed.
+6. Create a **scoped API token** with permission `Object Read & Write` limited to
+   this bucket. Save the access key ID and secret access key — these are the
+   values that go into the SOPS-encrypted `variables-base` secret as
+   `r2_access_key_id` / `r2_secret_access_key`.
+
+## Omni-side configuration
+
+Omni's "Control Plane Backups" feature writes etcd snapshots directly to S3-
+compatible storage. There is no in-cluster cron and no extra workload — the
+backup runs from Omni's control plane and only the resulting snapshot blob lands
+in R2.
+
+Configure once per cluster in the Omni UI (`Cluster → Backups`) **or** via
+`omnictl` with the values below.
+
+```bash
+# Example — run for each of dev and prod, substituting the cluster name.
+omnictl cluster set-backup \
+  --cluster <cluster-name> \
+  --type s3 \
+  --endpoint "https://634e9016d402443e427865dc35457728.r2.cloudflarestorage.com" \
+  --region auto \
+  --bucket devantler-platform-backups \
+  --prefix "omni-etcd/<cluster-name>" \
+  --access-key-id     "$R2_ACCESS_KEY_ID" \
+  --secret-access-key "$R2_SECRET_ACCESS_KEY" \
+  --schedule "@daily" \
+  --retention 14 \
+  --long-term-retention 4
+```
+
+| Setting               | Value                              |
+| --------------------- | ---------------------------------- |
+| Schedule              | `@daily`                           |
+| Daily retention       | 14 snapshots (~14 days)            |
+| Weekly long-term      | 4 snapshots (~28 days)             |
+| Encryption in transit | TLS to R2 endpoint                 |
+| Encryption at rest    | SSE-S3 (R2 default)                |
+| RPO target            | 24 h (matches plan goal)           |
+
+## Restore (high level)
+
+Detailed in `docs/dr/runbook.md` (PR #5). Summary:
+
+1. Provision a fresh Talos node from the snapshot used by `hetzner/`.
+2. In Omni, create a new cluster pointed at the same machine.
+3. `Cluster → Backups → Restore from S3` → pick the most recent snapshot under
+   `omni-etcd/<cluster-name>/`.
+4. Omni rolls a new etcd member from the snapshot and rejoins the control plane.
+5. Once the API server is back, Flux reconciles the rest of the platform from
+   GHCR — no further manual steps for the workload tier.
+
+## Local clusters
+
+Skipped. Local clusters use Docker, have a single control plane, and exist only
+for the lifetime of `ksail cluster create` → `ksail cluster delete`. There is
+nothing to restore that isn't already in this repo.
+
+## Related
+
+- [DR runbook](./runbook.md) (PR #5) — full rebuild-from-zero procedure
+- [Velero + CNPG backups](./velero-cnpg.md) (PR #4) — application/PV layer
+- [HA primitives](../../README.md) — PDBs, topology spread, rolling updates
+  (PRs #2a / #2b)

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -25,8 +25,28 @@ spec:
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload
                 value: oidc
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0
   # https://github.com/kubernetes-sigs/headlamp/blob/main/charts/headlamp/values.yaml
   values:
+    replicaCount: ${headlamp_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+      maxUnavailable: null
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: headlamp
+            app.kubernetes.io/instance: headlamp
     config:
       oidc:
         clientID: public-client

--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -25,6 +25,23 @@ spec:
               - op: add
                 path: /metadata/annotations/configmap.reloader.stakater.com~1reload
                 value: homepage
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0
+              - op: add
+                path: /spec/template/spec/topologySpreadConstraints
+                value:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: ScheduleAnyway
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: homepage
+                        app.kubernetes.io/instance: homepage
   # ICONS:
   # https://github.com/walkxcode/dashboard-icons
   # https://simpleicons.org

--- a/k8s/bases/apps/homepage/kustomization.yaml
+++ b/k8s/bases/apps/homepage/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - helm-repository.yaml
   - httproute.yaml
   - namespace.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/apps/homepage/pod-disruption-budget.yaml
+++ b/k8s/bases/apps/homepage/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: homepage
+      app.kubernetes.io/instance: homepage

--- a/k8s/bases/apps/whoami/helm-release.yaml
+++ b/k8s/bases/apps/whoami/helm-release.yaml
@@ -17,5 +17,31 @@ spec:
         name: whoami
   # https://github.com/cowboysysop/charts/blob/master/charts/whoami/values.yaml
   values:
+    replicaCount: ${whoami_replicas:=2}
+    pdb:
+      create: true
+      minAvailable: 1
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: whoami
+            app.kubernetes.io/instance: whoami
     ingress:
       enabled: false
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: whoami
+            patch: |
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0

--- a/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: oauth2-proxy
 spec:
   replicas: ${auth_proxy_replicas:=2}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: auth-proxy
@@ -17,6 +22,14 @@ spec:
       annotations:
         configmap.reloader.stakater.com/reload: auth-proxy-config
     spec:
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: auth-proxy
       containers:
         - name: traefik
           image: docker.io/library/traefik:v3.6
@@ -37,6 +50,10 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
       volumes:
         - name: config
           configMap:

--- a/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 resources:
   - config-map.yaml
   - deployment.yaml
+  - pod-disruption-budget.yaml
   - reference-grant.yaml
   - service.yaml

--- a/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-proxy
+  namespace: oauth2-proxy
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: auth-proxy

--- a/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
@@ -23,11 +23,57 @@ spec:
   # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   values:
     replicaCount: ${cert_manager_replicas:=2}
-    webhook:
-      replicaCount: ${cert_manager_replicas:=2}
-    cainjector:
-      replicaCount: ${cert_manager_replicas:=2}
     podDisruptionBudget:
       enabled: true
+      minAvailable: 1
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: cert-manager
+            app.kubernetes.io/instance: cert-manager
+    webhook:
+      replicaCount: ${cert_manager_replicas:=2}
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: webhook
+              app.kubernetes.io/instance: cert-manager
+    cainjector:
+      replicaCount: ${cert_manager_replicas:=2}
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cainjector
+              app.kubernetes.io/instance: cert-manager
     crds:
       enabled: true

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -46,10 +46,24 @@ spec:
     hubble:
       relay:
         replicas: ${cilium_replicas:=2}
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
       ui:
         replicas: ${cilium_replicas:=2}
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
     operator:
       replicas: ${cilium_replicas:=2}
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
     clustermesh:
       apiserver:
         replicas: ${cilium_replicas:=2}

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/helm-release.yaml
@@ -19,3 +19,16 @@ spec:
   # https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
   values:
     replicaCount: ${cloudnative_pg_replicas:=2}
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: cloudnative-pg
+            app.kubernetes.io/instance: cloudnative-pg

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - helm-release.yaml
   - helm-repository.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+      app.kubernetes.io/instance: cloudnative-pg

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -19,6 +19,17 @@ spec:
   # https://github.com/dexidp/helm-charts/blob/master/charts/dex/values.yaml
   values:
     replicaCount: ${dex_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: dex
+            app.kubernetes.io/instance: dex
     ingress:
       enabled: false
     envVars:

--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -17,4 +17,22 @@ spec:
         kind: HelmRepository
         name: kyverno
   # https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
-  values: {}
+  values:
+    admissionController:
+      replicas: ${kyverno_admission_replicas:=2}
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: admission-controller
+              app.kubernetes.io/instance: kyverno

--- a/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
@@ -16,4 +16,21 @@ spec:
         kind: HelmRepository
         name: metrics-server
   # https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
-  values: {}
+  values:
+    replicas: ${metrics_server_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: metrics-server
+            app.kubernetes.io/instance: metrics-server

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -21,6 +21,23 @@ spec:
     deploymentAnnotations:
       configmap.reloader.stakater.com/reload: oauth2-proxy
     replicaCount: ${oauth2_proxy_replicas:=2}
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+      maxUnavailable: null
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: oauth2-proxy
+            app.kubernetes.io/instance: oauth2-proxy
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     config:
       clientID: "${github_app_client_id}"
       clientSecret: "${github_app_client_secret}"

--- a/k8s/bases/infrastructure/controllers/reloader/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/reloader/helm-release.yaml
@@ -19,3 +19,19 @@ spec:
   values:
     reloader:
       reloadStrategy: annotations
+      enableHA: true
+      deployment:
+        replicas: ${reloader_replicas:=2}
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app: reloader-reloader
+        labels:
+          provider: stakater
+          group: com.stakater.platform
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1

--- a/k8s/bases/infrastructure/controllers/trust-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/trust-manager/helm-release.yaml
@@ -25,4 +25,13 @@ spec:
       enabled: true
     podDisruptionBudget:
       enabled: true
+      minAvailable: 1
     replicaCount: ${trust_manager_replicas:=2}
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: trust-manager
+            app.kubernetes.io/instance: trust-manager

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -20,3 +20,7 @@ spec:
   values:
     updater:
       enabled: true
+    admissionController:
+      replicaCount: ${vpa_admission_replicas:=2}
+      podDisruptionBudget:
+        minAvailable: 1

--- a/k8s/bases/variables/variables-base-config-map.yaml
+++ b/k8s/bases/variables/variables-base-config-map.yaml
@@ -6,3 +6,9 @@ metadata:
   namespace: flux-system
 data:
   cloudflare_account_id: 634e9016d402443e427865dc35457728
+  r2_endpoint: https://634e9016d402443e427865dc35457728.r2.cloudflarestorage.com
+  r2_region: auto
+  r2_bucket: devantler-platform-backups
+  r2_prefix_omni_etcd: omni-etcd
+  r2_prefix_velero: velero
+  r2_prefix_cnpg: cnpg

--- a/k8s/bases/variables/variables-base-secret.enc.yaml
+++ b/k8s/bases/variables/variables-base-secret.enc.yaml
@@ -5,6 +5,8 @@ metadata:
     namespace: flux-system
 stringData:
     cloudflare_api_token: ENC[AES256_GCM,data:ADfRMMzGdOp9oT0wAMLCvlP4QA/3I2S7Ts5LcMF0VZnb4+7nTTFTMLWSwn1k27Fem87bhLA=,iv:narD4cOgsbo8VyEeT4X00wcPFigDSDSHUwAQKjhZABc=,tag:uFKv6ZiBOk03c0YUI2wTbQ==,type:str]
+    r2_access_key_id: ENC[AES256_GCM,data:SbBQvC8ex2M10JHV6ogBFkvN+13ZNQc5hS7U,iv:5k7bOd/q75c146+HvEUZGsVLPDNc5qDE/u2KFGfs/3Y=,tag:DKrOyTVC6R0AMfBhiCZFAg==,type:str]
+    r2_secret_access_key: ENC[AES256_GCM,data:PdhgQ1d1pDW1lLcXasYG2roEG8qapUHpHM/goE+V1w==,iv:g3QCozVlZMEBRfMhVvfSf5i8lYK+3hnFPJ+fEjSJz4s=,tag:UJL+z0bQ2C7f71XJSdWCvQ==,type:str]
 sops:
     age:
         - recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
@@ -34,7 +36,7 @@ sops:
             VURIMUNTaXRVYXBTN3VTVEVQbXhFdkUK8ePnpPhd4qMdBiYz4kC+sNMDUvk9zL3z
             dV8JyF1+VFTiUPt3D4EZfrZsbKb6PMqo2lhC3lnBSQoJc2OK+emW4g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T18:16:20Z"
-    mac: ENC[AES256_GCM,data:ufa1Prg4dwd79qWTYT/ZU6oq388jVWWGfemc/g6Oim37uJr9afUIxo1H3myPvB5ReQMsjPyia1/Td2K1M/w1PIsznkKTZ55T5Rr2mdJDXc5OD+G2+CsmrrvrKYjS4iVdCWHtyFLeFlY0cij6HPKXAsyMqMDwdCNDiKx9GpK/xUM=,iv:zP1NmW40GjeQJwsiHdAylGSkrHO3afl0HWr9qWmMw4k=,tag:slfuG0J3sHMYxNL2Lv6F0w==,type:str]
+    lastmodified: "2026-04-18T22:09:18Z"
+    mac: ENC[AES256_GCM,data:c06gQllC6M2Nvb3zHmLdk9wMVRgY72ZjxQOwMmj2X5S3gQz5EkL7qZs+gw9MQgOYE8TdMXmRc0bhkxIL6nanrVpOdqEzTMZtcdXbmIP3JpyV+KVreX80hP0ovF8HaYHkf8C7cmZ0QYjCDLdbNw9rWCAeXUEX7vcvAtdvf5+Vf1Q=,iv:Ew3Jw1tbVyaMg0r02W9F+zl6qyVaBNvfo3zmsaYBG+w=,tag:MjcQQvHMSt0rp3KL4KLOxA==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
@@ -18,8 +18,8 @@ spec:
       k8s-app: kube-dns
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 1
+      maxSurge: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/k8s/providers/docker/infrastructure/controllers/coredns/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - corefile-config-map.yaml
   - deployment.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/docker/infrastructure/controllers/coredns/pod-disruption-budget.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/pod-disruption-budget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -29,8 +29,26 @@ spec:
               - op: add
                 path: /spec/template/spec/containers/0/args/2
                 value: http2
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0
+              - op: add
+                path: /spec/template/spec/topologySpreadConstraints
+                value:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: ScheduleAnyway
+                    labelSelector:
+                      matchLabels:
+                        app.kubernetes.io/name: cloudflare-tunnel
+                        app.kubernetes.io/instance: cloudflared
   # https://github.com/cloudflare/helm-charts/blob/main/charts/cloudflare-tunnel/values.yaml
   values:
+    replicaCount: ${cloudflared_replicas:=2}
     cloudflare:
       account: ${cloudflare_account_id}
       tunnelName: ${cloudflared_tunnel_name}

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/kustomization.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - helm-release.yaml
   - helm-repository.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/pod-disruption-budget.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflared
+  namespace: cloudflared
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflared

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/helm-release.yaml
@@ -15,3 +15,21 @@ spec:
         kind: HelmRepository
         name: hcloud
   interval: 10m0s
+  # https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/chart/values.yaml
+  values:
+    replicaCount: ${hcloud_ccm_replicas:=2}
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: hcloud-cloud-controller-manager
+                  app.kubernetes.io/instance: hcloud-cloud-controller-manager

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/kustomization.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/pod-disruption-budget.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-ccm/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hcloud-cloud-controller-manager
+      app.kubernetes.io/instance: hcloud-cloud-controller-manager

--- a/k8s/providers/omni/infrastructure/controllers/hcloud-csi/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/hcloud-csi/helm-release.yaml
@@ -21,7 +21,22 @@ spec:
     global:
       enableProvidedByTopology: true
     controller:
+      replicaCount: ${hcloud_csi_controller_replicas:=2}
       hcloudVolumeDefaultLocation: fsn1
+      podDisruptionBudget:
+        create: true
+        minAvailable: 1
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/component: controller
+                    app.kubernetes.io/name: hcloud-csi
+                    app.kubernetes.io/instance: hcloud-csi
     node:
       affinity:
         nodeAffinity:

--- a/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
@@ -13,4 +13,5 @@ spec:
         kind: HelmRepository
         name: origin-ca-issuer
   # https://github.com/cloudflare/origin-ca-issuer/blob/trunk/deploy/charts/origin-ca-issuer/values.yaml
-  values: {}
+  values:
+    replicaCount: ${origin_ca_issuer_replicas:=2}

--- a/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - helm-release.yaml
   - helm-repository.yaml
+  - pod-disruption-budget.yaml
   - https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml
   - https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml

--- a/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/pod-disruption-budget.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: origin-ca-issuer
+  namespace: cert-manager
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: origin-ca-issuer
+      app.kubernetes.io/instance: origin-ca-issuer


### PR DESCRIPTION
**Stacked on #1377 (which is stacked on #1376).** Will retarget to `main` automatically as those merge.

PR #3 of the HA & DR plan. Wires the **shared R2 backup destination** that PR #4 (Velero + CNPG) and Omni's built-in etcd backup feature both consume. No in-cluster workload — Omni writes snapshots directly to S3 from its own control plane.

## What's in this PR

- `k8s/bases/variables/variables-base-config-map.yaml` — `r2_endpoint`, `r2_region`, `r2_bucket`, plus per-consumer prefix keys (`r2_prefix_omni_etcd`, `r2_prefix_velero`, `r2_prefix_cnpg`). Available to all clusters via Flux `postBuild.substituteFrom`.
- `k8s/bases/variables/variables-base-secret.enc.yaml` — SOPS-encrypted placeholders `r2_access_key_id` / `r2_secret_access_key`. **Must be rotated in via `sops --set` with real R2 token values before deployment** (procedure in the doc).
- `docs/dr/omni-etcd-backups.md` — bucket settings (Object Lock 30d / versioning / SSE-S3), scoped-token recipe, `omnictl cluster set-backup` invocation, retention policy (14 daily + 4 weekly), restore overview.

## Why no manifests

Omni manages the control plane externally; the etcd snapshot job runs from Omni's side and only the encrypted blob lands in R2. There is nothing to deploy into the cluster for this PR.

## Why R2

- **Zero egress** → restoring from anywhere doesn't trigger a surprise bill.
- S3-compatible API works with Omni's built-in S3 backup target as-is.
- Co-located with the existing Cloudflare account.
- ≪ $0.05/mo for the etcd portion (snapshots <100 MB).

## Local clusters

Intentionally skipped — ephemeral, single-CP, fully reconstructed from this repo on every `ksail cluster create`.

## Sensitive values

All R2 credentials are SOPS-encrypted before they hit git (per the always-encrypted-at-rest goal). The placeholder values are clearly marked `REPLACE_ME_*`; CI will not consume them, and the runbook covers rotation.

## Validation

- `kubectl kustomize` succeeds for all three cluster overlays.
- `sops -d` round-trips the secret cleanly.

## Type of change

- [x] 🚀 New feature
- [x] 📚 Documentation
