### PR TITLE
feat(alerting): in-cluster Prometheus + Alertmanager -> webhook (PR #6, stacked on #1381)

### DIFF
--- a/docs/dr/README.md
+++ b/docs/dr/README.md
@@ -1,0 +1,12 @@
+# Disaster recovery & high availability
+
+This directory holds the operator-facing DR documentation for the platform.
+Start with [`runbook.md`](./runbook.md); the other documents go deeper on the
+specific layers it references.
+
+| Document                                 | Layer            |
+| ---------------------------------------- | ---------------- |
+| [runbook.md](./runbook.md)               | Procedure        |
+| [omni-etcd-backups.md](./omni-etcd-backups.md) | Control plane (PR #3) |
+| [velero-cnpg.md](./velero-cnpg.md)       | Apps + PVs (PR #4) |
+| [alerting.md](./alerting.md)             | Detection (PR #6) |

--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -1,0 +1,116 @@
+# In-cluster alerting
+
+`kube-prometheus-stack` (Prometheus + Alertmanager + node-exporter +
+kube-state-metrics) running per cluster, no Grafana, no remote-write, no
+SaaS. Alerts ship via webhook to a free destination (Discord channel /
+email-to-webhook bridge) — the URL is per-cluster and SOPS-encrypted.
+
+## Why no Grafana
+
+This is **alerting only**. Operators look at logs and `kubectl` for
+debugging; we don't run a dashboard tier on the homelab to keep the
+resource budget small (Grafana adds ~512 MiB and another HelmRelease to
+keep current).
+
+## Why no remote-write
+
+Same reason — no external dashboard tier. Critical alerts route directly
+out of Alertmanager.
+
+## What gets alerted
+
+See `k8s/bases/infrastructure/controllers/kube-prometheus-stack/rules/critical.yaml`.
+
+| Alert                       | Severity | Why                                       |
+| --------------------------- | -------- | ----------------------------------------- |
+| `NodeNotReady`              | critical | Single node loss; PDBs cover but you should still know |
+| `NodeDiskFillingUp`         | warning  | >90% root fs                              |
+| `PersistentVolumeFillingUp` | critical | >90% PVC                                  |
+| `CertificateExpiringSoon`   | warning  | <14 d to expiry, cert-manager not renewing |
+| `FluxKustomizationNotReady` | critical | Reconciliation broken >15 min             |
+| `VeleroBackupFailed`        | critical | Any failure in last hour                  |
+| `VeleroNoRecentBackup`      | critical | RPO breach -- no successful backup in 30h |
+| `CNPGNoRecentBackup`        | critical | Same, for Postgres                        |
+| `CNPGClusterDegraded`       | critical | Primary alone, no streaming replica       |
+
+`defaultRules.create: false` is set on the chart so we don't drown in the
+~200 generic chart-bundled alerts that aren't useful at homelab scale.
+
+## Caveat: in-cluster Alertmanager won't fire if the whole cluster is down
+
+This is the deliberate tradeoff for "no SaaS". Mitigations:
+
+1. **Daily Velero schedule + Omni etcd backups still run independently.**
+   On next recovery, you'll see the missed backup in R2.
+2. **PR #7 CI restore drill** asserts the rules render and Alertmanager
+   accepts them on every PR — so a regression in the alert spec is caught
+   before merge.
+3. If true off-cluster alerting becomes necessary later, the documented
+   follow-up is to add Grafana Cloud free tier (10k metrics, ample for
+   these alerts) and configure a remote-write target in
+   `prometheus.prometheusSpec.remoteWrite`. No code restructure required.
+
+## Per-environment webhook URL
+
+Stored in `variables-cluster-secret.enc.yaml` as `alertmanager_webhook_url`,
+substituted into the `alertmanager-webhook` Secret at apply time.
+
+| Env   | Where to set                                  | Suggestion             |
+| ----- | --------------------------------------------- | ---------------------- |
+| local | `k8s/clusters/local/variables/variables-cluster-secret.enc.yaml` (already filled with a non-resolvable invalid URL — alerts fail to send, on purpose) | n/a |
+| dev   | same path under `clusters/dev/`               | Discord #dev-alerts    |
+| prod  | same path under `clusters/prod/`              | Discord #prod-alerts   |
+
+To set:
+
+```bash
+sops --set '["stringData"]["alertmanager_webhook_url"] "<url>"' \
+  k8s/clusters/<env>/variables/variables-cluster-secret.enc.yaml
+```
+
+### Discord webhook recipe
+
+1. Server settings → Integrations → Webhooks → New Webhook → copy URL.
+2. Append `/slack` to the URL — Discord accepts Slack-formatted payloads
+   natively, and Alertmanager's `slack_configs` is a closer match. Or use
+   a tiny shim (e.g. `alertmanager-discord`) — tracked as a possible
+   follow-up but not required.
+3. Drop the URL into the SOPS secret per the command above.
+
+### Email-to-webhook bridge
+
+Free options: Mailgun (5k/mo free), Resend (3k/mo free), or AWS SES via
+its HTTPS API. Configure the same way — paste the webhook URL into the
+encrypted secret.
+
+## Local clusters
+
+Identical install, with:
+
+- Webhook URL pointed at `http://example.invalid/no-webhook-on-local`
+  (deliberately fails). CI asserts this fail mode is acceptable — the
+  alerts still fire inside Alertmanager, the webhook just can't reach
+  anywhere. PR #7 verifies the alert wiring; the lack of an external
+  destination is by design.
+
+## Tuning resource footprint
+
+Current chart values:
+
+| Component      | Requests              | Limits        |
+| -------------- | --------------------- | ------------- |
+| Prometheus     | 100m CPU / 512 Mi     | — / 1 Gi      |
+| Alertmanager   | 50m CPU / 64 Mi       | — / 128 Mi    |
+| Operator       | 50m CPU / 128 Mi      | — / 256 Mi    |
+| node-exporter  | (chart defaults)      | (chart defaults) |
+| kube-state-metrics | (chart defaults)  | (chart defaults) |
+
+Total ~1 GiB committed memory, well within 3× CX23 (24 GiB total). If
+this becomes too heavy, the first thing to drop is `nodeExporter` and
+the related node-level alerts.
+
+## Related
+
+- [DR runbook](./runbook.md) — what to do when an alert fires
+- [Velero + CNPG](./velero-cnpg.md) — the systems whose health is being checked
+- [HA primitives](../../README.md) — PDBs / topology spread (PRs #2a/#2b)

--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -1,0 +1,283 @@
+# Disaster recovery runbook
+
+The single source of truth for "how do I get the platform back" — covering
+single-node loss, full-cluster loss, and credential rotation. Designed so
+that with this repo + the off-cluster artifacts listed below + ~30 minutes
+of manual control-plane work, dev or prod can be reconstructed to a state
+indistinguishable from the day before the incident.
+
+> **RPO target:** 24 h (daily snapshots).
+> **RTO target:** 4 h (mostly slack for manual Omni / Cloudflare clicks; the
+> automated portion is &lt; 15 minutes in CI).
+
+---
+
+## Off-cluster artifacts you must keep safe
+
+The repo + these four items are the entire seed for a rebuild. Lose all of
+these simultaneously and you cannot recover.
+
+| Artifact                                | Where it lives                       | Recovery if lost                     |
+| --------------------------------------- | ------------------------------------ | ------------------------------------ |
+| **SOPS Age private keys** (one per env) | 1Password + hardware key, second loc | Re-encrypt all `*.enc.yaml` (below)  |
+| **Cloudflare R2 access keys**           | 1Password                            | Mint new in Cloudflare; SOPS-update  |
+| **Omni admin credentials**              | 1Password + Omni `omnictl` config    | Reset via Sidero support             |
+| **Cloudflare API token**                | 1Password                            | Mint new in Cloudflare dashboard     |
+
+> Recommendation: 1Password vault `platform-dr` shared with at least one
+> additional trusted operator, plus an offline copy on a hardware-encrypted
+> USB stick stored in a second physical location.
+
+---
+
+## Scenario 1 — Single node loss
+
+Expected behaviour: PDBs (PRs #2a / #2b) keep every multi-replica workload
+serving traffic. Omni replaces the failed node within ~5 minutes.
+
+**Action:** none required if PDBs and Omni autoscaling are healthy. Verify
+afterwards:
+
+```bash
+kubectl get nodes
+kubectl get pods -A --field-selector=status.phase!=Running
+kubectl get pdb -A    # all should show ALLOWED-DISRUPTIONS=1
+```
+
+If any workload is stuck in Pending because all replicas were on the dead
+node and the PDB is blocking eviction on the new one, force a rollout:
+
+```bash
+kubectl -n <ns> rollout restart deployment/<name>
+```
+
+---
+
+## Scenario 2 — Planned rolling Talos / Kubernetes upgrade
+
+Driven by Omni; nodes drain one at a time. PDBs hold the line.
+
+```bash
+# Pre-flight: confirm every multi-replica workload has a PDB
+kubectl get pdb -A
+
+# Pre-flight: confirm RollingUpdate strategy uses maxUnavailable: 0
+kubectl get deploy -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}\t{.spec.strategy.rollingUpdate.maxUnavailable}{"\n"}{end}'
+```
+
+If anything reports `maxUnavailable` other than `0`, that workload was
+either added after PR #2a/#2b or has a chart limitation — fix before
+upgrading.
+
+---
+
+## Scenario 3 — etcd corruption / control-plane loss
+
+Restore from the most recent Omni snapshot (PR #3).
+
+1. **Omni dashboard** → `Cluster → Backups → Restore from S3`.
+2. Pick the most recent snapshot under `omni-etcd/<cluster-name>/` (Omni
+   lists them automatically; default sort is most-recent-first).
+3. Confirm. Omni rolls a fresh etcd member from the snapshot and rejoins
+   it to the control plane.
+4. Wait for `kubectl get componentstatuses` (or `kubectl get --raw=/livez`)
+   to come green.
+5. Flux reconciles everything else from GHCR — no manual workload steps.
+
+If the dashboard is unavailable, `omnictl` equivalent:
+
+```bash
+omnictl cluster restore-backup \
+  --cluster <cluster-name> \
+  --snapshot <snapshot-id-from-omni>
+```
+
+**RPO:** ≤ 24 h (daily schedule). **RTO:** typically &lt; 15 min for the
+restore + ~5 min for Flux to converge.
+
+---
+
+## Scenario 4 — Full cluster rebuild from zero
+
+The "everything is gone" path. ~30 min of manual clicks + ~15 min of Flux
+reconciliation.
+
+```bash
+# 1. Provision a fresh Hetzner snapshot if needed
+./hetzner/create-snapshot.sh --token "$HCLOUD_TOKEN" --media-path /path/to/talos-metal.iso
+
+# 2. Provision the cluster nodes from that snapshot
+./hetzner/create-server.sh --token "$HCLOUD_TOKEN" --server-name <name> --image-id <id>
+# repeat for the desired control plane + worker count
+
+# 3. Register the cluster in Omni (UI: Add Cluster -> point at the new machines)
+
+# 4. Apply the Talos machine config from this repo (talos-omni/) via Omni's
+#    config-patches feature. This sets the encryption-at-rest key, CNI=none,
+#    etc. -- all values are committed here, no out-of-band drift.
+
+# 5. Bootstrap Flux against this repo
+ksail --config ksail.prod.yaml workload push       # packages -> GHCR
+ksail --config ksail.prod.yaml workload reconcile  # Flux pulls and applies
+# Flux will install Cilium, cert-manager, the rest of infrastructure, then apps
+
+# 6. Wait for Flux to settle
+flux get kustomizations -A
+# Re-run if any are NotReady; expect convergence in 10-15 minutes
+
+# 7. Restore Velero backups (apps + PVCs)
+kubectl -n velero create -f - <<EOF
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: rebuild-$(date +%s)
+  namespace: velero
+spec:
+  backupName: <pick-latest-from-velero-backup-get>
+  includedNamespaces:
+    - "*"
+  excludedNamespaces:
+    - kube-system
+    - velero
+EOF
+
+# 8. (If any CNPG Cluster exists) restore from R2
+kubectl cnpg restore <new-cluster-name> \
+  --backup <backup-name> \
+  --target-time '<RFC3339-timestamp-or-omit-for-latest>'
+```
+
+If this is the **first time** restoring after losing the SOPS keys, replace
+step 5 with the rotation flow in Scenario 6 first.
+
+---
+
+## Scenario 5 — Velero / CNPG restore (single namespace or app)
+
+Quick path for "I deleted the wrong PVC" or "this Postgres database needs
+to roll back to last night".
+
+```bash
+# Find the relevant backup
+kubectl -n velero get backups
+velero backup get   # if velero CLI installed locally
+
+# Namespace restore
+kubectl -n velero create -f - <<EOF
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: ns-restore-$(date +%s)
+  namespace: velero
+spec:
+  backupName: daily-full-<date>
+  includedNamespaces: ["<your-ns>"]
+EOF
+
+# CNPG point-in-time recovery (PITR is "free" once WAL archiving is on)
+kubectl cnpg restore <new-cluster-name> \
+  --source-cluster <old-cluster> \
+  --target-time '2026-04-17T22:00:00Z'
+```
+
+---
+
+## Scenario 6 — SOPS Age key rotation
+
+```bash
+# 1. Generate a new key
+age-keygen -o new-key.txt
+NEW_PUB=$(grep '^# public key' new-key.txt | cut -d: -f2 | tr -d ' ')
+
+# 2. Add the new pub key as a recipient *before* removing the old one
+#    (gives you a window where both keys can decrypt).
+yq -i ".creation_rules[].age += \",\n$NEW_PUB\"" .sops.yaml
+
+# 3. Re-encrypt every SOPS file with the new recipient list
+find . -name '*.enc.yaml' -print0 | xargs -0 -n1 sops updatekeys --yes
+
+# 4. Commit + merge. Verify Flux still decrypts (no errors in
+#    flux-system pods).
+
+# 5. Rotate the new key into your secret store, distribute to operators.
+
+# 6. Once everyone is on the new key, drop the old one from .sops.yaml
+#    and re-run sops updatekeys --yes one more time.
+
+# 7. Securely destroy old-key.txt copies.
+```
+
+---
+
+## Scenario 7 — R2 / Cloudflare credential rotation
+
+```bash
+# 1. Mint a new R2 token in the Cloudflare dashboard (scoped to the
+#    devantler-platform-backups bucket only). DO NOT revoke the old one
+#    yet -- there is a window where both must work.
+
+# 2. Update the encrypted secret in-place
+sops --set '["stringData"]["r2_access_key_id"] "<new-id>"' \
+  k8s/bases/variables/variables-base-secret.enc.yaml
+sops --set '["stringData"]["r2_secret_access_key"] "<new-secret>"' \
+  k8s/bases/variables/variables-base-secret.enc.yaml
+
+# 3. PR + merge. Flux propagates within one reconciliation cycle.
+
+# 4. Wait one Velero schedule + one CNPG WAL archive cycle to confirm
+#    the new credentials work end-to-end.
+kubectl -n velero get backups -w
+kubectl logs -n cnpg-system -l app.kubernetes.io/name=cloudnative-pg --tail=50
+
+# 5. Revoke the old token in Cloudflare.
+
+# 6. Update the in-Omni R2 credentials (Omni etcd backups, PR #3).
+omnictl cluster set-backup --cluster <c> --access-key-id <new> --secret-access-key <new>
+```
+
+---
+
+## Encryption-at-rest verification
+
+Run after any node replacement to confirm secrets are still ciphertext on
+disk.
+
+```bash
+# Pull a fresh etcd snapshot via talosctl
+talosctl --nodes <cp-node> etcd snapshot /tmp/etcd.snapshot
+
+# Inspect a Secret -- must NOT be plain text
+etcdctl --endpoints unix:///tmp/etcd.snapshot \
+  get --prefix /registry/secrets/ | head -c 200
+# Expect bytes that look like cipher (binary garbage). If you see
+# Kubernetes Secret YAML, the EncryptionConfiguration was lost.
+```
+
+This check is also asserted by the CI restore drill (PR #7).
+
+---
+
+## Local clusters
+
+Local clusters are ephemeral and reconstructed from this repo on every
+`ksail cluster create`. There is nothing meaningful to back up — the
+restore procedure for local is:
+
+```bash
+ksail cluster delete
+ksail cluster create
+ksail workload push && ksail workload reconcile
+```
+
+CI exercises this on every PR (`.github/workflows/ci.yaml`), and from PR
+#7 onward also exercises a Velero backup → restore against the in-cluster
+MinIO so the prod code path is regression-tested.
+
+---
+
+## Related documents
+
+- [HA & DR plan](../../README.md) — overall design
+- [Omni etcd backups](./omni-etcd-backups.md) — control-plane backups (PR #3)
+- [Velero + CNPG → R2](./velero-cnpg.md) — application/PV backups (PR #4)
+- [Alerting](./alerting.md) — automated detection of backup failures (PR #6)

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
@@ -1,0 +1,150 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+  labels:
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: 78.0.5
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+  #
+  # Trimmed-down install: Prometheus + Alertmanager + node-exporter +
+  # kube-state-metrics. No Grafana (no need; this is alerting-only,
+  # operators look at logs / kubectl directly). No remote-write -- alerts
+  # fire from in-cluster, ship via webhook to a free destination
+  # (Discord/email). Caveat documented in docs/dr/alerting.md: a fully
+  # offline cluster cannot self-alert; fine for homelab scope.
+  values:
+    crds:
+      enabled: true
+
+    grafana:
+      enabled: false
+
+    # We don't host an external Prometheus and don't expose this one.
+    prometheus:
+      prometheusSpec:
+        replicas: 1
+        retention: 14d
+        retentionSize: "5GiB"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
+        # Discover ServiceMonitors / PodMonitors / PrometheusRules from
+        # any namespace -- charts in this repo (Velero, CNPG, etc.) drop
+        # their own.
+        serviceMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        scrapeConfigSelectorNilUsesHelmValues: false
+        # External labels so the webhook payload identifies the source
+        # cluster.
+        externalLabels:
+          domain: ${domain}
+        # No persistence -- 14d/5GiB fits in memory + emptyDir for a
+        # homelab. PR #4 already backs up persistent state separately;
+        # losing the metrics history on a restart is acceptable.
+        storageSpec: {}
+
+    alertmanager:
+      alertmanagerSpec:
+        replicas: ${alertmanager_replicas:=2}
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: alertmanager
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+        externalUrl: ""
+      config:
+        global:
+          resolve_timeout: 5m
+        route:
+          group_by: ["alertname", "cluster", "severity"]
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 12h
+          receiver: webhook-critical
+          routes:
+            - matchers:
+                - severity = "critical"
+              receiver: webhook-critical
+              continue: false
+            - matchers:
+                - severity = "warning"
+              receiver: webhook-critical
+              repeat_interval: 24h
+        receivers:
+          - name: webhook-critical
+            webhook_configs:
+              - url_file: /etc/alertmanager/secrets/alertmanager-webhook/webhook_url
+                send_resolved: true
+        inhibit_rules:
+          - source_matchers: [severity = "critical"]
+            target_matchers: [severity = "warning"]
+            equal: [alertname, cluster, namespace]
+      secrets:
+        - alertmanager-webhook
+
+    # Don't try to scrape the API server / kubelet / etcd through the
+    # default ServiceMonitors here -- Talos exposes some of these
+    # differently and we don't need k8s-internal histograms for alerting.
+    # Targeted alerts in PrometheusRule cover what we actually care about.
+    kubeApiServer:
+      enabled: false
+    kubeControllerManager:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubeProxy:
+      enabled: false
+    kubeEtcd:
+      enabled: false
+    kubelet:
+      enabled: true
+
+    nodeExporter:
+      enabled: true
+    kube-state-metrics:
+      enabled: true
+
+    # Disable the bundled "default" Prometheus rules -- the chart ships
+    # ~200 alerts that mostly aren't relevant for a homelab. We add our
+    # own focused PrometheusRule (rules/critical.yaml) instead.
+    defaultRules:
+      create: false
+
+    prometheusOperator:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-repository.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: monitoring
+spec:
+  interval: 24h
+  url: https://prometheus-community.github.io/helm-charts

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - webhook-secret.yaml
+  - helm-release.yaml
+  - rules/critical.yaml

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  annotations:
+    goldilocks.fairwinds.com/vpa-update-mode: "auto"
+    goldilocks.fairwinds.com/vpa-min-replicas: "1"

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/rules/critical.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/rules/critical.yaml
@@ -1,0 +1,108 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: platform-critical
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: nodes
+      rules:
+        - alert: NodeNotReady
+          expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Node {{ $labels.node }} not Ready"
+            description: "Node {{ $labels.node }} has been NotReady for more than 10 minutes."
+
+        - alert: NodeDiskFillingUp
+          expr: |
+            (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|squashfs"}
+                  / node_filesystem_size_bytes{fstype!~"tmpfs|squashfs"})) * 100 > 90
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Node {{ $labels.instance }} disk >90 % full"
+            description: "Filesystem {{ $labels.mountpoint }} is {{ $value | humanize }}% full."
+
+    - name: storage
+      rules:
+        - alert: PersistentVolumeFillingUp
+          expr: |
+            (kubelet_volume_stats_used_bytes
+             / kubelet_volume_stats_capacity_bytes) * 100 > 90
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} >90 % full"
+            description: "PV {{ $labels.persistentvolumeclaim }} usage at {{ $value | humanize }}%."
+
+    - name: certificates
+      rules:
+        - alert: CertificateExpiringSoon
+          expr: |
+            (certmanager_certificate_expiration_timestamp_seconds - time()) / 86400 < 14
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in <14d"
+            description: "Renewal hasn't happened. cert-manager logs: kubectl logs -n cert-manager -l app=cert-manager"
+
+    - name: flux
+      rules:
+        - alert: FluxKustomizationNotReady
+          expr: |
+            gotk_reconcile_condition{type="Ready",status="False",
+                                     kind=~"Kustomization|HelmRelease"} == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Flux {{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }} not Ready"
+            description: "kubectl describe {{ $labels.kind }} -n {{ $labels.namespace }} {{ $labels.name }}"
+
+    - name: backups
+      rules:
+        - alert: VeleroBackupFailed
+          expr: increase(velero_backup_failure_total[1h]) > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: "Velero backup failure(s) in the last hour"
+            description: "{{ $value }} Velero backup(s) failed. kubectl -n velero get backups | grep -v Completed"
+
+        - alert: VeleroNoRecentBackup
+          expr: |
+            time() - max(velero_backup_last_successful_timestamp) > 60 * 60 * 30
+          labels:
+            severity: critical
+          annotations:
+            summary: "No successful Velero backup in >30h"
+            description: "RPO breached. Latest backup is older than 30h; daily schedule should run every 24h."
+
+        - alert: CNPGNoRecentBackup
+          expr: |
+            time() - cnpg_collector_last_failed_backup_timestamp == 0
+            unless on(cluster)
+            time() - cnpg_collector_last_available_backup_timestamp < 60 * 60 * 30
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG cluster {{ $labels.cluster }} has no successful backup in >30h"
+            description: "kubectl cnpg status {{ $labels.cluster }}"
+
+        - alert: CNPGClusterDegraded
+          expr: cnpg_pg_replication_in_recovery == 0 and on(namespace, cluster) cnpg_pg_replication_streaming_replicas < 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG cluster {{ $labels.cluster }} has no streaming replica"
+            description: "Single instance left -- a primary failure would lose data up to the last WAL archive."

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/webhook-secret.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/webhook-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-webhook
+  namespace: monitoring
+type: Opaque
+stringData:
+  # Webhook URL the central Alertmanager route ships every critical alert
+  # to. Substituted from variables-cluster (per-env) so each cluster can
+  # target its own Discord/email/whatever endpoint without leaking the URL
+  # across envs.
+  webhook_url: ${alertmanager_webhook_url}

--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - dex/
   - flux-operator/
   - goldilocks/
+  - kube-prometheus-stack/
   - kyverno/
   - metrics-server/
   - oauth2-proxy/

--- a/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
@@ -11,6 +11,7 @@ stringData:
     nextcloud_password: ENC[AES256_GCM,data:aOPpRXzSJOAFGPqLc0ilAiKzviv64HePTojAELFsZgLZ3iE9dgdfVoc=,iv:DbYSFKShFKvGlaRp+6KaB+++PCvhMsuo9mJdEFGCYnw=,tag:i0jjE/9sh+3aO7D1qJwIJg==,type:str]
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:OPsITgtvzc9OXqgla6i0FH8iWYhv3vMMI/U6wOPcmdvgdDxyPos7tWPnEPQ=,iv:jkH8RVAtaU95JsgX9DATkDN/TWLFG9Q/vIy8DGianuc=,tag:kLp+uGpDO9aHZODfMo8q0A==,type:str]
     flux_web_client_secret: ENC[AES256_GCM,data:cJYf/pa/wN0Vr3u20JYTkS8Hhla/MNE0pBS87fKYn7c=,iv:v+mIsjLJ7OH/9KNLol41GphlQbhu5adf2hLdIvgawrI=,tag:8kbMhm78JIC1mtnctcjKsQ==,type:str]
+    alertmanager_webhook_url: ENC[AES256_GCM,data:A9QjNrnuit0yaSB8MDbopJlXMEbfXquWbqkOyiUTJBnXc9Q=,iv:vgwwX/0PVkEjeKRNxuk1AHbAb9rDw2PMmBsPVfjUtNI=,tag:Wt4KKscb1+TucMRtxmTRlg==,type:str]
 sops:
     age:
         - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
@@ -22,7 +23,7 @@ sops:
             Wkd0QUJpak54NFNNQW0vNitpQUkxY1EKGMC7N4/jcg2qh27v7IdbT8Vpvs6Q260J
             /RTpDGrcuTmQb9cmJmV9lahq8AKbMfGjs7zKoGY1YodDczJlkPfysA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T15:50:26Z"
-    mac: ENC[AES256_GCM,data:apWmXuGgSC568vVJyt7bR47cqY5fFLZ80cpqaRwowjtqaBRUwz2QkYHOTpn/C27b1jv+rSMQQ77y7Th6BKiI8gbTbQNrIU9S5z84mpimFTuZnrIXYYIzZvGyt4lkSuakU0uDmLjbZ7fwfaY2MKtCW8uirTJRpY0pnOzkAAbup+g=,iv:TrbcgTfMqHiFtz+8gONGwnMXxh8f8OfxE60jXQCDPW0=,tag:JFVIorSv0wNr62BVF7ZoPQ==,type:str]
+    lastmodified: "2026-04-18T22:19:19Z"
+    mac: ENC[AES256_GCM,data:g4VCgwWOKHLcgNrQV+FBUsINHfp5liJtsguuWoiw5zPH6yDt/+wbet4UIjxuS0yMOT033rIDrY76+s98R1zaIPbfIXVBQVMVICYqXT1gytH/GHLE0Q1An85SfNh+DABqE2qVnxzOObluYYtR2KeKTzSv0guztcB2UcYmw1RMA3o=,iv:mQY1hVh9caY6gP177sm/YI9QvJrFqoisiTdqsm9GT8E=,tag:z9iEY/wsG4Gep/LKnO2bQQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/clusters/local/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/local/variables/variables-cluster-secret.enc.yaml
@@ -10,6 +10,7 @@ stringData:
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:JbqAbb2gRfXhD32bibQWen3VE8XLjAYtWxLnowW9kugEgPte5qPdAFBxHBQ=,iv:wpX4TJwS6FURhqO6t6WyA6x/yBuZMPofGwDrtLNk1Nk=,tag:V8eawWX2GKaGKI06X3V80w==,type:str]
     r2_access_key_id: ENC[AES256_GCM,data:ffb5pHo=,iv:tQzje24BZttIyLU3lTk5BC/qHSMZaN9V6MA1cxPPrEY=,tag:d9VWssiPdsu09lSEm9fS2g==,type:str]
     r2_secret_access_key: ENC[AES256_GCM,data:WWBsgU5bKMkPjVmQ8+LfGW3L77taJIKiWyQtyQ==,iv:gTK21tr6uun0c5UmvLP5G40vVyfFAgezVV8aymWpqeU=,tag:gEGSA45+yOhpg1moKwMA3A==,type:str]
+    alertmanager_webhook_url: ENC[AES256_GCM,data:WH2X/wjvJ47DPGkTkvbCadWAFDelXyKxd9Zqqy9i1cR3nIoS2K7dzwjR,iv:Jl6vnrBg0pandwv0CmHASDM4JRLfXFrL7EN78SxWHMA=,tag:Nr0loeKoXEeRuxqIAsXEuQ==,type:str]
 sops:
     age:
         - recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
@@ -21,7 +22,7 @@ sops:
             SjBVZURpUkc4eGJ4eFFFcGV2SUJuVkEKPYKtlz5eBFjChW02JeKqJxviRkJIGU9t
             GrLSSCJvxfCt1dUEkef2/lwSaLIggjtvSJLOxNa7hqQCI86Di5trxA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T22:13:48Z"
-    mac: ENC[AES256_GCM,data:sUhsws4t4lYWEOGbEz+v8lz1jKFzBcO8YAqIfs1uH5TWN6ifdR25kmjIVyMSwsXZNtRjWTK62ezY5vbJrsqEa3ydazY6zhXDnOAkwQKdH1yemLUe1SSntZzCnnNlbm95rHtpYzFOM0Pxw9p2sqL8P0Rhn+v16iRyq0MktYMtXTc=,iv:JKDVmzW8gBojxqh0K3sVkuHF1jt03LJ1n+jDD/Api34=,tag:t+/7ow/Eg9T/80xcOOkRjw==,type:str]
+    lastmodified: "2026-04-18T22:19:19Z"
+    mac: ENC[AES256_GCM,data:13mZt9SPzkc8GvVsjYWiKICQ2pvA+Pbv1CXYqjhfK7uwzv6GVZmv2/pAlil4Fnp02WcLu6R69Ryqcc7krTO/upyo3ia3VOVRYAsOHV3GSot/GVctgvvJU9Zv4PZfSvtOQ4dD1yYPcJ2S19AshIYIZOpo9sYP9PeFEfce0mHe1l0=,iv:wbG8+J9a1RLZDf0Cprzr7nWKPmCVX2kQr+PA1Ngoo6s=,tag:3gV0KH+xCV+bMjD9B95bzg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
@@ -10,6 +10,7 @@ stringData:
     hcloud_token: ENC[AES256_GCM,data:xYekiMOjhaxq/dyvslvXZKc8o3Jsp+m1ZgUyOVWBu4kFxGFtr61M7uPHfSd2axHdAiYud9ow3PdoCkF9gJyi4g==,iv:iO+iRnPi2dSgZOrWIPina3COpH0juVkuwAMYnVCvlr0=,tag:lr/7B77Ww1+qVDUK+Dz2gw==,type:str]
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:SHzKBurGHhzyaknPyzEy8UO1bDM9PYaCZTMi4vfhjp64Tz8KHyxQwiE5PNg=,iv:Z3KJ+tg7zAPLeJtTTmb0Bwd1wixzBQkFr/rlcMX1bw4=,tag:O6akeH2vZn9rH7kOUv4Eiw==,type:str]
     flux_web_client_secret: ENC[AES256_GCM,data:HG439eFsbyoURdS9ujcmxoRM1iyWr9S+GSMa4WWHahg=,iv:O7IXV1mvRPUL4XnVLsOcmq5DDprAFv+Shxxyf120jT4=,tag:7PbMQmnENjwOqPVXgmnTZg==,type:str]
+    alertmanager_webhook_url: ENC[AES256_GCM,data:/gDOR5MElmct7z/EIpxf5OLJdgVZ60VTJGnzCAqGO1BFM2E=,iv:XkmCTnd0atsS0HmidFlgQqGdh8ut11H0NLO9f5wVwTk=,tag:wqOk1V8i6O5Q+2wUp7r7Hg==,type:str]
 sops:
     age:
         - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
@@ -21,7 +22,7 @@ sops:
             RU02VGc0L1VxTThKK2ZEaDVMSGQ2cUUK2uCzHaosnnfRtgtFQrb5svaHNstLQZKV
             znAhCwrhlhGCuCCewEbyVB60FMMUIT1zhZMLmzIKbCTCn/wVlz5+yQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T15:50:32Z"
-    mac: ENC[AES256_GCM,data:XmTW6zVaSm0Bu4beNFvP42tia71CZMOI0UypasS0cSywdM7oHjF6IeU//WaQZxgflS2+P1aClZYQ8I0mqW1U3WrelLQY6jU8mmGilwJdOUT0TCOS99WNS/oqQ2rhjw6LnsdnLQZpLIK1MMx5m8gqIOG5EMuijhtTGNiHawcWJ1g=,iv:idcb17vEe6MAotnTWOmPtpfW5b+4ogv2hHhK9+NEKEw=,tag:U9A+NxqUlF5sioSxON5IEA==,type:str]
+    lastmodified: "2026-04-18T22:19:19Z"
+    mac: ENC[AES256_GCM,data:TJm1ax+FowUlaUgICZYUeRHjGU59hEepfYVxYvMpaMj1OGNPYAqxQZkVyu3uNSGclnZq3sCm8u2/2dv8z3Z3jx6pDHMQLv0QNnMRT8Nrk8NyvPtjuJnQUsv8gdzJq8/GwF5rzqTspGvtxSojHAh7QNjIWStB05VySWzeT/ABOKc=,iv:CsGWXbnEURdCWUkBlQQPqBn3MIOMissD4A/I6FxL01w=,tag:dsC5uc2cMCqQlu6dOmMLXw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
**Stacked on #1381 (-> #1380 -> #1379 -> #1377 -> #1376).** Will retarget upward as those merge.

PR #6 of the HA & DR plan: every cluster self-monitors the HA/DR signals introduced in PRs #1–#4 and ships criticals to a free webhook (Discord / email-to-webhook). No Grafana, no remote-write, no SaaS dependency.

## What's installed

- `prometheus-community/kube-prometheus-stack` 78.0.5
- Prometheus single replica, 14d / 5GiB retention, no PVC (metrics history is throw-away; durable state is on Velero/CNPG/etcd)
- Alertmanager: 2 replicas + PDB minAvailable=1 + hostname `topologySpread` (operator-tier pattern from PR #2b)
- node-exporter + kube-state-metrics enabled
- **`defaultRules.create: false`** — the chart's ~200 bundled alerts are noise at homelab scale; a focused `PrometheusRule` ships instead
- **Grafana disabled** — this is alerting-only; debugging is via logs + `kubectl`

## Alerts shipped

| Alert                       | Severity | Why                                       |
| --------------------------- | -------- | ----------------------------------------- |
| `NodeNotReady`              | critical | Single node loss; PDBs cover but you should know |
| `NodeDiskFillingUp`         | warning  | >90% root fs                              |
| `PersistentVolumeFillingUp` | critical | >90% PVC                                  |
| `CertificateExpiringSoon`   | warning  | <14d, cert-manager not renewing            |
| `FluxKustomizationNotReady` | critical | Reconciliation broken >15 min             |
| `VeleroBackupFailed`        | critical | Any failure in last 1h                    |
| `VeleroNoRecentBackup`      | critical | >30h since last success → RPO breach      |
| `CNPGNoRecentBackup`        | critical | Same, for Postgres                        |
| `CNPGClusterDegraded`       | critical | Primary alone, no streaming replica       |

## Routing

Single Alertmanager route → webhook receiver. The URL is mounted via `url_file` from the `alertmanager-webhook` Secret, whose value is substituted per-cluster from `variables-cluster.alertmanager_webhook_url` (SOPS-encrypted at rest).

## Per-env values

- **local**: `alertmanager_webhook_url = http://example.invalid/no-webhook-on-local` — intentionally non-resolvable. CI just verifies the rules + AM config render; lack of external delivery is by design.
- **dev / prod**: `REPLACE_ME_alertmanager_webhook_url` placeholder, encrypted. Must be rotated via `sops --set` before alerts are useful. Procedure in `docs/dr/alerting.md`.

## Documented caveat

In-cluster Alertmanager won't fire if the whole cluster is down. Acceptable for homelab scope. The follow-up if it becomes a real problem is to add Grafana Cloud free tier remote-write — no code restructure required.

## Validation

- `kubectl kustomize` succeeds for `clusters/{local,dev,prod}`
- `sops -d` round-trips all three updated cluster secrets

## Type of change

- [x] 🚀 New feature
- [x] 📚 Documentation
