### PR TITLE
refactor(dr): align R2 config with Omni single-bucket constraint + ship creds (PR #8, stacked on #1383)

### DIFF
--- a/docs/dr/omni-etcd-backups.md
+++ b/docs/dr/omni-etcd-backups.md
@@ -14,28 +14,36 @@ and CNPG.
   etcd portion. Velero + CNPG share the same bucket under separate prefixes.
 - Already part of the Cloudflare account that fronts the platform
 
-## Bucket layout
+## Single shared bucket (Omni constraint)
 
-One bucket per platform install, multiple prefixes:
+Omni supports exactly **one** backup-storage configuration for the whole Omni
+instance — there is no per-cluster override. All Omni-managed clusters share the
+same S3 target and Omni itself namespaces snapshots by cluster name underneath
+that target.
+
+To keep Velero and CNPG from colliding in that same bucket, they run under
+per-env prefixes:
 
 ```
 devantler-platform-backups/
-├── omni-etcd/<cluster-name>/...   ← this PR
-├── velero/                        ← PR #4
-└── cnpg/<cluster-name>/...        ← PR #4
+├── <omni-cluster-name>/...   ← Omni etcd snapshots, bucket root (managed by Omni)
+├── velero/dev/               ← Velero, dev cluster
+├── velero/prod/              ← Velero, prod cluster
+├── cnpg/dev/                 ← CNPG WAL/base backups, dev cluster
+└── cnpg/prod/                ← same, prod cluster
 ```
 
-Bucket name and prefixes are exposed via the shared `variables-base` ConfigMap
-in `k8s/bases/variables/variables-base-config-map.yaml`:
+Bucket and endpoint come from the shared `variables-base` ConfigMap in
+`k8s/bases/variables/variables-base-config-map.yaml`; per-env prefixes come from
+each `k8s/clusters/<env>/variables/variables-cluster-config-map.yaml`:
 
-| Key                     | Value                                |
-| ----------------------- | ------------------------------------ |
-| `r2_endpoint`           | `https://<account>.r2.cloudflarestorage.com` |
-| `r2_region`             | `auto`                               |
-| `r2_bucket`             | `devantler-platform-backups`         |
-| `r2_prefix_omni_etcd`   | `omni-etcd`                          |
-| `r2_prefix_velero`      | `velero`                             |
-| `r2_prefix_cnpg`        | `cnpg`                               |
+| Key                     | Where        | Value                                           |
+| ----------------------- | ------------ | ----------------------------------------------- |
+| `r2_endpoint`           | base         | `https://<account>.r2.cloudflarestorage.com`    |
+| `r2_region`             | base         | `auto`                                          |
+| `r2_bucket`             | base         | `devantler-platform-backups`                    |
+| `r2_prefix_velero`      | per-cluster  | `velero/dev` or `velero/prod` (local: `velero`) |
+| `r2_prefix_cnpg`        | per-cluster  | `cnpg/dev` or `cnpg/prod` (local: `cnpg`)       |
 
 ## R2 bucket settings (one-time, in Cloudflare dashboard)
 
@@ -45,42 +53,34 @@ in `k8s/bases/variables/variables-base-config-map.yaml`:
    deleting backups before the retention window.
 3. **Versioning**: enabled. Pairs with object lock and lets restores reach back
    past an accidental overwrite.
-4. **Lifecycle rules**:
-   - `omni-etcd/`: transition to Infrequent Access after 14 days (still cheap on
-     R2; mostly hygiene); abort incomplete multipart uploads after 1 day.
-   - `velero/`, `cnpg/`: same.
+4. **Lifecycle rules** (all under `devantler-platform-backups/`):
+   - `velero/` and `cnpg/`: transition to Infrequent Access after 14 days;
+     abort incomplete multipart uploads after 1 day.
+   - Bucket root (Omni snapshots): same.
 5. **Server-side encryption**: SSE-S3 (AES-256), which is the R2 default and
    cannot be disabled. No additional config needed.
-6. Create a **scoped API token** with permission `Object Read & Write` limited to
-   this bucket. Save the access key ID and secret access key — these are the
-   values that go into the SOPS-encrypted `variables-base` secret as
-   `r2_access_key_id` / `r2_secret_access_key`.
+6. Create a **scoped S3 API token** with permission `Object Read & Write`
+   limited to this bucket. Save the Access Key ID and Secret Access Key — these
+   are the values that go into the SOPS-encrypted cluster secrets as
+   `r2_access_key_id` / `r2_secret_access_key` (one copy in `dev`, one in
+   `prod`; the key can be the same or rotated independently — same bucket).
 
-## Omni-side configuration
+## Omni-side configuration (one-time, in the Omni UI)
 
-Omni's "Control Plane Backups" feature writes etcd snapshots directly to S3-
-compatible storage. There is no in-cluster cron and no extra workload — the
-backup runs from Omni's control plane and only the resulting snapshot blob lands
-in R2.
+Omni's **Settings → Backup Storage** page takes a single S3 config that applies
+to every cluster Omni manages. Open it and paste:
 
-Configure once per cluster in the Omni UI (`Cluster → Backups`) **or** via
-`omnictl` with the values below.
+| Field             | Value                                                               |
+| ----------------- | ------------------------------------------------------------------- |
+| Endpoint          | `https://634e9016d402443e427865dc35457728.r2.cloudflarestorage.com` |
+| Bucket            | `devantler-platform-backups`                                        |
+| Region            | `auto` (any value works; R2 ignores it)                             |
+| Access Key ID     | the R2 S3 token ID from step 6 above                                |
+| Secret Access Key | the R2 S3 token secret from step 6 above                            |
+| Session Token     | *(leave blank)*                                                     |
 
-```bash
-# Example — run for each of dev and prod, substituting the cluster name.
-omnictl cluster set-backup \
-  --cluster <cluster-name> \
-  --type s3 \
-  --endpoint "https://634e9016d402443e427865dc35457728.r2.cloudflarestorage.com" \
-  --region auto \
-  --bucket devantler-platform-backups \
-  --prefix "omni-etcd/<cluster-name>" \
-  --access-key-id     "$R2_ACCESS_KEY_ID" \
-  --secret-access-key "$R2_SECRET_ACCESS_KEY" \
-  --schedule "@daily" \
-  --retention 14 \
-  --long-term-retention 4
-```
+Save. Then for each cluster (dev, prod) enable backups under
+**Cluster → Settings → etcd Backups** with:
 
 | Setting               | Value                              |
 | --------------------- | ---------------------------------- |
@@ -91,6 +91,10 @@ omnictl cluster set-backup \
 | Encryption at rest    | SSE-S3 (R2 default)                |
 | RPO target            | 24 h (matches plan goal)           |
 
+Omni writes snapshots at `<bucket>/<cluster-name>/<snapshot-id>` — the
+per-cluster folder is added by Omni, not by us. That's why our own Velero/CNPG
+prefixes don't overlap.
+
 ## Restore (high level)
 
 Detailed in `docs/dr/runbook.md` (PR #5). Summary:
@@ -98,7 +102,7 @@ Detailed in `docs/dr/runbook.md` (PR #5). Summary:
 1. Provision a fresh Talos node from the snapshot used by `hetzner/`.
 2. In Omni, create a new cluster pointed at the same machine.
 3. `Cluster → Backups → Restore from S3` → pick the most recent snapshot under
-   `omni-etcd/<cluster-name>/`.
+   the target cluster's folder in the R2 bucket.
 4. Omni rolls a new etcd member from the snapshot and rejoins the control plane.
 5. Once the API server is back, Flux reconciles the rest of the platform from
    GHCR — no further manual steps for the workload tier.

--- a/k8s/bases/variables/variables-base-config-map.yaml
+++ b/k8s/bases/variables/variables-base-config-map.yaml
@@ -8,7 +8,11 @@ data:
   cloudflare_account_id: 634e9016d402443e427865dc35457728
   r2_endpoint: https://634e9016d402443e427865dc35457728.r2.cloudflarestorage.com
   r2_region: auto
+  # Shared bucket for Omni etcd snapshots, Velero, and CNPG across
+  # all clusters. Omni supports exactly one backup storage config and
+  # writes directly at bucket root (per-cluster folders managed by Omni
+  # itself), so Velero / CNPG must namespace themselves with per-env
+  # prefixes -- set in each clusters/<env>/variables-cluster-config-map.
   r2_bucket: devantler-platform-backups
-  r2_prefix_omni_etcd: omni-etcd
   r2_prefix_velero: velero
   r2_prefix_cnpg: cnpg

--- a/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
@@ -12,3 +12,7 @@ data:
   issuer_group: cert-manager.k8s.cloudflare.com
   issuer_kind: ClusterOriginIssuer
   issuer_name: cloudflare-origin
+  # Per-env prefixes inside the shared R2 bucket so dev/prod don't
+  # collide. Omni writes etcd snapshots at bucket root independently.
+  r2_prefix_velero: velero/dev
+  r2_prefix_cnpg: cnpg/dev

--- a/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-secret.enc.yaml
@@ -12,6 +12,8 @@ stringData:
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:OPsITgtvzc9OXqgla6i0FH8iWYhv3vMMI/U6wOPcmdvgdDxyPos7tWPnEPQ=,iv:jkH8RVAtaU95JsgX9DATkDN/TWLFG9Q/vIy8DGianuc=,tag:kLp+uGpDO9aHZODfMo8q0A==,type:str]
     flux_web_client_secret: ENC[AES256_GCM,data:cJYf/pa/wN0Vr3u20JYTkS8Hhla/MNE0pBS87fKYn7c=,iv:v+mIsjLJ7OH/9KNLol41GphlQbhu5adf2hLdIvgawrI=,tag:8kbMhm78JIC1mtnctcjKsQ==,type:str]
     alertmanager_webhook_url: ENC[AES256_GCM,data:A9QjNrnuit0yaSB8MDbopJlXMEbfXquWbqkOyiUTJBnXc9Q=,iv:vgwwX/0PVkEjeKRNxuk1AHbAb9rDw2PMmBsPVfjUtNI=,tag:Wt4KKscb1+TucMRtxmTRlg==,type:str]
+    r2_access_key_id: ENC[AES256_GCM,data:dDLLB1wPBBpe5ePpJ80/9cp7cIs84XglA9skhbrcT+c=,iv:fie4utRTFcU2KMvygo9UzfOTAi4+LHxBZs0SiW2/RgQ=,tag:DqvgeBRPzG8eEOJnPNk5ww==,type:str]
+    r2_secret_access_key: ENC[AES256_GCM,data:D8j7IuRS/DzIIl/tyJdFPl1OAKoqyiw650qTb8T3YWRFbCTSotkl3OuHc6bV4ijAIBf2aSKWj+zTTYlDyzv3LQ==,iv:yFF5N/7dkZPjkJYlqrsuszQwMlTU4wFlJfZC5TExBwI=,tag:mwj4e6pn+KfxTpRHZdZsmQ==,type:str]
 sops:
     age:
         - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
@@ -23,7 +25,7 @@ sops:
             Wkd0QUJpak54NFNNQW0vNitpQUkxY1EKGMC7N4/jcg2qh27v7IdbT8Vpvs6Q260J
             /RTpDGrcuTmQb9cmJmV9lahq8AKbMfGjs7zKoGY1YodDczJlkPfysA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T22:19:19Z"
-    mac: ENC[AES256_GCM,data:g4VCgwWOKHLcgNrQV+FBUsINHfp5liJtsguuWoiw5zPH6yDt/+wbet4UIjxuS0yMOT033rIDrY76+s98R1zaIPbfIXVBQVMVICYqXT1gytH/GHLE0Q1An85SfNh+DABqE2qVnxzOObluYYtR2KeKTzSv0guztcB2UcYmw1RMA3o=,iv:mQY1hVh9caY6gP177sm/YI9QvJrFqoisiTdqsm9GT8E=,tag:z9iEY/wsG4Gep/LKnO2bQQ==,type:str]
+    lastmodified: "2026-04-18T22:42:58Z"
+    mac: ENC[AES256_GCM,data:CIzPbY95Q0nrir0PUYM632PMR2/Ar7tnjmlnQg7snfcA8dgxRfBPur351hU8L8m3pro8pWswpoaWI8fDVVO3HEYWNuBNH8OS+zWrllypha5pCIesUTVdIOEradcKEuF1JVRk2Ln8etmF2IOi6tpQ8/yf+q0U0NkIjT9TsoiIX70=,iv:eDIALIx0jyH+oPbpvuYdqdhejdXlS/b7PZ4NFpZo050=,tag:Ap+ylR01IOcGKrBiwF3NTQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/clusters/local/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/local/variables/variables-cluster-config-map.yaml
@@ -18,5 +18,4 @@ data:
   r2_bucket: platform-backups
   r2_prefix_velero: velero
   r2_prefix_cnpg: cnpg
-  r2_prefix_omni_etcd: omni-etcd
 

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -12,3 +12,7 @@ data:
   issuer_group: cert-manager.k8s.cloudflare.com
   issuer_kind: ClusterOriginIssuer
   issuer_name: cloudflare-origin
+  # Per-env prefixes inside the shared R2 bucket so dev/prod don't
+  # collide. Omni writes etcd snapshots at bucket root independently.
+  r2_prefix_velero: velero/prod
+  r2_prefix_cnpg: cnpg/prod

--- a/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
@@ -11,6 +11,8 @@ stringData:
     oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:SHzKBurGHhzyaknPyzEy8UO1bDM9PYaCZTMi4vfhjp64Tz8KHyxQwiE5PNg=,iv:Z3KJ+tg7zAPLeJtTTmb0Bwd1wixzBQkFr/rlcMX1bw4=,tag:O6akeH2vZn9rH7kOUv4Eiw==,type:str]
     flux_web_client_secret: ENC[AES256_GCM,data:HG439eFsbyoURdS9ujcmxoRM1iyWr9S+GSMa4WWHahg=,iv:O7IXV1mvRPUL4XnVLsOcmq5DDprAFv+Shxxyf120jT4=,tag:7PbMQmnENjwOqPVXgmnTZg==,type:str]
     alertmanager_webhook_url: ENC[AES256_GCM,data:/gDOR5MElmct7z/EIpxf5OLJdgVZ60VTJGnzCAqGO1BFM2E=,iv:XkmCTnd0atsS0HmidFlgQqGdh8ut11H0NLO9f5wVwTk=,tag:wqOk1V8i6O5Q+2wUp7r7Hg==,type:str]
+    r2_access_key_id: ENC[AES256_GCM,data:VzXm35e7uS1M8Pj5wjhmWwmPMC/YFg3x1vceI9v66ng=,iv:8P+gW/nWsf/A6hggRB7hKeccfoU09g60qHO9jFT8JKU=,tag:JCT+V2uycM0wlIELDVFq4w==,type:str]
+    r2_secret_access_key: ENC[AES256_GCM,data:xlXQdDGk9skdFy4a34MzmrJDWdz2y/Qi9LCqyggJQArgjxqm54ahOr8+eb8pzBKWpsPhEik5EpjiSQ8o/eLsWw==,iv:+eeyqJqs9uITUTmmDcTq35ImMqRUCcNq3RGGupnMMJc=,tag:2dchTKGvVTyK+gGY4kEuhQ==,type:str]
 sops:
     age:
         - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
@@ -22,7 +24,7 @@ sops:
             RU02VGc0L1VxTThKK2ZEaDVMSGQ2cUUK2uCzHaosnnfRtgtFQrb5svaHNstLQZKV
             znAhCwrhlhGCuCCewEbyVB60FMMUIT1zhZMLmzIKbCTCn/wVlz5+yQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T22:19:19Z"
-    mac: ENC[AES256_GCM,data:TJm1ax+FowUlaUgICZYUeRHjGU59hEepfYVxYvMpaMj1OGNPYAqxQZkVyu3uNSGclnZq3sCm8u2/2dv8z3Z3jx6pDHMQLv0QNnMRT8Nrk8NyvPtjuJnQUsv8gdzJq8/GwF5rzqTspGvtxSojHAh7QNjIWStB05VySWzeT/ABOKc=,iv:CsGWXbnEURdCWUkBlQQPqBn3MIOMissD4A/I6FxL01w=,tag:dsC5uc2cMCqQlu6dOmMLXw==,type:str]
+    lastmodified: "2026-04-18T22:42:58Z"
+    mac: ENC[AES256_GCM,data:+yMWwwMYE/RK/i6ghZjWpPkplO6Wq0Bg00QWpbiuM3NeMz1uyo+fGsGPSGaS3DuRMhN8hgwyXeUdnW93PJxFjEWv3YzSIKpEYufSZDlpQowXq+WAWCXKoa+muRxf7v10Z4ebNFc7JjOrqe4l+jCCPmJfF9KJo2uJsQoeRSGzRhk=,iv:1IBbhFj7/n78WnR/q8LRElYp2Ikd2wLavDvUHKce/ls=,tag:EOVTdblxt5maSm4AeS87cw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
**Stacked on #1383 (-> #1382 -> #1381 -> #1380 -> #1379 -> #1377 -> #1376).** Will retarget upward as those merge.

Follow-up to the HA/DR stack: Omni's Settings → Backup Storage page takes exactly **one** S3 config for the whole Omni instance — so the earlier per-cluster / per-prefix design was wrong for the Omni layer. This PR consolidates on one shared bucket and fixes the collision risk for the other consumers.

## Changes

- **Dropped `r2_prefix_omni_etcd`** from base + local variables. We can't tell Omni to prefix; it writes snapshots at bucket root with its own per-cluster folders. Leaving the variable in would mis-document intent.
- **Added per-env `r2_prefix_velero` / `r2_prefix_cnpg`** in `clusters/{dev,prod}` so dev and prod don't collide inside the shared bucket:
  - `velero/dev/`, `velero/prod/`, `cnpg/dev/`, `cnpg/prod/`
  - Local keeps flat `velero` / `cnpg` (in-cluster MinIO, single cluster)
- **Rewrote `docs/dr/omni-etcd-backups.md`** to reflect the single-bucket layout, a single Omni Settings entry, and per-cluster `@daily` etcd schedules under Cluster → Settings → etcd Backups.
- **Rotated in real R2 creds** (Object Read & Write, scoped to `devantler-platform-backups`) into both `clusters/dev/variables/variables-cluster-secret.enc.yaml` and the prod equivalent. SOPS round-trips; `kubectl kustomize` green on all three envs.

## Bucket layout

```
devantler-platform-backups/
├── <omni-cluster-name>/...   ← Omni etcd snapshots (bucket root, Omni-managed)
├── velero/dev/               ← Velero, dev cluster
├── velero/prod/              ← Velero, prod cluster
├── cnpg/dev/                 ← CNPG, dev cluster
└── cnpg/prod/                ← CNPG, prod cluster
```

## You still need to do (one-time, UI-only)

1. **Cloudflare dashboard** → create R2 bucket `devantler-platform-backups` with Object Lock (Governance, 30d) + Versioning per `docs/dr/omni-etcd-backups.md`.
2. **Omni** → Settings → Backup Storage: paste the same endpoint, bucket, `auto` region, and R2 S3 credentials. Save.
3. **Omni** → Cluster → Settings → etcd Backups: toggle `@daily` for both `dev` and `prod` clusters.

## Type of change

- [x] 🔧 Refactor
- [x] 📚 Documentation
- [x] 🔐 Secret rotation
