### PR TITLE
fix(auth): put oauth2-proxy in front of auth-proxy

### DIFF
--- a/k8s/bases/apps/homepage/httproute.yaml
+++ b/k8s/bases/apps/homepage/httproute.yaml
@@ -12,6 +12,6 @@ spec:
     - ${domain}
   rules:
     - backendRefs:
-        - name: auth-proxy
+        - name: oauth2-proxy
           namespace: oauth2-proxy
           port: 80

--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -17,41 +17,16 @@ data:
       level: INFO
   dynamic.yaml: |
     http:
-      middlewares:
-        oauth2-forward-auth:
-          forwardAuth:
-            address: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local:80/oauth2/auth"
-            trustForwardHeader: true
-            authResponseHeaders:
-              - X-Auth-Request-User
-              - X-Auth-Request-Email
-        oauth2-signin:
-          errors:
-            status:
-              - "401"
-            service: oauth2-proxy
-            query: "/oauth2/start?rd={url}"
-        oauth2-auth:
-          chain:
-            middlewares:
-              - oauth2-signin
-              - oauth2-forward-auth
       routers:
         homepage:
           rule: "Host(`${domain}`)"
           entryPoints: ["web"]
-          middlewares: ["oauth2-auth"]
           service: homepage
         goldilocks:
           rule: "Host(`goldilocks.${domain}`)"
           entryPoints: ["web"]
-          middlewares: ["oauth2-auth"]
           service: goldilocks
       services:
-        oauth2-proxy:
-          loadBalancer:
-            servers:
-              - url: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local:80"
         homepage:
           loadBalancer:
             servers:

--- a/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
   - config-map.yaml
   - deployment.yaml
   - pod-disruption-budget.yaml
-  - reference-grant.yaml
   - service.yaml

--- a/k8s/bases/infrastructure/controllers/auth-proxy/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/reference-grant.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: allow-auth-proxy-backends
+  name: allow-oauth2-proxy-backends
   namespace: oauth2-proxy
 spec:
   from:
@@ -19,4 +19,4 @@ spec:
   to:
     - group: ""
       kind: Service
-      name: auth-proxy
+      name: oauth2-proxy

--- a/k8s/bases/infrastructure/controllers/goldilocks/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/goldilocks/httproute.yaml
@@ -20,6 +20,6 @@ spec:
     - goldilocks.${domain}
   rules:
     - backendRefs:
-        - name: auth-proxy
+        - name: oauth2-proxy
           namespace: oauth2-proxy
           port: 80

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -47,7 +47,7 @@ spec:
         github_users = ["devantler"]
         email_domains = [ "*" ]
         cookie_domains=[".${domain}"]
-        whitelist_domains = [".${domain}"]
+        whitelist_domains = ["${domain}", ".${domain}"]
         redirect_url = "https://oauth2-proxy.${domain}/oauth2/callback"
         upstreams = [ "http://auth-proxy.oauth2-proxy.svc.cluster.local:80" ]
         skip_provider_button = true

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -47,8 +47,9 @@ spec:
         github_users = ["devantler"]
         email_domains = [ "*" ]
         cookie_domains=[".${domain}"]
+        whitelist_domains = [".${domain}"]
         redirect_url = "https://oauth2-proxy.${domain}/oauth2/callback"
-        upstreams = [ "static://202" ]
+        upstreams = [ "http://auth-proxy.oauth2-proxy.svc.cluster.local:80" ]
         skip_provider_button = true
         reverse_proxy = true
     ingress:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - helm-repository.yaml
   - httproute.yaml
   - namespace.yaml
+  - reference-grant.yaml

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
@@ -1,4 +1,3 @@
-# TODO: Remove auth-proxy when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant


### PR DESCRIPTION
My first attempt in #1378 did not actually fix the flow: visiting a protected host rendered a literal `Found.` link, and after login landed on a blank `Authorized` page instead of the app.

Two bugs in the previous approach:

1. Traefik's [`errors`](https://doc.traefik.io/traefik/middlewares/http/errorpages/) middleware serves the downstream body with the **original error status** (the 401), not with the downstream's 302. The browser therefore rendered the 302 redirect body as literal text instead of following the redirect.
2. `{url}` is not a template variable in `errors.query`, so `rd` was sent literally. After login oauth2-proxy fell back to `/` and hit its own `upstreams = [ "static://202" ]`, which is where the `Authorized` dead-end page came from.

### Fix — invert the layers

Put `oauth2-proxy` **in front of** `auth-proxy`. oauth2-proxy natively issues a proper 302 to `/oauth2/start` on unauthenticated requests and redirects back to the original URL after sign-in, so we no longer need to synthesize that redirect in Traefik.

```
Before:                                       After:
Gateway → auth-proxy (forwardAuth→oauth2) →  Gateway → oauth2-proxy → auth-proxy (host route) →
         backend                                      backend
```

- `oauth2-proxy` HelmRelease: `upstreams` now point at the in-cluster `auth-proxy` Service; added `whitelist_domains = [".${domain}"]` so post-login redirects back to `platform.${domain}` / `goldilocks.${domain}` are accepted.
- `auth-proxy` ConfigMap: stripped `forwardAuth`, `errors`, `chain` middlewares and the internal `oauth2-proxy` service; kept only Host-based routing.
- `homepage` and `goldilocks` HTTPRoutes: backend changed from `auth-proxy` to `oauth2-proxy`.
- `ReferenceGrant`: retargeted to the `oauth2-proxy` Service; renamed to `allow-oauth2-proxy-backends`.

### Expected E2E flow

1. Browser hits `https://platform.devantler.tech/` → Gateway → oauth2-proxy.
2. oauth2-proxy sees no session → **302** to `/oauth2/start?rd=<original URL>`.
3. GitHub login → `/oauth2/callback` sets `.${domain}` cookie → **302** back to original URL.
4. Browser re-requests original URL with the cookie → oauth2-proxy validates → proxies to auth-proxy → homepage/goldilocks.

No manual "Found" link click, no "Authorized" dead end.

## Type of change

- [x] 🪲 Bug fix