### PR TITLE
fix(ha): scale operator-tier replicas to 1 on dev/prod

### DIFF
--- a/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
@@ -16,3 +16,17 @@ data:
   # collide. Omni writes etcd snapshots at bucket root independently.
   r2_prefix_velero: velero/dev
   r2_prefix_cnpg: cnpg/dev
+  # --- HA replica overrides for the 3× CX23 dev cluster ---
+  # Mirrors prod: user-facing stays at 2 replicas, operators drop to 1
+  # because they are leader-elected and single-replica operators are
+  # sufficient for the stated RPO/RTO. This keeps the cluster within
+  # CPU budget on the shared 6 vCPU footprint.
+  cert_manager_replicas: "1"
+  trust_manager_replicas: "1"
+  reloader_replicas: "1"
+  metrics_server_replicas: "1"
+  vpa_admission_replicas: "1"
+  cilium_replicas: "1"
+  velero_replicas: "1"
+  cloudnative_pg_replicas: "1"
+  alertmanager_replicas: "1"

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -16,3 +16,20 @@ data:
   # collide. Omni writes etcd snapshots at bucket root independently.
   r2_prefix_velero: velero/prod
   r2_prefix_cnpg: cnpg/prod
+  # --- HA replica overrides for the 3× CX23 prod cluster ---
+  # User-facing path keeps the default of 2 replicas for zero-downtime
+  # rolling updates (homepage, headlamp, whoami, dex, oauth2-proxy,
+  # auth-proxy, cloudflared, kyverno admission).
+  # Operators are leader-elected; 1 replica is sufficient — a brief blip
+  # during a rolling upgrade of the operator itself does not affect the
+  # data plane. Dropping them to 1 frees CPU headroom on the 6 vCPU
+  # total available after Talos + Cilium overhead.
+  cert_manager_replicas: "1"
+  trust_manager_replicas: "1"
+  reloader_replicas: "1"
+  metrics_server_replicas: "1"
+  vpa_admission_replicas: "1"
+  cilium_replicas: "1"
+  velero_replicas: "1"
+  cloudnative_pg_replicas: "1"
+  alertmanager_replicas: "1"


### PR DESCRIPTION
Follow-up to #1391. Prod CD run [24616903132](https://github.com/devantler-tech/platform/actions/runs/24616903132) got past the PrometheusRule CRD issue but then hit:

```
FailedScheduling  0/3 nodes are available: 3 Insufficient cpu
Deployment/oauth2-proxy/auth-proxy status: 'Failed'
```

With most operators bumped to `replicas=2` by the HA/DR PRs plus the new kube-prometheus-stack, the 3× CX23 (6 vCPU total) prod cluster is oversubscribed and auth-proxy / oauth2-proxy pods cannot schedule.

Operators are leader-elected — a single replica is HA-sufficient. A blip during the operator's own rolling upgrade does not affect the data plane, which is still protected by the user-facing 2-replica deployments.

Override `replicas=1` in dev and prod variables for: cert-manager, trust-manager, reloader, metrics-server, VPA admission, cilium-operator, velero, cloudnative-pg, alertmanager. The bases still default to 2 for larger clusters.