### PR TITLE
fix(ha): unblock stuck kyverno + cloudflared HelmReleases on prod

### DIFF
--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -9,6 +9,14 @@ metadata:
     helm.toolkit.fluxcd.io/remediation: enabled
 spec:
   interval: 2m
+  timeout: 15m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+      remediateLastFailure: true
   chart:
     spec:
       chart: kyverno

--- a/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml
@@ -8,6 +8,14 @@ metadata:
     helm.toolkit.fluxcd.io/remediation: enabled
 spec:
   interval: 2m
+  timeout: 10m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+      remediateLastFailure: true
   chart:
     spec:
       chart: cloudflare-tunnel


### PR DESCRIPTION
Prod has been stuck since v2.34.0 because kyverno and cloudflared HelmReleases hit the default `remediation.retries: 0` policy: one rollback and Flux gives up until the spec changes. Neither prior PR touched the spec of these HRs, so prod stayed Failed across v2.34.0-v2.34.3.

## What changes

- `k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml`: add `spec.install/upgrade.remediation.retries: -1`, `remediateLastFailure: true`, and `timeout: 15m`.
- `k8s/providers/omni/infrastructure/controllers/cloudflared/helm-release.yaml`: same, with `timeout: 10m`.

## Effect

The spec change bumps the HR generation, forcing a fresh reconcile that clears the stuck `Failed` phase. `retries: -1` means Flux will keep retrying indefinitely so any transient root cause (cert-sync race during HA rollout, PDB stalls, node pressure) self-heals without operator intervention.