### PR TITLE
fix(ha): kube-prometheus-stack 83.6.0 + velero 15m timeout

### DIFF
--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
@@ -11,14 +11,20 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 78.5.0
+      version: 83.6.0
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
   install:
     crds: CreateReplace
+    remediation:
+      retries: -1
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  timeout: 15m
   # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
   #
   # Trimmed-down install: Prometheus + Alertmanager + node-exporter +

--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -17,8 +17,14 @@ spec:
         name: vmware-tanzu
   install:
     crds: CreateReplace
+    remediation:
+      retries: -1
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  timeout: 15m
   # https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml
   values:
     image:


### PR DESCRIPTION
Prod v2.34.5 cleared the stuck cloudflared/kyverno HRs (thanks to the retries added in #1394), surfacing two new root causes:

## 1. kube-prometheus-stack stuck in upgrade/rollback loop

PR #1393 pinned the chart to 78.5.0, but prod already had release v2 at 83.6.0 (via an earlier reconcile). Downgrading fails because the in-cluster Alertmanager CR uses `.spec.hostNetwork` — a field only in the v83 schema — so both upgrade and rollback raise `field not declared in schema`. Fix forward by setting the spec to 83.6.0 to match the installed release.

## 2. velero pre-install hook timeout

The upstream `velero-upgrade-crds` Job hits the default 5 m Helm timeout on a cold prod cluster. Bumped `timeout: 15m`.

Both HRs also get explicit `install/upgrade.remediation.retries: -1` + `remediateLastFailure: true` so future transient failures self-heal, matching #1394.