### PR TITLE
fix(ha): bump velero to chart 12.0.0 (bitnami kubectl fix)

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: velero
-      version: 10.1.3
+      version: 12.0.0
       sourceRef:
         kind: HelmRepository
         name: vmware-tanzu
@@ -27,8 +27,6 @@ spec:
   timeout: 15m
   # https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml
   values:
-    image:
-      repository: velero/velero
     initContainers:
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.14.0


### PR DESCRIPTION
v2.34.6 CD reached velero as the only remaining stuck HR. Root cause: velero chart 10.1.3's `velero-upgrade-crds` pre-install Job pulls `docker.io/bitnamilegacy/kubectl` — same bitnami-deprecation hole we hit for MinIO earlier in this session. The image can't be pulled from prod so the Job sits in `InProgress` forever and the hook times out.

Upstream fixed this in chart 12.0.0 by switching to `registry.k8s.io/kubectl` (vmware-tanzu/helm-charts#706 / #698).

Also drop the now-redundant `image.repository: velero/velero` override (chart default already resolves to `docker.io/velero/velero`). Prod's release history already recorded an attempted v12 rollout that Helm rolled back, so the CRDs in-cluster are v12-shaped; aligning the spec to 12.0.0 lets Flux roll forward without another downgrade attempt.