### PR TITLE
fix(ha): fit velero+prometheus into 3-node CX23 prod

### DIFF
--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
@@ -48,10 +48,10 @@ spec:
         retentionSize: "5GiB"
         resources:
           requests:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 50m
+            memory: 256Mi
           limits:
-            memory: 1Gi
+            memory: 768Mi
         # Discover ServiceMonitors / PodMonitors / PrometheusRules from
         # any namespace -- charts in this repo (Velero, CNPG, etc.) drop
         # their own.

--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -66,10 +66,15 @@ spec:
     # Run Velero itself with HA primitives matching the rest of the
     # operator tier (PR #2b). Server is leader-elected so 2 replicas =
     # instant failover, not extra capacity.
+    #
+    # Intentionally no PodDisruptionBudget: velero uses leader election,
+    # so pod-level PDB adds no availability; with replicaCount=1 on prod
+    # (`velero_replicas=1`), a PDB with `minAvailable: 1` creates a
+    # classic deadlock where a rolling upgrade cannot evict the sole
+    # pod. `Recreate` strategy is a better fit: brief blip during an
+    # upgrade is acceptable for a backup controller and avoids requiring
+    # a surge pod that the CX23 prod nodes cannot host.
     replicaCount: ${velero_replicas:=2}
-    podDisruptionBudget:
-      enabled: true
-      minAvailable: 1
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -79,10 +84,7 @@ spec:
             app.kubernetes.io/name: velero
             app.kubernetes.io/instance: velero
     strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
+      type: Recreate
 
     # Node agent: DaemonSet, runs the Kopia uploader on every node that has
     # PVCs. Defaults are sane; just confirm rolling update.
@@ -118,7 +120,7 @@ spec:
 
     resources:
       requests:
-        cpu: 100m
-        memory: 256Mi
+        cpu: 25m
+        memory: 128Mi
       limits:
         memory: 512Mi


### PR DESCRIPTION
## Why

CD for `v2.34.7` failed with `FailedScheduling` across:

- `velero-*` Deployment pods (3× Insufficient cpu)
- `prometheus-kube-prometheus-stack-prometheus-0` StatefulSet pod (Insufficient cpu + memory on all 3 nodes)
- `node-agent-*` DaemonSet pods (Insufficient cpu on 1 node)

The prod cluster is 3× Hetzner CX23 (2 vCPU + 4 GB RAM each). After Talos/Cilium/SPIRE overhead the HA operator tier + a surge velero pod + Prometheus's 512Mi request + Alertmanager + CNPG + kyverno admission simply does not fit.

## What

**Velero**
- Drop the `PodDisruptionBudget` (velero is leader-elected; pod-level PDB adds no real availability). With `velero_replicas=1` on prod, `minAvailable: 1` deadlocked every rolling upgrade — eviction always violates the budget.
- Switch `strategy` from `RollingUpdate {maxSurge: 0, maxUnavailable: 1}` to `Recreate`. A backup controller can tolerate a ~15 s gap during upgrades, and `Recreate` never asks for surge capacity the cluster doesn't have.
- Trim resource requests: CPU `100m → 25m`, memory `256Mi → 128Mi`. Limit stays `512Mi`.

**kube-prometheus-stack**
- Trim Prometheus requests: CPU `100m → 50m`, memory `512Mi → 256Mi`. Limit `1Gi → 768Mi`. 14 d / 5 GiB retention unchanged.

## Verification

- CI must reconcile cleanly end-to-end.
- After merge + tag, watch Flux reconcile on prod: velero Deployment must schedule, Prometheus StatefulSet must schedule, `kubectl get helmrelease -A` must be `Ready=True` across the board.

Unblocks prod CD after v2.34.7 failure.