### PR TITLE
fix(ha): cap origin-ca-issuer CPU request on prod

### DIFF
--- a/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
+++ b/k8s/providers/omni/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
@@ -15,3 +15,13 @@ spec:
   # https://github.com/cloudflare/origin-ca-issuer/blob/trunk/deploy/charts/origin-ca-issuer/values.yaml
   values:
     replicaCount: ${origin_ca_issuer_replicas:=2}
+    # Chart default is 1 full CPU core per replica — absurd for a tiny
+    # webhook that signs a handful of certificates per day. Override to
+    # burstable-tier sizing so a 2-vCPU node can actually run something
+    # else.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi


### PR DESCRIPTION
## Problem

The prod cluster was stuck with `oauth2-proxy` and `velero` HelmReleases in `Ready=False` because rolling upgrades could not schedule a surge pod — every node reported `Insufficient cpu` (99% of 1950m allocatable reserved).

Hunting for the offender: **origin-ca-issuer** was requesting **1 full vCPU per replica**, chart default. With `replicas: 2` on prod that's 2 full cores reserved just to sign a handful of Cloudflare origin certs per day — more than a whole CX23 node (2 vCPU total).

## Fix

Override the chart defaults to burstable sizing matching the actual workload: `requests: cpu=10m memory=64Mi`, `limits: cpu=200m memory=128Mi`.

## Verification

Applied the live patch against prod before opening this PR (with `kubectl -n cert-manager scale deploy origin-ca-issuer --replicas=1` + force-delete the old 1000m pod to break out of the surge deadlock, then scale back to 2). After reconcile:

- All 4 Flux Kustomizations `Ready=True`
- All HelmReleases `Ready=True` (velero v12.0.0 upgrade finally applied; oauth2-proxy rolled forward)
- Node CPU dropped from 99% / 98% / 99% requested to 71-83% on the two worker-affine nodes

Closes the prod capacity cascade from the HA/DR PR stack (#1376 – #1397).