### PR TITLE
fix(auth): preserve original host in oauth2-proxy rd redirect

### DIFF
--- a/k8s/bases/apps/homepage/httproute.yaml
+++ b/k8s/bases/apps/homepage/httproute.yaml
@@ -11,7 +11,13 @@ spec:
   hostnames:
     - ${domain}
   rules:
-    - backendRefs:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://${domain}/
+      backendRefs:
         - name: oauth2-proxy
           namespace: oauth2-proxy
           port: 80

--- a/k8s/bases/infrastructure/controllers/goldilocks/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/goldilocks/httproute.yaml
@@ -19,7 +19,13 @@ spec:
   hostnames:
     - goldilocks.${domain}
   rules:
-    - backendRefs:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://goldilocks.${domain}/
+      backendRefs:
         - name: oauth2-proxy
           namespace: oauth2-proxy
           port: 80


### PR DESCRIPTION
After PR #1385, the OAuth flow almost works but lands users on `https://oauth2-proxy.${domain}/` (Traefik 404) instead of the originally requested host after GitHub login.

## Root cause

oauth2-proxy's [`rd` getter chain](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/pkg/app/redirect/getters.go) skips the `X-Forwarded-*` strategy when `req.Host == X-Forwarded-Host` — see [`IsForwardedRequest`](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/pkg/requests/util/util.go). Cilium Gateway preserves `Host`, so the strategy is skipped and `rd` falls back to the path-only `req.URL.RequestURI()` (i.e. `/`). After the cross-host GitHub callback, that relative `/` resolves to the callback host → `oauth2-proxy.${domain}/` → auth-proxy has no Host router → 404.

## Fix

Set `X-Auth-Request-Redirect` per HTTPRoute with the route's full origin URL using a Gateway API `RequestHeaderModifier` filter. That getter runs earlier in the chain, and the resulting `rd` is an absolute URL that survives the cross-host callback.

Deep-link paths are not preserved — users always land on `/` of the correct host. Preserving paths would require `Host` / `X-Forwarded-Host` rewrites that collide with auth-proxy's Host-based routing.

## Type of change

- [x] 🪲 Bug fix