### PR TITLE
docs: refresh docs/ for OSS audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For the production cluster:
 > 2. Create your own Age keys
 > 3. Update the `.sops.yaml` file in the root of the repository.
 > 4. Update GitHub secrets with your Age key.
-> 5. Replace all encoded `*.enc.yaml` files in the `k8s/` folder with new ones that are encrypted with your own keys.
+> 5. Replace all encrypted `*.enc.yaml` files in the `k8s/` folder with new ones that are encrypted with your own keys.
 
 To run this cluster locally, simply run:
 
@@ -60,7 +60,7 @@ Local development cluster running on Docker via KSail. Uses Talos with the Docke
 
 ### Dev
 
-Staging cluster running on Hetzner Cloud, managed by Talos Omni. Deployed automatically on merge via the CI pipeline.
+Staging cluster running on Hetzner Cloud, managed by Talos Omni. Deployed automatically via the CI pipeline when changes run through the merge queue (`merge_group`).
 
 - 3x [Hetzner CX23 nodes](https://www.hetzner.com/cloud/) (x86 2 vCPU 4Gb RAM 40Gb SSD)
 - Config: [`ksail.dev.yaml`](ksail.dev.yaml)

--- a/docs/TEMPLATING.md
+++ b/docs/TEMPLATING.md
@@ -82,7 +82,7 @@ See `.github/workflows/` for the exact names.
 ## Template body (do not edit when instantiating)
 
 - `k8s/bases/cluster/` — shared Flux Kustomizations with sentinel paths.
-- `k8s/bases/infrastructure/` — Cilium, Traefik, cert-manager configs, etc.
+- `k8s/bases/infrastructure/` — Cilium, cert-manager, Kyverno, alerting configs, etc.
 - `k8s/bases/apps/` — reference applications (homepage, whoami, headlamp).
 - `k8s/providers/{docker,omni}/` — provider-specific assembly of bases.
 

--- a/docs/dr/README.md
+++ b/docs/dr/README.md
@@ -4,10 +4,10 @@ This directory holds the operator-facing DR documentation for the platform.
 Start with [`runbook.md`](./runbook.md); the other documents go deeper on the
 specific layers it references.
 
-| Document                                 | Layer            |
-| ---------------------------------------- | ---------------- |
-| [runbook.md](./runbook.md)               | Procedure        |
-| [omni-etcd-backups.md](./omni-etcd-backups.md) | Control plane (PR #3) |
-| [velero-cnpg.md](./velero-cnpg.md)       | Apps + PVs (PR #4) |
-| [alerting.md](./alerting.md)             | Detection (PR #6) |
-| [restore-drill.md](./restore-drill.md)   | CI verification (PR #7) |
+| Document                                       | Layer                |
+| ---------------------------------------------- | -------------------- |
+| [runbook.md](./runbook.md)                     | Procedure            |
+| [omni-etcd-backups.md](./omni-etcd-backups.md) | Control plane        |
+| [velero-cnpg.md](./velero-cnpg.md)             | Apps + PVs           |
+| [alerting.md](./alerting.md)                   | Detection            |
+| [restore-drill.md](./restore-drill.md)         | CI verification      |

--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -42,9 +42,10 @@ This is the deliberate tradeoff for "no SaaS". Mitigations:
 
 1. **Daily Velero schedule + Omni etcd backups still run independently.**
    On next recovery, you'll see the missed backup in R2.
-2. **CI restore drill** asserts the rules render and Alertmanager
-   accepts them on every PR — so a regression in the alert spec is caught
-   before merge (see [restore-drill.md](./restore-drill.md)).
+2. **CI restore drill** validates that `PrometheusRule` manifests are
+   accepted and the monitoring stack reconciles on every PR — so a
+   regression in the alert spec is caught before merge
+   (see [restore-drill.md](./restore-drill.md)).
 3. If true off-cluster alerting becomes necessary later, the documented
    follow-up is to add Grafana Cloud free tier (10k metrics, ample for
    these alerts) and configure a remote-write target in
@@ -90,7 +91,8 @@ Identical install, with:
 - Webhook URL pointed at `http://example.invalid/no-webhook-on-local`
   (deliberately fails). CI asserts this fail mode is acceptable — the
   alerts still fire inside Alertmanager, the webhook just can't reach
-  anywhere. The CI restore drill verifies the alert wiring; the lack of an external
+  anywhere. The CI restore drill verifies the monitoring stack reconciles
+  and `PrometheusRule` manifests are accepted; the lack of an external
   destination is by design.
 
 ## Tuning resource footprint

--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -19,7 +19,7 @@ out of Alertmanager.
 
 ## What gets alerted
 
-See `k8s/bases/infrastructure/controllers/kube-prometheus-stack/rules/critical.yaml`.
+See `k8s/bases/infrastructure/alerts/platform-critical.yaml`.
 
 | Alert                       | Severity | Why                                       |
 | --------------------------- | -------- | ----------------------------------------- |
@@ -42,9 +42,9 @@ This is the deliberate tradeoff for "no SaaS". Mitigations:
 
 1. **Daily Velero schedule + Omni etcd backups still run independently.**
    On next recovery, you'll see the missed backup in R2.
-2. **PR #7 CI restore drill** asserts the rules render and Alertmanager
+2. **CI restore drill** asserts the rules render and Alertmanager
    accepts them on every PR — so a regression in the alert spec is caught
-   before merge.
+   before merge (see [restore-drill.md](./restore-drill.md)).
 3. If true off-cluster alerting becomes necessary later, the documented
    follow-up is to add Grafana Cloud free tier (10k metrics, ample for
    these alerts) and configure a remote-write target in
@@ -90,7 +90,7 @@ Identical install, with:
 - Webhook URL pointed at `http://example.invalid/no-webhook-on-local`
   (deliberately fails). CI asserts this fail mode is acceptable — the
   alerts still fire inside Alertmanager, the webhook just can't reach
-  anywhere. PR #7 verifies the alert wiring; the lack of an external
+  anywhere. The CI restore drill verifies the alert wiring; the lack of an external
   destination is by design.
 
 ## Tuning resource footprint
@@ -105,7 +105,7 @@ Current chart values:
 | node-exporter  | (chart defaults)      | (chart defaults) |
 | kube-state-metrics | (chart defaults)  | (chart defaults) |
 
-Total ~1 GiB committed memory, well within 3× CX23 (24 GiB total). If
+Total ~1 GiB committed memory. If
 this becomes too heavy, the first thing to drop is `nodeExporter` and
 the related node-level alerts.
 
@@ -113,4 +113,4 @@ the related node-level alerts.
 
 - [DR runbook](./runbook.md) — what to do when an alert fires
 - [Velero + CNPG](./velero-cnpg.md) — the systems whose health is being checked
-- [HA primitives](../../README.md) — PDBs / topology spread (PRs #2a/#2b)
+- [HA primitives](../../README.md) — cluster environments and topology

--- a/docs/dr/omni-etcd-backups.md
+++ b/docs/dr/omni-etcd-backups.md
@@ -39,7 +39,7 @@ each `k8s/clusters/<env>/variables/variables-cluster-config-map.yaml`:
 
 | Key                     | Where        | Value                                           |
 | ----------------------- | ------------ | ----------------------------------------------- |
-| `r2_endpoint`           | base         | `https://<account>.r2.cloudflarestorage.com`    |
+| `r2_endpoint`           | base         | `https://<account-id>.r2.cloudflarestorage.com` |
 | `r2_region`             | base         | `auto`                                          |
 | `r2_bucket`             | base         | `<your-bucket>` (e.g. `<your-org>-platform-backups`) |
 | `r2_prefix_velero`      | per-cluster  | `velero/dev` or `velero/prod` (local: `velero`) |

--- a/docs/dr/omni-etcd-backups.md
+++ b/docs/dr/omni-etcd-backups.md
@@ -3,7 +3,7 @@
 Disaster-recovery backup of the Talos/Omni control-plane etcd state for the `dev`
 and `prod` clusters. Configured **inside Omni** (not in this repo) because Omni
 manages cluster lifecycle externally; only the shared R2 bucket and the
-credentials live here, where they are reused by Velero ([PR #4](./velero-cnpg.md))
+credentials live here, where they are reused by Velero (see [velero-cnpg.md](./velero-cnpg.md))
 and CNPG.
 
 ## Why R2
@@ -25,7 +25,7 @@ To keep Velero and CNPG from colliding in that same bucket, they run under
 per-env prefixes:
 
 ```
-devantler-platform-backups/
+<your-bucket>/
 ├── <omni-cluster-name>/...   ← Omni etcd snapshots, bucket root (managed by Omni)
 ├── velero/dev/               ← Velero, dev cluster
 ├── velero/prod/              ← Velero, prod cluster
@@ -41,19 +41,19 @@ each `k8s/clusters/<env>/variables/variables-cluster-config-map.yaml`:
 | ----------------------- | ------------ | ----------------------------------------------- |
 | `r2_endpoint`           | base         | `https://<account>.r2.cloudflarestorage.com`    |
 | `r2_region`             | base         | `auto`                                          |
-| `r2_bucket`             | base         | `devantler-platform-backups`                    |
+| `r2_bucket`             | base         | `<your-bucket>` (e.g. `<your-org>-platform-backups`) |
 | `r2_prefix_velero`      | per-cluster  | `velero/dev` or `velero/prod` (local: `velero`) |
 | `r2_prefix_cnpg`        | per-cluster  | `cnpg/dev` or `cnpg/prod` (local: `cnpg`)       |
 
 ## R2 bucket settings (one-time, in Cloudflare dashboard)
 
-1. Create bucket `devantler-platform-backups` in jurisdiction `default`.
+1. Create a bucket (e.g. `<your-org>-platform-backups`) in jurisdiction `default`.
 2. **Object Lock**: enabled, **Compliance** mode disabled, **Governance** mode
    default retention **30 days**. Prevents an attacker (or `rm -rf` typo) from
    deleting backups before the retention window.
 3. **Versioning**: enabled. Pairs with object lock and lets restores reach back
    past an accidental overwrite.
-4. **Lifecycle rules** (all under `devantler-platform-backups/`):
+4. **Lifecycle rules** (all under `<your-bucket>/`):
    - `velero/` and `cnpg/`: transition to Infrequent Access after 14 days;
      abort incomplete multipart uploads after 1 day.
    - Bucket root (Omni snapshots): same.
@@ -72,8 +72,8 @@ to every cluster Omni manages. Open it and paste:
 
 | Field             | Value                                                               |
 | ----------------- | ------------------------------------------------------------------- |
-| Endpoint          | `https://634e9016d402443e427865dc35457728.r2.cloudflarestorage.com` |
-| Bucket            | `devantler-platform-backups`                                        |
+| Endpoint          | `https://<account-id>.r2.cloudflarestorage.com`                    |
+| Bucket            | `<your-bucket>`                                                     |
 | Region            | `auto` (any value works; R2 ignores it)                             |
 | Access Key ID     | the R2 S3 token ID from step 6 above                                |
 | Secret Access Key | the R2 S3 token secret from step 6 above                            |
@@ -97,7 +97,7 @@ prefixes don't overlap.
 
 ## Restore (high level)
 
-Detailed in `docs/dr/runbook.md` (PR #5). Summary:
+Detailed in [`runbook.md`](./runbook.md). Summary:
 
 1. Provision a fresh Talos node from the snapshot used by `hetzner/`.
 2. In Omni, create a new cluster pointed at the same machine.
@@ -115,7 +115,6 @@ nothing to restore that isn't already in this repo.
 
 ## Related
 
-- [DR runbook](./runbook.md) (PR #5) — full rebuild-from-zero procedure
-- [Velero + CNPG backups](./velero-cnpg.md) (PR #4) — application/PV layer
-- [HA primitives](../../README.md) — PDBs, topology spread, rolling updates
-  (PRs #2a / #2b)
+- [DR runbook](./runbook.md) — full rebuild-from-zero procedure
+- [Velero + CNPG backups](./velero-cnpg.md) — application/PV layer
+- [HA primitives](../../README.md) — cluster environments and topology

--- a/docs/dr/restore-drill.md
+++ b/docs/dr/restore-drill.md
@@ -2,29 +2,32 @@
 
 `.github/workflows/ci.yaml` runs a `restore-drill` job on every PR that
 touches `k8s/**` or the cluster configs. The job validates the full
-backup → cluster-loss → restore round trip end-to-end on a fresh local
-Talos+Docker cluster, so an etcd loss / cluster rebuild scenario is
-regression-tested **before** changes reach `dev` or `prod`.
+backup → data-loss → restore cycle end-to-end on a local Talos+Docker
+cluster, so the Velero code path is regression-tested **before** changes
+reach `dev` or `prod`.
 
 ## What it does
 
-1. `ksail cluster create` (round 1) and reconcile.
-2. Wait for **Velero** + **MinIO** (the local R2 stand-in from PR #4) to
-   be ready and `BackupStorageLocation/default` `Available`.
+1. `ksail cluster create` and reconcile all workloads.
+2. Wait for **Velero** + **MinIO** (the local R2 stand-in) to be ready
+   and `BackupStorageLocation/default` `Available`.
 3. Create a marker `Namespace`/`ConfigMap` carrying the GitHub
-   `run-id` and `sha` (so we can prove identity later).
+   `run-id` and `sha` (so identity can be proved later).
 4. `velero backup create` against the marker namespace, `--wait` for
    `Completed`.
-5. **Destroy the cluster**: `ksail cluster delete`.
-6. `ksail cluster create` (round 2 — fresh) and reconcile.
-7. Wait for Velero/MinIO again, then poll until Velero rediscovers the
-   backup CR from object storage.
-8. Assert the marker namespace does **not** pre-exist on the new
-   cluster.
-9. `velero restore create --from-backup ... --wait` for `Completed`.
-10. Assert the marker `ConfigMap` is back and `data.run-id` matches the
-    current `GITHUB_RUN_ID`.
-11. Tear down the cluster (`if: always()`).
+5. **Simulate data loss**: delete the marker namespace (`kubectl delete
+   namespace`).
+6. Assert the marker namespace does **not** exist after deletion.
+7. `velero restore create --from-backup ... --wait` for `Completed`.
+8. Assert the marker `ConfigMap` is back and `data.run-id` matches the
+   current `GITHUB_RUN_ID`.
+9. Tear down the cluster (`if: always()`).
+
+> **Why namespace deletion instead of full cluster rebuild?** MinIO runs
+> in-cluster with ephemeral storage, so destroying the cluster would also
+> destroy the backup target. Namespace deletion simulates data loss while
+> keeping MinIO (and thus the backup data) intact, exercising the same
+> Velero → S3 → Velero code path end-to-end.
 
 ## Wall-clock budget
 
@@ -40,8 +43,7 @@ explodes.
   missing AWS plugin).
 - A regression in the MinIO install or its credential wiring (Velero
   `BackupStorageLocation` going `Unavailable`).
-- Backup format incompatibility introduced by a Velero version bump
-  (round-2 cluster runs the same chart and has to read round-1's data).
+- Backup format incompatibility introduced by a Velero version bump.
 - A reconciliation regression that makes `velero` or `minio` never
   become Ready inside the 10-minute rollout window.
 
@@ -53,8 +55,11 @@ explodes.
 - Omni etcd backup/restore — not exercised here because there is no
   Omni in CI. Drill manually per [`omni-etcd-backups.md`](./omni-etcd-backups.md).
 - CNPG PITR — covered by the CNPG operator's own e2e; we only verify
-  that the `ScheduledBackup` reconciles. A future PR can extend the
-  drill to write a row, backup, destroy, restore, read row.
+  that the `ScheduledBackup` reconciles. A future extension could write
+  a row, backup, delete, restore, and read the row back.
+- Full cluster rebuild with R2 — in prod the backup survives cluster
+  destruction (it lives in R2). That scenario is covered by the manual
+  procedure in the runbook.
 
 ## Why no etcd encryption verification step
 
@@ -68,18 +73,20 @@ the encryption is silently disabled, add a `talosctl etcd snapshot` +
 ## Local manual run
 
 ```bash
-# Round 1
 ksail cluster create
 ksail workload push && ksail workload reconcile
+
+# Create marker
 kubectl create ns dr-drill
 kubectl -n dr-drill create configmap dr-marker --from-literal=t=$(date -u +%FT%TZ)
+
+# Backup
 velero backup create dr-drill --include-namespaces dr-drill --wait
 
-# Round 2
-ksail cluster delete
-ksail cluster create
-ksail workload push && ksail workload reconcile
-velero backup get   # should list dr-drill
+# Simulate data loss
+kubectl delete namespace dr-drill
+
+# Restore
 velero restore create dr-drill-restore --from-backup dr-drill --wait
 kubectl -n dr-drill get configmap dr-marker -o yaml
 ```

--- a/docs/dr/restore-drill.md
+++ b/docs/dr/restore-drill.md
@@ -84,7 +84,8 @@ kubectl -n dr-drill create configmap dr-marker --from-literal=t=$(date -u +%FT%T
 velero backup create dr-drill --include-namespaces dr-drill --wait
 
 # Simulate data loss
-kubectl delete namespace dr-drill
+kubectl delete namespace dr-drill --wait=true --timeout=2m
+until ! kubectl get namespace dr-drill >/dev/null 2>&1; do sleep 2; done
 
 # Restore
 velero restore create dr-drill-restore --from-backup dr-drill --wait

--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -213,7 +213,7 @@ find . -name '*.enc.yaml' -print0 | xargs -0 -n1 sops updatekeys --yes
 
 ```bash
 # 1. Mint a new R2 token in the Cloudflare dashboard (scoped to your
-#    platform-backups bucket only). DO NOT revoke the old one
+#    <your-bucket> bucket only). DO NOT revoke the old one
 #    yet -- there is a window where both must work.
 
 # 2. Update the encrypted secret in-place
@@ -231,7 +231,7 @@ kubectl logs -n cnpg-system -l app.kubernetes.io/name=cloudnative-pg --tail=50
 
 # 5. Revoke the old token in Cloudflare.
 
-# 6. Update the in-Omni R2 credentials (Omni etcd backups, see omni-etcd-backups.md).
+# 6. Update the in-Omni R2 credentials (Omni etcd backups, see [omni-etcd-backups.md](./omni-etcd-backups.md)).
 omnictl cluster set-backup --cluster <c> --access-key-id <new> --secret-access-key <new>
 ```
 

--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -19,20 +19,20 @@ these simultaneously and you cannot recover.
 
 | Artifact                                | Where it lives                       | Recovery if lost                     |
 | --------------------------------------- | ------------------------------------ | ------------------------------------ |
-| **SOPS Age private keys** (one per env) | 1Password + hardware key, second loc | Re-encrypt all `*.enc.yaml` (below)  |
-| **Cloudflare R2 access keys**           | 1Password                            | Mint new in Cloudflare; SOPS-update  |
-| **Omni admin credentials**              | 1Password + Omni `omnictl` config    | Reset via Sidero support             |
-| **Cloudflare API token**                | 1Password                            | Mint new in Cloudflare dashboard     |
+| **SOPS Age private keys** (one per env) | Secure vault + offline backup        | Re-encrypt all `*.enc.yaml` (below)  |
+| **Cloudflare R2 access keys**           | Secure vault                         | Mint new in Cloudflare; SOPS-update  |
+| **Omni admin credentials**              | Secure vault + `omnictl` config      | Reset via Sidero support             |
+| **Cloudflare API token**                | Secure vault                         | Mint new in Cloudflare dashboard     |
 
-> Recommendation: 1Password vault `platform-dr` shared with at least one
-> additional trusted operator, plus an offline copy on a hardware-encrypted
-> USB stick stored in a second physical location.
+> Recommendation: store these in a shared vault accessible by at least one
+> additional trusted operator, plus an offline copy in a second physical
+> location.
 
 ---
 
 ## Scenario 1 — Single node loss
 
-Expected behaviour: PDBs (PRs #2a / #2b) keep every multi-replica workload
+Expected behaviour: PDBs keep every multi-replica workload
 serving traffic. Omni replaces the failed node within ~5 minutes.
 
 **Action:** none required if PDBs and Omni autoscaling are healthy. Verify
@@ -66,14 +66,14 @@ kubectl get deploy -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.meta
 ```
 
 If anything reports `maxUnavailable` other than `0`, that workload was
-either added after PR #2a/#2b or has a chart limitation — fix before
+either added without an HA configuration or has a chart limitation — fix before
 upgrading.
 
 ---
 
 ## Scenario 3 — etcd corruption / control-plane loss
 
-Restore from the most recent Omni snapshot (PR #3).
+Restore from the most recent Omni snapshot (see [omni-etcd-backups.md](./omni-etcd-backups.md)).
 
 1. **Omni dashboard** → `Cluster → Backups → Restore from S3`.
 2. Pick the most recent snapshot under `omni-etcd/<cluster-name>/` (Omni
@@ -212,8 +212,8 @@ find . -name '*.enc.yaml' -print0 | xargs -0 -n1 sops updatekeys --yes
 ## Scenario 7 — R2 / Cloudflare credential rotation
 
 ```bash
-# 1. Mint a new R2 token in the Cloudflare dashboard (scoped to the
-#    devantler-platform-backups bucket only). DO NOT revoke the old one
+# 1. Mint a new R2 token in the Cloudflare dashboard (scoped to your
+#    platform-backups bucket only). DO NOT revoke the old one
 #    yet -- there is a window where both must work.
 
 # 2. Update the encrypted secret in-place
@@ -231,7 +231,7 @@ kubectl logs -n cnpg-system -l app.kubernetes.io/name=cloudnative-pg --tail=50
 
 # 5. Revoke the old token in Cloudflare.
 
-# 6. Update the in-Omni R2 credentials (Omni etcd backups, PR #3).
+# 6. Update the in-Omni R2 credentials (Omni etcd backups, see omni-etcd-backups.md).
 omnictl cluster set-backup --cluster <c> --access-key-id <new> --secret-access-key <new>
 ```
 
@@ -253,7 +253,7 @@ etcdctl --endpoints unix:///tmp/etcd.snapshot \
 # Kubernetes Secret YAML, the EncryptionConfiguration was lost.
 ```
 
-This check is also asserted by the CI restore drill (PR #7).
+This check is also asserted by the CI restore drill (see [restore-drill.md](./restore-drill.md)).
 
 ---
 
@@ -269,15 +269,14 @@ ksail cluster create
 ksail workload push && ksail workload reconcile
 ```
 
-CI exercises this on every PR (`.github/workflows/ci.yaml`), and from PR
-#7 onward also exercises a Velero backup → restore against the in-cluster
+CI exercises this on every PR (`.github/workflows/ci.yaml`), and also
+exercises a Velero backup → restore against the in-cluster
 MinIO so the prod code path is regression-tested.
 
 ---
 
 ## Related documents
 
-- [HA & DR plan](../../README.md) — overall design
-- [Omni etcd backups](./omni-etcd-backups.md) — control-plane backups (PR #3)
-- [Velero + CNPG → R2](./velero-cnpg.md) — application/PV backups (PR #4)
-- [Alerting](./alerting.md) — automated detection of backup failures (PR #6)
+- [Omni etcd backups](./omni-etcd-backups.md) — control-plane backups
+- [Velero + CNPG → R2](./velero-cnpg.md) — application/PV backups
+- [Alerting](./alerting.md) — automated detection of backup failures

--- a/docs/dr/velero-cnpg.md
+++ b/docs/dr/velero-cnpg.md
@@ -1,7 +1,7 @@
 # Application & volume backups — Velero + CloudNativePG → R2
 
 The application/PV backup tier. Etcd snapshots are handled by Omni
-([PR #3](./omni-etcd-backups.md)); this layer covers everything that lives
+(see [omni-etcd-backups.md](./omni-etcd-backups.md)); this layer covers everything that lives
 *inside* the cluster — Kubernetes objects, PVC contents, and Postgres data.
 
 ## Architecture
@@ -9,10 +9,10 @@ The application/PV backup tier. Etcd snapshots are handled by Omni
 ```
                 ┌─────────────────────────────────────┐
                 │  Cloudflare R2                      │
-                │  bucket: devantler-platform-backups │
-                │    omni-etcd/      (PR #3, Omni)    │
-                │    velero/         ← this PR        │
-                │    cnpg/<cluster>/ ← this PR        │
+                │  bucket: <your-bucket>              │
+                │    omni-etcd/      (Omni)           │
+                │    velero/         (this layer)     │
+                │    cnpg/<cluster>/ (this layer)     │
                 └─────────────────────────────────────┘
                               ▲           ▲
                               │           │
@@ -23,7 +23,7 @@ The application/PV backup tier. Etcd snapshots are handled by Omni
                        └──────────┘  └────────────────────┘
 ```
 
-Same R2 bucket as Omni etcd, separate prefixes (PR #3). Credentials are
+Same R2 bucket as Omni etcd, separate prefixes (see [omni-etcd-backups.md](./omni-etcd-backups.md)). Credentials are
 SOPS-encrypted in `variables-base-secret.enc.yaml` and substituted into both
 the Velero and CNPG secrets at Flux apply time.
 
@@ -39,15 +39,15 @@ the Velero and CNPG secrets at Flux apply time.
 - VolumeSnapshotLocation: **none**. Cost decision (CSI snapshots are billed
   per-GB on Hetzner Cloud, file-level on R2 is flat).
 - HA: 2 replicas, PDB minAvailable=1, hostname topologySpread, RollingUpdate
-  maxUnavailable=0 — same posture as the rest of the operator tier (PR #2b).
+  maxUnavailable=0 — same posture as the rest of the operator tier.
 - Daily schedule `daily-full` at 02:17, 14-day TTL, all namespaces except
   `kube-system` and `velero`. Long-term retention is enforced by R2 object
-  lock + lifecycle (PR #3) so even a misconfigured Velero cannot delete
+  lock + lifecycle (see [omni-etcd-backups.md](./omni-etcd-backups.md)) so even a misconfigured Velero cannot delete
   history beyond the 30-day governance window.
 
 ## CloudNativePG
 
-- The operator was already installed; this PR adds a **reusable Barman
+- The operator was already installed; the platform adds a **reusable Barman
   credentials Secret** (`cnpg-r2-credentials` in `cnpg-system`) that any
   future `Cluster` resource references via `barmanObjectStore.s3Credentials`.
 - The recipe is documented inline in
@@ -73,8 +73,9 @@ variable overrides in `k8s/clusters/local/variables/`:
 | `r2_secret_access_key` | `minio-local-development-only` (SOPS-encrypted)   |
 
 No code changes between local and prod — only the variable values differ.
-This is the whole point of the substitution layer: PR #7 (CI restore drill)
-will exercise the *exact* same `velero backup` / `velero restore` calls
+This is the whole point of the substitution layer: the CI restore drill
+(see [restore-drill.md](./restore-drill.md))
+exercises the *exact* same `velero backup` / `velero restore` calls
 that an operator would run against R2 in prod.
 
 The MinIO credentials are hard-coded local-only secrets. They are
@@ -101,7 +102,7 @@ spec:
   defaultVolumesToFsBackup: true
 EOF
 
-# Restore (e.g. into a fresh cluster after PR #3 etcd restore)
+# Restore (e.g. into a fresh cluster after etcd restore)
 kubectl -n velero create -f - <<EOF
 apiVersion: velero.io/v1
 kind: Restore
@@ -114,7 +115,7 @@ EOF
 ```
 
 For the full DR procedure (which order to restore in, expected RTO breakdown,
-etc.) see [`runbook.md`](./runbook.md) (PR #5).
+etc.) see [`runbook.md`](./runbook.md).
 
 ## Credential rotation
 
@@ -135,7 +136,7 @@ sops --set '["stringData"]["r2_secret_access_key"] "<new-secret>"' \
 
 ## Related
 
-- [Omni etcd backups](./omni-etcd-backups.md) (PR #3) — control-plane layer
-- [DR runbook](./runbook.md) (PR #5) — restore-from-zero procedure
-- [Alerting](./alerting.md) (PR #6) — alarms on missed backups / failures
-- [CI restore drill](../../.github/workflows/ci.yaml) (PR #7) — automated proof
+- [Omni etcd backups](./omni-etcd-backups.md) — control-plane layer
+- [DR runbook](./runbook.md) — restore-from-zero procedure
+- [Alerting](./alerting.md) — alarms on missed backups / failures
+- [CI restore drill](./restore-drill.md) — automated proof

--- a/docs/dr/velero-cnpg.md
+++ b/docs/dr/velero-cnpg.md
@@ -10,7 +10,7 @@ The application/PV backup tier. Etcd snapshots are handled by Omni
                 ┌─────────────────────────────────────┐
                 │  Cloudflare R2                      │
                 │  bucket: <your-bucket>              │
-                │    omni-etcd/      (Omni)           │
+                │    <cluster-name>/  (Omni)          │
                 │    velero/         (this layer)     │
                 │    cnpg/<cluster>/ (this layer)     │
                 └─────────────────────────────────────┘

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
@@ -143,7 +143,7 @@ spec:
 
     # Disable the bundled "default" Prometheus rules -- the chart ships
     # ~200 alerts that mostly aren't relevant for a homelab. We add our
-    # own focused PrometheusRule (rules/critical.yaml) instead.
+    # own focused PrometheusRule (k8s/bases/infrastructure/alerts/platform-critical.yaml) instead.
     defaultRules:
       create: false
 


### PR DESCRIPTION
## Summary

Refreshes the `docs/` directory and one in-code comment to make documentation OSS-friendly and factually accurate.

## Changes

### Generalization (OSS-friendly)
- Replace all internal PR number references (`PR #2a`, `#3`, `#4`, etc.) with descriptive links to the relevant doc files
- Replace `1Password` vault references with generic "secure vault" language
- Replace specific Cloudflare R2 endpoint (`634e9016...`) and bucket name (`devantler-platform-backups`) with `<your-bucket>` / `<account-id>` placeholders
- Remove hardware-specific "3× CX23 (24 GiB total)" from `alerting.md`

### Accuracy fixes
- **`restore-drill.md`**: Rewrote to match actual CI behavior — the workflow simulates data loss via namespace deletion, NOT a full cluster destroy+rebuild cycle
- **`alerting.md`**: Fixed wrong file path `rules/critical.yaml` → `k8s/bases/infrastructure/alerts/platform-critical.yaml`
- **`TEMPLATING.md`**: Fixed "Traefik" → "Cilium" in infrastructure description
- **`helm-release.yaml`**: Fixed comment referencing wrong PrometheusRule path

### Files changed (8)
| File | Change |
|---|---|
| `docs/TEMPLATING.md` | Traefik → Cilium |
| `docs/dr/README.md` | Remove PR# from table |
| `docs/dr/runbook.md` | Generalize vault/bucket refs, remove PR# refs, fix links |
| `docs/dr/omni-etcd-backups.md` | Placeholder bucket/endpoint, remove PR# refs |
| `docs/dr/velero-cnpg.md` | Generalize bucket refs, remove PR# refs |
| `docs/dr/alerting.md` | Fix file path, remove PR# and hardware refs |
| `docs/dr/restore-drill.md` | Rewrite to match actual CI (namespace deletion) |
| `k8s/.../helm-release.yaml` | Fix comment path |