### PR TITLE
ci: add require-checks-in-pr action to aggregate CI checks

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup KSail
-        uses: devantler-tech/actions/setup-ksail-cli@79063198d351a69bbd89369465004417ab01f173 # v3.0.0
+        uses: devantler-tech/actions/setup-ksail-cli@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0
 
       - name: ⚙️ Setup omnictl
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,7 +164,7 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup KSail
-        uses: devantler-tech/actions/setup-ksail-cli@79063198d351a69bbd89369465004417ab01f173 # v3.0.0
+        uses: devantler-tech/actions/setup-ksail-cli@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0
 
       - name: 🔐 Create SOPS Age key
         env:
@@ -306,7 +306,7 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup KSail
-        uses: devantler-tech/actions/setup-ksail-cli@79063198d351a69bbd89369465004417ab01f173 # v3.0.0
+        uses: devantler-tech/actions/setup-ksail-cli@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0
 
       - name: ⚙️ Setup omnictl
         env:
@@ -418,3 +418,24 @@ jobs:
           echo "::group::Recent events (warnings)"
           kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -50
           echo "::endgroup::"
+
+  ci-required-checks:
+    name: ✅ Required Checks
+    runs-on: ubuntu-latest
+    needs: [changes, system-test, restore-drill, deploy-dev]
+    if: always()
+    permissions: {}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: 📊 Evaluate job results
+        uses: devantler-tech/actions/require-checks-in-pr@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0
+        with:
+          job-results: >-
+            ${{ needs.changes.result }}
+            ${{ needs.system-test.result }}
+            ${{ needs.restore-drill.result }}
+            ${{ needs.deploy-dev.result }}

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -28,4 +28,4 @@ jobs:
         with:
           persist-credentials: false
       - name: 🔄 Sync labels
-        uses: devantler-tech/actions/sync-github-labels@79063198d351a69bbd89369465004417ab01f173 # v3.0.0
+        uses: devantler-tech/actions/sync-github-labels@1f66c91d45d374ceac9fe830a783444ebc9be958 # v3.2.0


### PR DESCRIPTION
## Summary

Add a `ci-required-checks` job to the CI workflow that aggregates all job results into a single required check using [`devantler-tech/actions/require-checks-in-pr`](https://github.com/devantler-tech/actions/tree/main/require-checks-in-pr). This gives the org-wide ruleset a single stable check name (`✅ Required Checks`) to require.

## Changes

- **`.github/workflows/ci.yaml`** — Add `ci-required-checks` job that depends on all existing jobs (`changes`, `system-test`, `restore-drill`, `deploy-dev`), runs with `if: always()`, and reports aggregate pass/fail
- **`.github/workflows/ci.yaml`**, **`cd.yaml`**, **`sync-labels.yaml`** — Bump `devantler-tech/actions/*` pins from v3.0.0 → v3.2.0