### PR TITLE
feat: add RWX storage support via Longhorn on Hetzner clusters

### DIFF
--- a/docs/rwx-storage.md
+++ b/docs/rwx-storage.md
@@ -124,7 +124,7 @@ When upgrading Talos nodes, **always use `--preserve`** to avoid wiping `/var/li
 talosctl upgrade --nodes <IP> --image <IMAGE> --preserve
 ```
 
-See [Longhorn Talos Linux Support](https://longhorn.io/docs/1.8.1/advanced-resources/os-distro-specific/talos-linux-support/#talos-linux-upgrades) for recovery steps if data is accidentally wiped.
+See [Longhorn Talos Linux Support](https://longhorn.io/docs/advanced-resources/os-distro-specific/talos-linux-support/#talos-linux-upgrades) for recovery steps if data is accidentally wiped.
 
 ## Scaling
 

--- a/docs/rwx-storage.md
+++ b/docs/rwx-storage.md
@@ -16,31 +16,47 @@ Hetzner Cloud Volume (per worker)
 
 ## Prerequisites
 
-### 1. Custom Talos ISO with Longhorn extensions
+### 1. Custom Talos installer image with Longhorn extensions
 
 Longhorn requires two Talos system extensions baked into the installer image:
 
 - `siderolabs/iscsi-tools` — iSCSI initiator/target for Longhorn's data plane
 - `siderolabs/util-linux-tools` — provides `fstrim` for Longhorn volume trimming
 
-Generate a custom ISO via [Talos Image Factory](https://factory.talos.dev):
+The extensions are configured via [Talos Image Factory](https://factory.talos.dev).
+A schematic ID encodes the set of extensions; it is referenced in
+`talos/cluster/install-image.yaml` as `machine.install.image`. Nodes boot
+from the standard Hetzner Talos ISO but install the custom image (with
+extensions) to disk during first boot or upgrade.
 
-1. Select **Talos v1.11.2** (matching the version pinned in `ksail.{dev,prod}.yaml`)
-2. Choose **Hetzner Cloud** as the platform
-3. Add system extensions: `iscsi-tools`, `util-linux-tools`
-4. Download the **ISO** (amd64)
-5. Upload to Hetzner Cloud:
-   ```bash
-   hcloud iso upload --name talos-v1.11.2-longhorn talos-amd64.iso
-   ```
-6. Note the ISO ID from the output
-7. Update `ksail.dev.yaml` and `ksail.prod.yaml`:
-   ```yaml
-   spec:
-     cluster:
-       talos:
-         iso: <NEW_ISO_ID>
-   ```
+To **regenerate the schematic** (e.g. when adding more extensions or bumping
+the Talos version):
+
+```bash
+# Create a new schematic via the Image Factory API
+curl -s -X POST https://factory.talos.dev/schematics \
+  -H 'Content-Type: application/yaml' -d '
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/iscsi-tools
+      - siderolabs/util-linux-tools
+      - siderolabs/qemu-guest-agent
+'
+# → {"id":"<SCHEMATIC_ID>"}
+
+# Update talos/cluster/install-image.yaml:
+#   machine.install.image: factory.talos.dev/installer/<SCHEMATIC_ID>:v<TALOS_VERSION>
+```
+
+To **apply the new image to existing nodes**:
+
+```bash
+talosctl upgrade \
+  --nodes <IP> \
+  --image factory.talos.dev/installer/<SCHEMATIC_ID>:v<TALOS_VERSION> \
+  --preserve
+```
 
 ### 2. Hetzner Cloud Volumes for workers
 

--- a/docs/rwx-storage.md
+++ b/docs/rwx-storage.md
@@ -18,10 +18,12 @@ Hetzner Cloud Volume (per worker)
 
 ### 1. Custom Talos installer image with Longhorn extensions
 
-Longhorn requires two Talos system extensions baked into the installer image:
+Longhorn requires two Talos system extensions baked into the installer image.
+The installer image also includes one additional recommended extension:
 
-- `siderolabs/iscsi-tools` — iSCSI initiator/target for Longhorn's data plane
-- `siderolabs/util-linux-tools` — provides `fstrim` for Longhorn volume trimming
+- `siderolabs/iscsi-tools` — **required** by Longhorn for the iSCSI initiator/target data plane
+- `siderolabs/util-linux-tools` — **required** by Longhorn for `fstrim` volume trimming
+- `siderolabs/qemu-guest-agent` — **recommended** for Hetzner Cloud VM integration (not required by Longhorn)
 
 The extensions are configured via [Talos Image Factory](https://factory.talos.dev).
 A schematic ID encodes the set of extensions; it is referenced in
@@ -69,13 +71,12 @@ Each worker node needs a dedicated Hetzner Cloud Volume mounted at `/var/lib/lon
 hcloud server list
 
 # Create a volume and attach it to a worker
+# Do NOT use --format — Talos expects to partition/format the disk itself
 # The volume appears as /dev/sdb on the worker
 hcloud volume create \
   --name <cluster>-worker-<n>-longhorn \
   --size 20 \
-  --server <worker-server-name> \
-  --format ext4 \
-  --location fsn1
+  --server <worker-server-name>
 ```
 
 The Talos machine config patch (`talos/workers/longhorn.yaml`) handles mounting `/dev/sdb` at `/var/lib/longhorn`.

--- a/docs/rwx-storage.md
+++ b/docs/rwx-storage.md
@@ -81,6 +81,10 @@ hcloud volume create \
 
 The Talos machine config patch (`talos/workers/longhorn.yaml`) handles mounting `/dev/sdb` at `/var/lib/longhorn`.
 
+> **Verify the device path** after attaching: on Hetzner Cloud, the first attached volume
+> consistently appears as `/dev/sdb`. Confirm with `talosctl disks --nodes <worker-ip>`.
+> If the volume shows a different path, update `talos/workers/longhorn.yaml` accordingly.
+
 ## StorageClasses
 
 | StorageClass | Default | Access Modes | Backing |

--- a/docs/rwx-storage.md
+++ b/docs/rwx-storage.md
@@ -75,7 +75,7 @@ hcloud server list
 # The volume appears as /dev/sdb on the worker
 hcloud volume create \
   --name <cluster>-worker-<n>-longhorn \
-  --size 20 \
+  --size 50 \
   --server <worker-server-name>
 ```
 
@@ -156,4 +156,13 @@ To change the Hetzner volume size:
 hcloud volume resize --size 50 <volume-id>
 ```
 
-After resizing, Longhorn detects the additional space automatically.
+After resizing, the Hetzner block device grows immediately but the XFS partition and filesystem must be expanded:
+
+```bash
+# From a privileged pod on the worker (or via talosctl debug container):
+sgdisk -e /dev/sdb          # Fix GPT to use all space
+growpart /dev/sdb 1          # Grow partition 1 to fill disk
+xfs_growfs /var/lib/longhorn # Expand XFS filesystem online
+```
+
+Longhorn detects the additional space automatically once the filesystem is grown.

--- a/docs/rwx-storage.md
+++ b/docs/rwx-storage.md
@@ -1,0 +1,138 @@
+# RWX Storage with Longhorn
+
+Longhorn provides ReadWriteMany (RWX) storage on Hetzner clusters (dev/prod) using dedicated Hetzner Cloud Volumes attached to each worker node. It replaces the `hcloud` StorageClass as the cluster default.
+
+> **Local Docker clusters do not support Longhorn** — the iSCSI kernel modules required by Longhorn are not available in Docker-based Talos containers.
+
+## Architecture
+
+```
+Hetzner Cloud Volume (per worker)
+  └── mounted at /var/lib/longhorn (Talos machine config)
+        └── Longhorn engine
+              ├── longhorn StorageClass (default — RWO + RWX)
+              └── hcloud StorageClass (non-default — Hetzner block only)
+```
+
+## Prerequisites
+
+### 1. Custom Talos ISO with Longhorn extensions
+
+Longhorn requires two Talos system extensions baked into the installer image:
+
+- `siderolabs/iscsi-tools` — iSCSI initiator/target for Longhorn's data plane
+- `siderolabs/util-linux-tools` — provides `fstrim` for Longhorn volume trimming
+
+Generate a custom ISO via [Talos Image Factory](https://factory.talos.dev):
+
+1. Select **Talos v1.11.2** (matching the version pinned in `ksail.{dev,prod}.yaml`)
+2. Choose **Hetzner Cloud** as the platform
+3. Add system extensions: `iscsi-tools`, `util-linux-tools`
+4. Download the **ISO** (amd64)
+5. Upload to Hetzner Cloud:
+   ```bash
+   hcloud iso upload --name talos-v1.11.2-longhorn talos-amd64.iso
+   ```
+6. Note the ISO ID from the output
+7. Update `ksail.dev.yaml` and `ksail.prod.yaml`:
+   ```yaml
+   spec:
+     cluster:
+       talos:
+         iso: <NEW_ISO_ID>
+   ```
+
+### 2. Hetzner Cloud Volumes for workers
+
+Each worker node needs a dedicated Hetzner Cloud Volume mounted at `/var/lib/longhorn`.
+
+**Create and attach volumes** (repeat for each worker):
+
+```bash
+# List servers to find worker names
+hcloud server list
+
+# Create a volume and attach it to a worker
+# The volume appears as /dev/sdb on the worker
+hcloud volume create \
+  --name <cluster>-worker-<n>-longhorn \
+  --size 20 \
+  --server <worker-server-name> \
+  --format ext4 \
+  --location fsn1
+```
+
+The Talos machine config patch (`talos/workers/longhorn.yaml`) handles mounting `/dev/sdb` at `/var/lib/longhorn`.
+
+## StorageClasses
+
+| StorageClass | Default | Access Modes | Backing |
+|---|---|---|---|
+| `longhorn` | ✅ Yes | RWO, RWX | Longhorn on Hetzner volumes |
+| `hcloud` | ❌ No | RWO only | Hetzner Cloud Block Storage |
+
+### Using RWX volumes
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-data
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  # storageClassName: longhorn  # optional — it's the default
+```
+
+### Using Hetzner block storage explicitly
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fast-block
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: hcloud
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+## Tunable variables
+
+These variables can be overridden per environment in `k8s/clusters/<env>/variables/variables-cluster-config-map.yaml`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `longhorn_replica_count` | `2` | Number of volume replicas (should match worker count) |
+| `longhorn_csi_attacher_replicas` | `1` | CSI attacher replica count |
+| `longhorn_csi_provisioner_replicas` | `1` | CSI provisioner replica count |
+| `longhorn_csi_resizer_replicas` | `1` | CSI resizer replica count |
+| `longhorn_csi_snapshotter_replicas` | `1` | CSI snapshotter replica count |
+| `longhorn_ui_replicas` | `1` | Longhorn UI replica count |
+
+## Talos upgrades
+
+When upgrading Talos nodes, **always use `--preserve`** to avoid wiping `/var/lib/longhorn`:
+
+```bash
+talosctl upgrade --nodes <IP> --image <IMAGE> --preserve
+```
+
+See [Longhorn Talos Linux Support](https://longhorn.io/docs/1.8.1/advanced-resources/os-distro-specific/talos-linux-support/#talos-linux-upgrades) for recovery steps if data is accidentally wiped.
+
+## Scaling
+
+To change the Hetzner volume size:
+
+```bash
+# Volumes can only be resized up, not down
+hcloud volume resize --size 50 <volume-id>
+```
+
+After resizing, Longhorn detects the additional space automatically.

--- a/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/dev/variables/variables-cluster-config-map.yaml
@@ -32,4 +32,6 @@ data:
   hetzner_lb_type: "lb11"
   # --- Hetzner Cloud Network ---
   hcloud_network: "dev-network"
+  # --- Longhorn distributed storage ---
+  longhorn_replica_count: "2"
 

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -35,4 +35,6 @@ data:
   hetzner_lb_type: "lb11"
   # --- Hetzner Cloud Network ---
   hcloud_network: "prod-network"
+  # --- Longhorn distributed storage ---
+  longhorn_replica_count: "2"
 

--- a/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
@@ -19,7 +19,11 @@ spec:
   # https://github.com/hetznercloud/csi-driver/blob/main/chart/values.yaml
   values:
     global:
-      enableProvidedByTopology: true
+      # enableProvidedByTopology adds an allowedTopologies constraint to the
+      # StorageClass that conflicts with the CSI provisioner's topology
+      # matching when volumeBindingMode is WaitForFirstConsumer.  Disabling
+      # it avoids "topology not in requisite" provisioning failures.
+      enableProvidedByTopology: false
     controller:
       replicaCount: ${hcloud_csi_controller_replicas:=2}
       hcloudVolumeDefaultLocation: fsn1

--- a/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
@@ -55,7 +55,7 @@ spec:
                       - "robot"
     storageClasses:
       - name: hcloud
-        defaultStorageClass: true
+        defaultStorageClass: false
         reclaimPolicy: Delete
         extraParameters:
           csi.storage.k8s.io/node-publish-secret-name: luks-encryption

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - hcloud-ccm/
   - hcloud-csi/
   - kubelet-serving-cert-approver/
+  - longhorn/
   - origin-ca-issuer/

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -53,9 +53,3 @@ spec:
 
     longhornUI:
       replicas: ${longhorn_ui_replicas:=1}
-
-    longhornManager:
-      tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -35,6 +35,10 @@ spec:
       defaultReplicaCount: ${longhorn_replica_count:=2}
       # Reclaim space from deleted volumes automatically.
       autoDeletePodWhenVolumeDetachedUnexpectedly: true
+      # Only create default disks on nodes explicitly labeled for storage.
+      # This prevents control plane nodes (which lack dedicated volumes)
+      # from hosting replicas and running out of memory.
+      createDefaultDiskOnLabeledNodesOnly: true
 
     persistence:
       # Longhorn is the default StorageClass (replaces hcloud for new PVCs).

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+  labels:
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  chart:
+    spec:
+      chart: longhorn
+      version: 1.8.2
+      sourceRef:
+        kind: HelmRepository
+        name: longhorn
+  interval: 10m0s
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  timeout: 10m
+  # https://github.com/longhorn/charts/blob/master/charts/longhorn/values.yaml
+  values:
+    defaultSettings:
+      defaultDataPath: /var/lib/longhorn
+      # Match the number of workers so every volume is replicated across
+      # all available nodes.
+      defaultReplicaCount: ${longhorn_replica_count:=2}
+      # Reclaim space from deleted volumes automatically.
+      autoDeletePodWhenVolumeDetachedUnexpectedly: true
+
+    persistence:
+      # Longhorn is the default StorageClass (replaces hcloud for new PVCs).
+      defaultClass: true
+      defaultClassReplicaCount: ${longhorn_replica_count:=2}
+      # RWX support via Longhorn's built-in NFS server.
+      defaultFsType: ext4
+      reclaimPolicy: Delete
+
+    # Resource-conscious settings for cx23 workers (2 vCPU, 4 GB RAM).
+    csi:
+      attacherReplicaCount: ${longhorn_csi_attacher_replicas:=1}
+      provisionerReplicaCount: ${longhorn_csi_provisioner_replicas:=1}
+      resizerReplicaCount: ${longhorn_csi_resizer_replicas:=1}
+      snapshotterReplicaCount: ${longhorn_csi_snapshotter_replicas:=1}
+
+    longhornUI:
+      replicas: ${longhorn_ui_replicas:=1}
+
+    longhornManager:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-repository.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-repository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+spec:
+  url: https://charts.longhorn.io

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - helm-release.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system
+  labels:
+    # Longhorn requires privileged pod security for its engine, manager,
+    # and CSI driver components.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/talos/cluster/install-image.yaml
+++ b/talos/cluster/install-image.yaml
@@ -1,8 +1,9 @@
-# Use a custom Talos installer image from the Image Factory that includes
-# the system extensions required by Longhorn:
-#   - siderolabs/iscsi-tools     (iSCSI initiator/target for Longhorn data plane)
-#   - siderolabs/util-linux-tools (fstrim for Longhorn volume trimming)
-#   - siderolabs/qemu-guest-agent (Hetzner Cloud VM integration)
+# Use a custom Talos installer image from the Image Factory that includes:
+#   Longhorn-required extensions:
+#     - siderolabs/iscsi-tools      (iSCSI initiator/target for Longhorn data plane)
+#     - siderolabs/util-linux-tools (fstrim for Longhorn volume trimming)
+#   Hetzner-recommended extension:
+#     - siderolabs/qemu-guest-agent (Hetzner Cloud VM integration)
 #
 # Schematic: https://factory.talos.dev/?arch=amd64&extensions=siderolabs%2Fiscsi-tools&extensions=siderolabs%2Fqemu-guest-agent&extensions=siderolabs%2Futil-linux-tools&target=hcloud&version=1.11.2
 machine:

--- a/talos/cluster/install-image.yaml
+++ b/talos/cluster/install-image.yaml
@@ -1,0 +1,10 @@
+# Use a custom Talos installer image from the Image Factory that includes
+# the system extensions required by Longhorn:
+#   - siderolabs/iscsi-tools     (iSCSI initiator/target for Longhorn data plane)
+#   - siderolabs/util-linux-tools (fstrim for Longhorn volume trimming)
+#   - siderolabs/qemu-guest-agent (Hetzner Cloud VM integration)
+#
+# Schematic: https://factory.talos.dev/?arch=amd64&extensions=siderolabs%2Fiscsi-tools&extensions=siderolabs%2Fqemu-guest-agent&extensions=siderolabs%2Futil-linux-tools&target=hcloud&version=1.11.2
+machine:
+  install:
+    image: factory.talos.dev/installer/e187c9b90f773cd8c84e5a3265c5554ee787b2fe67b508d9f955e90e7ae8c96c:v1.11.2

--- a/talos/workers/longhorn.yaml
+++ b/talos/workers/longhorn.yaml
@@ -1,0 +1,22 @@
+# Longhorn on Talos requires kubelet extra mounts so the CSI driver can
+# access the host data directory.  The /dev mount is required for
+# Longhorn to manage block devices directly.
+#
+# An extra Hetzner Cloud Volume must be attached to each worker and
+# mounted at /var/lib/longhorn (see machine.disks below).  The second
+# SCSI device (/dev/sdb) is the standard path for the first attached
+# Hetzner volume.
+machine:
+  disks:
+    - device: /dev/sdb
+      partitions:
+        - mountpoint: /var/lib/longhorn
+  kubelet:
+    extraMounts:
+      - destination: /var/lib/longhorn
+        type: bind
+        source: /var/lib/longhorn
+        options:
+          - bind
+          - rshared
+          - rw

--- a/talos/workers/longhorn.yaml
+++ b/talos/workers/longhorn.yaml
@@ -7,13 +7,13 @@
 # Hetzner volume.  Verify with `talosctl disks --nodes <worker-ip>` and
 # update the device path below if it differs on your nodes.
 machine:
+  nodeLabels:
+    node.longhorn.io/create-default-disk: "true"
   disks:
     - device: /dev/sdb
       partitions:
         - mountpoint: /var/lib/longhorn
   kubelet:
-    nodeLabels:
-      node.longhorn.io/create-default-disk: "true"
     extraMounts:
       - destination: /var/lib/longhorn
         type: bind

--- a/talos/workers/longhorn.yaml
+++ b/talos/workers/longhorn.yaml
@@ -1,6 +1,5 @@
 # Longhorn on Talos requires kubelet extra mounts so the CSI driver can
-# access the host data directory.  The /dev mount is required for
-# Longhorn to manage block devices directly.
+# access the host data directory.
 #
 # An extra Hetzner Cloud Volume must be attached to each worker and
 # mounted at /var/lib/longhorn (see machine.disks below).  The second

--- a/talos/workers/longhorn.yaml
+++ b/talos/workers/longhorn.yaml
@@ -11,6 +11,8 @@ machine:
       partitions:
         - mountpoint: /var/lib/longhorn
   kubelet:
+    nodeLabels:
+      node.longhorn.io/create-default-disk: "true"
     extraMounts:
       - destination: /var/lib/longhorn
         type: bind

--- a/talos/workers/longhorn.yaml
+++ b/talos/workers/longhorn.yaml
@@ -4,7 +4,8 @@
 # An extra Hetzner Cloud Volume must be attached to each worker and
 # mounted at /var/lib/longhorn (see machine.disks below).  The second
 # SCSI device (/dev/sdb) is the standard path for the first attached
-# Hetzner volume.
+# Hetzner volume.  Verify with `talosctl disks --nodes <worker-ip>` and
+# update the device path below if it differs on your nodes.
 machine:
   disks:
     - device: /dev/sdb


### PR DESCRIPTION
## Summary

Deploy Longhorn as the default StorageClass on Hetzner (dev/prod) clusters, providing native ReadWriteMany (RWX) support via its built-in NFS server. Follows the approach of attaching dedicated Hetzner Cloud Volumes to each worker node and having Longhorn manage distributed, replicated storage on top.

## Changes

- **Longhorn Flux resources** — `k8s/providers/hetzner/infrastructure/controllers/longhorn/` with HelmRelease (v1.8.2), HelmRepository, namespace (`longhorn-system` with privileged PSS), and kustomization
- **Talos worker patch** — `talos/workers/longhorn.yaml` mounts `/dev/sdb` at `/var/lib/longhorn` and adds kubelet extra mounts for the CSI driver
- **hcloud StorageClass demoted** — `defaultStorageClass: false` so Longhorn takes over as the cluster default
- **Per-env variables** — `longhorn_replica_count` added to dev/prod ConfigMaps (defaults to `2`)
- **Documentation** — `docs/rwx-storage.md` covers prerequisites, custom Talos ISO generation, volume provisioning, StorageClass usage, and Talos upgrade safety

## Prerequisites (manual steps before deploying)

1. **Generate custom Talos ISO** with `iscsi-tools` + `util-linux-tools` extensions via [Talos Image Factory](https://factory.talos.dev), upload to Hetzner, and update ISO IDs in `ksail.{dev,prod}.yaml`
2. **Provision Hetzner volumes** — one per worker node, attached as `/dev/sdb`

See [docs/rwx-storage.md](docs/rwx-storage.md) for detailed instructions.

## Architecture

| StorageClass | Default | Access Modes | Backing |
|---|---|---|---|
| `longhorn` | ✅ Yes | RWO, RWX | Longhorn on dedicated Hetzner volumes |
| `hcloud` | ❌ No | RWO only | Hetzner Cloud Block Storage |

> **Note**: Local Docker clusters are not affected — Longhorn requires iSCSI kernel modules unavailable in Docker-based Talos.