### PR TITLE
fix(ci): restore kubeconfig from secret before cluster update

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -41,11 +41,11 @@ jobs:
         # Workaround: ksail cluster update can't refresh the Hetzner
         # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
         env:
-          PROD_KUBECONFIG: ${{ secrets.PROD_KUBECONFIG }}
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         run: |
           mkdir -p ~/.kube
           umask 077
-          echo "${PROD_KUBECONFIG}" > ~/.kube/config
+          echo "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
       - name: 🔄 Create or update cluster

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,18 +37,21 @@ jobs:
           echo "${SOPS_AGE_KEY}" > ~/.config/sops/age/keys.txt
           chmod 600 ~/.config/sops/age/keys.txt
 
+      - name: 🔑 Restore kubeconfig
+        # Workaround: ksail cluster update can't refresh the Hetzner
+        # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
+        env:
+          PROD_KUBECONFIG: ${{ secrets.PROD_KUBECONFIG }}
+        run: |
+          mkdir -p ~/.kube
+          umask 077
+          echo "${PROD_KUBECONFIG}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
       - name: 🔄 Create or update cluster
         run: |
           if ksail --config ksail.prod.yaml cluster info > /dev/null 2>&1; then
-            if [ -f "$HOME/.kube/config" ]; then
-              ksail --config ksail.prod.yaml cluster update
-            else
-              # Workaround: ksail cluster update can't refresh Hetzner
-              # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
-              echo "⚠️ Cluster exists but kubeconfig is missing. Recreating..."
-              ksail --config ksail.prod.yaml cluster delete --force || true
-              ksail --config ksail.prod.yaml cluster create
-            fi
+            ksail --config ksail.prod.yaml cluster update
           else
             ksail --config ksail.prod.yaml cluster create
           fi

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -40,7 +40,15 @@ jobs:
       - name: 🔄 Create or update cluster
         run: |
           if ksail --config ksail.prod.yaml cluster info > /dev/null 2>&1; then
-            ksail --config ksail.prod.yaml cluster update
+            if [ -f "$HOME/.kube/config" ]; then
+              ksail --config ksail.prod.yaml cluster update
+            else
+              # Workaround: ksail cluster update can't refresh Hetzner
+              # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
+              echo "⚠️ Cluster exists but kubeconfig is missing. Recreating..."
+              ksail --config ksail.prod.yaml cluster delete --force || true
+              ksail --config ksail.prod.yaml cluster create
+            fi
           else
             ksail --config ksail.prod.yaml cluster create
           fi

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           mkdir -p ~/.kube
           umask 077
-          echo "${KUBE_CONFIG}" > ~/.kube/config
+          printf '%s' "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
       - name: 🔄 Update cluster

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -38,8 +38,11 @@ jobs:
           chmod 600 ~/.config/sops/age/keys.txt
 
       - name: 🔑 Restore kubeconfig
-        # Workaround: ksail cluster update can't refresh the Hetzner
-        # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
+        # ksail cluster update needs a valid kubeconfig to detect the current
+        # cluster state. Without it, the component detector returns defaults and
+        # triggers spurious changes that all fail. The KUBE_CONFIG secret must be
+        # kept up-to-date from the homelab after any cluster recreation.
+        # See devantler-tech/ksail#4369 for the upstream design context.
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         run: |
@@ -48,13 +51,8 @@ jobs:
           echo "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
-      - name: 🔄 Create or update cluster
-        run: |
-          if ksail --config ksail.prod.yaml cluster info > /dev/null 2>&1; then
-            ksail --config ksail.prod.yaml cluster update
-          else
-            ksail --config ksail.prod.yaml cluster create
-          fi
+      - name: 🔄 Update cluster
+        run: ksail --config ksail.prod.yaml cluster update
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,11 +156,11 @@ jobs:
         # Workaround: ksail cluster update can't refresh the Hetzner
         # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
         env:
-          DEV_KUBECONFIG: ${{ secrets.DEV_KUBECONFIG }}
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         run: |
           mkdir -p ~/.kube
           umask 077
-          echo "${DEV_KUBECONFIG}" > ~/.kube/config
+          echo "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
       - name: 🔄 Create or update cluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,18 +152,21 @@ jobs:
           echo "${SOPS_AGE_KEY}" > ~/.config/sops/age/keys.txt
           chmod 600 ~/.config/sops/age/keys.txt
 
+      - name: 🔑 Restore kubeconfig
+        # Workaround: ksail cluster update can't refresh the Hetzner
+        # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
+        env:
+          DEV_KUBECONFIG: ${{ secrets.DEV_KUBECONFIG }}
+        run: |
+          mkdir -p ~/.kube
+          umask 077
+          echo "${DEV_KUBECONFIG}" > ~/.kube/config
+          chmod 600 ~/.kube/config
+
       - name: 🔄 Create or update cluster
         run: |
           if ksail --config ksail.dev.yaml cluster info > /dev/null 2>&1; then
-            if [ -f "$HOME/.kube/config" ]; then
-              ksail --config ksail.dev.yaml cluster update
-            else
-              # Workaround: ksail cluster update can't refresh Hetzner
-              # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
-              echo "⚠️ Cluster exists but kubeconfig is missing. Recreating..."
-              ksail --config ksail.dev.yaml cluster delete --force || true
-              ksail --config ksail.dev.yaml cluster create
-            fi
+            ksail --config ksail.dev.yaml cluster update
           else
             ksail --config ksail.dev.yaml cluster create
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,8 +153,11 @@ jobs:
           chmod 600 ~/.config/sops/age/keys.txt
 
       - name: 🔑 Restore kubeconfig
-        # Workaround: ksail cluster update can't refresh the Hetzner
-        # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
+        # ksail cluster update needs a valid kubeconfig to detect the current
+        # cluster state. Without it, the component detector returns defaults and
+        # triggers spurious changes that all fail. The KUBE_CONFIG secret must be
+        # kept up-to-date from the homelab after any cluster recreation.
+        # See devantler-tech/ksail#4369 for the upstream design context.
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         run: |
@@ -163,13 +166,8 @@ jobs:
           echo "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
-      - name: 🔄 Create or update cluster
-        run: |
-          if ksail --config ksail.dev.yaml cluster info > /dev/null 2>&1; then
-            ksail --config ksail.dev.yaml cluster update
-          else
-            ksail --config ksail.dev.yaml cluster create
-          fi
+      - name: 🔄 Update cluster
+        run: ksail --config ksail.dev.yaml cluster update
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,15 @@ jobs:
       - name: 🔄 Create or update cluster
         run: |
           if ksail --config ksail.dev.yaml cluster info > /dev/null 2>&1; then
-            ksail --config ksail.dev.yaml cluster update
+            if [ -f "$HOME/.kube/config" ]; then
+              ksail --config ksail.dev.yaml cluster update
+            else
+              # Workaround: ksail cluster update can't refresh Hetzner
+              # kubeconfig on ephemeral runners (devantler-tech/ksail#4369).
+              echo "⚠️ Cluster exists but kubeconfig is missing. Recreating..."
+              ksail --config ksail.dev.yaml cluster delete --force || true
+              ksail --config ksail.dev.yaml cluster create
+            fi
           else
             ksail --config ksail.dev.yaml cluster create
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
         run: |
           mkdir -p ~/.kube
           umask 077
-          echo "${KUBE_CONFIG}" > ~/.kube/config
+          printf '%s' "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
       - name: 🔄 Update cluster


### PR DESCRIPTION
## Summary

`ksail cluster update` fails on ephemeral CI runners because `RefreshKubeconfig` is a no-op for Hetzner Talos clusters. The kubeconfig generated during `cluster create` doesn't persist between workflow runs, causing all component reconciliation to fail:

```
✗ failed to install Flux: failed to create helm client:
  failed to access kubeconfig file: stat /home/runner/.kube/config: no such file or directory
```

This started after #1424 (migrate from Omni to Hetzner provider). With Omni, `RefreshKubeconfig` fetched credentials from the Omni API. With Hetzner, it's a no-op.

## Changes

- **CI workflow** (`ci.yaml`): Restore kubeconfig from `KUBE_CONFIG` GitHub secret before running `cluster update`
- **CD workflow** (`cd.yaml`): Same for prod

The cluster lifecycle (create/delete) is managed exclusively from the homelab. CI/CD only runs `cluster update` against an existing cluster, relying on a fresh kubeconfig written to the `KUBE_CONFIG` environment secret after each cluster recreation.

## Root Cause

In ksail's Talos provisioner, [`RefreshKubeconfig`](https://github.com/devantler-tech/ksail/blob/main/pkg/svc/provisioner/cluster/talos/provisioner.go#L262-L274) returns `nil` immediately for non-Omni providers, leaving the kubeconfig unrefreshed.

## Upstream Issue

Filed as devantler-tech/ksail#4369 — once ksail implements kubeconfig refresh for Hetzner, the `KUBE_CONFIG` secret dependency can be removed.

Fixes the merge queue blockage affecting all PRs with k8s changes.