### PR TITLE
fix: enable CSI and persistence for FleetDM on local Docker clusters

### DIFF
--- a/k8s/bases/cluster/apps-flux-kustomization.yaml
+++ b/k8s/bases/cluster/apps-flux-kustomization.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 60m
-  timeout: 3m
+  timeout: 5m
   retryInterval: 2m
   path: providers/__PROVIDER__/apps
   sourceRef:

--- a/k8s/providers/docker/apps/fleetdm/patches/helm-release-patch.yaml
+++ b/k8s/providers/docker/apps/fleetdm/patches/helm-release-patch.yaml
@@ -8,20 +8,19 @@ spec:
     replicas: 1
     vulnProcessing:
       dedicated: false
-    # Local Docker cluster has no default StorageClass (see minio pattern:
-    # emptyDir for local S3). Disable persistence for both MySQL and Redis
-    # so stateful pods can schedule. Data is throw-away in local/CI.
     mysql:
       architecture: standalone
       secondary:
         replicaCount: 0
       primary:
         persistence:
-          enabled: false
+          enabled: true
+          size: 2Gi
     redis:
       architecture: standalone
       replica:
         replicaCount: 0
       master:
         persistence:
-          enabled: false
+          enabled: true
+          size: 1Gi

--- a/k8s/providers/docker/infrastructure/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ../../../bases/infrastructure/
   - cluster-issuers/
+  - local-path-storage-namespace.yaml

--- a/k8s/providers/docker/infrastructure/local-path-storage-namespace.yaml
+++ b/k8s/providers/docker/infrastructure/local-path-storage-namespace.yaml
@@ -1,0 +1,12 @@
+---
+# Labels the local-path-storage namespace with privileged PSA enforcement.
+# The local-path-provisioner (CSI) creates short-lived helper pods that use
+# hostPath volumes to provision PVCs — this violates the default "baseline"
+# PodSecurity policy, so the namespace must be exempted.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/ksail.yaml
+++ b/ksail.yaml
@@ -14,6 +14,7 @@ spec:
     distribution: Talos
     provider: Docker
     cni: Cilium
+    csi: Enabled
     gitOpsEngine: Flux
     sops:
       ageKeyEnvVar: 


### PR DESCRIPTION
FleetDM reconciliation from scratch on local Docker clusters took 20+ minutes due to VPA Auto mode evicting MySQL/Redis pods that had no persistence. Eviction destroyed in-memory data, causing `fleet-migration` to succeed once but `fleet` to find an uninitialized DB on restart, entering CrashLoopBackOff.

The fix enables persistence so VPA evictions are non-destructive, while keeping VPA Auto mode fully active:

- **CSI**: Added `csi: Enabled` to `ksail.yaml` so KSail installs `local-path-provisioner`, providing a default `local-path` StorageClass
- **Persistence**: Enabled MySQL (2Gi) and Redis (1Gi) persistence in the Docker overlay patch
- **PodSecurity**: Added a `local-path-storage` namespace manifest with `privileged` PSA label in the Docker infrastructure layer -- the provisioner's hostPath helper pods are otherwise blocked by Talos's default `baseline` enforcement
- **Timeout**: Increased apps Flux Kustomization timeout from 3m to 5m to accommodate FleetDM's full startup chain (MySQL -> migration -> fleet)

Verified via full E2E test: cluster create, workload push, reconcile -- all Flux Kustomizations ready, all HelmReleases succeeded, FleetDM stable with PVCs bound.

## Type of change

Select the appropriate options and delete the rest:

- [x] 🪲 Bug fix