### PR TITLE
refactor(ci): use config timeout instead of CLI override

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: 🔁 Trigger Flux reconciliation
         id: reconcile
-        run: ksail --config ksail.prod.yaml workload reconcile --timeout 30m
+        run: ksail --config ksail.prod.yaml workload reconcile
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,19 +65,11 @@ jobs:
           hosts-file: ${{ vars.HOSTS_FILE }}
           root-ca-cert-file: ${{ vars.ROOT_CA_CERT_FILE }}
           push: "true"
-          # Reconcile handled by explicit step below so we can extend the
-          # timeout past the action's built-in default (the HA/DR stack
-          # adds Velero + MinIO + kube-prometheus-stack which can push
-          # reconciliation past the default 5m budget on GHA runners).
-          reconcile: "false"
+          reconcile: "true"
           delete: "false"
 
-      - name: 🔁 Reconcile with extended timeout
-        id: reconcile
-        run: ksail workload reconcile --timeout 30m
-
       - name: 🩺 Diagnose Flux on failure
-        if: failure() && steps.reconcile.outcome == 'failure'
+        if: failure()
         run: |
           set +e
           echo "::group::Nodes"
@@ -172,7 +164,7 @@ jobs:
 
       - name: 🔁 Trigger Flux reconciliation
         id: reconcile
-        run: ksail --config ksail.dev.yaml workload reconcile --timeout 30m
+        run: ksail --config ksail.dev.yaml workload reconcile
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}

--- a/ksail.dev.yaml
+++ b/ksail.dev.yaml
@@ -10,7 +10,7 @@ spec:
     distributionConfig: talos
     connection:
       context: admin@dev
-      timeout: 10m
+      timeout: 15m
     distribution: Talos
     provider: Hetzner
     cni: Cilium

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -10,7 +10,7 @@ spec:
     distributionConfig: talos
     connection:
       context: admin@prod
-      timeout: 10m
+      timeout: 15m
     distribution: Talos
     provider: Hetzner
     cni: Cilium

--- a/ksail.yaml
+++ b/ksail.yaml
@@ -10,7 +10,7 @@ spec:
     distributionConfig: talos-local
     connection:
       context: admin@local
-      timeout: 4m
+      timeout: 15m
     distribution: Talos
     provider: Docker
     cni: Cilium


### PR DESCRIPTION
The CI and CD workflows used `--timeout 30m` CLI overrides and a separate reconcile step to work around the default 5m reconcile timeout. KSail's `workload reconcile` already falls back to `spec.cluster.connection.timeout` from the config file, so we can set the timeout there instead and let the action handle reconciliation directly.

Analysis of recent CI runs showed reconcile times ranging from 4-11 minutes on GHA Docker runners and ~2 minutes on Hetzner prod. A 15m timeout gives comfortable headroom over the observed peak without the excessive 30m ceiling that would delay failure detection.

**Changes:**
- Set `connection.timeout: 15m` in `ksail.yaml` (was 4m), `ksail.dev.yaml` (was 10m), and `ksail.prod.yaml` (was 10m)
- Re-enabled `reconcile: "true"` in the CI system-test action, removing the separate reconcile step
- Dropped `--timeout 30m` from the dev and prod reconcile commands in `ci.yaml` and `cd.yaml`

## Type of change

- [x] 🧹 Refactor