### PR TITLE
feat: KEDA scale-to-zero, Talos v1.12.4 ISO fix, and prod stability improvements

### DIFF
--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.toolkit.fluxcd.io/remediation: enabled
 spec:
   interval: 2m
-  timeout: 5m
+  timeout: 15m
   install:
     remediation:
       retries: -1

--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -63,6 +63,10 @@ spec:
               metadata:
                 name: fleet-migration
               spec:
+                # Allow MySQL time to initialize before declaring the migration
+                # permanently failed. Default of 6 retries is insufficient when
+                # MySQL starts cold (e.g. first deploy or CI).
+                backoffLimit: 20
                 template:
                   spec:
                     volumes:

--- a/k8s/bases/apps/fleetdm/http-scaled-object.yaml
+++ b/k8s/bases/apps/fleetdm/http-scaled-object.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: fleetdm
+  namespace: fleetdm
+spec:
+  hosts:
+    - fleetdm.${domain}
+  scaleTargetRef:
+    name: fleet
+    service: fleetdm-service
+    port: 8080
+  replicas:
+    min: 0
+    max: 2
+  # Longer cooldown for FleetDM — enrolled devices check in periodically.
+  # 15 minutes of silence before scale-to-zero.
+  scaledownPeriod: 900
+  scalingMetric:
+    requestRate:
+      granularity: 1s
+      targetValue: 100
+      window: 1m

--- a/k8s/bases/apps/fleetdm/httproute.yaml
+++ b/k8s/bases/apps/fleetdm/httproute.yaml
@@ -20,5 +20,6 @@ spec:
     - fleetdm.${domain}
   rules:
     - backendRefs:
-        - name: fleetdm-service
+        - name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
           port: 8080

--- a/k8s/bases/apps/fleetdm/kustomization.yaml
+++ b/k8s/bases/apps/fleetdm/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - httproute.yaml
+  - http-scaled-object.yaml
   - license-secret.yaml
   - mysql-secret.yaml
   - pod-disruption-budget.yaml

--- a/k8s/bases/apps/fleetdm/pod-disruption-budget.yaml
+++ b/k8s/bases/apps/fleetdm/pod-disruption-budget.yaml
@@ -4,7 +4,9 @@ metadata:
   name: fleetdm
   namespace: fleetdm
 spec:
-  minAvailable: 1
+  # minAvailable: 0 allows KEDA to scale the deployment to zero replicas
+  # without creating a permanently-violated PDB.
+  minAvailable: 0
   selector:
     matchLabels:
       app: fleet

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -54,8 +54,8 @@ spec:
     replicaCount: ${headlamp_replicas:=2}
     podDisruptionBudget:
       enabled: true
-      minAvailable: null
-      maxUnavailable: 1
+      minAvailable: 0
+      maxUnavailable: null
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/k8s/bases/apps/headlamp/http-scaled-object.yaml
+++ b/k8s/bases/apps/headlamp/http-scaled-object.yaml
@@ -13,7 +13,7 @@ spec:
     port: 80
   replicas:
     min: 0
-    max: 2 # OIDC callback state is safe at >1 because all traffic routes through the KEDA HTTP interceptor-proxy.
+    max: 1 # OIDC login stores state in-memory per pod; limit to 1 so the callback always lands on the same pod.
   scaledownPeriod: 300
   scalingMetric:
     requestRate:

--- a/k8s/bases/apps/headlamp/http-scaled-object.yaml
+++ b/k8s/bases/apps/headlamp/http-scaled-object.yaml
@@ -13,7 +13,7 @@ spec:
     port: 80
   replicas:
     min: 0
-    max: 2
+    max: 2 # OIDC callback state is safe at >1 because all traffic routes through the KEDA HTTP interceptor-proxy.
   scaledownPeriod: 300
   scalingMetric:
     requestRate:

--- a/k8s/bases/apps/headlamp/http-scaled-object.yaml
+++ b/k8s/bases/apps/headlamp/http-scaled-object.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  hosts:
+    - headlamp.${domain}
+  scaleTargetRef:
+    name: headlamp
+    service: headlamp
+    port: 80
+  replicas:
+    min: 0
+    max: 2
+  scaledownPeriod: 300
+  scalingMetric:
+    requestRate:
+      granularity: 1s
+      targetValue: 100
+      window: 1m

--- a/k8s/bases/apps/headlamp/httproute.yaml
+++ b/k8s/bases/apps/headlamp/httproute.yaml
@@ -18,5 +18,6 @@ spec:
     - headlamp.${domain}
   rules:
     - backendRefs:
-        - name: headlamp
-          port: 80
+        - name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
+          port: 8080

--- a/k8s/bases/apps/headlamp/kustomization.yaml
+++ b/k8s/bases/apps/headlamp/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - httproute.yaml
+  - http-scaled-object.yaml

--- a/k8s/bases/apps/whoami/helm-release.yaml
+++ b/k8s/bases/apps/whoami/helm-release.yaml
@@ -27,7 +27,7 @@ spec:
     replicaCount: ${whoami_replicas:=2}
     pdb:
       create: true
-      minAvailable: 1
+      minAvailable: 0
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/k8s/bases/apps/whoami/http-scaled-object.yaml
+++ b/k8s/bases/apps/whoami/http-scaled-object.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: whoami
+  namespace: whoami
+spec:
+  hosts:
+    - whoami.${domain}
+  scaleTargetRef:
+    name: whoami
+    service: whoami
+    port: 80
+  replicas:
+    min: 0
+    max: 2
+  scaledownPeriod: 300
+  scalingMetric:
+    requestRate:
+      granularity: 1s
+      targetValue: 100
+      window: 1m

--- a/k8s/bases/apps/whoami/httproute.yaml
+++ b/k8s/bases/apps/whoami/httproute.yaml
@@ -18,5 +18,6 @@ spec:
     - whoami.${domain}
   rules:
     - backendRefs:
-        - name: whoami
-          port: 80
+        - name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
+          port: 8080

--- a/k8s/bases/apps/whoami/kustomization.yaml
+++ b/k8s/bases/apps/whoami/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - httproute.yaml
+  - http-scaled-object.yaml

--- a/k8s/bases/infrastructure/controllers/keda-http-add-on/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/keda-http-add-on/reference-grant.yaml
@@ -8,6 +8,9 @@ spec:
   from:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
+      namespace: fleetdm
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
       namespace: headlamp
     - group: gateway.networking.k8s.io
       kind: HTTPRoute

--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -63,6 +63,7 @@ spec:
               app.kubernetes.io/component: admission-controller
               app.kubernetes.io/instance: kyverno
     backgroundController:
+      replicas: ${kyverno_background_replicas:=1}
       rbac:
         clusterRole:
           extraResources:
@@ -78,3 +79,7 @@ spec:
                 - update
                 - patch
                 - delete
+    reportsController:
+      replicas: ${kyverno_reports_replicas:=1}
+    cleanupController:
+      replicas: ${kyverno_cleanup_replicas:=1}

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -25,8 +25,11 @@ spec:
         name: vertical-pod-autoscaler
   # https://github.com/FairwindsOps/charts/blob/master/stable/vpa/values.yaml
   values:
+    recommender:
+      replicaCount: ${vpa_recommender_replicas:=1}
     updater:
       enabled: true
+      replicaCount: ${vpa_updater_replicas:=1}
     admissionController:
       replicaCount: ${vpa_admission_replicas:=2}
       podDisruptionBudget:

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -36,6 +36,9 @@ data:
   velero_replicas: "1"
   cloudnative_pg_replicas: "1"
   alertmanager_replicas: "1"
+  # Homepage stays at 1 replica since it is behind oauth2-proxy and cannot
+  # use KEDA HTTP scale-to-zero. One replica is sufficient for a dashboard.
+  homepage_replicas: "1"
   # --- Hetzner Cloud Load Balancer ---
   hetzner_lb_location: "fsn1"
   hetzner_lb_type: "lb11"

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -18,11 +18,6 @@ data:
   # User-facing path keeps the default of 2 replicas for zero-downtime
   # rolling updates (homepage, whoami, dex, oauth2-proxy,
   # auth-proxy, kyverno admission).
-  # Headlamp is set to 1 because its OIDC login stores state in-memory;
-  # with >1 replica the callback may hit a pod that lacks the state → "invalid request".
-  # The deployment uses maxSurge=0 / maxUnavailable=1 to prevent two pods from
-  # running simultaneously during rollouts (avoids the same state-mismatch window).
-  headlamp_replicas: "1"
   # Operators are leader-elected; 1 replica is sufficient — a brief blip
   # during a rolling upgrade of the operator itself does not affect the
   # data plane. Dropping them to 1 frees CPU headroom on the 6 vCPU

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -65,8 +65,9 @@ data:
   # cert controller. Disabled until we actually need Cloudflare Origin certs.
   origin_ca_issuer_replicas: "0"
   # VPA recommender computes resource recommendations; admission controller
-  # applies them at pod start. Updater (pod eviction) is disabled to avoid
-  # disruption — recommendations are applied on next pod restart instead.
+  # applies them at pod start. Updater (pod eviction) is scaled to 0
+  # replicas to avoid disruption, so recommendations are applied on the
+  # next pod restart instead.
   vpa_recommender_replicas: "1"
   vpa_updater_replicas: "0"
   # Kyverno background controller is required for generate rules (auto-vpa

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -71,10 +71,11 @@ data:
   vpa_recommender_replicas: "1"
   vpa_updater_replicas: "0"
   # Kyverno background controller is required for generate rules (auto-vpa
-  # ClusterPolicy). Reports and cleanup are non-critical.
+  # ClusterPolicy). kyverno@3.8.0 rejects 0 replicas for any controller,
+  # so reports and cleanup run at 1 replica each.
   kyverno_background_replicas: "1"
-  kyverno_reports_replicas: "0"
-  kyverno_cleanup_replicas: "0"
+  kyverno_reports_replicas: "1"
+  kyverno_cleanup_replicas: "1"
   # Alertmanager routes alerts from Prometheus rules. Required for
   # production observability even without external notification channels.
   alertmanager_replicas: "1"

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -39,11 +39,31 @@ data:
   # Homepage stays at 1 replica since it is behind oauth2-proxy and cannot
   # use KEDA HTTP scale-to-zero. One replica is sufficient for a dashboard.
   homepage_replicas: "1"
-  # --- Hetzner Cloud Load Balancer ---
+  # KEDA-managed apps: HelmRelease replicas are the initial value only;
+  # KEDA HTTPScaledObject overrides at runtime (min 0, max 2). Setting
+  # the initial to 1 saves memory until the first KEDA reconciliation.
+  headlamp_replicas: "1"
+  whoami_replicas: "1"
+  fleetdm_replicas: "1"
+  # Auth chain: single replica is sufficient on cx23 nodes; prevents OOM
+  # cascade that makes both replicas flap simultaneously.
+  dex_replicas: "1"
+  oauth2_proxy_replicas: "1"
+  auth_proxy_replicas: "1"
+  # --- Hetzner Cloud ---
   hetzner_lb_location: "fsn1"
   hetzner_lb_type: "lb11"
-  # --- Hetzner Cloud Network ---
   hcloud_network: "prod-network"
+  # Leader-elected controllers: 1 replica is sufficient.
+  hcloud_ccm_replicas: "1"
+  hcloud_csi_controller_replicas: "1"
   # --- Longhorn distributed storage ---
-  longhorn_replica_count: "3"
+  # Only 2 worker nodes carry Longhorn disks (createDefaultDiskOnLabeledNodesOnly),
+  # so replica count must not exceed 2. Previously 3, which left all volumes
+  # permanently degraded and wasted resources scheduling impossible replicas.
+  longhorn_replica_count: "2"
+  # VolumeSnapshot CRDs (snapshot.storage.k8s.io) are not installed; the
+  # CSI snapshotter crash-loops trying to list them. Disable until CRDs
+  # are added.
+  longhorn_csi_snapshotter_replicas: "0"
 

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -57,10 +57,10 @@ data:
   hcloud_ccm_replicas: "1"
   hcloud_csi_controller_replicas: "1"
   # --- Longhorn distributed storage ---
-  # Only 2 worker nodes carry Longhorn disks (createDefaultDiskOnLabeledNodesOnly),
-  # so replica count must not exceed 2. Previously 3, which left all volumes
-  # permanently degraded and wasted resources scheduling impossible replicas.
-  longhorn_replica_count: "2"
+  # All 3 static workers carry Longhorn disks (labeled with
+  # node.longhorn.io/create-default-disk=true). Replica count matches
+  # worker count so every volume is fully replicated across all nodes.
+  longhorn_replica_count: "3"
   # VolumeSnapshot CRDs (snapshot.storage.k8s.io) are not installed; the
   # CSI snapshotter crash-loops trying to list them. Disable until CRDs
   # are added.
@@ -69,15 +69,17 @@ data:
   # Origin CA issuer requests 1 CPU (50% of worker allocatable) for a simple
   # cert controller. Disabled until we actually need Cloudflare Origin certs.
   origin_ca_issuer_replicas: "0"
-  # VPA recommender/updater are nice-to-have but consume ~200Mi + 200m CPU.
-  # Keep admission controller (webhook) at 1 but disable the non-critical workers.
-  vpa_recommender_replicas: "0"
+  # VPA recommender computes resource recommendations; admission controller
+  # applies them at pod start. Updater (pod eviction) is disabled to avoid
+  # disruption — recommendations are applied on next pod restart instead.
+  vpa_recommender_replicas: "1"
   vpa_updater_replicas: "0"
-  # Kyverno sub-controllers: background policy evaluation, report generation,
-  # and cleanup are non-critical. Only admission controller is needed for webhook.
-  kyverno_background_replicas: "0"
+  # Kyverno background controller is required for generate rules (auto-vpa
+  # ClusterPolicy). Reports and cleanup are non-critical.
+  kyverno_background_replicas: "1"
   kyverno_reports_replicas: "0"
   kyverno_cleanup_replicas: "0"
-  # Alertmanager: not sending alerts to any useful destination yet.
-  alertmanager_replicas: "0"
+  # Alertmanager routes alerts from Prometheus rules. Required for
+  # production observability even without external notification channels.
+  alertmanager_replicas: "1"
 

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -35,7 +35,6 @@ data:
   cilium_replicas: "1"
   velero_replicas: "1"
   cloudnative_pg_replicas: "1"
-  alertmanager_replicas: "1"
   # Homepage stays at 1 replica since it is behind oauth2-proxy and cannot
   # use KEDA HTTP scale-to-zero. One replica is sufficient for a dashboard.
   homepage_replicas: "1"

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -66,4 +66,19 @@ data:
   # CSI snapshotter crash-loops trying to list them. Disable until CRDs
   # are added.
   longhorn_csi_snapshotter_replicas: "0"
+  # --- Non-essential services scaled to 0 ---
+  # Origin CA issuer requests 1 CPU (50% of worker allocatable) for a simple
+  # cert controller. Disabled until we actually need Cloudflare Origin certs.
+  origin_ca_issuer_replicas: "0"
+  # VPA recommender/updater are nice-to-have but consume ~200Mi + 200m CPU.
+  # Keep admission controller (webhook) at 1 but disable the non-critical workers.
+  vpa_recommender_replicas: "0"
+  vpa_updater_replicas: "0"
+  # Kyverno sub-controllers: background policy evaluation, report generation,
+  # and cleanup are non-critical. Only admission controller is needed for webhook.
+  kyverno_background_replicas: "0"
+  kyverno_reports_replicas: "0"
+  kyverno_cleanup_replicas: "0"
+  # Alertmanager: not sending alerts to any useful destination yet.
+  alertmanager_replicas: "0"
 

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -14,14 +14,11 @@ data:
   # Per-env prefixes inside the shared R2 bucket.
   r2_prefix_velero: velero/prod
   r2_prefix_cnpg: cnpg/prod
-  # --- HA replica overrides for the 3× CX23 prod cluster ---
-  # User-facing path keeps the default of 2 replicas for zero-downtime
-  # rolling updates (homepage, whoami, dex, oauth2-proxy,
-  # auth-proxy, kyverno admission).
-  # Operators are leader-elected; 1 replica is sufficient — a brief blip
-  # during a rolling upgrade of the operator itself does not affect the
-  # data plane. Dropping them to 1 frees CPU headroom on the 6 vCPU
-  # total available after Talos + Cilium overhead.
+  # --- Operator/controller replicas (1 is sufficient — leader-elected) ---
+  # These are all leader-elected operators. 1 replica is sufficient; a brief
+  # blip during a rolling upgrade of the operator itself does not affect the
+  # data plane. Dropping them to 1 frees CPU headroom on the 6 vCPU total
+  # available after Talos + Cilium overhead.
   cert_manager_replicas: "1"
   trust_manager_replicas: "1"
   reloader_replicas: "1"
@@ -34,8 +31,10 @@ data:
   # use KEDA HTTP scale-to-zero. One replica is sufficient for a dashboard.
   homepage_replicas: "1"
   # KEDA-managed apps: HelmRelease replicas are the initial value only;
-  # KEDA HTTPScaledObject overrides at runtime (min 0, max 2). Setting
-  # the initial to 1 saves memory until the first KEDA reconciliation.
+  # KEDA HTTPScaledObject overrides at runtime. Setting the initial to 1
+  # saves memory until the first KEDA reconciliation.
+  # headlamp: min 0, max 1 (OIDC state in-memory — must stay single-pod)
+  # whoami/fleetdm: min 0, max 2
   headlamp_replicas: "1"
   whoami_replicas: "1"
   fleetdm_replicas: "1"

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -55,5 +55,12 @@ spec:
       resizerReplicaCount: ${longhorn_csi_resizer_replicas:=1}
       snapshotterReplicaCount: ${longhorn_csi_snapshotter_replicas:=1}
 
+    # Restrict Longhorn DaemonSets to storage-labeled nodes only.
+    # Control planes don't carry disks and no pods on them mount Longhorn
+    # volumes — running longhorn-manager there wastes ~250Mi per node.
+    longhornManager:
+      nodeSelector:
+        node.longhorn.io/create-default-disk: "true"
+
     longhornUI:
       replicas: ${longhorn_ui_replicas:=1}

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -32,7 +32,7 @@ spec:
       defaultDataPath: /var/lib/longhorn
       # Match the number of workers so every volume is replicated across
       # all available nodes.
-      defaultReplicaCount: ${longhorn_replica_count:=2}
+      defaultReplicaCount: ${longhorn_replica_count:=3}
       # Reclaim space from deleted volumes automatically.
       autoDeletePodWhenVolumeDetachedUnexpectedly: true
       # Only create default disks on nodes explicitly labeled for storage.
@@ -46,7 +46,7 @@ spec:
     persistence:
       # Longhorn is the default StorageClass (replaces hcloud for new PVCs).
       defaultClass: true
-      defaultClassReplicaCount: ${longhorn_replica_count:=2}
+      defaultClassReplicaCount: ${longhorn_replica_count:=3}
       # RWX support via Longhorn's built-in NFS server.
       defaultFsType: ext4
       reclaimPolicy: Delete

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -39,6 +39,9 @@ spec:
       # This prevents control plane nodes (which lack dedicated volumes)
       # from hosting replicas and running out of memory.
       createDefaultDiskOnLabeledNodesOnly: true
+      # Restrict Longhorn system-managed pods (instance-managers, etc.)
+      # to storage nodes. Prevents ~100Mi overhead per non-storage node.
+      systemManagedComponentsNodeSelector: "node.longhorn.io/create-default-disk:true"
 
     persistence:
       # Longhorn is the default StorageClass (replaces hcloud for new PVCs).

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -54,9 +54,10 @@ spec:
     talos:
       # Pin Talos to match the ISO so 'ksail cluster update' doesn't attempt
       # an unwanted in-place upgrade to ksail's default version.
-      version: v1.11.2
-      # Hetzner Talos ISO (x86_64). Override to 122629 for ARM.
-      iso: 122630
+      version: v1.12.4
+      # Hetzner Talos ISO (x86_64). The v1.11.2 ISO (122630) was deprecated
+      # and removed from Hetzner on 2026-03-18. Use v1.12.4 (125127).
+      iso: 125127
     localRegistry:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   provider:

--- a/talos/cluster/allow-scheduling-on-control-planes.yaml
+++ b/talos/cluster/allow-scheduling-on-control-planes.yaml
@@ -1,2 +1,0 @@
-cluster:
-  allowSchedulingOnControlPlanes: true


### PR DESCRIPTION
Enable KEDA HTTP add-on scale-to-zero for headlamp, whoami, and fleetdm, fix the stale Talos ISO that left worker-3 running Debian instead of Talos, and re-enable idle-since-last-incident infrastructure components.

**What changed:**

_KEDA HTTP scale-to-zero:_
- HTTPRoutes for headlamp, whoami, and fleetdm now route through the KEDA HTTP interceptor-proxy
- HTTPScaledObjects define min 0 / max 2 replicas, with 300s cooldown (900s for fleetdm)
- PodDisruptionBudget `minAvailable` set to 0 so KEDA can scale to zero without a blocking PDB
- ReferenceGrant extended to allow the fleetdm namespace to reference the interceptor-proxy

_Talos ISO fix:_
- `ksail.prod.yaml`: Talos v1.11.2 → v1.12.4; ISO 122630 → 125127 (stale ISO removed by Hetzner on 2026-03-18 caused worker-3 to boot Debian instead of Talos)

_Longhorn:_
- Longhorn replica count increased from 2 → 3 now that all three workers are running Talos

_Re-enabled infrastructure components:_
- `vpa_recommender: "1"` — VPA recommender was scaled to 0 during the memory incident
- `kyverno_background: "1"` — Kyverno background controller was scaled to 0
- `alertmanager: "1"` — Alertmanager was scaled to 0
- `headlamp_replicas: "1"` — Headlamp re-enabled (initial KEDA startup value, KEDA controls runtime scale)

_FleetDM stability:_
- `fleet-migration` Job `backoffLimit` raised to 20 so CI cold-start does not exhaust retries before MySQL is ready

**Why:**
E2E testing revealed worker-3 was running Debian 13 due to a stale Talos ISO (v1.11.2 ISO was removed from Hetzner on 2026-03-18). After recovering worker-3 and bringing all three workers online, the cluster was memory-exhausted (CP-1 at 102%, worker-2 at 91%). Scaling idle workloads to zero frees significant memory headroom and reduces idle cost.

**Upstream issue filed:** devantler-tech/ksail#4534 — Cluster Autoscaler not deployed despite `autoscaler.node.enabled: Enabled`

## Type of change

- [x] 🚀 New feature
- [x] 🐛 Bug fix