### PR TITLE
feat(homepage): single pane of glass for all cluster services

### DIFF
--- a/k8s/bases/apps/fleetdm/httproute.yaml
+++ b/k8s/bases/apps/fleetdm/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Fleet
     gethomepage.dev/description: Open-source device management (MDM + osquery).
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Device Management
     gethomepage.dev/icon: si-coderwall-#40B5A4
 spec:
   parentRefs:

--- a/k8s/bases/apps/headlamp/httproute.yaml
+++ b/k8s/bases/apps/headlamp/httproute.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Headlamp
     gethomepage.dev/description: A web UI for managing Kubernetes clusters.
-    gethomepage.dev/group: Management
+    gethomepage.dev/group: Kubernetes
     gethomepage.dev/icon: https://pbs.twimg.com/profile_images/1537480067227566080/waXG0X7n_400x400.jpg
 spec:
   parentRefs:

--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -72,10 +72,6 @@ data:
             href: https://unifi.ui.com
             description: Central hub for managing on-prem UniFi network infrastructure.
     - Analytics:
-        - Disqus:
-            icon: si-disqus-#2E9FFF
-            href: https://disqus.com
-            description: Platform to track and moderate embedded comments on my sites.
         - Google Analytics:
             icon: google-analytics
             href: https://analytics.google.com
@@ -84,10 +80,6 @@ data:
         - Grafana:
             icon: grafana
             href: https://devantler.grafana.net
-            description: Central hub for monitoring my infrastructure.
-        - BetterStack:
-            icon: https://cdn.brandfetch.io/idzOqqi9J1/w/400/h/400/theme/dark/icon.jpeg
-            href: https://telemetry.betterstack.com/
             description: Central hub for monitoring my infrastructure.
   bookmarks.yaml: |
     - Personal:

--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -18,6 +18,10 @@ data:
     layout:
       Kubernetes:
         icon: si-talos-#FF7300
+      Device Management:
+        icon: mdi-cellphone-cog
+      Diagnostics:
+        icon: mdi-stethoscope
       Cloud:
         icon: si-hetzner
       Network:
@@ -90,7 +94,7 @@ data:
         - Personal Site:
             - icon: github-light
               href: https://devantler.tech
-    - GitHub Organization:
+    - GitHub:
         - GitHub:
             - icon: github-light
               href: https://github.com
@@ -109,7 +113,7 @@ data:
         - Projects:
             - icon: si-github-#181717
               href: https://github.com/orgs/devantler-tech/projects/5
-    - Developer Platforms:
+    - Developer Tools:
         - Codecov:
             - icon: si-codecov-#F01F7A
               href: https://app.codecov.io
@@ -119,6 +123,12 @@ data:
         - Renovate:
             - icon: si-renovatebot-#007fa0
               href: https://developer.mend.io
+        - skills.sh:
+            - icon: mdi-certificate-outline
+              href: https://skills.sh
+        - lllm-stats.com:
+            - icon: mdi-chart-bar
+              href: https://lllm-stats.com
     - Kubernetes:
         - ArtifactHUB:
             - icon: si-artifacthub-#417598

--- a/k8s/bases/apps/whoami/httproute.yaml
+++ b/k8s/bases/apps/whoami/httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: whoami
   namespace: whoami
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Whoami
+    gethomepage.dev/description: HTTP echo service for network diagnostics.
+    gethomepage.dev/group: Diagnostics
+    gethomepage.dev/icon: mdi-network-check
 spec:
   parentRefs:
     - name: platform


### PR DESCRIPTION
The homepage at `platform.devantler.tech` was missing several cluster services and had outdated external service entries, making it an incomplete starting point for navigating the platform.

## Changes

**New cluster service on dashboard**
- Added `gethomepage.dev` annotations to the Whoami HTTPRoute so the echo service appears under a new **Diagnostics** group.

**Recategorized existing services by product type**
- Headlamp: `Management` -> `Kubernetes` (sits alongside Flux Status as a cluster management UI)
- FleetDM: `Management` -> `Device Management` (reflects its MDM/osquery product category)

**Updated homepage layout**
- Added layout entries with icons for the two new groups: `Device Management` (`mdi-cellphone-cog`) and `Diagnostics` (`mdi-stethoscope`).

**Bookmarks cleanup and additions**
- Renamed `GitHub Organization` -> `GitHub` (shorter, clearer)
- Renamed `Developer Platforms` -> `Developer Tools` (broader scope)
- Added `skills.sh` and `lllm-stats.com` under Developer Tools
- Removed Disqus (Analytics) and BetterStack (Monitoring) - no longer in use