### PR TITLE
fix(homepage): enable Gateway API HTTPRoute auto-discovery

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -32,6 +32,7 @@ data:
         icon: si-googleanalytics
   kubernetes.yaml: |
     mode: cluster
+    gateway: true
   widgets.yaml: |
     - logo:
         icon: https://avatars.githubusercontent.com/u/178524219?v=4&s=200


### PR DESCRIPTION
Homepage's Kubernetes service discovery was not picking up services annotated on Gateway API HTTPRoute resources because the `gateway: true` setting was missing from `kubernetes.yaml`. This adds that single setting so auto-discovery works for HTTPRoutes -- not just Ingresses.

Fixes #1473 follow-up (services not appearing on dashboard)

## Type of change

- [x] 🪲 Bug fix