### PR TITLE
feat(fleetdm): add premium license key

### DIFF
--- a/k8s/bases/apps/fleetdm/README.md
+++ b/k8s/bases/apps/fleetdm/README.md
@@ -42,6 +42,7 @@ substituted at Flux reconcile time:
 | `fleetdm_mysql_root_password` | MySQL root password. |
 | `fleetdm_mysql_replication_password` | MySQL replication user password. |
 | `fleetdm_redis_password` | Redis password. |
+| `fleetdm_license_key` | **Fleet premium license JWT.** Unlocks premium features. The current value is a trial license expiring 2025-05-01 — replace with a paid license before expiry or Fleet will revert to the free tier. |
 
 ### Rotating / regenerating
 

--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -117,6 +117,8 @@ spec:
       # TLS terminates at the platform Gateway (Traefik / Cilium).
       tls:
         enabled: false
+      license:
+        licenseKey: ${fleetdm_license_key}
     # Run vulnerability processing in a dedicated container so the API
     # pods don't OOM every hour during the scan.
     vulnProcessing:

--- a/k8s/clusters/local/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/local/variables/variables-cluster-secret.enc.yaml
@@ -16,6 +16,7 @@ stringData:
     fleetdm_mysql_root_password: ENC[AES256_GCM,data:XyBIoD1uu5MZjPcnoK0pBeeeBl4Jf5TJsAB5VA==,iv:nTTUgQ3PUoXhJeCadhb6XNUUl9ftoY03uwQA1AHt4Kg=,tag:uwnuYPW4BYHnVzpZuClXDA==,type:str]
     fleetdm_mysql_replication_password: ENC[AES256_GCM,data:kKwAZ4KvDySzS3ghIMBYjjpDXlm0LmOa7MGOgQ==,iv:acEBfNf8qUC0HyF/na24QU6BJRjNi0Oci1fbawVkB4Q=,tag:FnYs5rMPjJ8mBAO8kZWQyg==,type:str]
     fleetdm_redis_password: ENC[AES256_GCM,data:pn14I89hBxFcMtITVvyfFSmFD2xzTyqi32ZyZQ==,iv:7yZVScmLt4KBadC87kw4RGUJGALKOC9DMKD01Ty2TiQ=,tag:w1yOeRai3WRBrLFDOtnlsQ==,type:str]
+    fleetdm_license_key: ENC[AES256_GCM,data:+1E5ngW9DcFmes2WurDE4Lod0Hc+NxrLYo4aR43n92sNtPTexCjJIdp1NUZEcPA4q/bnC+Lv4JnXO78FBdYFHIcHXpoBIk8yBsSf/ACI9DfCSe+UGXv34ZNFa4Wq4rz358Oy64soB8m2YCNpK+jVzl2Zzr56wGbUo92tPou1Au1xE17zUN+oiFCxfBFWiNFU91wvgnn+ZI+nIgr8y/PB9dsX/cp+FRKHmuysXS4tN6atdQvhZ2TVvGrKpr0D/J52V5K4O0PcpMv2/HZKtKYAtq/3aTHJ5D6jmDPThKwIJooGbwl1Oj53Rn1nCzSA5pTvrJygnbKNvfkJQh3egGPtNbhQQ5WUhgqsPr0seKpoyTJhZcZrsejz/hX3WIi7cakrnCfeqFCICv2RAZACJ595f21Z7LpsJl0Ea/ZNEBOlN6MfZWlIBBLvvhvg5KUvr6uURXn4Q2gVq3qee3TtLg/zLWEVbJmgfg==,iv:NQNsTyKQy0LWumLchB7auN3/ru6qZ8bvry43vvdxAT4=,tag:Eu2niEcF3mw8z8yxUXbtyw==,type:str]
 sops:
     age:
         - recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
@@ -27,7 +28,7 @@ sops:
             SjBVZURpUkc4eGJ4eFFFcGV2SUJuVkEKPYKtlz5eBFjChW02JeKqJxviRkJIGU9t
             GrLSSCJvxfCt1dUEkef2/lwSaLIggjtvSJLOxNa7hqQCI86Di5trxA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-20T14:21:13Z"
-    mac: ENC[AES256_GCM,data:/SibU1D/g2B2vTUYkVW+ekJ41DBx4m6pA3XdSXNjLWco6nALLXVPPWPWpSDl+zDUXWeBAZ8f3zs58X0fNi1X11l53i56R35jyufF9MKDK/UUd/e4Hi3WRQ02I3Ajqlz2DYeB4h5tJ2WRRW3V5S2rO358mpzJWME+U34c7lJp+hQ=,iv:KS52vjORE6CN6+ZOasOUv3G8SbNA8BWCIh2WsBBeYxE=,tag:xShc3U+Ng0poUsHrsQYHDw==,type:str]
+    lastmodified: "2026-05-03T09:27:48Z"
+    mac: ENC[AES256_GCM,data:MelPfV/fO8aVjGormsqudzgTjPqx+xWmdzTNOySZcYIyqbG+733deMIQ6yJMCET6oO3hi+bWNEkc0mzip2lstx/ByyIcxlDBc0/cIHKeb3zEpMNrQqGF9TpFmTxsahQrrivVvb5O0X9otcW9JPsKVAZMKCcWb48gpyg38d6Uf1c=,iv:ug/lTht20MZu56hBHko3QGDV/aOpn5h5r3iN5OVjtxg=,tag:nI1Ewqc48oQjWMGyAU+/tQ==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-secret.enc.yaml
@@ -18,6 +18,7 @@ stringData:
     fleetdm_mysql_root_password: ENC[AES256_GCM,data:IeBcQNmB0exCwq20xeVWH+7og4z7aZnsFhKYHQ==,iv:UdN57SactXnvosVzax1KU4MZYAuJSv0K95lqsfNcNt8=,tag:2L18k/R/6+or/uqOrqCcGA==,type:str]
     fleetdm_mysql_replication_password: ENC[AES256_GCM,data:XPbyWt+VNCBP0BZDh+T0RNpnSzaejAjZGUtVLA==,iv:8M1ZUK5PBpDkawDpC4wOwOvnAt+/UWL60ia45wblb/g=,tag:sD9ZiF9ii7W7FosZLbjydw==,type:str]
     fleetdm_redis_password: ENC[AES256_GCM,data:vI+eG0CBmJS06fbpyt0ItA2mwz6Aho53Uz/ZCA==,iv:vfofWc8rWMJgwCGP9fMmpMZJYdgupNE0BaV7Jm/EmPQ=,tag:T9tou8hWP2dQvsLfG4ZEJQ==,type:str]
+    fleetdm_license_key: ENC[AES256_GCM,data:TcgYxslcyxcP6Shtl/oaduDdSDDew5LRrb+e2mUpmHUFEf5MxWkuHMnbN4weC/a6h43cRyBO4J/wR9ebgXbyV83cPgu2OyNWnVhjYleUhBScrmY49m0YJ7wV9D1qw6ZK7FOMb4+LhiXjObSatSz4j0zFF2oLOGRNFxa0byB8hjJjYNDhCjyyECt1+j61EZzhYsyxVKQhu2EXtEO01jTJV/bPC1emf9q8xD0KssmQC6fTOpc1PwxTv1ALWuqGtlJAVNak3JVwplRed5BCavBNIdlWz6UYRq+JJLVOzGu3KhD7k6xOtaLofCjz2JWLCNaGuummfOTjwDO/oeabmDvXNFuM3Xy2KXomq2MvpCcbW3tu8SEQIbD5hk2MYXzq8SEgvtKKONsoy7umWFclC4r7K6frxckn6qFirqvo0ghudEcRO/bUquuoDcGpEQMosz0xIdal3DGTVo7uhNPj/ZZyP5Toxxk63A==,iv:JHoPBnR/Vuo0aZBm3KQgetiaOmbt5BsTeclohJxfl8U=,tag:8n1l/Ae93hTtwRv1vG2sTw==,type:str]
 sops:
     age:
         - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
@@ -29,7 +30,7 @@ sops:
             QndONmlMTjRrRGEreTRMQzUwMVlDb1EKpadmj6A61r1FWRYDNw0HLnKIeIC4ArhG
             hxNTRDANgoOVXwuP/7SpOnE0+0W0lGA7V5DGe58lnbhCgUktsBxxyw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-01T05:52:52Z"
-    mac: ENC[AES256_GCM,data:IFWvlX1SfZ5uoWAtgWRRhzVzYCaIjH6xDMFCrv56HEfDQWHwQbhjm5MIYNnAccyQTPXvKft+NJNAQYObzQuSuU9N1Hdik3INSXpwDwhigWP6iZTsPa1LePas8HBf0lQxNT95UZyb+vhe90ZxhazMTb8/O9cHEDsT3sBCj8bKoBM=,iv:o6ch6AM/9Bkinb849auC5bYCPBqm95SPicBP+Ei1nZI=,tag:MMusRnt5wHXeWWKCF6Cb9g==,type:str]
+    lastmodified: "2026-05-03T09:27:53Z"
+    mac: ENC[AES256_GCM,data:ecHs9bPYmZSkLpOIRCswi+Uaq1exbAUNvIkaqSYDFgCeZwtP55IbwqIlQVJOAG1Nf24hTJ5GI1VGG5kwDgIZ+q1ZkLLpty9Pe+3L1un2nt8L99Lj1LDpuuUt8kuH6Y5PAk9W8JVFNKtmySPtA1Clm+jlYn8M+/akZb5WBDjJ98c=,iv:stxiSugYCd5fd2KYzx1gUtcWPTg6C4u0AutUoH4bTY4=,tag:mQqweEgQYBzGVeqWt59Arg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
Add the FleetDM trial license key so the Fleet server unlocks premium features.

The license JWT is stored as `fleetdm_license_key` in both cluster SOPS secrets (local and prod), encrypted with each environment's Age key. The HelmRelease wires it to `fleet.license.licenseKey` via Flux variable substitution, consistent with how other sensitive values like `fleetdm_server_private_key` are handled.