### PR TITLE
feat(infrastructure): add OpenCost for FinOps cost allocation

### DIFF
--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - kyverno/
   - metrics-server/
   - oauth2-proxy/
+  - opencost/
   - reloader/
   - trust-manager/
   - velero/

--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: opencost
-      version: 2.5.17
+      version: 2.5.14
       sourceRef:
         kind: HelmRepository
         name: opencost

--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -7,13 +7,6 @@ metadata:
     helm.toolkit.fluxcd.io/remediation: enabled
 spec:
   interval: 2m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: opencost

--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -1,0 +1,78 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opencost
+  namespace: opencost
+  labels:
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  interval: 2m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: opencost
+      version: 2.5.17
+      sourceRef:
+        kind: HelmRepository
+        name: opencost
+  # https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/values.yaml
+  #
+  # Lightweight FinOps cost allocation. Points at the existing
+  # kube-prometheus-stack Prometheus and uses custom pricing derived from
+  # Hetzner Cloud CX23 hourly rates (€0.0064/hr for 2 vCPU / 4 GB RAM).
+  values:
+    opencost:
+      prometheus:
+        internal:
+          enabled: false
+        external:
+          enabled: true
+          url: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+
+      # Hetzner Cloud custom pricing — CX23 rates decomposed into
+      # per-resource-unit hourly USD costs (EUR/USD ≈ 1.09).
+      # https://www.hetzner.com/cloud#pricing
+      # https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart
+      customPricing:
+        enabled: true
+        createConfigmap: true
+        provider: custom
+        costModel:
+          description: "Hetzner Cloud CX23 — 2 vCPU / 4 GB / 40 GB NVMe (50/50 CPU-RAM split)"
+          CPU: 0.00175
+          spotCPU: 0
+          RAM: 0.00088
+          spotRAM: 0
+          GPU: 0
+          storage: 0.00008
+          zoneNetworkEgress: 0.001
+          regionNetworkEgress: 0.001
+          internetNetworkEgress: 0.001
+
+      exporter:
+        replicas: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 55Mi
+          limits:
+            memory: 256Mi
+
+      ui:
+        enabled: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 55Mi
+          limits:
+            memory: 128Mi
+
+      metrics:
+        serviceMonitor:
+          enabled: true

--- a/k8s/bases/infrastructure/controllers/opencost/helm-repository.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: opencost
+  namespace: opencost
+spec:
+  url: https://opencost.github.io/opencost-helm-chart

--- a/k8s/bases/infrastructure/controllers/opencost/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - helm-repository.yaml

--- a/k8s/bases/infrastructure/controllers/opencost/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opencost


### PR DESCRIPTION
## Summary

Adds [OpenCost](https://www.opencost.io/) (CNCF Sandbox) as a lightweight FinOps cost allocation tool for the platform.

## Motivation

The platform has no visibility into per-workload or per-namespace Kubernetes cost allocation. With production running 6+ Hetzner CX23 instances (plus autoscaler pools), understanding where money is spent is essential for informed scaling and budgeting decisions.

## Why OpenCost?

| Criterion | OpenCost | Kubecost | Crane |
|---|---|---|---|
| License | Apache-2.0 (CNCF) | Commercial (IBM) | Apache-2.0 (CNCF) |
| Footprint | ~55 Mi RAM | ~512 Mi+ | Heavy |
| Hetzner custom pricing | ✅ | ✅ | ❌ |
| Overlaps existing autoscaling | No | No | Yes (VPA/KEDA/CA) |

- **Leverages existing stack** — plugs into the existing `kube-prometheus-stack` Prometheus, kube-state-metrics, and node-exporter.
- **Custom pricing for Hetzner** — CX23 rates decomposed into per-resource hourly USD costs.
- **Minimal footprint** — 10m CPU / 55Mi RAM requests, well within CX23 budget.
- **No overlap** — stays in cost-visibility lane; VPA/KEDA/Cluster Autoscaler already handle optimization.

## Changes

- `k8s/bases/infrastructure/controllers/opencost/` — HelmRepository, HelmRelease, namespace, kustomization
- `k8s/bases/infrastructure/controllers/kustomization.yaml` — register `opencost/`

## Hetzner Pricing Configuration

Derived from CX23 at €0.0064/hr (2 vCPU / 4 GB RAM), 50/50 CPU-RAM split, EUR/USD ≈ 1.09:

| Resource | Rate (USD/hr) |
|---|---|
| CPU | $0.00175/core |
| RAM | $0.00088/GB |
| Storage | $0.00008/GB |
| Network | $0.001/GB |

## Access

```bash
kubectl port-forward -n opencost svc/opencost 9090:9090
# Open http://localhost:9090
```

## References

- [OpenCost docs](https://www.opencost.io/docs/)
- [OpenCost custom pricing](https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart)
- [Hetzner Cloud pricing](https://www.hetzner.com/cloud#pricing)