### PR TITLE
feat: bootstrap wedding-app tenant

### DIFF
--- a/k8s/bases/apps/wedding-app/kustomization.yaml
+++ b/k8s/bases/apps/wedding-app/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- fleetdm/
-- headlamp/
-- homepage/
-- whoami/
-- wedding-app/
+- namespace.yaml
+- rolebinding.yaml
+- serviceaccount.yaml
+- sync.yaml

--- a/k8s/bases/apps/wedding-app/namespace.yaml
+++ b/k8s/bases/apps/wedding-app/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: wedding-app

--- a/k8s/bases/apps/wedding-app/rolebinding.yaml
+++ b/k8s/bases/apps/wedding-app/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: wedding-app
+  namespace: wedding-app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: wedding-app
+  namespace: wedding-app

--- a/k8s/bases/apps/wedding-app/serviceaccount.yaml
+++ b/k8s/bases/apps/wedding-app/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: wedding-app
+  namespace: wedding-app

--- a/k8s/bases/apps/wedding-app/sync.yaml
+++ b/k8s/bases/apps/wedding-app/sync.yaml
@@ -20,8 +20,12 @@ metadata:
   namespace: wedding-app
 spec:
   interval: 1m
+  timeout: 5m
+  retryInterval: 2m
   path: ./deploy
   prune: true
+  wait: true
+  force: true
   serviceAccountName: wedding-app
   sourceRef:
     kind: OCIRepository

--- a/k8s/bases/apps/wedding-app/sync.yaml
+++ b/k8s/bases/apps/wedding-app/sync.yaml
@@ -9,7 +9,7 @@ spec:
   interval: 1m
   ref:
     tag: latest
-  url: oci://ghcr.io/devantler-tech/wedding-app-manifests
+  url: oci://ghcr.io/devantler-tech/wedding-app/manifests
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/k8s/bases/apps/wedding-app/sync.yaml
+++ b/k8s/bases/apps/wedding-app/sync.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: wedding-app
 spec:
   interval: 1m
-  path: ./k8s
+  path: ./deploy
   prune: true
   serviceAccountName: wedding-app
   sourceRef:

--- a/k8s/bases/apps/wedding-app/sync.yaml
+++ b/k8s/bases/apps/wedding-app/sync.yaml
@@ -9,7 +9,7 @@ spec:
   interval: 1m
   ref:
     tag: latest
-  url: oci://ghcr.io/devantler-tech/wedding-app/deploy
+  url: oci://ghcr.io/devantler-tech/wedding-app-manifests
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/k8s/bases/apps/wedding-app/sync.yaml
+++ b/k8s/bases/apps/wedding-app/sync.yaml
@@ -1,0 +1,29 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: wedding-app
+  namespace: wedding-app
+spec:
+  interval: 1m
+  ref:
+    tag: latest
+  url: oci://ghcr.io/devantler-tech/wedding-app/deploy
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: wedding-app
+  namespace: wedding-app
+spec:
+  interval: 1m
+  path: ./k8s
+  prune: true
+  serviceAccountName: wedding-app
+  sourceRef:
+    kind: OCIRepository
+    name: wedding-app
+  targetNamespace: wedding-app

--- a/k8s/providers/docker/apps/kustomization.yaml
+++ b/k8s/providers/docker/apps/kustomization.yaml
@@ -14,3 +14,15 @@ patches:
       name: fleetdm
       namespace: fleetdm
     path: fleetdm/patches/helm-release-patch.yaml
+  - target:
+      group: source.toolkit.fluxcd.io
+      kind: OCIRepository
+      name: wedding-app
+      namespace: wedding-app
+    path: wedding-app/patches/ocirepository-patch.yaml
+  - target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization
+      name: wedding-app
+      namespace: wedding-app
+    path: wedding-app/patches/kustomization-patch.yaml

--- a/k8s/providers/docker/apps/wedding-app/patches/kustomization-patch.yaml
+++ b/k8s/providers/docker/apps/wedding-app/patches/kustomization-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: wedding-app
+  namespace: wedding-app
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: Ignore

--- a/k8s/providers/docker/apps/wedding-app/patches/ocirepository-patch.yaml
+++ b/k8s/providers/docker/apps/wedding-app/patches/ocirepository-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: wedding-app
+  namespace: wedding-app
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: Ignore


### PR DESCRIPTION
Bootstraps the [devantler-tech/wedding-app](https://github.com/devantler-tech/wedding-app) tenant on this platform using the KSail tenant pattern.

## What changed and why?

- Added `k8s/bases/apps/wedding-app/` with tenant manifests generated by `ksail tenant create`
- Registered `wedding-app/` in `k8s/bases/apps/kustomization.yaml`
- Fixed the OCIRepository `spec.url` from `oci://ghcr.io/devantler-tech/wedding-app` to `oci://ghcr.io/devantler-tech/wedding-app/manifests` to prevent tag collision between Docker images and Kubernetes manifest OCI artifacts
- Added `timeout: 5m`, `retryInterval: 2m`, `wait: true`, `force: true` to the tenant Kustomization to match the platform pattern
- Updated `spec.path` from `./k8s` to `./deploy` — the wedding-app repo uses `deploy/` for its Kubernetes manifests

### Tenant pattern

Each tenant gets:
- A dedicated `Namespace` (`wedding-app`)
- A `ServiceAccount` + `RoleBinding` (cluster-role: `edit`) for Flux to use
- An `OCIRepository` pointing to `oci://ghcr.io/devantler-tech/wedding-app/manifests` (the OCI artifact path; separate from Docker images at the registry root)
- A `Kustomization` that reconciles `./deploy` from the OCI artifact into the `wedding-app` namespace

## Type of change

- [x] 🚀 New feature