### PR TITLE
fix(fleetdm): use secretKeyRef for license key

### DIFF
--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -32,7 +32,7 @@ spec:
             patch: |
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload
-                value: mysql,redis
+                value: mysql,redis,fleet-license
               - op: add
                 path: /spec/strategy
                 value:
@@ -118,7 +118,8 @@ spec:
       tls:
         enabled: false
       license:
-        licenseKey: ${fleetdm_license_key}
+        secretName: fleet-license
+        licenseKey: license-key
     # Run vulnerability processing in a dedicated container so the API
     # pods don't OOM every hour during the scan.
     vulnProcessing:

--- a/k8s/bases/apps/fleetdm/kustomization.yaml
+++ b/k8s/bases/apps/fleetdm/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - httproute.yaml
+  - license-secret.yaml
   - mysql-secret.yaml
   - pod-disruption-budget.yaml
   - redis-secret.yaml

--- a/k8s/bases/apps/fleetdm/license-secret.yaml
+++ b/k8s/bases/apps/fleetdm/license-secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: fleet-license
+  namespace: fleetdm
+stringData:
+  license-key: ${fleetdm_license_key}


### PR DESCRIPTION
The Fleet Helm chart does not accept `fleet.license.licenseKey` as a literal JWT value. It uses it as a `secretKeyRef.key` — the key name inside a Kubernetes Secret referenced by `fleet.license.secretName`.

This creates a dedicated `license-secret.yaml` that stores the JWT (substituted from the Flux SOPS variable) and configures the HelmRelease to reference it via `secretKeyRef`.

Changes:
- New `license-secret.yaml` with `fleet-license` Secret containing the JWT under the `license-key` key
- HelmRelease: set `fleet.license.secretName: fleet-license` and `fleet.license.licenseKey: license-key`
- Added `fleet-license` to the Reloader annotation so pods restart on license changes
- Added to kustomization.yaml resources