### PR TITLE
fix: resolve NOT FOUND status for Flux and FleetDM in homepage

### DIFF
--- a/k8s/bases/apps/fleetdm/httproute.yaml
+++ b/k8s/bases/apps/fleetdm/httproute.yaml
@@ -5,10 +5,12 @@ metadata:
   namespace: fleetdm
   annotations:
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: Fleet
+    gethomepage.dev/name: FleetDM
     gethomepage.dev/description: Open-source device management (MDM + osquery).
     gethomepage.dev/group: Device Management
     gethomepage.dev/icon: si-coderwall-#40B5A4
+    gethomepage.dev/href: https://fleetdm.${domain}
+    gethomepage.dev/pod-selector: app=fleet
 spec:
   parentRefs:
     - name: platform

--- a/k8s/bases/infrastructure/controllers/flux-operator/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/httproute.yaml
@@ -5,10 +5,12 @@ metadata:
   namespace: flux-system
   annotations:
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: Flux Status
+    gethomepage.dev/name: Flux
     gethomepage.dev/description: Real-time status dashboard for Flux GitOps pipelines.
     gethomepage.dev/group: Kubernetes
     gethomepage.dev/icon: flux-cd
+    gethomepage.dev/href: https://flux.${domain}
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=flux-operator
 spec:
   parentRefs:
     - name: platform


### PR DESCRIPTION
Homepage auto-discovers services from `gethomepage.dev/*` annotations on HTTPRoute resources. Flux and FleetDM appeared in the dashboard but showed "NOT FOUND" because homepage's `getUrlFromHttpRoute()` fails to construct a URL when HTTPRoute rules use catch-all routing (no `matches` field) and no explicit `href` annotation is provided.

Flux has an additional complication: its web UI requires OAuth2/OIDC authentication, so any health-check ping to `https://flux.<domain>` receives a redirect rather than a 200, which also triggers "NOT FOUND".

**Fix:** Add two annotations to both HTTPRoutes:
- `gethomepage.dev/href` -- provides the external URL directly, bypassing the broken URL construction.
- `gethomepage.dev/pod-selector` -- shows pod health via the Kubernetes API instead of pinging the URL, avoiding OAuth2 redirects and the `flux-system` CiliumNetworkPolicy that restricts port 9080 access.

**Renames:**
- `Flux Status` -> `Flux`
- `Fleet` -> `FleetDM`