### PR TITLE
feat(headlamp): add OpenCost plugin for FinOps cost visibility

### DIFF
--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -112,6 +112,10 @@ spec:
               "https://github.com/headlamp-k8s/plugins/releases/download/keda-0.1.1-beta/headlamp-k8s-keda-0.1.1-beta.tar.gz" \
               "b3394a77fba6ae63c6b24b90880a75c54c41f872e079bddf975df4b65ba5b61e" \
               "keda"
+            install_plugin \
+              "https://github.com/headlamp-k8s/plugins/releases/download/opencost-0.1.3/headlamp-k8s-opencost-0.1.3.tar.gz" \
+              "cb3e67aa5bb8cc4869037b9024f58c95acfc1bc23ab6cbc80aa36e0c37ec21bd" \
+              "opencost"
         volumeMounts:
           - name: headlamp-plugins
             mountPath: /headlamp/plugins


### PR DESCRIPTION
## Description

Add the [OpenCost Headlamp plugin](https://github.com/headlamp-k8s/plugins/tree/main/opencost) (v0.1.3) to the init container plugin installation script. This integrates OpenCost cost allocation data directly into the Headlamp dashboard UI, complementing the OpenCost backend added in #1478.

## Changes

- Added `opencost` plugin (v0.1.3) to the Headlamp `initContainers` install script in `k8s/bases/apps/headlamp/helm-release.yaml`
- Uses the same SHA256-verified tarball download pattern as existing plugins (Flux, Prometheus, cert-manager, plugin-catalog, KEDA)

## Validation

- `ksail workload validate` passes (143 files validated)