### PR TITLE
fix(renovate): add 7-day minimum release age cooldown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
     ":semanticCommitTypeAll(fix)"
   ],
   "assigneesFromCodeOwners": true,
+  "minimumReleaseAge": "7 days",
   "flux": {
     "fileMatch": [
       "^k8s/.+\\.ya?ml$"


### PR DESCRIPTION
Adds a `minimumReleaseAge` of 7 days to the Renovate configuration so dependency upgrade PRs are only created after a new version has been available for at least a week. This reduces churn from unstable or quickly-patched releases.

## Type of change

- [x] 🧹 Refactor