### PR TITLE
feat(headlamp): persist plugins across KEDA scale-to-zero

### DIFF
--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -65,6 +65,22 @@ spec:
                 value:
                   name: tmp-dir
                   mountPath: /tmp
+          - target:
+              kind: Deployment
+              name: headlamp
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: headlamp
+              spec:
+                template:
+                  spec:
+                    volumes:
+                      - name: plugins-dir
+                        emptyDir: null
+                        persistentVolumeClaim:
+                          claimName: headlamp
   # https://github.com/kubernetes-sigs/headlamp/blob/main/charts/headlamp/values.yaml
   values:
     replicaCount: ${headlamp_replicas:=2}
@@ -109,5 +125,12 @@ spec:
         installOptions:
           parallel: true
           maxConcurrent: 3
+    persistentVolumeClaim:
+      enabled: true
+      accessModes:
+        - ReadWriteOnce
+      size: 256Mi
+    podSecurityContext:
+      fsGroup: 101
     ingress:
       enabled: false

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -126,10 +126,7 @@ spec:
           parallel: true
           maxConcurrent: 3
     persistentVolumeClaim:
-      enabled: true
-      accessModes:
-        - ReadWriteOnce
-      size: 256Mi
+      enabled: false
     podSecurityContext:
       fsGroup: 101
     ingress:

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -83,7 +83,7 @@ spec:
                           claimName: headlamp
   # https://github.com/kubernetes-sigs/headlamp/blob/main/charts/headlamp/values.yaml
   values:
-    replicaCount: ${headlamp_replicas:=2}
+    replicaCount: ${headlamp_replicas:=1}
     podDisruptionBudget:
       enabled: true
       minAvailable: 0

--- a/k8s/bases/apps/headlamp/kustomization.yaml
+++ b/k8s/bases/apps/headlamp/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - pvc.yaml
   - helm-release.yaml
   - helm-repository.yaml
   - httproute.yaml

--- a/k8s/bases/apps/headlamp/pvc.yaml
+++ b/k8s/bases/apps/headlamp/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 256Mi


### PR DESCRIPTION
## Summary

Headlamp plugins are stored in an `emptyDir` volume at `/headlamp/plugins`. When KEDA scales the pod to zero, the volume is destroyed and all 5 plugins (flux, cert-manager, keda, opencost, kubescape) must be re-downloaded on every cold start.

## Changes

Replace the `plugins-dir` emptyDir with a standalone PVC managed by Flux (not the Helm chart):

- **Standalone PVC** — `pvc.yaml` creates a 256Mi ReadWriteOnce PVC in the headlamp namespace, managed by Flux kustomize controller (not Helm)
- **Disable chart PVC** — `persistentVolumeClaim.enabled: false` prevents the Helm chart from creating its own PVC, avoiding Helm `--wait` deadlock with `WaitForFirstConsumer` binding mode + KEDA scale-to-zero
- **Set fsGroup** — `podSecurityContext.fsGroup: 101` so the headlamp process (GID 101) can write to the PVC
- **Swap volume source** — strategic merge postRenderer patch replaces `plugins-dir` from emptyDir → PVC (`claimName: headlamp`)
- **Set replicaCount to 1** — aligns with HTTPScaledObject `max: 1` and RWO access mode

No provider-specific or network policy changes needed. Both `local-path-provisioner` (Docker) and Longhorn (Hetzner) provide default StorageClasses.

## Why a standalone PVC instead of the chart PVC?

The Headlamp chart's `persistentVolumeClaim.enabled: true` creates the PVC inside the Helm release. Helm's `--wait` then blocks until the PVC is `Bound`. With `WaitForFirstConsumer` binding mode (used by local-path-provisioner), the PVC stays `Pending` until a pod mounts it. But KEDA scales pods to 0 before binding occurs, creating a deadlock. Moving the PVC to the kustomize layer avoids this.

## How it works

1. KEDA scales replicas to 0 → pod deleted, but PVC remains bound
2. On scale-up → new pod mounts the existing PVC with plugins intact
3. The pluginctl sidecar (`--watch`) verifies plugins — fast no-op when already installed