### PR TITLE
feat: add Talos security hardening patches

### DIFF
--- a/talos-local/cluster/rotate-server-certificates.yaml
+++ b/talos-local/cluster/rotate-server-certificates.yaml
@@ -1,0 +1,4 @@
+machine:
+  kubelet:
+    extraArgs:
+      rotate-server-certificates: "true"

--- a/talos/cluster/audit-logging.yaml
+++ b/talos/cluster/audit-logging.yaml
@@ -1,0 +1,91 @@
+# Kubernetes API server audit logging.
+#
+# Places an audit policy file on disk and configures the API server to
+# write audit events to a log file on the EPHEMERAL partition.
+#
+# Policy highlights:
+#   - Secret access logged at Metadata (content never recorded)
+#   - RBAC mutations logged at RequestResponse (full detail)
+#   - Workload mutations logged at Request level
+#   - Health/metrics endpoints and watch noise suppressed
+#
+# Log rotation: 30 days, 3 backups, 100 MB max per file.
+#
+# Reference: https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
+machine:
+  files:
+    - content: |
+        apiVersion: audit.k8s.io/v1
+        kind: Policy
+        rules:
+          # Skip noisy health/metrics endpoints
+          - level: None
+            nonResourceURLs:
+              - /healthz*
+              - /readyz*
+              - /livez*
+              - /metrics
+              - /openapi/*
+
+          # Skip watch/list on high-volume resources to reduce noise
+          - level: None
+            verbs: ["watch"]
+            resources:
+              - group: ""
+                resources: ["events", "endpoints"]
+
+          # Secret access — always Metadata (never log secret content)
+          - level: Metadata
+            resources:
+              - group: ""
+                resources: ["secrets"]
+
+          # RBAC mutations — full detail for forensics
+          - level: RequestResponse
+            resources:
+              - group: "rbac.authorization.k8s.io"
+            verbs: ["create", "update", "patch", "delete"]
+
+          # Workload mutations — request body for change tracking
+          - level: Request
+            resources:
+              - group: ""
+                resources:
+                  - pods
+                  - services
+                  - namespaces
+                  - serviceaccounts
+                  - persistentvolumeclaims
+              - group: "apps"
+                resources:
+                  - deployments
+                  - daemonsets
+                  - statefulsets
+              - group: "batch"
+                resources:
+                  - jobs
+                  - cronjobs
+            verbs: ["create", "update", "patch", "delete"]
+
+          # Catch-all — Metadata for everything else (skip RequestReceived stage)
+          - level: Metadata
+            omitStages:
+              - RequestReceived
+      permissions: 0o644
+      path: /var/etc/kubernetes/audit/audit-policy.yaml
+      op: create
+cluster:
+  apiServer:
+    extraArgs:
+      audit-log-path: /var/log/kubernetes/audit/audit.log
+      audit-log-maxage: "30"
+      audit-log-maxbackup: "3"
+      audit-log-maxsize: "100"
+      audit-policy-file: /etc/kubernetes/audit/audit-policy.yaml
+    extraVolumes:
+      - hostPath: /var/etc/kubernetes/audit
+        mountPath: /etc/kubernetes/audit
+        readonly: true
+      - hostPath: /var/log/kubernetes/audit
+        mountPath: /var/log/kubernetes/audit
+        readonly: false

--- a/talos/cluster/audit-logging.yaml
+++ b/talos/cluster/audit-logging.yaml
@@ -27,7 +27,7 @@ machine:
               - /metrics
               - /openapi/*
 
-          # Skip watch/list on high-volume resources to reduce noise
+          # Skip watch on high-volume resources to reduce noise
           - level: None
             verbs: ["watch"]
             resources:
@@ -73,6 +73,10 @@ machine:
               - RequestReceived
       permissions: 0o644
       path: /var/etc/kubernetes/audit/audit-policy.yaml
+      op: create
+    - content: ""
+      permissions: 0o644
+      path: /var/log/kubernetes/audit/.gitkeep
       op: create
 cluster:
   apiServer:

--- a/talos/cluster/disk-encryption.yaml
+++ b/talos/cluster/disk-encryption.yaml
@@ -1,0 +1,32 @@
+# Encrypt STATE and EPHEMERAL partitions with nodeID-derived keys (LUKS2).
+#
+# nodeID uses the Hetzner VM UUID to derive the encryption key, protecting
+# against drive recovery/reuse (e.g. recycled cloud volumes, stolen disks).
+# This is the strongest option available on Hetzner Cloud (no TPM/SecureBoot).
+#
+# EPHEMERAL uses lockToState so its data is irrecoverable if STATE is wiped,
+# preventing orphaned workload data from surviving a node reset.
+#
+# ⚠️  DESTRUCTIVE: Only takes effect on empty/unformatted partitions.
+#     Existing clusters require a rolling rebuild — see:
+#     https://docs.siderolabs.com/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-encryption#going-from-unencrypted-to-encrypted-and-vice-versa
+#
+# Reference: https://docs.siderolabs.com/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: STATE
+encryption:
+  provider: luks2
+  keys:
+    - nodeID: {}
+      slot: 0
+---
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+encryption:
+  provider: luks2
+  keys:
+    - nodeID: {}
+      slot: 0
+      lockToState: true

--- a/talos/cluster/ingress-firewall-default.yaml
+++ b/talos/cluster/ingress-firewall-default.yaml
@@ -1,0 +1,12 @@
+# Block all ingress traffic by default. Explicit allow rules are defined
+# per node role in control-planes/ and workers/ directories.
+#
+# In block mode Talos automatically:
+#   - Allows traffic on lo, siderolink, kubespan interfaces
+#   - Allows ICMP/ICMPv6 at 5 pkt/s (blocks timestamp/address-mask CVE-1999-0524)
+#   - Allows traffic between Kubernetes pod/service subnets (native routing CNIs)
+#
+# Reference: https://docs.siderolabs.com/talos/v1.12/networking/ingress-firewall
+apiVersion: v1alpha1
+kind: NetworkDefaultActionConfig
+ingress: block

--- a/talos/control-planes/ingress-firewall.yaml
+++ b/talos/control-planes/ingress-firewall.yaml
@@ -1,0 +1,106 @@
+# Ingress firewall rules for control-plane nodes.
+# Requires NetworkDefaultActionConfig (ingress: block) from cluster/.
+#
+# Policy summary:
+#   - apid (50000) and Kubernetes API (6443): open to all (external management)
+#   - kubelet (10250), trustd (50001): cluster-internal only
+#   - etcd (2379-2380): cluster-internal only (Hetzner assigns IPs dynamically)
+#   - Cilium VXLAN (8472), health (4240): cluster-internal only
+#   - NodePort range (30000-32767): cluster-internal (Hetzner Cloud LB)
+#   - Node exporter (9100): cluster-internal (Prometheus scraping)
+#
+# Cluster network CIDR: 10.0.0.0/16 (from ksail.prod.yaml networkCidr)
+#
+# Reference: https://docs.siderolabs.com/talos/v1.12/networking/ingress-firewall
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: apid-ingress
+portSelector:
+  ports:
+    - 50000
+  protocol: tcp
+ingress:
+  - subnet: 0.0.0.0/0
+  - subnet: ::/0
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: kubernetes-api-ingress
+portSelector:
+  ports:
+    - 6443
+  protocol: tcp
+ingress:
+  - subnet: 0.0.0.0/0
+  - subnet: ::/0
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: kubelet-ingress
+portSelector:
+  ports:
+    - 10250
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: trustd-ingress
+portSelector:
+  ports:
+    - 50001
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: etcd-ingress
+portSelector:
+  ports:
+    - 2379-2380
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cni-vxlan-ingress
+portSelector:
+  ports:
+    - 8472
+  protocol: udp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cilium-health-ingress
+portSelector:
+  ports:
+    - 4240
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: nodeport-ingress
+portSelector:
+  ports:
+    - 30000-32767
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: node-exporter-ingress
+portSelector:
+  ports:
+    - 9100
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16

--- a/talos/workers/ingress-firewall.yaml
+++ b/talos/workers/ingress-firewall.yaml
@@ -1,0 +1,73 @@
+# Ingress firewall rules for worker nodes.
+# Requires NetworkDefaultActionConfig (ingress: block) from cluster/.
+#
+# Policy summary (workers are more restrictive than control planes):
+#   - apid (50000): cluster-internal only (manage workers via CPs)
+#   - kubelet (10250): cluster-internal only
+#   - Cilium VXLAN (8472), health (4240): cluster-internal only
+#   - NodePort range (30000-32767): cluster-internal (Hetzner Cloud LB)
+#   - Node exporter (9100): cluster-internal (Prometheus scraping)
+#
+# Cluster network CIDR: 10.0.0.0/16 (from ksail.prod.yaml networkCidr)
+#
+# Reference: https://docs.siderolabs.com/talos/v1.12/networking/ingress-firewall
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: apid-ingress
+portSelector:
+  ports:
+    - 50000
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: kubelet-ingress
+portSelector:
+  ports:
+    - 10250
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cni-vxlan-ingress
+portSelector:
+  ports:
+    - 8472
+  protocol: udp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cilium-health-ingress
+portSelector:
+  ports:
+    - 4240
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: nodeport-ingress
+portSelector:
+  ports:
+    - 30000-32767
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: node-exporter-ingress
+portSelector:
+  ports:
+    - 9100
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16


### PR DESCRIPTION
Adds Talos machine config patches to harden both local and prod clusters, based on the [Talos Security Checklist](https://docs.siderolabs.com/talos/v1.13/security/talos-security-checklist).

Fixes #1505 is deferred — see below.

## Changes

### Ingress Firewall (prod)
- `talos/cluster/ingress-firewall-default.yaml` — `NetworkDefaultActionConfig` with `ingress: block`
- `talos/control-planes/ingress-firewall.yaml` — 9 `NetworkRuleConfig` rules: apid + K8s API open to all; kubelet, trustd, etcd, VXLAN, health, NodePort, node-exporter cluster-only (`10.0.0.0/16`)
- `talos/workers/ingress-firewall.yaml` — 6 `NetworkRuleConfig` rules: all ports cluster-only (more restrictive than CPs)

### Disk Encryption (prod)
- `talos/cluster/disk-encryption.yaml` — `VolumeConfig` for STATE and EPHEMERAL with `nodeID` LUKS2 encryption. EPHEMERAL uses `lockToState: true`.
- ⚠️ **Destructive**: Only applies to empty partitions. Existing cluster requires a rolling rebuild.

### Kubernetes Audit Logging (prod)
- `talos/cluster/audit-logging.yaml` — Audit policy via `machine.files` + API server args/volumes. Secrets at Metadata, RBAC at RequestResponse, workloads at Request. 30-day rotation.

### Rotate Server Certificates (local)
- `talos-local/cluster/rotate-server-certificates.yaml` — Enables kubelet certificate rotation (already on prod, now consistent).

### Deferred
- **API access restriction** (`allowed-cidrs`): Deferred to #1505. GitHub Actions runner IPs are too broad for allowlisting, and management IP is dynamic. Needs VPN/static IP solution.

## Type of change

- [x] 🚀 New feature