### PR TITLE
chore(ci): temporarily disable prod deploy on merge_group

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,7 +132,12 @@ jobs:
   deploy-prod:
     name: 🚀 Deploy to Prod
     needs: [changes]
-    if: github.event_name == 'merge_group' && needs.changes.outputs.k8s == 'true'
+    # TEMPORARILY DISABLED: concurrent merge_group runs were clobbering the
+    # prod cluster CP server types (cx33 → cx23) via `ksail cluster update`
+    # against stale kubeconfigs while devantler/feat-self-hosted-secrets-vault
+    # (PR #1510) was in flight. Re-enable once #1510 lands and the cluster is
+    # stable.
+    if: false && github.event_name == 'merge_group' && needs.changes.outputs.k8s == 'true'
     runs-on: ubuntu-latest
     environment: prod
     concurrency:


### PR DESCRIPTION
## Why

Concurrent `merge_group` runs were clobbering the prod cluster CP server types (cx33 → cx23) via `ksail cluster update` against stale kubeconfigs while #1510 (self-hosted OpenBao + ESO) was in flight.

Disable `deploy-prod` until #1510 lands and the cluster is stable.

## What

- Add `if: false && …` to the `deploy-prod` job so it always skips on `merge_group`.
- Required-checks aggregator still resolves cleanly (skipped jobs satisfy `success() || skipped()`).

## Re-enable

Revert this change once #1510 is merged and the prod cluster is healthy. Track via #1510.
