### PR TITLE
feat(apps): add ascoachingogvaner tenant

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,3 +1,4 @@
+127.0.0.1 ascoachingogvaner.platform.lan
 127.0.0.1 budget.platform.lan
 127.0.0.1 dex.platform.lan
 127.0.0.1 fleetdm.platform.lan

--- a/k8s/bases/apps/ascoachingogvaner/ghcr-auth-secret.enc.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/ghcr-auth-secret.enc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: ghcr-auth
+    namespace: ascoachingogvaner
+type: kubernetes.io/dockerconfigjson
+stringData:
+    .dockerconfigjson: ENC[AES256_GCM,data:LG0K2hS1L/3WfJKLIIa0NrYe635tX1JOAHiZ+S0Phj693HB3ocByZKuOqggVYKzO5fvQyTKzf2+Knlr25SSb+pMlCl1bnK18eJrBWifKhM/fH0wAlIBdQbBX4/iUeW49rKjmBaq72mfMrfvR19U2l8uPxXRxnn/SIelytHMmr4D6EIU+ewAvl95QarGGDDoTJyTDrmnD4YeHWH4nVw9nug9Raf3mBWB8bBZUTtiBk2p7najSuWXwEg==,iv:H3Tix9G5l7uuW68SaRE0MBzdCvwINDjxZlOU/j9d+ZQ=,tag:2Tw+JX4qJ7IZJn5vzSRMWg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3OGJPVGJrZWN1UkM4ZzdD
+            RUVwb3lPSS93NTk0eUJLUlUzcEcxWmFpb20wCnZSMi9xeDVTTHp1RCsvQzBJczR2
+            V1ZBcFJkMVNJaXllZlFhblI2M01vTWcKLS0tIE9RckNWbXNFWXlMQkhzTnFNRHhU
+            UDhnNUNsUzhHRUFZNVF6U2ZmVTYyMGsKiEjXPCQFTehvVXLiUWp9WLoq4FGg84kw
+            K4p2iFto4k8ZVRpAqtpXfhmhukEm8nOMT36QXh+W6gAkBHTjb/CTRg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsRC9sZkxZWXp0ZG53NGlH
+            VkErL2NRWW50MTlrZG00cGFHSFRFZ1BOVmpvCmhrRC93QnJrV0x6VXBhNmNFYWpS
+            NlhSU1ZnSnJDUWxVZHdxNkhXQzY4c0kKLS0tIG05UEdPYUVXL2ZDLzFlVHYxTzda
+            U0VZM2l5YTZ0ZGxGdWFSZlBFVks4dmsKgihrihlz7xxpOHhV58xVFynIjwVUU46w
+            0JaC8MNgjFnv+K3RJMCP9CCdFocqSHY0N3NOdFGeiVNYVWC65kkVlg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-23T02:45:51Z"
+    mac: ENC[AES256_GCM,data:oghem/c0rvi5CMIa1GsCBVPr8VJ/nfKFfMyMqESm6jlxdkeAJuqSnFeGwKnQYgi5TOxCG0NjeizbT5qsTBdDke5I74W3l5+si/R9fliav5auikWvMMuuLS/YJemppO6DcPG4VipbJOpu5THzFHHZJ1OjanaWE4oyvm8DqWGw35U=,iv:ngQH8xm8ffGLD8uDdQpEdORbaH3D7gdiru0G3z1qhzE=,tag:mXIpuQXq5UEnII7L4L+GZg==,type:str]
+    version: 3.13.1

--- a/k8s/bases/apps/ascoachingogvaner/ghcr-auth-secret.enc.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/ghcr-auth-secret.enc.yaml
@@ -5,28 +5,28 @@ metadata:
     namespace: ascoachingogvaner
 type: kubernetes.io/dockerconfigjson
 stringData:
-    .dockerconfigjson: ENC[AES256_GCM,data:LG0K2hS1L/3WfJKLIIa0NrYe635tX1JOAHiZ+S0Phj693HB3ocByZKuOqggVYKzO5fvQyTKzf2+Knlr25SSb+pMlCl1bnK18eJrBWifKhM/fH0wAlIBdQbBX4/iUeW49rKjmBaq72mfMrfvR19U2l8uPxXRxnn/SIelytHMmr4D6EIU+ewAvl95QarGGDDoTJyTDrmnD4YeHWH4nVw9nug9Raf3mBWB8bBZUTtiBk2p7najSuWXwEg==,iv:H3Tix9G5l7uuW68SaRE0MBzdCvwINDjxZlOU/j9d+ZQ=,tag:2Tw+JX4qJ7IZJn5vzSRMWg==,type:str]
+    .dockerconfigjson: ENC[AES256_GCM,data:3P+D6cmpxxI9aWaZIEZApV53gInJ6SPohxNjcI8vVLBcJWrR8g25sxU2Fiaf9U4cU+Iz5f0v1kBksLDi6UfTfCnv39R71LAR5GMiv4vgy/ZfRDWMlXugYd3y3q2oIJuw6iEF+oaUTwJX+Td5yNi9LGHu073LHB7qS2b87tSq6XT1UN2obtyjBQMDjYgEtN6aVJ7hi6lMyZKRY+TvsfZJ0hajl6Mm4hRUer/tGTfeyaX5kg==,iv:j4EZUb0wIYRsIjAwFRngak1T0wUlInTGqQSuDexlytM=,tag:0lYN0d8WiYIHg/CKVuCT1Q==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3OGJPVGJrZWN1UkM4ZzdD
-            RUVwb3lPSS93NTk0eUJLUlUzcEcxWmFpb20wCnZSMi9xeDVTTHp1RCsvQzBJczR2
-            V1ZBcFJkMVNJaXllZlFhblI2M01vTWcKLS0tIE9RckNWbXNFWXlMQkhzTnFNRHhU
-            UDhnNUNsUzhHRUFZNVF6U2ZmVTYyMGsKiEjXPCQFTehvVXLiUWp9WLoq4FGg84kw
-            K4p2iFto4k8ZVRpAqtpXfhmhukEm8nOMT36QXh+W6gAkBHTjb/CTRg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUWXRRMDhsTW9OV0xBSGJJ
+            VDk2Q0ZmQ0FPeE9jNHl2alEycFFxazBhNnpRCkNUSFp3cThSMjc0YzlhTUFFUG9F
+            UC9nbXRTSTErdnJHSVI2Q3E3bzVHZTAKLS0tIHJNQkdhOE5BY2t5YloxQmxaWGQ5
+            M0ZjUjNINHBpNkgyUHFxZHg5NERSczQKnGww7c/MiNYmGHpt6zYxQdXq+sWgeW4q
+            twKNRVw3/8o7Ue1eKZHaQfHXH61dd2vT084NVVFCkMftb963CU2ehQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsRC9sZkxZWXp0ZG53NGlH
-            VkErL2NRWW50MTlrZG00cGFHSFRFZ1BOVmpvCmhrRC93QnJrV0x6VXBhNmNFYWpS
-            NlhSU1ZnSnJDUWxVZHdxNkhXQzY4c0kKLS0tIG05UEdPYUVXL2ZDLzFlVHYxTzda
-            U0VZM2l5YTZ0ZGxGdWFSZlBFVks4dmsKgihrihlz7xxpOHhV58xVFynIjwVUU46w
-            0JaC8MNgjFnv+K3RJMCP9CCdFocqSHY0N3NOdFGeiVNYVWC65kkVlg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKZW9KbmRWMnRvODdRbUJk
+            UzRrVjlaR3l1MW9lcks3VlZ5ditrZDBjZUZNCmJFVGdWclRrR2xybTlRcUFwN0l3
+            QlFhaGtPcTA4eDN4YmZjYXZ3U2kxdkEKLS0tIDV0T0VXTjNKSTBUdUVMenprYk81
+            WVhFa2VRNFREMG9zYzVCUkxTR0xSZEkKi0/0oqsIBe/BWBaht9u0W1VCwUt0/BG1
+            cwNfaFSI2U6UudGzVm5NlfE6dzHwqUTptZoFfNLh712eUHgP+QTkGw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-23T02:45:51Z"
-    mac: ENC[AES256_GCM,data:oghem/c0rvi5CMIa1GsCBVPr8VJ/nfKFfMyMqESm6jlxdkeAJuqSnFeGwKnQYgi5TOxCG0NjeizbT5qsTBdDke5I74W3l5+si/R9fliav5auikWvMMuuLS/YJemppO6DcPG4VipbJOpu5THzFHHZJ1OjanaWE4oyvm8DqWGw35U=,iv:ngQH8xm8ffGLD8uDdQpEdORbaH3D7gdiru0G3z1qhzE=,tag:mXIpuQXq5UEnII7L4L+GZg==,type:str]
+    lastmodified: "2026-05-23T03:19:06Z"
+    mac: ENC[AES256_GCM,data:V1lc+q7ys9nWG76dqVGOUz26JZpb6386jhWkUUtl4pJmIQTaOvLxkD7+Ux1nPn2tDaGf3fcrZChTAloIhMevvObTkpfQ0JPnWHx8li+XzcK+CWlbFBHki1tjHi4ri66GaltYLoquFzDOoiRmF6mp+E1l2isUPCUiyUeGWuhZ/NA=,iv:IDBPvoQhVL/fuE1AnjMOPwFkVZ9GkEtSy6K30A94GLc=,tag:NsPCTo67Mf+f48Hya7n2GQ==,type:str]
     version: 3.13.1

--- a/k8s/bases/apps/ascoachingogvaner/kustomization.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ghcr-auth-secret.enc.yaml
+  - namespace.yaml
+  - rolebinding.yaml
+  - serviceaccount.yaml
+  - sops-age-secret.enc.yaml
+  - sync.yaml
+  - networkpolicy.yaml

--- a/k8s/bases/apps/ascoachingogvaner/namespace.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: ascoachingogvaner

--- a/k8s/bases/apps/ascoachingogvaner/networkpolicy.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/networkpolicy.yaml
@@ -1,0 +1,56 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ascoachingogvaner
+  namespace: ascoachingogvaner
+spec:
+  endpointSelector: {}
+  ingress:
+    # Gateway ingress
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+    # Intra-namespace (app → db, db replication)
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: ascoachingogvaner
+    # CNPG operator needs to reach DB status endpoint (port 8000)
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: cnpg-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+            - port: "5432"
+              protocol: TCP
+    # Metrics scraping from monitoring namespace
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9187"
+              protocol: TCP
+  egress:
+    # Intra-namespace (app → db)
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: ascoachingogvaner
+    # Kube API (for CNPG operator managing the cluster)
+    - toEntities:
+        - kube-apiserver
+    # DNS resolution
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/k8s/bases/apps/ascoachingogvaner/rolebinding.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: ascoachingogvaner
+  namespace: ascoachingogvaner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: ascoachingogvaner
+  namespace: ascoachingogvaner

--- a/k8s/bases/apps/ascoachingogvaner/serviceaccount.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: ascoachingogvaner
+  namespace: ascoachingogvaner
+automountServiceAccountToken: false
+imagePullSecrets:
+  - name: ghcr-auth

--- a/k8s/bases/apps/ascoachingogvaner/sops-age-secret.enc.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/sops-age-secret.enc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: sops-age
+    namespace: ascoachingogvaner
+stringData:
+    age.agekey: ENC[AES256_GCM,data:MuL/HJC07KDLFqslEnD5VHX2bGoWIQpqVsDiHGN4EUduHBniEvWfAE9UTkVGcQivGAbRf6iQU/A0Ze9aB3tD/iECNg/Pu67Y7YQ=,iv:CUgjyBnhv57t4ss9Qqvstk2eZn7IY4lmAia1Yys+ZOI=,tag:Z2Rg+2dLGmOM1SHr0XaFJA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCRDBPMm1VeVhkVnRIckFh
+            dmU5MEdvOTIyQy9CeEdKTFRRVU04MlBqUm5RCnFacHpsUmhLanlYV2RtQXNOTEhv
+            RG91dUxDK3NIRXNHMXNnV2w5TVBUUWsKLS0tIFh2cFFnS0lwZEF2Y2YrVXhqK0Fi
+            aWFEODAwT3RJT0svMWd1WnIyK3lwLzQKN0ZInQdL7JHFxWaWoDzlta5jvjYMuVh3
+            Wljg3vH/xd6YoHtQuAZDrht1g75vqtllnxGZUWgKOrqjpL8d+4T1/Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBESnMvS2dnbXQ2OXQwV0I4
+            UFNtbnlIOGJJTXZaVzR5K2tBbjRmRStuUUJzCjB0RmxpUHZJM1VGRmdrOFdjVjlz
+            UGRySHRVd3BIS0tjbmpRNWpSclNxekUKLS0tIDRhNHorakF2NDJlUDNMV3lmTkxm
+            U0hiekFhMWwvc0VUdnRZc0Q0WWlsYkEKhpkQJxCzNMSkdugLHIlSYaipCPguIAS3
+            FhxP6BxS+vZcqqrNcsRZmhsjPtSRXouOXL+Y4mjSN1DizNrlnggT3A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-23T02:44:27Z"
+    mac: ENC[AES256_GCM,data:OO9JuMgJ0RSfAXJakEQhWabZ47mgYPKH8FXabhclW+LTJlEm+yGCBYybOe7VrU6+2teYmZ9vvzxXhvHspYuLtPS9Xmzvb4fuAqf80ZGV8VhUw1hzPUIZlG0j1/S9XuLZHSdKBKElPNP5hgm/5ZcGuopUzrSc3qbmpXHnqaE5zos=,iv:6OG7WO5GDqfm8qJp2as6LZo/CDl22VsiAFQ2NG6wpG0=,tag:Y746c7QLmWyhmczI8g0dvQ==,type:str]
+    version: 3.13.1

--- a/k8s/bases/apps/ascoachingogvaner/sync.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/sync.yaml
@@ -1,0 +1,41 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: ascoachingogvaner
+  namespace: ascoachingogvaner
+spec:
+  interval: 1m
+  ref:
+    tag: latest
+  url: oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests
+  secretRef:
+    name: ghcr-auth
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  annotations:
+    ksail.devantler.tech/reconcile-exclude: "true"
+  name: ascoachingogvaner
+  namespace: ascoachingogvaner
+spec:
+  interval: 1m
+  timeout: 5m
+  retryInterval: 2m
+  path: .
+  prune: true
+  wait: true
+  force: true
+  serviceAccountName: ascoachingogvaner
+  sourceRef:
+    kind: OCIRepository
+    name: ascoachingogvaner
+  targetNamespace: ascoachingogvaner
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/k8s/bases/apps/kustomization.yaml
+++ b/k8s/bases/apps/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - actual-budget/
+- ascoachingogvaner/
 - fleetdm/
 - headlamp/
 - homepage/

--- a/k8s/providers/docker/apps/kustomization.yaml
+++ b/k8s/providers/docker/apps/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # wedding-app excluded: prod-only tenant needing GHCR, CNPG, and longhorn
+  # wedding-app & ascoachingogvaner excluded: prod-only tenants needing GHCR, CNPG, and longhorn
   # fleetdm excluded: heavy app (MySQL + Redis + migration) that consistently
   #   times out in Docker CI due to controller scheduling delays; Docker overlay
   #   uses substantially different config (standalone DBs, default storageClass)

--- a/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ascoachingogvaner
+  namespace: ascoachingogvaner
+spec:
+  patches:
+    - target:
+        group: postgresql.cnpg.io
+        kind: Cluster
+        name: ascoaching-db
+      patch: |
+        apiVersion: postgresql.cnpg.io/v1
+        kind: Cluster
+        metadata:
+          name: ascoaching-db
+        spec:
+          storage:
+            storageClass: longhorn
+    - target:
+        kind: HTTPRoute
+        name: ascoachingogvaner
+      patch: |
+        - op: replace
+          path: /spec/hostnames
+          value:
+            - ascoachingogvaner.platform.devantler.tech

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../../bases/apps/
 patches:
   - target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization
+      name: ascoachingogvaner
+      namespace: ascoachingogvaner
+    path: ascoachingogvaner/patches/kustomization-patch.yaml
+  - target:
       kind: HelmRelease
       name: fleetdm
       namespace: fleetdm


### PR DESCRIPTION
## Summary

Adds a new **prod-only tenant** `ascoachingogvaner` for the AS Coaching og Vaner website,
mirroring the `wedding-app` setup. The app itself lives in the new private repo
[devantler-tech/ascoachingogvaner](https://github.com/devantler-tech/ascoachingogvaner)
([app PR #1](https://github.com/devantler-tech/ascoachingogvaner/pull/1)); this PR only adds
the thin tenant wiring that syncs its published OCI manifests.

- `k8s/bases/apps/ascoachingogvaner/` — namespace, service account, `edit` rolebinding (for CNPG),
  Cilium network policy, SOPS-encrypted `ghcr-auth` + `sops-age` secrets, and an `OCIRepository`
  + Flux `Kustomization` syncing `oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests`
- `k8s/providers/hetzner/apps/ascoachingogvaner/patches/` — CNPG `storageClass: longhorn` +
  HTTPRoute host `ascoachingogvaner.platform.devantler.tech`
- Wired into `bases/apps` + `hetzner/apps` kustomizations; excluded from `docker` (GHCR/CNPG/longhorn)
- `hosts` — local `ascoachingogvaner.platform.lan`
- A dedicated age keypair was generated for this tenant; `sops-age` carries its private key
  (sealed to the cluster keys), and the app's `deploy/admin-code-secret.enc.yaml` is encrypted to it.

## ⚠️ Required before merge
- [ ] **Replace the placeholder `ghcr-auth` token** in `k8s/bases/apps/ascoachingogvaner/ghcr-auth-secret.enc.yaml`
      with a real GHCR `read:packages` token (the `.dockerconfigjson` currently contains
      `REPLACE_WITH_GHCR_READ_PACKAGES_TOKEN`).
- [ ] Publish the app image + OCI manifests (tag a release in the app repo) so the OCIRepository has something to sync.

## Test plan
- [x] `kubectl kustomize k8s/bases/apps/` builds; tenant resources present
- [x] `kubectl kustomize k8s/providers/hetzner/apps/` builds; prod hostname + longhorn patch applied
- [x] `kubectl kustomize k8s/clusters/{prod,local}/` build (local excludes the tenant)
- [x] SOPS round-trip verified: cluster key decrypts `sops-age`; tenant key decrypts the app secret
- [ ] CI full-cluster system test (runs on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)