### PR TITLE
fix(talos): allow pod CIDR on kubelet + node-exporter ingress

### DIFF
--- a/talos/control-planes/ingress-firewall.yaml
+++ b/talos/control-planes/ingress-firewall.yaml
@@ -119,4 +119,10 @@ portSelector:
     - 9100
   protocol: tcp
 ingress:
+  # Node CIDR covers cross-node scrapes: Cilium masquerades pod->node-IP
+  # traffic to the source node IP. Same-node scrapes (the Prometheus pod
+  # hitting the hostNetwork node-exporter on its own node) are NOT
+  # masqueraded, so node-exporter sees the raw pod IP and the pod CIDR must
+  # be allowed too.
   - subnet: 10.0.0.0/16
+  - subnet: 10.244.0.0/16

--- a/talos/control-planes/ingress-firewall.yaml
+++ b/talos/control-planes/ingress-firewall.yaml
@@ -43,7 +43,12 @@ portSelector:
     - 10250
   protocol: tcp
 ingress:
+  # Node CIDR covers cross-node scrapes: Cilium masquerades pod->node-IP
+  # traffic to the source node IP. Same-node scrapes (a pod hitting its own
+  # node's kubelet) are NOT masqueraded, so the kubelet sees the raw pod IP
+  # and the pod CIDR must be allowed too.
   - subnet: 10.0.0.0/16
+  - subnet: 10.244.0.0/16
 ---
 apiVersion: v1alpha1
 kind: NetworkRuleConfig

--- a/talos/workers/ingress-firewall.yaml
+++ b/talos/workers/ingress-firewall.yaml
@@ -31,7 +31,12 @@ portSelector:
     - 10250
   protocol: tcp
 ingress:
+  # Node CIDR covers cross-node scrapes: Cilium masquerades pod->node-IP
+  # traffic to the source node IP. Same-node scrapes (e.g. the local
+  # metrics-server replica hitting its own kubelet) are NOT masqueraded, so
+  # the kubelet sees the raw pod IP and the pod CIDR must be allowed too.
   - subnet: 10.0.0.0/16
+  - subnet: 10.244.0.0/16
 ---
 apiVersion: v1alpha1
 kind: NetworkRuleConfig

--- a/talos/workers/ingress-firewall.yaml
+++ b/talos/workers/ingress-firewall.yaml
@@ -87,4 +87,10 @@ portSelector:
     - 9100
   protocol: tcp
 ingress:
+  # Node CIDR covers cross-node scrapes: Cilium masquerades pod->node-IP
+  # traffic to the source node IP. Same-node scrapes (the Prometheus pod
+  # hitting the hostNetwork node-exporter on its own node) are NOT
+  # masqueraded, so node-exporter sees the raw pod IP and the pod CIDR must
+  # be allowed too.
   - subnet: 10.0.0.0/16
+  - subnet: 10.244.0.0/16


### PR DESCRIPTION
## Summary
Fix nodes intermittently showing `0% / 0 B` CPU+memory (e.g. blank on the Homepage dashboard, observed on `prod-worker-1`), plus the same defect on the node-exporter scrape path.

Root cause: Cilium (tunnel mode, masquerade on) rewrites **cross-node** pod→node-IP traffic to the source node IP, but **same-node** pod→its-own-node-IP traffic keeps the raw pod IP `10.244.x.x`. Two Talos ingress firewall rules only allowed the node CIDR `10.0.0.0/16`, so same-node scrapes were dropped (`context deadline exceeded`):

- **`kubelet-ingress` (:10250)** — a metrics-server replica scraping the kubelet on its *own* node was dropped, so `kubectl top` returned `<unknown>` for whichever node served the request.
- **`node-exporter-ingress` (:9100)** — node-exporter is a hostNetwork DaemonSet; the Prometheus pod scraping node-exporter on its *own* node was dropped, so that node's target was down.

Both rules now also allow the pod CIDR `10.244.0.0/16`, mirroring the existing `hubble-peer-ingress` rule that already lists both CIDRs. Applied to both the worker and control-plane patches for consistency.

## Notes
- These are Talos machine-config patches — they take effect after a `ksail cluster update` (or the prod CI deploy). The ingress firewall is runtime config, so no node reboot is required.

## Test plan
- [ ] Apply Talos config to prod (`ksail cluster update`) / merge to trigger CI deploy.
- [ ] `kubectl --context admin@prod top nodes` returns CPU/memory for all 6 nodes (no `<unknown>`).
- [ ] metrics-server logs no longer show `Failed to scrape node, timeout to access kubelet`.
- [ ] Prometheus `up{job="node-exporter"}` is `1` for all instances (including Prometheus's own node).
- [ ] Homepage dashboard shows non-zero CPU/memory for every node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)