### PR TITLE
fix(headlamp): bump kubescape plugin to v0.11.2

### DIFF
--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -126,7 +126,7 @@ spec:
             version: 0.1.3
           - name: headlamp_kubescape
             source: https://artifacthub.io/packages/headlamp/kubescape-headlamp-plugin/headlamp_kubescape
-            version: 0.11.0
+            version: 0.11.2
         installOptions:
           parallel: true
           maxConcurrent: 3


### PR DESCRIPTION
## Summary
- The Headlamp Kubescape plugin was missing from the UI sidebar (expected below KEDA).
- Root cause: the plugin was pinned to `0.11.0` in the Headlamp `pluginsManager` config, but that version no longer exists on ArtifactHub. The plugin-manager sidecar failed with `error: Plugin version 0.11.0 not found`, so the bundle never landed in the plugins PVC and no sidebar entry rendered. The other four plugins (flux, cert-manager, keda, opencost) installed fine.
- Bumped the pin to `0.11.2`, the only currently published version of the `kubescape-headlamp-plugin` package.

## Diagnosis
From the `headlamp-plugin` sidecar logs:
```
5 of 5 (headlamp_kubescape): error: Plugin version 0.11.0 not found. Please check the plugin details.
info: Bulk installation completed: {"total":5,"failed":1,"skipped":0,"successful":4}
```

## Test plan
- [ ] After merge, Flux reconciles the HelmRelease and the sidecar (`watchPlugins: true`) reinstalls plugins from the updated config.
- [ ] Confirm `headlamp_kubescape` installs successfully in the `headlamp-plugin` sidecar logs.
- [ ] Confirm the Kubescape entry appears below KEDA in the Headlamp sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)