### PR TITLE
fix(talos): allow pod CIDR on node-exporter ingress firewall

### DIFF
--- a/talos/control-planes/ingress-firewall.yaml
+++ b/talos/control-planes/ingress-firewall.yaml
@@ -114,4 +114,10 @@ portSelector:
     - 9100
   protocol: tcp
 ingress:
+  # Node CIDR covers cross-node scrapes: Cilium masquerades pod->node-IP
+  # traffic to the source node IP. Same-node scrapes (the Prometheus pod
+  # hitting the hostNetwork node-exporter on its own node) are NOT
+  # masqueraded, so node-exporter sees the raw pod IP and the pod CIDR must
+  # be allowed too.
   - subnet: 10.0.0.0/16
+  - subnet: 10.244.0.0/16

--- a/talos/workers/ingress-firewall.yaml
+++ b/talos/workers/ingress-firewall.yaml
@@ -82,4 +82,10 @@ portSelector:
     - 9100
   protocol: tcp
 ingress:
+  # Node CIDR covers cross-node scrapes: Cilium masquerades pod->node-IP
+  # traffic to the source node IP. Same-node scrapes (the Prometheus pod
+  # hitting the hostNetwork node-exporter on its own node) are NOT
+  # masqueraded, so node-exporter sees the raw pod IP and the pod CIDR must
+  # be allowed too.
   - subnet: 10.0.0.0/16
+  - subnet: 10.244.0.0/16


### PR DESCRIPTION
## Summary
The `node-exporter-ingress` NetworkRuleConfig (`:9100`) in both the worker and control-plane Talos firewall patches only permitted the node CIDR `10.0.0.0/16`. node-exporter is a hostNetwork DaemonSet scraped by kube-prometheus-stack Prometheus.

Cilium (tunnel mode, masquerade on) rewrites **cross-node** pod→node-IP traffic to the source node IP, but **same-node** pod→its-own-node-IP traffic keeps the raw pod IP `10.244.x.x`. So the Prometheus pod scraping node-exporter on its *own* node was silently dropped, leaving that node's target down.

This adds the pod CIDR `10.244.0.0/16` to the rule in both files, mirroring the existing `hubble-peer-ingress` rule (and the `kubelet-ingress` fix) that already list both CIDRs.

## Verification (live `admin@prod`)
Prometheus targets API showed exactly one `node-exporter` target down — `10.0.1.5:9100` (`prod-worker-3`), the node the Prometheus pod runs on — with `context deadline exceeded` (a timeout, i.e. silent DROP). The other 5 were up.

## Notes
- These are Talos machine-config patches — they take effect after a `ksail cluster update` (or the prod CI deploy). Runtime firewall config, so no node reboot required.
- Overlaps with #1547, which bundles this same node-exporter fix together with the `kubelet-ingress` (:10250) fix. Merge whichever you prefer and close/rebase the other to avoid double-applying.

## Test plan
- [ ] Apply Talos config to prod (`ksail cluster update`) / merge to trigger CI deploy.
- [ ] Prometheus `up{job="node-exporter"}` is `1` for all instances, including `10.0.1.5` (Prometheus's own node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)