### PR TITLE
feat: select app manifests by OCI semver; drop image-automation controllers

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/sync.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m
   ref:
-    tag: latest
+    semver: ">=0.0.0"
   url: oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests
   secretRef:
     name: ghcr-auth

--- a/k8s/bases/apps/wedding-app/sync.yaml
+++ b/k8s/bases/apps/wedding-app/sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m
   ref:
-    tag: latest
+    semver: ">=0.0.0"
   url: oci://ghcr.io/devantler-tech/wedding-app/manifests
   secretRef:
     name: ghcr-auth

--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -1,8 +1,13 @@
-# Extends the KSail-bootstrapped FluxInstance to include image automation
-# controllers (image-reflector-controller + image-automation-controller).
-# KSail creates the initial FluxInstance during `ksail cluster create`;
-# this resource is reconciled by the infrastructure-controllers Flux
-# Kustomization post-bootstrap in the Hetzner (prod) environment only.
+# Sets the authoritative FluxInstance spec for the prod cluster: pins the
+# Flux distribution and patches kustomize-controller with
+# --requeue-dependency=5s for faster dependency retries. KSail creates the
+# initial FluxInstance during `ksail cluster create`; this resource is
+# reconciled by the infrastructure-controllers Flux Kustomization
+# post-bootstrap in the Hetzner (prod) environment only.
+#
+# App image updates use OCIRepository semver selection (see
+# k8s/bases/apps/*/sync.yaml), so the image-reflector/-automation
+# controllers are intentionally not enabled.
 ---
 apiVersion: fluxcd.controlplane.io/v1
 kind: FluxInstance
@@ -18,8 +23,6 @@ spec:
     - kustomize-controller
     - helm-controller
     - notification-controller
-    - image-reflector-controller
-    - image-automation-controller
   cluster:
     type: kubernetes
     multitenant: false


### PR DESCRIPTION
## Summary

Completes OCI-native image automation for tenant apps, per the [Flux OCI artifacts cheatsheet](https://fluxcd.io/flux/cheatsheets/oci-artifacts/).

- `k8s/bases/apps/{wedding-app,ascoachingogvaner}/sync.yaml`: `OCIRepository.ref` `tag: latest` → `semver: ">=0.0.0"`. source-controller now auto-selects the newest published manifests version — this is the automation, no `ImageUpdateAutomation`/Git write-back. The apps publish digest-pinned, semver-tagged, cosign-signed manifests via the `publish-app` reusable workflow (devantler-tech/reusable-workflows#233).
- `flux-instance.yaml`: remove `image-reflector-controller` + `image-automation-controller`. They were enabled for a Git-based automation that was never wired up and cannot drive OCIRepository sources. The `$imagepolicy` marker mismatch behind the original "not auto-updating" bug.

## ⚠️ Merge order (important)

`ref.semver` errors if **no** semver-tagged artifact exists yet (today only `…/manifests:latest` exists). Merge in this order:

1. devantler-tech/reusable-workflows#233
2. devantler-tech/wedding-app#52 and devantler-tech/ascoachingogvaner#6 → each cuts a release that publishes the first `…/manifests:<semver>`
3. **This PR last**, after confirming `…/manifests:<semver>` exists in GHCR for both apps.

Merging this triggers the prod release → `ksail cluster update` + `workload push` + `reconcile`.

## Follow-up: enable signature verification

The artifacts are already cosign-signed. Once a signed release exists, add `verify` to each OCIRepository (one identity covers all tenants since they sign through the shared workflow). Validate the exact cert identity from the first release before enabling, since a wrong identity halts reconciliation:

```yaml
  verify:
    provider: cosign
    matchOIDCIdentity:
      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
        subject: "^https://github\\.com/devantler-tech/reusable-workflows/\\.github/workflows/publish-app\\.yaml@refs/heads/main$"
```

## Test plan

- [ ] After merge order respected: `flux get sources oci -A` shows both OCIRepositories Ready on the newest semver.
- [ ] A subsequent tenant release bumps the selected version and rolls the Deployment automatically.
- [ ] `verify` follow-up: confirm cert identity, enable, reconcile stays Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)