### PR TITLE
fix(cluster-policies): stop auto-vpa from evicting stateful pods

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -70,8 +70,14 @@ spec:
               kind: StatefulSet
               name: "{{request.object.metadata.name}}"
             updatePolicy:
-              updateMode: "InPlaceOrRecreate"
-              minReplicas: 1
+              # StatefulSets here are singletons backed by ReadWriteOnce hcloud
+              # volumes. Evicting such a pod to apply a recommendation reschedules
+              # it before the old VolumeAttachment releases, causing a Multi-Attach
+              # error and an outage (this took down fleetdm-mysql + the fleet API).
+              # "Initial" still right-sizes pods at creation but never evicts a
+              # running stateful pod, so recommendations land on the next natural
+              # restart (rollout, node maintenance) instead of mid-flight.
+              updateMode: "Initial"
             resourcePolicy:
               containerPolicies:
                 - containerName: "*"


### PR DESCRIPTION
## Summary

`fleetdm` was repeatedly failing: probe failures (`connection refused` / HTTP 500) on the fleet API and a `FailedAttachVolume` Multi-Attach error on `fleetdm-mysql-0`. Root cause traced to the cluster-wide `auto-vpa` ClusterPolicy, not to fleetdm itself.

## Root cause

The `auto-vpa` policy generates a VPA in `updateMode: InPlaceOrRecreate` with `minReplicas: 1` for **every** StatefulSet. VPA decided to apply a memory recommendation to `fleetdm-mysql` and, unable to resize in place, **evicted** the singleton `fleetdm-mysql-0` pod (`EvictedByVPA`). The rescheduled pod tried to re-attach its `ReadWriteOnce` `hcloud` volume before the old `VolumeAttachment` released → **Multi-Attach error** → MySQL down ~1 min → fleet `/healthz` returned 500, then the liveness probe failed with `connection refused` and the container restarted.

Every StatefulSet in the cluster is a singleton on an RWO `hcloud` volume (`fleetdm-mysql`, `fleetdm-redis-master`, `openbao`), so this was a latent cluster-wide fault that happened to surface on fleetdm first.

## Change

- StatefulSet VPA rule switched from `InPlaceOrRecreate` to `updateMode: "Initial"`, and the now-irrelevant `minReplicas: 1` removed.
  - `Initial` still right-sizes pods at **creation** (preserving the "don't over-request resources" goal) but **never evicts a running stateful pod**. Recommendations land on the next natural restart (rollout, node maintenance).
- Deployment and DaemonSet rules are unchanged — they tolerate eviction (multiple replicas / rolling updates).

Since the generate rule uses `synchronize: true`, once Flux reconciles this policy Kyverno will flip the live `fleetdm-mysql` / `redis` / `openbao` VPAs to `Initial` automatically — no manual VPA edits required.

## Notes for reviewer

- `kubectl kustomize k8s/bases/infrastructure/cluster-policies/` builds cleanly; rendered StatefulSet rule shows `updateMode: Initial`.
- Out of scope / possible follow-up: the fleet chart wires `/healthz` into the **liveness** probe, so a brief DB outage restarts the container. Moving the DB dependency to readiness-only would harden the cascade but requires overriding the chart's probes.

## Test plan

- [ ] Flux applies the updated ClusterPolicy
- [ ] Confirm `kubectl -n fleetdm get vpa` shows `fleetdm-mysql` (and `fleetdm-redis-master`, `openbao`) in `Initial` mode
- [ ] Confirm no further `EvictedByVPA` / `FailedAttachVolume` events on stateful pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)