### PR TITLE
fix(ci): pass APP_PRIVATE_KEY with the name create-release declares

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,4 +16,4 @@ jobs:
       pull-requests: write # comment on related PRs
       id-token: write # provenance signing
     secrets:
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

The `Release` workflow has been failing with `startup_failure` ("workflow file issue") on **every push to main all day** — no `v*` tag is cut, so `cd.yaml` never runs and nothing deploys. This blocks all platform deployments (recent app/infra merges included).

## Root cause

`release.yaml` calls `create-release.yaml@v3.1.4`, which declares:
```yaml
secrets:
  APP_PRIVATE_KEY:
    required: true
```
…but the caller passed it as **`app-private-key`** (kebab-case):
```yaml
secrets:
  app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
```
Passing a secret the reusable workflow doesn't declare — and omitting the required `APP_PRIVATE_KEY` — makes GitHub reject the call at startup. (The tenant repos already use `APP_PRIVATE_KEY`, which is why their releases work.)

## Fix

Rename the passed secret key to `APP_PRIVATE_KEY` to match the reusable workflow's declaration. One line.

## Effect

Once merged, the next push to main starts `Release` cleanly → semantic-release cuts a tag → `cd.yaml` runs `ksail cluster update` + `workload push` + `reconcile`, deploying everything currently sitting on main (including the OCI image-automation from #1552).

🤖 Generated with [Claude Code](https://claude.com/claude-code)