### PR TITLE
fix(ci): pin ksail install to v7.19.0 (v7.20.0 CLI assets missing)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,18 @@
   "github-actions": {
     "enabled": false
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Bump the pinned ksail CLI version in workflows (Dependabot can't track a curl-downloaded release asset).",
+      "fileMatch": [
+        "^\\.github/workflows/(cd|ci)\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) extractVersion=(?<extractVersion>\\S+)\\s+KSAIL_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
   "minor": {
     "automerge": true
   },

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -26,7 +26,17 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup KSail
-        uses: devantler-tech/actions/setup-ksail-cli@59d3ffbe1a9437fcc39e2794fa2f221abe878310 # v3.3.0
+        # TEMP: pinned to v7.19.0. The v7.20.0 release shipped only desktop
+        # artifacts (CLI binaries missing), so `brew install ksail` 404s on the
+        # linux tarball. Revert to setup-ksail-cli once a complete ksail release
+        # exists. See devantler-tech/ksail v7.20.0 CD failure.
+        env:
+          KSAIL_VERSION: "7.19.0"
+        run: |
+          curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
+          tar -xzf /tmp/ksail.tar.gz -C /tmp
+          sudo install /tmp/ksail /usr/local/bin/ksail
+          ksail --version
 
       - name: 🔐 Create SOPS Age key
         env:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,6 +31,7 @@ jobs:
         # linux tarball. Revert to setup-ksail-cli once a complete ksail release
         # exists. See devantler-tech/ksail v7.20.0 CD failure.
         env:
+          # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
           KSAIL_VERSION: "7.19.0"
         run: |
           curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,7 +189,17 @@ jobs:
           persist-credentials: false
 
       - name: ⚙️ Setup KSail
-        uses: devantler-tech/actions/setup-ksail-cli@59d3ffbe1a9437fcc39e2794fa2f221abe878310 # v3.3.0
+        # TEMP: pinned to v7.19.0. The v7.20.0 release shipped only desktop
+        # artifacts (CLI binaries missing), so `brew install ksail` 404s on the
+        # linux tarball. Revert to setup-ksail-cli once a complete ksail release
+        # exists. See devantler-tech/ksail v7.20.0 CD failure.
+        env:
+          KSAIL_VERSION: "7.19.0"
+        run: |
+          curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
+          tar -xzf /tmp/ksail.tar.gz -C /tmp
+          sudo install /tmp/ksail /usr/local/bin/ksail
+          ksail --version
 
       - name: 🔐 Create SOPS Age key
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,7 @@ jobs:
         # linux tarball. Revert to setup-ksail-cli once a complete ksail release
         # exists. See devantler-tech/ksail v7.20.0 CD failure.
         env:
+          # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
           KSAIL_VERSION: "7.19.0"
         run: |
           curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz


### PR DESCRIPTION
## Problem

Every platform deploy fails at **Setup KSail**:
```
Download failed: https://github.com/devantler-tech/ksail/releases/download/v7.20.0/ksail_7.20.0_linux_amd64.tar.gz → 404
```
The ksail **v7.20.0** release shipped only **desktop** artifacts (`KSail_7.20.0_darwin_arm64.zip` + `ksail-desktop_*_checksums.txt`); the **CLI matrix** (`ksail_7.20.0_linux_amd64.tar.gz`, …) was never published (its CD run failed on the desktop Windows build + an immutable-release publish error). The release is immutable, so the assets can't be added — `brew install ksail` (via `setup-ksail-cli`) 404s.

## Fix (temporary)

`setup-ksail-cli` has no version input, so pin by installing the **v7.19.0** Linux binary directly in `cd.yaml` and `ci.yaml`. Revert to the action once a complete ksail release exists.

```yaml
env:
  KSAIL_VERSION: "7.19.0"
run: |
  curl -fsSL ".../v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
  tar -xzf /tmp/ksail.tar.gz -C /tmp
  sudo install /tmp/ksail /usr/local/bin/ksail
  ksail --version
```

## Effect

Unblocks the deploy: with the `release.yaml` secret fix (#1555) already merged, the next push to main runs `Release` → `cd.yaml` installs ksail v7.19.0 and runs `cluster update` + `workload push` + `reconcile`, finally deploying the OCI image-automation on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)