### PR TITLE
fix(cd): restore TALOS_CONFIG so cluster update can reach Talos

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -62,6 +62,20 @@ jobs:
           printf '%s' "${KUBE_CONFIG}" > ~/.kube/config
           chmod 600 ~/.kube/config
 
+      - name: 🔑 Restore talosconfig
+        # ksail cluster update talks to the Talos API to sync machine config.
+        # Without the talosconfig it uses stale/derived certs and fails with
+        # "x509: certificate signed by unknown authority (talos)". The
+        # TALOS_CONFIG secret must be kept up-to-date from the homelab after any
+        # cluster recreation, same as KUBE_CONFIG.
+        env:
+          TALOS_CONFIG: ${{ secrets.TALOS_CONFIG }}
+        run: |
+          mkdir -p ~/.talos
+          umask 077
+          printf '%s' "${TALOS_CONFIG}" > ~/.talos/config
+          chmod 600 ~/.talos/config
+
       - name: 🔄 Update cluster
         run: ksail --config ksail.prod.yaml cluster update
         env:


### PR DESCRIPTION
## Problem

`cd.yaml` deploys fail at **🔄 Update cluster**:
```
failed to sync cluster secrets: failed to fetch machine config from 178.105.204.76:
tls: failed to verify certificate: x509: certificate signed by unknown authority (… "talos")
```

The job restores `KUBE_CONFIG` → `~/.kube/config`, but **never restores `TALOS_CONFIG`** to `~/.talos/config`. So `ksail cluster update` talks to the Talos API with a stale/derived client cert and can't verify the node. The `TALOS_CONFIG` environment secret already exists — it just wasn't wired into the workflow.

Confirmed by re-running the deploy after refreshing `KUBE_CONFIG` alone: it still failed identically on the Talos cert.

## Fix

Add a **Restore talosconfig** step mirroring the kubeconfig restore, writing the `TALOS_CONFIG` secret to `~/.talos/config`. The `TALOS_CONFIG` (and `KUBE_CONFIG`) secrets were refreshed from the homelab (verified `talosctl` reaches node 178.105.204.76).

## Effect

`ksail cluster update` authenticates to Talos → succeeds → `workload push` + `reconcile` run → the OCI image-automation finally deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)