### PR TITLE
fix(openbao): allow external-secrets to seed infrastructure/git/*

### DIFF
--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -319,6 +319,9 @@ spec:
               path "secret/data/infrastructure/oidc/*" {
                 capabilities = ["create", "update", "read"]
               }
+              path "secret/data/infrastructure/git/*" {
+                capabilities = ["create", "update", "read"]
+              }
               path "secret/data/apps/fleetdm/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -344,6 +347,9 @@ spec:
                 capabilities = ["create", "update", "read"]
               }
               path "secret/metadata/infrastructure/oidc/*" {
+                capabilities = ["create", "update", "read"]
+              }
+              path "secret/metadata/infrastructure/git/*" {
                 capabilities = ["create", "update", "read"]
               }
               path "secret/metadata/apps/fleetdm/*" {


### PR DESCRIPTION
## Problem

The v1.0.2 deploy succeeded, but the image-automation never applied. Root cause: the `seed-image-automation-git` PushSecret (added in #1552) writes the GitHub App key to `secret/infrastructure/git/image-automation`, and external-secrets gets **403 permission denied** there:
```
GET .../v1/secret/data/infrastructure/git/image-automation → 403 permission denied
```
`vault-seed-write` enumerates allowed seed paths (`infrastructure/backup/*`, `dns/*`, `hcloud/*`, `tls/*`, `oidc/*`, `apps/*`, `flux/*`) but **not `infrastructure/git/*`**. So the PushSecret stays `InProgress` → fails the **`infrastructure` Kustomization health check** (20m timeout) → blocks the **`apps`** layer → the whole reconcile stalls (no image-automation, and no other app changes apply either).

## Fix

Add `secret/data/infrastructure/git/*` and `secret/metadata/infrastructure/git/*` to the `vault-seed-write` policy (the `external-secrets` role already has this policy). Its `read` capability also authorizes the `image-automation-git-auth` ExternalSecret, so no extra read policy is needed.

## Effect

The vault-config Job re-runs (force-recreate on spec change) → updates the OpenBao policy → the PushSecret writes successfully → `infrastructure` health check passes → `apps` reconciles → the OCI image-automation (semver OCIRepository, ImageRepository/ImagePolicy, GitRepository via GitHub App, ImageUpdateAutomation) finally applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)