### PR TITLE
feat(apps): verify cosign signatures on app OCI artifacts

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/sync.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/sync.yaml
@@ -12,6 +12,11 @@ spec:
   url: oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests
   secretRef:
     name: ghcr-auth
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/k8s/bases/apps/wedding-app/sync.yaml
+++ b/k8s/bases/apps/wedding-app/sync.yaml
@@ -12,6 +12,11 @@ spec:
   url: oci://ghcr.io/devantler-tech/wedding-app/manifests
   secretRef:
     name: ghcr-auth
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Summary
- Enable keyless cosign signature verification (`spec.verify`) on the `wedding-app` and `ascoachingogvaner` OCIRepositories.
- Artifacts are signed in `reusable-workflows/.github/workflows/publish-app.yaml` via GitHub Actions OIDC (Fulcio/Rekor). source-controller now rejects any manifest not signed by that reusable workflow before reconciling it.

## Identity validated
The signing identity was extracted from the live signed artifacts (cert SAN) and validated with `cosign verify` against both `wedding-app/manifests:1.5.9` and `ascoachingogvaner/manifests:1.0.1`:

- issuer: `^https://token\.actions\.githubusercontent\.com$`
- subject: `^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$`

The subject matches the reusable workflow path with any pinned ref (`@.+`), so it survives Renovate/Dependabot bumps of the workflow SHA without breaking verification. A negative control (wrong path) was confirmed to fail.

## Test plan
- [x] Extracted cert SAN from both live artifacts (identical identity)
- [x] `cosign verify` exit 0 for both artifacts with the resilient regex
- [x] Negative control (wrong subject) correctly rejected
- [ ] After merge + deploy: confirm both OCIRepositories stay `Ready=True` (verification passes against live artifacts, no reconciliation halt)

Generated with Claude Code
