### PR TITLE
fix(ci): provide APP_PRIVATE_KEY under its required name to Sync Cluster Policies

### DIFF
--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -18,4 +18,4 @@ jobs:
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:
-      app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
The `Sync Cluster Policies` workflow has `startup_failure`d on every run for weeks — the last 30+ runs are all `startup_failure` (zero jobs start), so policy sync has been non-functional. It did succeed historically, before the break.

## Root cause
The caller maps the GitHub App key under the wrong secret name:

```yaml
secrets:
  app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
```

The reusable workflow `devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@v3.2.0` declares its secret as **`APP_PRIVATE_KEY`** with `required: true` — and has used that exact name since v2.0.0 (no rename). `app-private-key` is not a declared secret of the reusable workflow, so the **required** `APP_PRIVATE_KEY` is never provided → GitHub rejects the call at startup → `startup_failure` with no jobs. The past successes line up with a period when the caller's key matched the interface.

## Fix
Rename the caller's secret key to `APP_PRIVATE_KEY`, restoring the interface match. One-line, behaviour-preserving.

## Validation
Matches the reusable workflow's declared interface (`APP_PRIVATE_KEY`, `required: true`). The next scheduled/dispatch run will start and generate the App token. Note: the reusable job opens a policy-sync PR via that App token — confirm the GitHub App is installed with the needed scopes when promoting.
