### PR TITLE
feat(rbac): tenant ESO self-service — tenant-edit ClusterRole + ClusterSecretStore guard

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-secret-stores.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-secret-stores.yaml
@@ -1,0 +1,89 @@
+# Confines self-service tenants to their OWN namespaced SecretStore and blocks
+# any reference to the shared cluster-scoped ClusterSecretStore.
+#
+# Why: tenants are granted edit on ExternalSecret/PushSecret/SecretStore (see
+# cluster-roles/external-secrets-tenant-edit.yaml) so they can manage their own
+# OpenBao-backed secrets. Referencing a ClusterSecretStore needs no RBAC on the
+# store object, and the shared ClusterSecretStore/openbao authenticates as the
+# `external-secrets` SA/role (broad infra + seed-write policies). Without this
+# guard a tenant could point an ExternalSecret/PushSecret at the shared store
+# and read/write OpenBao keys outside its own apps/<tenant>/* prefix — a
+# privilege-escalation path. A tenant must instead create its own namespaced
+# SecretStore authenticating via a tenant-scoped Vault role.
+#
+# Scope: only ksail-generated tenant namespaces (labelled
+# app.kubernetes.io/managed-by: ksail) — currently ascoachingogvaner and
+# wedding-app, plus any future tenant — so platform/infra namespaces that
+# legitimately use the ClusterSecretStore (actual-budget, fleetdm, openbao,
+# cert-manager, external-dns, flux-system, velero, …) are unaffected.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-tenant-secret-stores
+  annotations:
+    policies.kyverno.io/title: Restrict Tenant SecretStores
+    policies.kyverno.io/category: Security, External Secrets
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: ExternalSecret, PushSecret
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Blocks ExternalSecret and PushSecret resources in ksail tenant namespaces
+      from referencing the cluster-scoped ClusterSecretStore (top-level store
+      ref or per-entry sourceRef overrides). Tenants must use their own
+      namespaced SecretStore, which authenticates via a tenant-scoped Vault role
+      limited to secret/data/apps/<tenant>/*, preserving per-tenant isolation.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: externalsecret-no-clustersecretstore
+      match:
+        any:
+          - resources:
+              kinds:
+                - ExternalSecret
+              namespaceSelector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: ksail
+      validate:
+        message: >-
+          Tenant ExternalSecrets must reference a namespaced SecretStore
+          (kind: SecretStore), not the shared ClusterSecretStore. Create a
+          SecretStore in this namespace that authenticates via your
+          tenant-scoped Vault role.
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec.secretStoreRef.kind || '' }}"
+                operator: Equals
+                value: ClusterSecretStore
+              - key: "{{ request.object.spec.data[].sourceRef.storeRef.kind || `[]` }}"
+                operator: AnyIn
+                value:
+                  - ClusterSecretStore
+              - key: "{{ request.object.spec.dataFrom[].sourceRef.storeRef.kind || `[]` }}"
+                operator: AnyIn
+                value:
+                  - ClusterSecretStore
+    - name: pushsecret-no-clustersecretstore
+      match:
+        any:
+          - resources:
+              kinds:
+                - PushSecret
+              namespaceSelector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: ksail
+      validate:
+        message: >-
+          Tenant PushSecrets must reference a namespaced SecretStore
+          (kind: SecretStore), not the shared ClusterSecretStore. Create a
+          SecretStore in this namespace that authenticates via your
+          tenant-scoped Vault role.
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec.secretStoreRefs[].kind || `[]` }}"
+                operator: AnyIn
+                value:
+                  - ClusterSecretStore

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - best-practices/add-security-context.yaml
   - best-practices/auto-vpa.yaml
   - best-practices/disable-default-sa-automount.yaml
+  - best-practices/restrict-tenant-secret-stores.yaml
   - best-practices/validate-host-restrictions.yaml
   - best-practices/validate-pod-security.yaml
   - flux/enforce-flux-best-practices.yaml

--- a/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
@@ -1,0 +1,36 @@
+# Aggregate ClusterRole that extends the built-in 'edit' ClusterRole with
+# External Secrets verbs so any ServiceAccount bound to 'edit' (e.g. the
+# ascoachingogvaner tenant) can manage its own ExternalSecret, PushSecret and
+# Password generator resources in its namespace — letting a tenant own the
+# full lifecycle of its OpenBao-backed secrets from its own deploy artifact.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-tenant-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - externalsecrets
+      - pushsecrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["generators.external-secrets.io"]
+    resources:
+      - passwords
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
@@ -6,9 +6,10 @@
 #
 # Forward-looking platform primitive: no tenant uses it yet. When a tenant
 # adopts OpenBao-backed secrets it also gets a dedicated, tenant-scoped Vault
-# role + policy (added to vault-config/job.yaml, limited to
-# secret/apps/<tenant>/*) and points its resources at its OWN namespaced
-# SecretStore authenticating via that role.
+# role + policy (added to vault-config/job.yaml, limited to the KV v2 paths
+# secret/data/apps/<tenant>/* and secret/metadata/apps/<tenant>/*) and points
+# its resources at its OWN namespaced SecretStore (remoteRef keys
+# apps/<tenant>/* with the store's path: secret) authenticating via that role.
 #
 # Grants only namespaced SecretStores (not the cluster-scoped
 # ClusterSecretStore), so a tenant is confined to its tenant-scoped Vault role

--- a/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
@@ -1,15 +1,18 @@
 # Aggregate ClusterRole that extends the built-in 'edit' ClusterRole with
-# External Secrets verbs so any ServiceAccount bound to 'edit' (e.g. the
-# ascoachingogvaner tenant) can manage its own SecretStore, ExternalSecret,
-# PushSecret and Password generator resources in its namespace — letting a
-# tenant own the full lifecycle of its OpenBao-backed secrets from its own
-# deploy artifact.
+# External Secrets verbs, so a self-service tenant whose ServiceAccount is
+# bound to 'edit' can manage its own SecretStore, ExternalSecret, PushSecret
+# and Password generator resources in its namespace — owning the full
+# lifecycle of its OpenBao-backed secrets from its own deploy artifact.
 #
-# Note: this grants only namespaced SecretStores (not the cluster-scoped
-# ClusterSecretStore). Each tenant points its resources at its OWN namespaced
-# SecretStore, which authenticates via a tenant-scoped Vault role limited to
-# secret/apps/<tenant>/* (see vault-config/job.yaml), so a tenant cannot read
-# or write infra or other tenants' secrets.
+# Forward-looking platform primitive: no tenant uses it yet. When a tenant
+# adopts OpenBao-backed secrets it also gets a dedicated, tenant-scoped Vault
+# role + policy (added to vault-config/job.yaml, limited to
+# secret/apps/<tenant>/*) and points its resources at its OWN namespaced
+# SecretStore authenticating via that role.
+#
+# Grants only namespaced SecretStores (not the cluster-scoped
+# ClusterSecretStore), so a tenant is confined to its tenant-scoped Vault role
+# and can never read or write infra or other tenants' secrets.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
@@ -1,8 +1,15 @@
 # Aggregate ClusterRole that extends the built-in 'edit' ClusterRole with
 # External Secrets verbs so any ServiceAccount bound to 'edit' (e.g. the
-# ascoachingogvaner tenant) can manage its own ExternalSecret, PushSecret and
-# Password generator resources in its namespace — letting a tenant own the
-# full lifecycle of its OpenBao-backed secrets from its own deploy artifact.
+# ascoachingogvaner tenant) can manage its own SecretStore, ExternalSecret,
+# PushSecret and Password generator resources in its namespace — letting a
+# tenant own the full lifecycle of its OpenBao-backed secrets from its own
+# deploy artifact.
+#
+# Note: this grants only namespaced SecretStores (not the cluster-scoped
+# ClusterSecretStore). Each tenant points its resources at its OWN namespaced
+# SecretStore, which authenticates via a tenant-scoped Vault role limited to
+# secret/apps/<tenant>/* (see vault-config/job.yaml), so a tenant cannot read
+# or write infra or other tenants' secrets.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -13,6 +20,7 @@ metadata:
 rules:
   - apiGroups: ["external-secrets.io"]
     resources:
+      - secretstores
       - externalsecrets
       - pushsecrets
     verbs:

--- a/k8s/bases/infrastructure/cluster-roles/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cnpg-tenant-edit.yaml
+  - external-secrets-tenant-edit.yaml
   - gateway-tenant-edit.yaml

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -279,20 +279,6 @@ spec:
               }
               POLICY
 
-              # Tenant-scoped policy: read (ExternalSecret) + write (PushSecret
-              # seed) limited to the tenant's own prefix. Attached ONLY to the
-              # tenant's own Vault role below — never to the shared
-              # external-secrets role — so a tenant can never reach infra or
-              # another tenant's secrets via the shared ClusterSecretStore.
-              bao policy write app-ascoachingogvaner - <<'POLICY'
-              path "secret/data/apps/ascoachingogvaner/*" {
-                capabilities = ["create", "update", "read"]
-              }
-              path "secret/metadata/apps/ascoachingogvaner/*" {
-                capabilities = ["create", "update", "read"]
-              }
-              POLICY
-
               bao policy write infra-oidc-readonly - <<'POLICY'
               path "secret/data/infrastructure/oidc/*" {
                 capabilities = ["read"]
@@ -385,20 +371,6 @@ spec:
                 bound_service_account_names=external-secrets \
                 bound_service_account_namespaces=external-secrets \
                 policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-wedding-readonly,infra-oidc-readonly,vault-seed-write \
-                ttl=1h
-
-              # Per-tenant role for self-service tenants that manage their own
-              # OpenBao-backed secrets from their deploy artifact. Bound to the
-              # tenant's ServiceAccount and carrying ONLY the tenant-scoped
-              # policy, so each tenant is isolated to its own apps/<tenant>/*
-              # prefix — tenants never share a role or reach each other's (or
-              # infra) secrets. The tenant's namespaced SecretStore authenticates
-              # via this role (not the shared external-secrets role). Add one
-              # role + one app-<tenant> policy per self-service tenant.
-              bao write auth/kubernetes/role/ascoachingogvaner \
-                bound_service_account_names=ascoachingogvaner \
-                bound_service_account_namespaces=ascoachingogvaner \
-                policies=app-ascoachingogvaner \
                 ttl=1h
 
               # Snapshot CronJob needs health check read

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -279,9 +279,17 @@ spec:
               }
               POLICY
 
-              bao policy write app-ascoachingogvaner-readonly - <<'POLICY'
+              # Tenant-scoped policy: read (ExternalSecret) + write (PushSecret
+              # seed) limited to the tenant's own prefix. Attached ONLY to the
+              # tenant's own Vault role below — never to the shared
+              # external-secrets role — so a tenant can never reach infra or
+              # another tenant's secrets via the shared ClusterSecretStore.
+              bao policy write app-ascoachingogvaner - <<'POLICY'
               path "secret/data/apps/ascoachingogvaner/*" {
-                capabilities = ["read"]
+                capabilities = ["create", "update", "read"]
+              }
+              path "secret/metadata/apps/ascoachingogvaner/*" {
+                capabilities = ["create", "update", "read"]
               }
               POLICY
 
@@ -334,9 +342,6 @@ spec:
               path "secret/data/apps/wedding-app/*" {
                 capabilities = ["create", "update", "read"]
               }
-              path "secret/data/apps/ascoachingogvaner/*" {
-                capabilities = ["create", "update", "read"]
-              }
               path "secret/data/flux/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -367,9 +372,6 @@ spec:
               path "secret/metadata/apps/wedding-app/*" {
                 capabilities = ["create", "update", "read"]
               }
-              path "secret/metadata/apps/ascoachingogvaner/*" {
-                capabilities = ["create", "update", "read"]
-              }
               path "secret/metadata/flux/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -382,7 +384,21 @@ spec:
               bao write auth/kubernetes/role/external-secrets \
                 bound_service_account_names=external-secrets \
                 bound_service_account_namespaces=external-secrets \
-                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-wedding-readonly,app-ascoachingogvaner-readonly,infra-oidc-readonly,vault-seed-write \
+                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-wedding-readonly,infra-oidc-readonly,vault-seed-write \
+                ttl=1h
+
+              # Per-tenant role for self-service tenants that manage their own
+              # OpenBao-backed secrets from their deploy artifact. Bound to the
+              # tenant's ServiceAccount and carrying ONLY the tenant-scoped
+              # policy, so each tenant is isolated to its own apps/<tenant>/*
+              # prefix — tenants never share a role or reach each other's (or
+              # infra) secrets. The tenant's namespaced SecretStore authenticates
+              # via this role (not the shared external-secrets role). Add one
+              # role + one app-<tenant> policy per self-service tenant.
+              bao write auth/kubernetes/role/ascoachingogvaner \
+                bound_service_account_names=ascoachingogvaner \
+                bound_service_account_namespaces=ascoachingogvaner \
+                policies=app-ascoachingogvaner \
                 ttl=1h
 
               # Snapshot CronJob needs health check read

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -279,6 +279,12 @@ spec:
               }
               POLICY
 
+              bao policy write app-ascoachingogvaner-readonly - <<'POLICY'
+              path "secret/data/apps/ascoachingogvaner/*" {
+                capabilities = ["read"]
+              }
+              POLICY
+
               bao policy write infra-oidc-readonly - <<'POLICY'
               path "secret/data/infrastructure/oidc/*" {
                 capabilities = ["read"]
@@ -328,6 +334,9 @@ spec:
               path "secret/data/apps/wedding-app/*" {
                 capabilities = ["create", "update", "read"]
               }
+              path "secret/data/apps/ascoachingogvaner/*" {
+                capabilities = ["create", "update", "read"]
+              }
               path "secret/data/flux/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -358,6 +367,9 @@ spec:
               path "secret/metadata/apps/wedding-app/*" {
                 capabilities = ["create", "update", "read"]
               }
+              path "secret/metadata/apps/ascoachingogvaner/*" {
+                capabilities = ["create", "update", "read"]
+              }
               path "secret/metadata/flux/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -370,7 +382,7 @@ spec:
               bao write auth/kubernetes/role/external-secrets \
                 bound_service_account_names=external-secrets \
                 bound_service_account_namespaces=external-secrets \
-                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-wedding-readonly,infra-oidc-readonly,vault-seed-write \
+                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-wedding-readonly,app-ascoachingogvaner-readonly,infra-oidc-readonly,vault-seed-write \
                 ttl=1h
 
               # Snapshot CronJob needs health check read


### PR DESCRIPTION
## What

Platform primitives that let a self-service tenant own its OpenBao-backed secrets from its own deploy artifact, **with enforced per-tenant isolation**:

1. **`cluster-roles/external-secrets-tenant-edit.yaml`** — `aggregate-to-edit` ClusterRole granting tenants edit on namespaced `secretstores`, `externalsecrets`, `pushsecrets` (`external-secrets.io`) and `passwords` (`generators.external-secrets.io`). Not `clustersecretstores`. Mirrors `cnpg-tenant-edit` / `gateway-tenant-edit`.
2. **`cluster-policies/best-practices/restrict-tenant-secret-stores.yaml`** — Kyverno `ClusterPolicy` (Enforce) that **denies ExternalSecret/PushSecret referencing a `ClusterSecretStore`** (top-level `secretStoreRef`/`secretStoreRefs` and per-entry `sourceRef.storeRef`) in ksail tenant namespaces.

## Security model

Granting tenants ESO edit isn't enough on its own: referencing the shared `ClusterSecretStore/openbao` needs no RBAC on the store, and that store authenticates as the broad `external-secrets` role (infra read + seed-write) — a privilege-escalation path to secrets outside `apps/<tenant>/*` (raised in review). Closed by the Kyverno guard:

- Tenants can only create resources that reference a **namespaced** `SecretStore` (which a tenant points at a **tenant-scoped Vault role** limited to `secret/data/apps/<tenant>/*`).
- The guard is scoped via `namespaceSelector: app.kubernetes.io/managed-by: ksail` — the signature ksail stamps on every tenant namespace (currently `ascoachingogvaner`, `wedding-app`; any future tenant inherits it automatically). Platform/infra namespaces that legitimately use the `ClusterSecretStore` (actual-budget, fleetdm, openbao, cert-manager, external-dns, flux-system, velero, …) lack the label and are unaffected.

## Why this is just the generic enabler

It originally also provisioned a tenant-scoped Vault role/policy + SecretStore for **ascoachingogvaner**. That app is now being converted to a fully static site (devantler-tech/ascoachingogvaner#9) and needs **no secrets**, so the tenant-specific pieces were reverted. What remains is the reusable, enforced platform primitive. **No tenant uses it today**, so the Kyverno policy is purely preventive (nothing to break). A future tenant adopting OpenBao secrets adds its own `app-<tenant>` Vault role/policy here + a namespaced SecretStore in its repo — the reverted commits + devantler-tech/ascoachingogvaner#8 are the reference design.

## Validation

`ksail --config ksail.prod.yaml workload validate` and `ksail workload validate` → 262 files validated. Purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)