### PR TITLE
chore(ascoachingogvaner): cut over to static v1.1.0, drop dead CNPG db config

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/networkpolicy.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/networkpolicy.yaml
@@ -6,43 +6,14 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    # Gateway ingress
+    # Gateway ingress — static site served by unprivileged nginx on 8080
     - fromEntities:
         - ingress
       toPorts:
         - ports:
-            - port: "3000"
-              protocol: TCP
-    # Intra-namespace (app → db, db replication)
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: ascoachingogvaner
-    # CNPG operator needs to reach DB status endpoint (port 8000)
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: cnpg-system
-      toPorts:
-        - ports:
-            - port: "8000"
-              protocol: TCP
-            - port: "5432"
-              protocol: TCP
-    # Metrics scraping from monitoring namespace
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: monitoring
-      toPorts:
-        - ports:
-            - port: "9187"
+            - port: "8080"
               protocol: TCP
   egress:
-    # Intra-namespace (app → db)
-    - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: ascoachingogvaner
-    # Kube API (for CNPG operator managing the cluster)
-    - toEntities:
-        - kube-apiserver
     # DNS resolution
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/apps/ascoachingogvaner/sync.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m
   ref:
-    tag: 1.0.1 # {"$imagepolicy": "ascoachingogvaner:ascoachingogvaner:tag"}
+    tag: 1.1.0 # {"$imagepolicy": "ascoachingogvaner:ascoachingogvaner:tag"}
   url: oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests
   secretRef:
     name: ghcr-auth

--- a/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
@@ -6,18 +6,6 @@ metadata:
 spec:
   patches:
     - target:
-        group: postgresql.cnpg.io
-        kind: Cluster
-        name: ascoaching-db
-      patch: |
-        apiVersion: postgresql.cnpg.io/v1
-        kind: Cluster
-        metadata:
-          name: ascoaching-db
-        spec:
-          storage:
-            storageClass: longhorn
-    - target:
         kind: HTTPRoute
         name: ascoachingogvaner
       patch: |


### PR DESCRIPTION
> 🤖 **AI-generated PR** — created by Claude Code (Opus 4.7). Please review carefully before merging.

## What

Cuts the ascoachingogvaner tenant over to the fully static site (devantler-tech/ascoachingogvaner#9, released **v1.1.0**) and removes the platform-side config that existed only for the now-deleted database. This is an **atomic cutover** — the artifact pin and the overlay flip together in a single merge:

1. **`sync.yaml`** — bump OCIRepository `ref.tag` `1.0.1 → 1.1.0` (the static release; `manifests:1.1.0` is published in GHCR). The `$imagepolicy` setter marker is preserved.
2. **`kustomization-patch.yaml`** — remove the `postgresql.cnpg.io/Cluster` `ascoaching-db` patch (HTTPRoute hostname patch kept).
3. **`networkpolicy.yaml`** (`CiliumNetworkPolicy`) — drop the DB-only rules (cnpg-system 8000/5432, monitoring 9187, intra-namespace ingress/egress, kube-apiserver egress) and correct the gateway-ingress port **3000 → 8080** (the static app is unprivileged nginx on 8080). DNS egress kept.

## Why atomic

Splitting these breaks prod:
- **Tag bump alone** → the leftover CNPG patch matches nothing in the 1.1.0 artifact → `no matches for Id …Cluster.ascoaching-db` → tenant build fails.
- **Overlay cleanup alone** (tag still 1.0.1) → netpol flips to 8080 + drops DB rules while the old app still serves on 3000 with a live DB → old app goes dark.

`flux-image-automation` cannot advance the tag itself — it pushes directly to protected `main` and has never landed a commit — so the bump is done here.

## ⚠️ Prod impact

Merging rolls the static site live and, via `prune: true`, **deletes the CNPG `Cluster/ascoaching-db`** (intended by #9; irreversible DB teardown).

## Coordination

- devantler-tech/ascoachingogvaner#9 — the static conversion (merged, released v1.1.0).
- devantler-tech/platform#1582 — drops the tenant's now-dead SOPS decryption. Not required for this cutover; safe to merge as follow-up cleanup (the decryption block is harmless once the artifact ships no encrypted files).

## Validation

Both pass on this branch (rebased on current `main`):

- `ksail --config ksail.prod.yaml workload validate` → ✔ 260 files validated
- `ksail workload validate` → ✔ 260 files validated
