### PR TITLE
ci: drop manual stuck-HelmRelease reset step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,29 +279,6 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
 
-      - name: 🔧 Reset stuck HelmReleases
-        continue-on-error: true
-        run: |
-          # HelmReleases may be stuck in Failed state after a cluster outage (e.g.
-          # Kyverno webhook unavailable during recovery exhausted the retry budget).
-          # Suspend + resume clears the failure status so the new OCI artifact spec
-          # (with explicit remediation) can take effect on the next reconcile.
-          kubectl get helmreleases.helm.toolkit.fluxcd.io -A -o json 2>/dev/null | \
-            jq -r '.items[] | select(.status.conditions // [] | any(.type == "Ready" and .status == "False" and (.reason // "" | test("Failed|Stalled")))) | "\(.metadata.namespace) \(.metadata.name)"' | \
-          while read -r ns name; do
-            printf 'Resetting stuck HelmRelease: %s/%s\n' "$ns" "$name"
-            kubectl patch helmrelease.helm.toolkit.fluxcd.io "$name" -n "$ns" \
-              --type=merge -p '{"spec":{"suspend":true}}' || true
-          done
-          sleep 5
-          kubectl get helmreleases.helm.toolkit.fluxcd.io -A -o json 2>/dev/null | \
-            jq -r '.items[] | select(.spec.suspend == true) | "\(.metadata.namespace) \(.metadata.name)"' | \
-          while read -r ns name; do
-            printf 'Resuming HelmRelease: %s/%s\n' "$ns" "$name"
-            kubectl patch helmrelease.helm.toolkit.fluxcd.io "$name" -n "$ns" \
-              --type=merge -p '{"spec":{"suspend":false}}' || true
-          done
-
       - name: 🔁 Trigger Flux reconciliation
         id: reconcile
         run: ksail --config ksail.prod.yaml workload reconcile


### PR DESCRIPTION
## What

Removes the `🔧 Reset stuck HelmReleases` step from the merge-queue prod-deploy job in `.github/workflows/ci.yaml`.

The step ran between `📦 Push manifests to GHCR` and `🔁 Trigger Flux reconciliation`, listing HelmReleases stuck in a `Failed`/`Stalled` Ready state and clearing them via a `suspend: true` → `suspend: false` patch loop.

## Why

KSail now performs this stuck-HelmRelease suspend/resume natively during `workload reconcile`, so the manual loop is redundant.

## Notes for reviewers

- The step only existed in `ci.yaml`. `cd.yaml` never had it (it already goes straight from push → reconcile), so no change was needed there.
- No other references to the step remain in `.github/` or `docs/`.
- Both `ci.yaml` and `cd.yaml` still parse as valid YAML; surrounding steps are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)