### PR TITLE
fix(ascoachingogvaner): reconcile static tenant (tag 1.1.0, drop CNPG patch)

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/networkpolicy.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/networkpolicy.yaml
@@ -13,36 +13,7 @@ spec:
         - ports:
             - port: "3000"
               protocol: TCP
-    # Intra-namespace (app → db, db replication)
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: ascoachingogvaner
-    # CNPG operator needs to reach DB status endpoint (port 8000)
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: cnpg-system
-      toPorts:
-        - ports:
-            - port: "8000"
-              protocol: TCP
-            - port: "5432"
-              protocol: TCP
-    # Metrics scraping from monitoring namespace
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: monitoring
-      toPorts:
-        - ports:
-            - port: "9187"
-              protocol: TCP
   egress:
-    # Intra-namespace (app → db)
-    - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: ascoachingogvaner
-    # Kube API (for CNPG operator managing the cluster)
-    - toEntities:
-        - kube-apiserver
     # DNS resolution
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/apps/ascoachingogvaner/sync.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m
   ref:
-    tag: 1.0.1 # {"$imagepolicy": "ascoachingogvaner:ascoachingogvaner:tag"}
+    tag: 1.1.0 # {"$imagepolicy": "ascoachingogvaner:ascoachingogvaner:tag"}
   url: oci://ghcr.io/devantler-tech/ascoachingogvaner/manifests
   secretRef:
     name: ghcr-auth

--- a/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
@@ -5,18 +5,10 @@ metadata:
   namespace: ascoachingogvaner
 spec:
   patches:
-    - target:
-        group: postgresql.cnpg.io
-        kind: Cluster
-        name: ascoaching-db
-      patch: |
-        apiVersion: postgresql.cnpg.io/v1
-        kind: Cluster
-        metadata:
-          name: ascoaching-db
-        spec:
-          storage:
-            storageClass: longhorn
+    # The static ascoachingogvaner app no longer ships a CNPG Cluster (it was
+    # removed in the static-site conversion, ascoachingogvaner v1.1.0), so the
+    # former Cluster/ascoaching-db storageClass patch is gone — patching a
+    # non-existent target fails the kustomize build.
     - target:
         kind: HTTPRoute
         name: ascoachingogvaner


### PR DESCRIPTION
## 🛑 Prod breakage — ascoachingogvaner tenant reconciliation is failing

The static-site conversion ([ascoachingogvaner#9](https://github.com/devantler-tech/ascoachingogvaner/pull/9), released **v1.1.0**) and the SOPS removal (#1582) merged into platform **v1.2.0** without the coordinating tenant changes, leaving a broken state on `main`:

1. **SOPS ciphertext (active now):** the tenant `OCIRepository` is still pinned at app **`1.0.1`**, which ships the SOPS-encrypted `admin-code-secret.enc.yaml`. #1582 removed the Kustomization's `decryption: sops`, so Flux applies the encrypted Secret raw → reconcile fails. Image-automation hadn't advanced the tag (10+ min after v1.1.0 publish).
2. **CNPG patch mismatch (latent):** the hetzner overlay patches `Cluster/ascoaching-db`, which the static **v1.1.0** no longer ships → patching a non-existent target fails the kustomize build, so even after the tag advances the tenant would stay broken.

## Fix

| File | Change |
|---|---|
| `k8s/bases/apps/ascoachingogvaner/sync.yaml` | Bump OCIRepository tag **`1.0.1` → `1.1.0`** (static manifest artifact; tag verified published in GHCR). 1.1.0 has no `*.enc.yaml`, so the already-removed SOPS decryption is correct. |
| `…/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml` | Drop the `Cluster/ascoaching-db` storageClass patch (keep the HTTPRoute hostname patch). |
| `k8s/bases/apps/ascoachingogvaner/networkpolicy.yaml` | Remove dead DB rules (cnpg-system 8000/5432, postgres-exporter 9187, intra-ns + kube-apiserver egress); keep gateway ingress `:3000` + DNS egress. |

## Validation / caveats

- `ksail --config ksail.prod.yaml workload validate` → 261 files validated.
- The CNPG-patch fix is a **Flux runtime** behavior (`spec.patches` is data in the Kustomization CR), so static build can't exercise it — correctness is by inspection. The tenant is prod-only, so CI's system test doesn't cover it either.
- The tag bump matches what image-automation would commit (semver `>=1.0.0` → `1.1.0`); doing it here closes the SOPS window deterministically since automation hadn't.

**Recommend fast-tracking** (promote/merge) to clear the prod failure. After merge + reconcile, the tenant serves the static v1.1.0 site with no secrets and no DB. If you have cluster access, worth confirming the `ascoachingogvaner` Kustomization goes Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)