### PR TITLE
fix(ci): create skills-sync PR with an App token so required CI runs

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -15,6 +15,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@e173ff69586caa379a77782b947f1b47166f922e # v1.39.0+ (post skills-lock refactor)
+    uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@e173ff69586caa379a77782b947f1b47166f922e # v4.0.1
     with:
       dir: .agents/skills
+      # Create the update PR with a GitHub App token so it triggers this
+      # repo's required CI (a PR opened with GITHUB_TOKEN does not), instead
+      # of landing permanently blocked on missing required checks.
+      use-app-token: true
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
The daily **Update Copilot Skills** workflow (`update-skills.yaml`) opens its
PR with the default `GITHUB_TOKEN`. A PR created with `GITHUB_TOKEN` does **not**
trigger the caller's `on: pull_request` / `push` CI, so the required status
checks never report — the PR (currently [#1590](https://github.com/devantler-tech/platform/pull/1590))
lands **permanently `BLOCKED`** on missing required checks and the skills never
actually sync. It shows only `CodeQL` / `Analyze (actions)` succeeding (those run
regardless), with the required CI absent.

## Fix
Adopt the reusable workflow's `use-app-token: true` input with the org
`APP_PRIVATE_KEY` secret (paired with the existing `APP_ID` repo variable). The
App-token PR triggers CI normally, so required checks report and the PR can merge.

This mirrors the identical fix already shipped and merged for the **plugins** repo
([plugins#10](https://github.com/devantler-tech/plugins/pull/10)) — platform was the
remaining un-migrated caller of the same reusable workflow. The pinned SHA
`e173ff69` is already **v4.0.1**, which supports `use-app-token` (added in v3.3.0),
so no pin bump is needed. Platform already uses `secrets.APP_PRIVATE_KEY` in
`sync-cluster-policies.yaml`, so the credentials are available.

Also corrected the stale/misleading pin comment (`# v1.39.0+ (post skills-lock
refactor)` → `# v4.0.1`) to match the actual pinned SHA and the convention used by
the other reusable-workflow callers in this repo (e.g. `release.yaml`).

## Validation
`actionlint .github/workflows/update-skills.yaml` → clean (exit 0). Additive and
backward-compatible; affects only how the scheduled skills-sync PR is created.
The change can't be exercised by this PR's own CI (the workflow is
schedule/dispatch-only) — the next scheduled run (or a `workflow_dispatch`) will
confirm the resulting PR triggers required CI.