### PR TITLE
fix(kyverno): set pod-level seccompProfile on CRD-migration hook job

### DIFF
--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -139,3 +139,13 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+    crds:
+      migration:
+        # The kyverno-migrate-resources post-upgrade hook job sets seccompProfile
+        # only at the container level; our require-seccomp-profile ClusterPolicy
+        # checks pod-level securityContext, so set it here too (chart default is {})
+        # to keep the hook pod compliant and stop background-scan PolicyViolations.
+        podSecurityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## What

Set `crds.migration.podSecurityContext` (`runAsNonRoot: true` + `seccompProfile.type: RuntimeDefault`) on the Kyverno `HelmRelease`, matching the pattern already used for the four Kyverno controllers in the same file.

## Why

While investigating recurring cluster warnings, two of them traced to a single root cause: the `kyverno-migrate-resources` **Completed** Helm `post-upgrade` hook pod.

- The `validate-pod-security` ClusterPolicy runs in **Enforce** mode with `background: true`. Its background scanner keeps re-evaluating the lingering Completed hook pod and emitting a `PolicyViolation` on every scan (the events surfaced in both the `default` and `kyverno` namespaces).
- The single failing rule is `require-seccomp-profile`, which checks the **pod-level** `/spec/securityContext/seccompProfile`. The chart's hook job sets seccomp only at the **container** level (`crds.migration.podSecurityContext` defaults to `{}`).
- PolicyReport for the pod: **4 PASS / 1 FAIL** — the FAIL being this rule.

## Effect

Because this is a values change, Flux runs a `helm upgrade`, which re-runs the post-upgrade hook. The chart's default `before-hook-creation` delete policy replaces the current non-compliant pod with a compliant one, clearing the recurring warnings.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` build.
- `kubectl kustomize k8s/bases/infrastructure/controllers/kyverno/` builds with the new block.
- `helm template kyverno/kyverno --version 3.8.1` with the value set confirms the `kyverno-migrate-resources` Job now renders a **pod-level** `securityContext` with `seccompProfile: RuntimeDefault`.

## Out of scope (investigated, no change)

The third warning — Headlamp readiness probe `connection refused` on :4466 — is benign. It's a KEDA scale-to-zero shutdown race (`HTTPScaledObject` `min: 0`, `scaledownPeriod: 300`): the readiness probe fires once as the container stops listening during scale-down. The replacement pod cold-starts with zero probe failures; routing/availability are unaffected. Silencing it would mean giving up scale-to-zero, so no change was made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)