### PR TITLE
ci: gate deploys on no new cluster event warnings

### DIFF
--- a/.github/actions/check-event-warnings/action.yaml
+++ b/.github/actions/check-event-warnings/action.yaml
@@ -1,0 +1,89 @@
+name: Check for new event warnings
+description: >
+  Fail when a cluster is still emitting Warning events after a successful
+  deployment. Records a marker timestamp, lets the cluster settle, then
+  inspects Warning events whose most-recent occurrence is at/after the marker —
+  i.e. warnings still firing at steady state (crash loops, repeated probe
+  failures, image back-off, etc.). Transient one-shot warnings emitted during
+  bootstrap are ignored because they fired before the marker. The full Warning
+  history is always printed for context.
+
+inputs:
+  context:
+    description: kubectl context to target. Empty uses the kubeconfig current-context.
+    required: false
+    default: ""
+  settle-seconds:
+    description: How long to let the cluster settle before sampling Warning events.
+    required: false
+    default: "90"
+  fail-on-warning:
+    description: Fail the step when steady-state Warning events are found.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: 🔎 Check for new event warnings
+      shell: bash
+      env:
+        KUBECTL_CONTEXT: ${{ inputs.context }}
+        SETTLE_SECONDS: ${{ inputs.settle-seconds }}
+        FAIL_ON_WARNING: ${{ inputs.fail-on-warning }}
+      run: |
+        set -euo pipefail
+
+        kc=(kubectl)
+        if [ -n "${KUBECTL_CONTEXT}" ]; then
+          kc+=(--context "${KUBECTL_CONTEXT}")
+        fi
+
+        # Record the marker BEFORE settling so the observation window is exactly
+        # the settle period. RFC3339 UTC timestamps compare correctly as strings
+        # when truncated to second precision (fixed-width prefix).
+        marker=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        echo "Marker: ${marker} — letting the cluster settle for ${SETTLE_SECONDS}s, then sampling Warning events that fired at/after the marker."
+        sleep "${SETTLE_SECONDS}"
+
+        events_json=$("${kc[@]}" get events -A -o json)
+
+        # Normalise both event shapes (core/v1 Event and events.k8s.io/v1) and
+        # keep only Warnings whose most-recent occurrence is at/after the marker.
+        new_warnings=$(printf '%s' "${events_json}" | jq -c --arg marker "${marker}" '
+          [ .items[]
+            | select(.type == "Warning")
+            | (.series.lastObservedTime // .lastTimestamp // .deprecatedLastTimestamp // .eventTime // .metadata.creationTimestamp) as $ts
+            | select($ts != null and ($ts[0:19]) >= ($marker[0:19]))
+            | { ns:     (.metadata.namespace // .involvedObject.namespace // .regarding.namespace // "-"),
+                reason: (.reason // "-"),
+                obj:    "\(.involvedObject.kind // .regarding.kind // "?")/\(.involvedObject.name // .regarding.name // "?")",
+                msg:    ((.message // .note // "") | gsub("\\s+"; " ") | .[0:300]),
+                count:  (.count // .series.count // .deprecatedCount // 1),
+                ts:     $ts }
+          ]
+          | sort_by(.ts)
+        ')
+        count=$(printf '%s' "${new_warnings}" | jq 'length')
+
+        echo "::group::New Warning events since ${marker} (${count})"
+        if [ "${count}" -eq 0 ]; then
+          echo "None — no Warning events fired during the ${SETTLE_SECONDS}s steady-state window. ✅"
+        else
+          printf '%s' "${new_warnings}" | jq -r '.[] | "\(.ts)  [\(.ns)] \(.obj)  \(.reason) (x\(.count)): \(.msg)"'
+        fi
+        echo "::endgroup::"
+
+        # Always print the full Warning history (any time) for context — report-only.
+        echo "::group::All Warning events (history, report-only)"
+        "${kc[@]}" get events -A --field-selector type=Warning --sort-by=.lastTimestamp 2>/dev/null | tail -200 || echo "(none / unavailable)"
+        echo "::endgroup::"
+
+        if [ "${count}" -gt 0 ]; then
+          summary=$(printf '%s' "${new_warnings}" | jq -r 'group_by(.reason) | map("\(length)× \(.[0].reason)") | join(", ")')
+          if [ "${FAIL_ON_WARNING}" = "true" ]; then
+            echo "::error title=New event warnings after deploy::${count} Warning event(s) still firing at steady state: ${summary}. See the 'Check for new event warnings' step log."
+            exit 1
+          fi
+          echo "::warning title=New event warnings after deploy::${count} Warning event(s) still firing at steady state: ${summary}. (report-only)"
+        fi

--- a/.github/actions/check-event-warnings/action.yaml
+++ b/.github/actions/check-event-warnings/action.yaml
@@ -80,10 +80,14 @@ runs:
         echo "::endgroup::"
 
         if [ "${count}" -gt 0 ]; then
-          summary=$(printf '%s' "${new_warnings}" | jq -r 'group_by(.reason) | map("\(length)× \(.[0].reason)") | join(", ")')
+          # Per-reason occurrence totals: sum .count rather than count event
+          # objects, since one crash-looping pod is a single Event with
+          # count=N. jq's group_by sorts its input internally, so the timestamp
+          # ordering of new_warnings never splits a reason across groups.
+          summary=$(printf '%s' "${new_warnings}" | jq -r 'group_by(.reason) | map("\(.[0].reason) ×\(map(.count) | add)") | join(", ")')
           if [ "${FAIL_ON_WARNING}" = "true" ]; then
-            echo "::error title=New event warnings after deploy::${count} Warning event(s) still firing at steady state: ${summary}. See the 'Check for new event warnings' step log."
+            echo "::error title=New event warnings after deploy::${count} distinct Warning event(s) still firing at steady state (by reason, ×=occurrences): ${summary}. See the 'Check for new event warnings' step log."
             exit 1
           fi
-          echo "::warning title=New event warnings after deploy::${count} Warning event(s) still firing at steady state: ${summary}. (report-only)"
+          echo "::warning title=New event warnings after deploy::${count} distinct Warning event(s) still firing at steady state (by reason, ×=occurrences): ${summary}. (report-only)"
         fi

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -134,6 +134,14 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
 
+      # After a successful prod reconcile, require the live cluster to stop
+      # emitting Warning events. Pinned to the same admin@prod context the rest
+      # of the prod steps use.
+      - name: 🔎 Require no new event warnings
+        uses: ./.github/actions/check-event-warnings
+        with:
+          context: admin@prod
+
       - name: 🩺 Diagnose Flux on failure
         if: failure() && steps.reconcile.conclusion == 'failure'
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,12 @@ jobs:
           reconcile: "true"
           delete: "false"
 
+      # Gate on a quiet steady state: after a successful reconcile the cluster
+      # should stop emitting Warning events. Catches crash loops / probe
+      # failures / back-off that bootstrap warnings would otherwise mask.
+      - name: 🔎 Require no new event warnings
+        uses: ./.github/actions/check-event-warnings
+
       - name: 🩺 Diagnose Flux on failure
         if: failure()
         run: |
@@ -286,6 +292,14 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+      # After a successful prod reconcile, require the live cluster to stop
+      # emitting Warning events. Pinned to the same admin@prod context the rest
+      # of the prod steps use.
+      - name: 🔎 Require no new event warnings
+        uses: ./.github/actions/check-event-warnings
+        with:
+          context: admin@prod
 
       - name: 🩺 Diagnose Flux on failure
         if: failure() && steps.reconcile.outcome == 'failure'


### PR DESCRIPTION
## What

Adds a hard CI/CD gate that **requires the cluster to stop emitting `Warning` events after a successful deployment**, and reports any warnings to the GitHub Action log.

New local composite action [`.github/actions/check-event-warnings`](.github/actions/check-event-warnings/action.yaml), wired into all three deploy paths:

| Workflow / job | When | kubectl context |
|---|---|---|
| `ci.yaml` → `system-test` | after a successful System Test (PR, ephemeral Talos+Docker cluster) | current (local) |
| `ci.yaml` → `deploy-prod` | after a successful prod reconcile (`merge_group`) | `admin@prod` |
| `cd.yaml` → `deploy-prod` | after a successful prod reconcile (`v*` tag) | `admin@prod` |

## How — post-reconcile settle window

1. Records a marker timestamp, then lets the cluster settle (default **90s**).
2. Pulls `kubectl get events -A -o json` and keeps only `Warning` events whose **most-recent occurrence is at/after the marker** — warnings still firing at steady state (crash loops, repeated probe failures, image back-off).
3. Transient one-shot bootstrap warnings (`FailedScheduling`, startup probe failures, image back-off during pull) fired *before* the marker and are therefore ignored — they would otherwise mask real problems and make any "fail on any warning" check useless.
4. **Reports** matches in a `New Warning events` log group plus a full `All Warning events (history)` group (always printed, report-only), then **fails** the step with a `::error::` annotation summarising counts by reason.

Because the step carries no `if:`, it runs only when the deploy/reconcile step succeeded. On failure the existing `if: failure()` Flux-diagnose (system-test) and `if: always()` cluster-delete steps still run.

## Robustness
- Handles **both** event API shapes — core/v1 (`lastTimestamp`, `message`, `involvedObject`) and `events.k8s.io/v1` (`series.lastObservedTime`, `note`, `regarding`).
- Compares RFC3339 timestamps at second precision so microsecond `eventTime` values sort correctly.
- `fail-on-warning` input (default `true`) lets any call site be flipped to report-only without a rewrite.

## Reviewer notes / risk
- **Prod is a hard gate** (per request). A single fresh warning in the live prod cluster during the 90s window will fail the deploy. Given prod is mid-stabilization, if this proves noisy the lowest-friction dial-back is `fail-on-warning: false` on the two prod call sites (keeps reporting, stops blocking).
- The settle window (`settle-seconds`, default 90) is tunable per call site.

## Validation
- `actionlint` clean on both workflows; `shellcheck` clean (only the shebang artifact from script extraction); `bash -n` OK.
- Action script run end-to-end against synthetic event JSON covering both API shapes: ✅ hard-fail path (exit 1 + `::error::`), ✅ report-only path (exit 0 + `::warning::`), ✅ clean steady state (exit 0, "None").
- No cluster was run locally (static validation only, per AGENTS.md).