### PR TITLE
feat(fleetdm): rotate MySQL fleet user via OpenBao Database engine (Phase 1)

### DIFF
--- a/k8s/bases/apps/fleetdm/external-secrets.yaml
+++ b/k8s/bases/apps/fleetdm/external-secrets.yaml
@@ -73,10 +73,13 @@ spec:
 # user's password, and the fleet server reads the current value from THIS
 # secret (FLEET_MYSQL_PASSWORD is patched in the helm-release postRenderer).
 # Read via the VaultDynamicSecret generator because ESO's Vault provider
-# supports KV only. The generator returns {username, password, ttl, ...};
-# rewrite renames `password` -> `mysql-password`; the extra keys (username,
-# ttl, last_vault_rotation, ...) land as benign extras in the Secret.
-# Short refreshInterval bounds the post-rotation reconnect window.
+# supports KV only. The generator returns {username, password, ttl,
+# last_vault_rotation, rotation_period}; `ttl` decrements every refresh and
+# would change the Secret on every reconcile, causing Reloader to restart
+# fleet every minute. Project ONLY `password` into the Secret (as
+# `mysql-password`) via target.template so the Secret content is stable
+# between rotations and Reloader fires only when the password actually
+# changes. Short refreshInterval bounds the post-rotation reconnect window.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -87,13 +90,13 @@ spec:
   target:
     name: mysql-fleet-rotated
     creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        mysql-password: "{{ .password }}"
   dataFrom:
     - sourceRef:
         generatorRef:
           apiVersion: generators.external-secrets.io/v1alpha1
           kind: VaultDynamicSecret
           name: fleetdm-mysql-static-cred
-      rewrite:
-        - regexp:
-            source: "^password$"
-            target: "mysql-password"

--- a/k8s/bases/apps/fleetdm/external-secrets.yaml
+++ b/k8s/bases/apps/fleetdm/external-secrets.yaml
@@ -66,3 +66,34 @@ spec:
       remoteRef:
         key: apps/fleetdm/license
         property: license-key
+---
+# Holds the OpenBao-rotated password for the fleet MySQL user. The bitnami
+# mysql subchart bootstraps the user from the KV-sourced `mysql` Secret above;
+# after that, the OpenBao Database engine static role takes over rotating the
+# user's password, and the fleet server reads the current value from THIS
+# secret (FLEET_MYSQL_PASSWORD is patched in the helm-release postRenderer).
+# Read via the VaultDynamicSecret generator because ESO's Vault provider
+# supports KV only. The generator returns {username, password, ttl, ...};
+# rewrite renames `password` -> `mysql-password`; the extra keys (username,
+# ttl, last_vault_rotation, ...) land as benign extras in the Secret.
+# Short refreshInterval bounds the post-rotation reconnect window.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mysql-fleet-rotated
+  namespace: fleetdm
+spec:
+  refreshInterval: 1m
+  target:
+    name: mysql-fleet-rotated
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: VaultDynamicSecret
+          name: fleetdm-mysql-static-cred
+      rewrite:
+        - regexp:
+            source: "^password$"
+            target: "mysql-password"

--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -33,7 +33,7 @@ spec:
             patch: |
               - op: add
                 path: /metadata/annotations/secret.reloader.stakater.com~1reload
-                value: mysql,redis,fleet-license
+                value: mysql,mysql-fleet-rotated,redis,fleet-license
               - op: add
                 path: /spec/strategy
                 value:
@@ -163,7 +163,12 @@ spec:
                           - name: FLEET_MYSQL_PASSWORD
                             valueFrom:
                               secretKeyRef:
-                                name: mysql
+                                # OpenBao-rotated via the Database engine static
+                                # role for the 'fleet' MySQL user. The KV-sourced
+                                # `mysql` Secret is used only to bootstrap the
+                                # user at chart init; after the static role
+                                # rotates it, fleet reads the current value here.
+                                name: mysql-fleet-rotated
                                 key: mysql-password
                     containers:
                       - name: fleet
@@ -173,6 +178,16 @@ spec:
                         volumeMounts:
                           - name: fleet-home
                             mountPath: /home/fleet
+                        # Override the chart's default FLEET_MYSQL_PASSWORD
+                        # (which points at the KV-bootstrapped `mysql` Secret)
+                        # to read the OpenBao-rotated value. Strategic merge by
+                        # env `name` replaces just this entry.
+                        env:
+                          - name: FLEET_MYSQL_PASSWORD
+                            valueFrom:
+                              secretKeyRef:
+                                name: mysql-fleet-rotated
+                                key: mysql-password
   valuesFrom:
     - kind: Secret
       name: fleetdm-server-key

--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -125,6 +125,16 @@ spec:
                         volumeMounts:
                           - name: fleet-home
                             mountPath: /home/fleet
+                        # The migration Job runs on every helm install/upgrade
+                        # AFTER the static role has rotated the fleet password,
+                        # so it must use the rotated credential too — not the
+                        # stale KV-bootstrap value from the `mysql` Secret.
+                        env:
+                          - name: FLEET_MYSQL_PASSWORD
+                            valueFrom:
+                              secretKeyRef:
+                                name: mysql-fleet-rotated
+                                key: mysql-password
           - target:
               kind: Deployment
               name: fleet

--- a/k8s/bases/apps/fleetdm/kustomization.yaml
+++ b/k8s/bases/apps/fleetdm/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - httproute.yaml
   - http-scaled-object.yaml
   - external-secrets.yaml
+  - mysql-static-cred-generator.yaml
   - server-key-external-secret.yaml
   - networkpolicy.yaml
   - pod-disruption-budget.yaml

--- a/k8s/bases/apps/fleetdm/mysql-static-cred-generator.yaml
+++ b/k8s/bases/apps/fleetdm/mysql-static-cred-generator.yaml
@@ -1,0 +1,24 @@
+# Reads the OpenBao Database-engine static credential for the fleet MySQL user.
+# ESO's Vault provider supports the KV engine only, so the database engine must
+# be read through a generator. Authenticates the same way as the `openbao`
+# ClusterSecretStore (Kubernetes auth, role `external-secrets`). The mysql
+# ExternalSecret consumes this via `dataFrom` and maps `password` -> the
+# `mysql-password` key. OpenBao rotates this on its static-role schedule; the
+# generator re-reads on each ExternalSecret refresh (validated on ESO v2.5.0).
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: VaultDynamicSecret
+metadata:
+  name: fleetdm-mysql-static-cred
+  namespace: fleetdm
+spec:
+  path: "database/static-creds/fleet"
+  method: GET
+  provider:
+    server: "http://openbao.openbao.svc.cluster.local:8200"
+    auth:
+      kubernetes:
+        mountPath: "kubernetes"
+        role: "external-secrets"
+        serviceAccountRef:
+          name: "external-secrets"
+          namespace: "external-secrets"

--- a/k8s/bases/apps/fleetdm/networkpolicy.yaml
+++ b/k8s/bases/apps/fleetdm/networkpolicy.yaml
@@ -25,6 +25,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: fleetdm
+    # OpenBao Database secrets engine: the OpenBao server connects to MySQL
+    # to manage and rotate the 'fleet' user's password (static role). The
+    # mysql-database-plugin runs in-process in the OpenBao server pod.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: openbao
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
   egress:
     # Intra-namespace (fleet → mysql, fleet → redis)
     - toEndpoints:

--- a/k8s/bases/infrastructure/controllers/openbao/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/networkpolicy.yaml
@@ -54,4 +54,15 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+    # FleetDM MySQL — the Database secrets engine connects to MySQL to
+    # validate database/config/fleetdm-mysql and to rotate the 'fleet'
+    # user's password (the mysql-database-plugin runs in-process inside
+    # the OpenBao server pod, so the egress originates from this namespace).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: fleetdm
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
 

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -273,6 +273,15 @@ spec:
               }
               POLICY
 
+              # Read the OpenBao-rotated MySQL credential for the fleet app user
+              # (Database secrets engine static role). Consumed by ESO via the
+              # VaultDynamicSecret generator in the fleetdm namespace.
+              bao policy write app-fleetdm-db-readonly - <<'POLICY'
+              path "database/static-creds/fleet" {
+                capabilities = ["read"]
+              }
+              POLICY
+
               bao policy write app-wedding-readonly - <<'POLICY'
               path "secret/data/apps/wedding-app/*" {
                 capabilities = ["read"]
@@ -370,7 +379,7 @@ spec:
               bao write auth/kubernetes/role/external-secrets \
                 bound_service_account_names=external-secrets \
                 bound_service_account_namespaces=external-secrets \
-                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-wedding-readonly,infra-oidc-readonly,vault-seed-write \
+                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-fleetdm-db-readonly,app-wedding-readonly,infra-oidc-readonly,vault-seed-write \
                 ttl=1h
 
               # Snapshot CronJob needs health check read
@@ -423,6 +432,55 @@ spec:
               else
                 echo "OIDC secret not yet available -- skipping OIDC configuration."
                 echo "It will be configured on the next vault-config reconciliation."
+              fi
+
+              # --- 7. Database secrets engine: fleetdm MySQL static-role rotation ---
+              # OpenBao owns and periodically rotates the 'fleet' MySQL user's
+              # password; ESO reads the current value via the VaultDynamicSecret
+              # generator in the fleetdm namespace.
+              if ! bao secrets list -format=json | grep -q '"database/"'; then
+                echo "Enabling database secrets engine..."
+                bao secrets enable database
+              else
+                echo "Database secrets engine already enabled."
+              fi
+
+              # OpenBao needs MySQL admin (root) creds to manage the fleet user;
+              # the root password is seeded into KV by the fleetdm PushSecret.
+              FLEET_DB_ROOT=$(bao kv get -mount=secret -field=mysql-root-password apps/fleetdm/mysql 2>/dev/null || echo "")
+              if [ -n "$FLEET_DB_ROOT" ]; then
+                # Writing the connection validates connectivity, so this 400s
+                # until fleetdm-mysql is up (apps layer). Treat that as expected
+                # on early passes -- Flux recreates this Job (force annotation)
+                # and the block succeeds once MySQL is reachable.
+                echo "Configuring fleetdm MySQL database connection..."
+                if bao write database/config/fleetdm-mysql \
+                  plugin_name=mysql-database-plugin \
+                  allowed_roles="fleet" \
+                  connection_url="{{username}}:{{password}}@tcp(fleetdm-mysql.fleetdm.svc.cluster.local:3306)/" \
+                  username="root" \
+                  password="$FLEET_DB_ROOT" 2>/dev/null; then
+
+                  # Create the static role only if absent: creation triggers an
+                  # initial rotation of the 'fleet' user's password (the fleetdm
+                  # ExternalSecret + Reloader then pick it up). Guarding avoids
+                  # re-rotating on every idempotent Job re-run. App user only,
+                  # never root.
+                  if ! bao read database/static-roles/fleet >/dev/null 2>&1; then
+                    bao write database/static-roles/fleet \
+                      db_name=fleetdm-mysql \
+                      username="fleet" \
+                      rotation_period="${fleetdm_mysql_rotation_period:=2160h}"
+                    echo "fleetdm MySQL static role created."
+                  else
+                    echo "fleetdm MySQL static role already exists."
+                  fi
+                else
+                  echo "fleetdm MySQL not reachable yet -- skipping DB role config."
+                  echo "It will be configured on the next vault-config reconciliation."
+                fi
+              else
+                echo "fleetdm MySQL root credential not in KV yet -- skipping DB role config."
               fi
 
               echo "Vault configuration complete."


### PR DESCRIPTION
Implements **Phase 1** of the secret-rotation design (merged in [#1603](https://github.com/devantler-tech/platform/pull/1603)).

## What

OpenBao owns the `fleet` MySQL user via the **Database secrets engine + a static role** (rotation_period defaults to 90d). The fleet server reads the current rotated password via ESO's **`VaultDynamicSecret` generator** (the Vault provider is KV-only, so the database engine cannot be a plain ExternalSecret), wired through a new `mysql-fleet-rotated` Secret. The bitnami subchart still bootstraps the user from the KV-sourced `mysql` Secret — so fresh installs work.

## Bootstrap-safe design

| Secret | Source | Used by |
| --- | --- | --- |
| `mysql` (unchanged) | KV (`apps/fleetdm/mysql`) | bitnami mysql chart creates the `fleet` user with this on first install |
| `mysql-fleet-rotated` (new) | `VaultDynamicSecret` generator → `database/static-creds/fleet` | fleet **server** reads `FLEET_MYSQL_PASSWORD` from here (patched in helm-release postRenderer for both `fleet-db-init` and the main `fleet` container) |

Reloader watches `mysql-fleet-rotated` too, so the fleet pods restart when the password rotates. Short refresh (`1m`) bounds the post-rotation reconnect window.

## OpenBao side (`vault-config` Job)

- Enables the `database` engine; configures the `fleetdm-mysql` connection using the KV-seeded root password; creates static role `fleet` (`rotation_period: ${fleetdm_mysql_rotation_period:=2160h}`, **app user only — never root**).
- Guarded with `bao read database/static-roles/fleet` so idempotent re-runs do **not** trigger re-rotation.
- New policy `app-fleetdm-db-readonly` bound to the `external-secrets` Kubernetes auth role.
- Skips gracefully if MySQL is not reachable yet (apps layer not deployed) — Flux re-runs the Job on the next reconcile, mirroring the OIDC block.

## Why this design (and what was rejected)

A simpler approach — pointing the existing `mysql` ExternalSecret's `mysql-password` at the generator — was rejected: it **breaks fresh installs**, because the generator can't read `database/static-creds/fleet` until the static role exists, but the role requires MySQL + the `fleet` user to exist. Chicken-and-egg. The two-secret bootstrap-safe design above avoids that: the chart bootstraps the user from KV; OpenBao adopts and rotates it; the fleet server reads the rotated value from a separate secret.

Validated upfront (per the design doc): the **`VaultDynamicSecret` generator re-reads on each refresh** (isolated kind spike, ESO v2.5.0 — confirmed in source). So rotation propagates; no silent-rotation time-bomb.

## Residual risks

- **Cross-layer timing on fresh install / DR rebuild.** `vault-config` lives in `infrastructure-controllers` but the static role can only be created after MySQL (in `apps`) is up. So the first vault-config run skips the DB block, apps deploys MySQL, then vault-config re-runs (force-recreated by Flux) and creates the static role → initial rotation → ESO + Reloader. The fleet **server** crash-loops until `mysql-fleet-rotated` is created, then recovers. **CI's full system test is the convergence validator**; if it flakes, the rotation_period / reconcile intervals can be tuned, or the vault-config block can be moved.
- **Post-rotation window**: bounded by the 1m refreshInterval + a pod restart. Acceptable for fleetdm (not user-critical 24/7).
- **Rollback**: revert this PR; if the static role had already rotated `fleet`, manually `ALTER USER fleet IDENTIFIED BY '<KV mysql-password>'` to restore. The DB engine mount can stay (unused) or be disabled.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` both build.
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` both pass: **255 files validated**.
- CI's full Talos + Docker system test exercises the OpenBao DB engine + static role + generator + ESO + fleet bring-up end-to-end — please watch the system-test job before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)