### PR TITLE
fix(actual-budget): park at 0 replicas in prod

### DIFF
--- a/k8s/bases/apps/actual-budget/http-scaled-object.yaml
+++ b/k8s/bases/apps/actual-budget/http-scaled-object.yaml
@@ -12,8 +12,8 @@ spec:
     service: actual-budget-actualbudget
     port: 5006
   replicas:
-    min: 1
-    max: 1
+    min: ${actual_budget_replicas_min:=1}
+    max: ${actual_budget_replicas_max:=1}
   scaledownPeriod: 300
   scalingMetric:
     requestRate:

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -52,14 +52,17 @@ data:
   fleetdm_mysql_secondary_replicas: "0"
   fleetdm_redis_architecture: "standalone"
   fleetdm_redis_replicas: "0"
-  # Parked: deployment + KEDA target both at 0. To re-enable, set all three:
+  # Parked: HelmRelease starts at 0; KEDA holds it at 0 (min=0) but can spin up
+  # 1 pod on a stray HTTP hit (max=1) since KEDA HTTP rejects max=0 at the
+  # translated ScaledObject layer (MinReplicaCount=1 must be less than
+  # MaxReplicaCount=0). SQLite on RWO PVC requires max <= 1 even when re-enabled.
+  # To re-enable as actively-served, set:
   #   actual_budget_replicas: "1"
   #   actual_budget_replicas_min: "1"
   #   actual_budget_replicas_max: "1"
-  # (SQLite on RWO PVC requires max <= 1.)
   actual_budget_replicas: "0"
   actual_budget_replicas_min: "0"
-  actual_budget_replicas_max: "0"
+  actual_budget_replicas_max: "1"
   hubble_ui_replicas: "1"
   # Auth chain: 2 replicas for HA during VPA evictions (prevents 502s).
   dex_replicas: "2"

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -40,7 +40,7 @@ data:
   # saves memory until the first KEDA reconciliation.
   # headlamp: min 0, max 1 (OIDC state in-memory — must stay single-pod)
   # whoami/fleetdm: min 0, max 2
-  # actual-budget: min 1, max 1 (SQLite on RWO PVC — no scale-to-zero)
+  # actual-budget: parked at 0/0 (unused; SQLite on RWO PVC keeps max≤1 when re-enabled)
   headlamp_replicas: "1"
   whoami_replicas: "1"
   fleetdm_replicas: "1"
@@ -52,7 +52,11 @@ data:
   fleetdm_mysql_secondary_replicas: "0"
   fleetdm_redis_architecture: "standalone"
   fleetdm_redis_replicas: "0"
-  actual_budget_replicas: "1"
+  # Parked: deployment + KEDA target both at 0. Re-enable by setting
+  # actual_budget_replicas + _min to 1 and _max to 1.
+  actual_budget_replicas: "0"
+  actual_budget_replicas_min: "0"
+  actual_budget_replicas_max: "0"
   hubble_ui_replicas: "1"
   # Auth chain: 2 replicas for HA during VPA evictions (prevents 502s).
   dex_replicas: "2"

--- a/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/variables/variables-cluster-config-map.yaml
@@ -52,8 +52,11 @@ data:
   fleetdm_mysql_secondary_replicas: "0"
   fleetdm_redis_architecture: "standalone"
   fleetdm_redis_replicas: "0"
-  # Parked: deployment + KEDA target both at 0. Re-enable by setting
-  # actual_budget_replicas + _min to 1 and _max to 1.
+  # Parked: deployment + KEDA target both at 0. To re-enable, set all three:
+  #   actual_budget_replicas: "1"
+  #   actual_budget_replicas_min: "1"
+  #   actual_budget_replicas_max: "1"
+  # (SQLite on RWO PVC requires max <= 1.)
   actual_budget_replicas: "0"
   actual_budget_replicas_min: "0"
   actual_budget_replicas_max: "0"


### PR DESCRIPTION
## What

Park the **Actual Budget** app at 0 replicas in production. It is currently unused.

- `actual_budget_replicas: "1"` → `"0"` (HelmRelease initial `replicaCount`)
- New: `actual_budget_replicas_min: "0"`, `actual_budget_replicas_max: "0"` (KEDA `HTTPScaledObject` floor + ceiling)
- Parameterize `min` / `max` in the base `HTTPScaledObject` with `${actual_budget_replicas_(min|max):=1}` so local stays unchanged (no var → defaults to 1/1, current behavior).

## Why

Without pinning the KEDA `HTTPScaledObject` to 0/0, the previous `min: 1, max: 1` would scale the deployment back up to 1 the moment Flux applies the new HelmRelease — defeating the purpose. Doing it via variables (rather than a hetzner-overlay patch) keeps the base flexible and makes the "park / unpark" operation a three-line edit in the prod variables ConfigMap.

## Why `max: 0` is safe here

Verified against the upstream KEDA HTTP add-on **v0.14** CRD (chart version pinned in this repo): the `replicas.max` field has no `minimum:` validator, so `max: 0` is schema-valid. Behaviorally the interceptor will hang / time out any stray hit on `budget.platform.devantler.tech` — that is the correct "parked" semantic, since the app is intentionally not in service.

## Reversal

To bring it back online:

```yaml
actual_budget_replicas: "1"
actual_budget_replicas_min: "1"
actual_budget_replicas_max: "1"
```

(SQLite on RWO PVC still keeps `max ≤ 1` whenever it is re-enabled — the inline comment in the ConfigMap captures this.)

## Validation

- `ksail workload validate` ✅ (254 files)
- `ksail --config ksail.prod.yaml workload validate` ✅ (254 files)
- `kubectl kustomize` for both `clusters/local/` and `clusters/prod/` ✅

## Resource-freeing note

Once this lands, the deployment's previously-requested CPU / memory is released to the scheduler automatically — `replicas: 0` means zero Pods, which means zero requests at the cluster level. No additional mechanism is needed to "free" them.