### PR TITLE
feat(homepage): smooth load + single-pane-of-glass for all UI apps

### DIFF
--- a/hosts
+++ b/hosts
@@ -3,7 +3,6 @@
 127.0.0.1 dex.platform.lan
 127.0.0.1 fleetdm.platform.lan
 127.0.0.1 flux.platform.lan
-127.0.0.1 goldilocks.platform.lan
 127.0.0.1 headlamp.platform.lan
 127.0.0.1 oauth2-proxy.platform.lan
 127.0.0.1 platform.lan

--- a/k8s/bases/apps/headlamp/httproute.yaml
+++ b/k8s/bases/apps/headlamp/httproute.yaml
@@ -9,6 +9,8 @@ metadata:
     gethomepage.dev/description: A web UI for managing Kubernetes clusters.
     gethomepage.dev/group: Kubernetes
     gethomepage.dev/icon: https://pbs.twimg.com/profile_images/1537480067227566080/waXG0X7n_400x400.jpg
+    gethomepage.dev/href: https://headlamp.${domain}
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=headlamp
 spec:
   parentRefs:
     - name: platform

--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -10,11 +10,19 @@ data:
     favicon: https://avatars.githubusercontent.com/u/178524219?v=4&s=32
     theme: dark
     color: slate
-    cardBlur: sm
-    background:
-      image: https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
-      blur: sm
-      opacity: 70
+    # No background.image — eliminates the cold-load white→image flash and
+    # the cross-origin Unsplash dependency. The dark gradient backdrop is
+    # painted from custom.css below; cardBlur is omitted because there is
+    # no underlying image for backdrop-filter to blur.
+    headerStyle: clean
+    statusStyle: dot
+    iconStyle: gradient
+    hideVersion: true
+    target: _blank
+    # Layout order also controls render order on the page. Groups not listed
+    # here still appear (Homepage falls back to alphabetical) but get a generic
+    # icon — keep this in sync with the gethomepage.dev/group annotations on
+    # the HTTPRoutes under k8s/bases/apps/** and the service entries below.
     layout:
       Kubernetes:
         icon: si-talos-#FF7300
@@ -22,6 +30,14 @@ data:
         icon: mdi-cellphone-cog
       Diagnostics:
         icon: mdi-stethoscope
+      Security:
+        icon: mdi-shield-lock
+      Finance:
+        icon: mdi-finance
+      Personal Sites:
+        icon: mdi-web
+      Customer Sites:
+        icon: mdi-briefcase-account
       Cloud:
         icon: si-hetzner
       Network:
@@ -140,5 +156,21 @@ data:
             - icon: si-nuget-#1088d6
               href: https://www.nuget.org
   docker.yaml: ""
-  custom.css: ""
+  # Backdrop replaces the previous remote Unsplash background image — no
+  # cross-origin asset, no cold-load flash. A slate-950 base plus two soft
+  # radial auras (blue top-left, violet bottom-right) gives a modern
+  # ambient-mesh feel without any image to download or composite. Applied
+  # to html+body so it covers the viewport even on tall scrollable pages,
+  # and `background-attachment: fixed` keeps the gradient anchored while
+  # cards scroll over it.
+  custom.css: |
+    html,
+    body {
+      background-color: rgb(2, 6, 23);
+      background-image:
+        radial-gradient(at 18% 12%, rgba(59, 130, 246, 0.18), transparent 55%),
+        radial-gradient(at 82% 88%, rgba(168, 85, 247, 0.14), transparent 55%);
+      background-attachment: fixed;
+      background-repeat: no-repeat;
+    }
   custom.js: ""

--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -52,6 +52,20 @@ spec:
                       matchLabels:
                         app.kubernetes.io/name: homepage
                         app.kubernetes.io/instance: homepage
+          # Flicker fix: with replicaCount=2 and the chart's default ClusterIP
+          # service, the Kubernetes widget's poll for node/cluster CPU/memory
+          # round-robins between two pods that each maintain their own
+          # kube-apiserver watcher cache — values pop between slightly-stale
+          # and slightly-fresh on every refresh. Pinning to ClientIP keeps
+          # each oauth2-proxy backend stuck to one homepage replica so the
+          # widget reads from a consistent cache.
+          - target:
+              kind: Service
+              name: homepage
+            patch: |
+              - op: add
+                path: /spec/sessionAffinity
+                value: ClientIP
   # ICONS:
   # https://github.com/walkxcode/dashboard-icons
   # https://simpleicons.org

--- a/k8s/bases/apps/whoami/httproute.yaml
+++ b/k8s/bases/apps/whoami/httproute.yaml
@@ -9,6 +9,8 @@ metadata:
     gethomepage.dev/description: HTTP echo service for network diagnostics.
     gethomepage.dev/group: Diagnostics
     gethomepage.dev/icon: mdi-network-check
+    gethomepage.dev/href: https://whoami.${domain}
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=whoami
 spec:
   parentRefs:
     - name: platform

--- a/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
@@ -13,3 +13,25 @@ spec:
           path: /spec/hostnames
           value:
             - ascoachingogvaner.platform.devantler.tech
+    # Surface this tenant on the homepage dashboard. The HTTPRoute ships
+    # from an external OCI artifact (ghcr.io/devantler-tech/ascoachingogvaner),
+    # so the gethomepage.dev/* annotations have to be injected here rather
+    # than committed at the source. Strategic merge (not JSON patch) so we
+    # add to — rather than overwrite — any annotations that already exist
+    # on the upstream HTTPRoute.
+    - target:
+        kind: HTTPRoute
+        name: ascoachingogvaner
+      patch: |
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ascoachingogvaner
+          annotations:
+            gethomepage.dev/enabled: "true"
+            gethomepage.dev/name: AS Coaching og Væren
+            gethomepage.dev/description: Personal/business static site.
+            gethomepage.dev/group: Customer Sites
+            gethomepage.dev/icon: mdi-account-tie
+            gethomepage.dev/href: https://ascoachingogvaner.platform.devantler.tech
+            gethomepage.dev/pod-selector: app.kubernetes.io/name=ascoachingogvaner

--- a/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
@@ -25,3 +25,25 @@ spec:
           path: /spec/hostnames
           value:
             - wedding.platform.devantler.tech
+    # Surface this tenant on the homepage dashboard. The HTTPRoute ships
+    # from an external OCI artifact (ghcr.io/devantler-tech/wedding-app),
+    # so the gethomepage.dev/* annotations have to be injected here rather
+    # than committed at the source. Strategic merge (not JSON patch) so we
+    # add to — rather than overwrite — any annotations that already exist
+    # on the upstream HTTPRoute.
+    - target:
+        kind: HTTPRoute
+        name: wedding-app
+      patch: |
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: wedding-app
+          annotations:
+            gethomepage.dev/enabled: "true"
+            gethomepage.dev/name: Wedding
+            gethomepage.dev/description: Wedding RSVP and information site.
+            gethomepage.dev/group: Personal Sites
+            gethomepage.dev/icon: mdi-ring
+            gethomepage.dev/href: https://wedding.platform.devantler.tech
+            gethomepage.dev/pod-selector: app.kubernetes.io/name=wedding-app


### PR DESCRIPTION
Eliminates the cold-load flicker and surfaces every UI-bearing app on the dashboard, so the homepage is genuinely the one entry point for every hosted service.

## Flicker — two root causes

1. **Remote Unsplash background image** (~2000px wide) applied via inline style after React hydration. Browser painted default white before the image — and before the slate theme color — applied, producing a visible flash on every cold load and after each oauth2-proxy redirect.
2. **`replicaCount=2` with default ClusterIP, no session affinity.** The Kubernetes widget polls cluster/node CPU+memory every few seconds; round-robin between two pods (each with its own kube-apiserver watcher cache) made values pop between slightly-stale and slightly-fresh on every refresh.

## Fix

- Drop `background.image`, `background.blur`, `background.opacity`, and `cardBlur` entirely. Replace with a soft two-point radial mesh gradient in `custom.css` (slate-950 base, subtle blue + violet auras, `background-attachment: fixed`). Zero remote assets — flicker is now structurally impossible.
- Lean into Homepage's own modern UI options: `headerStyle: clean`, `statusStyle: dot`, `iconStyle: gradient`, `hideVersion: true`, `target: _blank`.
- Pin the homepage Service to `sessionAffinity: ClientIP` via a post-renderer patch so each oauth2-proxy backend sticks to one homepage replica and the widget reads from a consistent cache.

## Coverage

Every UI-bearing HTTPRoute now carries `gethomepage.dev/*` annotations so auto-discovery picks them up:

| App | Group | Source of annotations |
|---|---|---|
| actual-budget | Finance | base (existing) |
| whoami | Diagnostics | base — added `href` + `pod-selector` |
| fleetdm | Device Management | base (existing) |
| headlamp | Kubernetes | base — added `href` + `pod-selector` |
| openbao (Vault) | Security | base (existing) |
| flux-operator | Kubernetes | base (existing) |
| hubble-ui | Diagnostics | base (existing) |
| wedding-app | Personal Sites | hetzner Flux Kustomization patch (new) |
| ascoachingogvaner | Customer Sites | hetzner Flux Kustomization patch (new) |

`wedding-app` and `ascoachingogvaner` ship their HTTPRoute from external OCI artifacts (`oci://ghcr.io/devantler-tech/{wedding-app,ascoachingogvaner}/manifests`), so the annotations are injected via the existing Flux Kustomization `spec.patches` — the same place that already rewrites their hostnames. Strategic-merge patch (not JSON-Patch `op: add /metadata/annotations`) so we merge into — rather than overwrite — any annotations on the upstream HTTPRoute.

The `layout:` in `settings.yaml` now lists the previously-unmapped groups (`Security`, `Finance`, `Personal Sites`, `Customer Sites`) with intentional icons and a deliberate render order.

Correctly excluded from auto-discovery: the HTTP→HTTPS redirect route, homepage's own route, oauth2-proxy, and dex (OIDC IdP — only visited as a login redirect).

## Cleanup

- Removed the stale `goldilocks.platform.lan` line from `hosts` — no Goldilocks resources exist anywhere in the repo.

## Validation

- \`ksail --config ksail.yaml workload validate\` → 254/254 files validated ✓
- \`ksail --config ksail.prod.yaml workload validate\` → 254/254 files validated ✓
- \`kubectl kustomize\` of both \`k8s/clusters/local\` and \`k8s/clusters/prod\` build clean
- \`kubectl kustomize k8s/providers/hetzner/apps/\` confirms the wedding-app / ascoachingogvaner Flux Kustomization carries the new strategic-merge patch alongside the existing hostname patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)