### PR TITLE
docs(security): add vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,102 @@
+# Security Policy
+
+## Supported versions
+
+This repository is a continuously-deployed GitOps platform; only the `main`
+branch and the most recent `v*` tag deployed to production are supported.
+Older tags are kept for history and disaster-recovery purposes only and do
+not receive security backports.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security reports.** Please use one of the
+following private channels:
+
+1. **Preferred** — open a private security advisory via GitHub:
+   <https://github.com/devantler-tech/platform/security/advisories/new>.
+   This keeps the report inside the repository's coordinated-disclosure
+   workflow and gives us a private space to discuss and patch.
+2. As a fallback, email <nikolaiemildamm@icloud.com> with `[platform-security]`
+   in the subject line.
+
+When you report, please include:
+
+- A description of the issue and the impact you believe it has.
+- Steps to reproduce, ideally with a minimal proof of concept.
+- The commit SHA or release tag the report applies to.
+- Any suggested remediation, if you have one.
+
+## Response targets
+
+We are a single-maintainer project; responses are best-effort but we aim for:
+
+| Severity | First acknowledgement | Triage decision | Fix or mitigation |
+| -------- | --------------------- | --------------- | ----------------- |
+| Critical | 48 hours              | 5 days          | 14 days           |
+| High     | 5 days                | 14 days         | 30 days           |
+| Medium   | 14 days               | 30 days         | next minor        |
+| Low      | 30 days               | next minor      | next minor        |
+
+Severity follows the [CVSS v3.1] vector in the report; in case of
+disagreement the maintainer's assessment is used and recorded in the
+advisory.
+
+## Coordinated disclosure
+
+We follow a 90-day disclosure window by default, counting from the
+acknowledgement date. We will publish a GitHub Security Advisory and credit
+reporters who wish to be credited. If a fix is impractical within 90 days we
+will request an extension before the window closes.
+
+## Scope
+
+In scope:
+
+- Manifests under `k8s/` and Talos patches under `talos/` and `talos-local/`.
+- Workflow definitions under `.github/workflows/` and supporting scripts.
+- Documentation that, if wrong, would lead an operator to a weaker
+  configuration (notably `docs/dr/`, `docs/secret-rotation.md`,
+  `docs/oidc-kubectl.md`).
+- The KSail configuration files (`ksail.yaml`, `ksail.prod.yaml`) and the
+  Hetzner provisioning script under `hetzner/`.
+
+Out of scope:
+
+- Vulnerabilities in upstream container images, Helm charts, or
+  Talos/Kubernetes itself. Please report those to the respective upstream
+  projects. We will of course update the affected component once an upstream
+  fix is available; tracking issues for that are welcome as normal issues.
+- Theoretical findings on encrypted SOPS payloads (`*.enc.yaml`). The
+  ciphertext is intentionally checked into git; finding ciphertext is not a
+  vulnerability. The corresponding private Age keys are not stored in this
+  repository.
+- Self-XSS, missing security headers on pages that do not handle authenticated
+  state, and other findings without a realistic exploit path.
+
+## Cryptographic material
+
+- All in-repo secrets are SOPS-encrypted with Age (`.sops.yaml` lists the
+  current recipients). Reporting that ciphertext is present in git is not a
+  vulnerability.
+- The platform OCI artifact published to GHCR is signed via cosign keyless
+  signing (Fulcio + Rekor) against the GitHub Actions OIDC identity of this
+  repository's `cd.yaml` workflow. Tampering would require compromising
+  Fulcio, Rekor, or the workflow itself.
+- Talos PKI, OpenBao unseal material, and the Hetzner API token are the
+  three pieces of cryptographic material whose loss would force a full
+  cluster rebuild; their custody is documented in `docs/dr/runbook.md`.
+
+## Public-repository hardening
+
+Because this repository is public, the following constraints apply to all
+contributions:
+
+- Plaintext secrets must never be committed. All Kubernetes Secrets and any
+  other sensitive material must be SOPS-encrypted (`*.enc.yaml`) and gated
+  by the `.sops.yaml` rules.
+- Third-party GitHub Actions must be pinned by commit SHA (not by tag).
+  Renovate keeps these up to date.
+- The platform OCI artifact is signed and verified end-to-end; bypassing
+  that verification in a PR is treated as a security regression.
+
+[CVSS v3.1]: https://www.first.org/cvss/v3.1/specification-document

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,8 +57,9 @@ In scope:
 - Documentation that, if wrong, would lead an operator to a weaker
   configuration (notably `docs/dr/`, `docs/secret-rotation.md`,
   `docs/oidc-kubectl.md`).
-- The KSail configuration files (`ksail.yaml`, `ksail.prod.yaml`) and the
-  Hetzner provisioning script under `hetzner/`.
+- The KSail configuration files (`ksail.yaml`, `ksail.prod.yaml`). KSail's
+  native Hetzner provider owns the Hetzner Cloud provisioning lifecycle;
+  there is no in-repo provisioning script.
 
 Out of scope:
 
@@ -78,10 +79,16 @@ Out of scope:
 - All in-repo secrets are SOPS-encrypted with Age (`.sops.yaml` lists the
   current recipients). Reporting that ciphertext is present in git is not a
   vulnerability.
-- The platform OCI artifact published to GHCR is signed via cosign keyless
-  signing (Fulcio + Rekor) against the GitHub Actions OIDC identity of this
-  repository's `cd.yaml` workflow. Tampering would require compromising
-  Fulcio, Rekor, or the workflow itself.
+- The platform OCI artifact published to GHCR is **planned** to be signed
+  via cosign keyless signing (Fulcio + Rekor) against the GitHub Actions
+  OIDC identity of this repository's `cd.yaml` workflow. The signing step
+  is being introduced in a separate PR; consumer-side `OCIRepository.spec.verify`
+  is a follow-up after that. Until both are merged and rolled out, the
+  artifact is **not** yet cryptographically verified end-to-end — operate
+  on the assumption that the deploy pipeline is the only enforcement of
+  artifact integrity. See `docs/dr/crypto-custody.md` for the target
+  design and the role of the `matchOIDCIdentity` regex as the policy
+  decision point.
 - Talos PKI, OpenBao unseal material, and the Hetzner API token are the
   three pieces of cryptographic material whose loss would force a full
   cluster rebuild; their custody is documented in `docs/dr/runbook.md`.
@@ -95,8 +102,14 @@ contributions:
   other sensitive material must be SOPS-encrypted (`*.enc.yaml`) and gated
   by the `.sops.yaml` rules.
 - Third-party GitHub Actions must be pinned by commit SHA (not by tag).
-  Renovate keeps these up to date.
-- The platform OCI artifact is signed and verified end-to-end; bypassing
-  that verification in a PR is treated as a security regression.
+  Dependabot is configured to update these (`.github/dependabot.yaml`);
+  Renovate handles other ecosystems but is intentionally disabled for
+  GitHub Actions to avoid two tools racing on the same files.
+- Once cosign keyless signing and consumer-side `spec.verify` are landed
+  (tracked separately in the security-hardening series), bypassing
+  artifact verification in a PR will be treated as a security regression.
+  Until then, the deploy pipeline (`.github/workflows/cd.yaml`) is the
+  only enforcement of artifact integrity; review PRs that touch it with
+  the same care as PRs that would touch verification config.
 
 [CVSS v3.1]: https://www.first.org/cvss/v3.1/specification-document


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of a security-hardening series preparing this repository for public visibility. See the overall plan in the conversation that produced these PRs.

## What

Adds a root-level `SECURITY.md` covering:

- private reporting via GitHub Security Advisories (with email fallback);
- supported versions (`main` + most recent `v*`);
- response targets sized for a single-maintainer project;
- 90-day coordinated-disclosure window with credited disclosure;
- explicit in/out-of-scope sections (notably, SOPS ciphertext is **not** in scope — the private Age keys are not in this repo);
- public-repo contribution constraints (no plaintext secrets, SHA-pinned actions, end-to-end signed OCI verification);
- the platform's cryptographic root-of-trust (SOPS Age, cosign keyless, Talos PKI, OpenBao unseal material).

## Why

Going public without a disclosure policy invites researchers to file findings as public issues. This file gives GitHub a target for the "Security" tab and links from the new-issue chooser.

## Validation

Pure documentation change; nothing to build or apply. Verified the file renders correctly via the GitHub PR diff.

## Notes

The file refers to a few mechanisms that will be wired up by subsequent PRs in this series (cosign keyless on the platform OCI artifact, third-party action SHA pinning) — they are accurate descriptions of where we are going, and each lands in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)