### PR TITLE
chore(security): strip stale Age recipient from variables-base-secret

### DIFF
--- a/k8s/bases/variables/variables-base-secret.enc.yaml
+++ b/k8s/bases/variables/variables-base-secret.enc.yaml
@@ -9,34 +9,25 @@ stringData:
     r2_secret_access_key: ENC[AES256_GCM,data:PdhgQ1d1pDW1lLcXasYG2roEG8qapUHpHM/goE+V1w==,iv:g3QCozVlZMEBRfMhVvfSf5i8lYK+3hnFPJ+fEjSJz4s=,tag:UJL+z0bQ2C7f71XJSdWCvQ==,type:str]
 sops:
     age:
-        - recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArWXFZaE4wZHdnRTZNTG9a
-            R2tuNjlxVWVZZkZ1ZlBEaC8xNXVPQXNkUGlRCm50OXhRbE9oaHVZNnJEcTZhd1RD
-            TnBoS2ptWmZKS0d5OUljSHUzUEUvU0UKLS0tIDlnbjdLRjEzQkZYY1FRTXdKWEJQ
-            cnlhTm1SbXBoenBRMGtUL1Z2a0N2c2MKrTlbTvgyx4a+PU8yZ6vUJeeQ7qCIrFP4
-            pC/nbMK1GmFF6NTJKEQPL495PnAVeJ4L7MVeVGkYky9MZVdO4gzsoQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByZ0dKVzlWUHFGZjkzT2Fa
+            MDA2TWpjZ3R4Sm1id1MwaXJDcC8vZ2VyMDBvCnVzQ2R6NVN5QTRPOTRPUlFXK3dl
+            dFZaTFRmSVVKRWk5T2JlMjdnUFVMcVUKLS0tIG5lRW9VL2k4bkQ2WHc3aVNUT0JN
+            b09tc1BKcC9ManZIcjRNRWdNUnRlQkEKyHHYlCkiNozfc9igMjtUuS480W4ZZ/bm
+            zQMzqfYZzRcOgvQn/ZN6UfI1pJvP+5gyWCyn2pszWDMp4Vhwu9oBxA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c
-          enc: |
+          recipient: age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFWE1aM081a1RBdk1waVdS
-            NDJCUC9SUHdhcGFiTDQ4aFJ0WDRPOUlHRVFjCm1xU3FhenR1YkpZdjc2Q1Jlblh3
-            SUFHSSt5ODZ3VWJYZWdlRWsvM3VTOFkKLS0tIG82VE1PalFCdEd3UERkUzJXRmcx
-            QXgzcTA5MjJkR0dHcEZMSXJBQUZ3SUUK3QiSFp1vw2+9Nqdud5/rGrJbv9BSz80B
-            8b0X8WVPB/60oLgDZEglRv8J+Ktq5UGNdfnIZ3Ckx4WkCTfSi3iYUQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPZzdvcGZBWlUrU3dVVUxa
+            VkRQcC9DVExOd3BDWjI1SHBETUJyS1FKTkRjCjJFZExqMUxxSjhVTFFtTUxYV1U1
+            N2V2UzJKWXpUZzBlaUhlS2o5T3M1eG8KLS0tIGx5OE1GZzIwaXpPMmVtMmNqdDV5
+            bkdBL2M2NGRmU0UzdVhhNmQyS1FrOHcKntnuB5lrMYQFoqWt2TdDcy8hYp2h8pgS
+            AF6/Z85IymNcYOAoOF/VUt41wG8OvYcTBo7P+0XdwxRs7F+EQh+9gA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRamdtVks5ancwaFR4aU5S
-            SUR3M2lOMHhsNzlYZytZbCs3a0lmT0RFTTFFCmNUdzZRZW03NGtYbnNhekwxUjRp
-            b0wxUTVEb0N2dUlnakczSXNqa2NOUDgKLS0tIDM4Um9xT0ZqQzVTYnNsWnpGOFR5
-            VURIMUNTaXRVYXBTN3VTVEVQbXhFdkUK8ePnpPhd4qMdBiYz4kC+sNMDUvk9zL3z
-            dV8JyF1+VFTiUPt3D4EZfrZsbKb6PMqo2lhC3lnBSQoJc2OK+emW4g==
-            -----END AGE ENCRYPTED FILE-----
+          recipient: age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6
+    encrypted_regex: ^(data|stringData)$
     lastmodified: "2026-04-18T22:09:18Z"
     mac: ENC[AES256_GCM,data:c06gQllC6M2Nvb3zHmLdk9wMVRgY72ZjxQOwMmj2X5S3gQz5EkL7qZs+gw9MQgOYE8TdMXmRc0bhkxIL6nanrVpOdqEzTMZtcdXbmIP3JpyV+KVreX80hP0ovF8HaYHkf8C7cmZ0QYjCDLdbNw9rWCAeXUEX7vcvAtdvf5+Vf1Q=,iv:Ew3Jw1tbVyaMg0r02W9F+zl6qyVaBNvfo3zmsaYBG+w=,tag:MjcQQvHMSt0rp3KL4KLOxA==,type:str]
-    encrypted_regex: ^(data|stringData)$
     version: 3.12.2


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of the security-hardening series (Phase 0.4 — Age recipient audit).

## What

Re-ran `sops updatekeys` on `k8s/bases/variables/variables-base-secret.enc.yaml` so its SOPS key-wrap matches the current `.sops.yaml` recipient list.

Before:

```
age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq  (current local)
age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6  (current prod)
age188ez3ur89qj7pmnyyqhcp9nmxp7lvsa72plph0frkfh9tt7n5guqs0vz6c  ← STALE, not in .sops.yaml
```

After: only the two current recipients remain wrapped.

## Why

A stale recipient in a SOPS file means anyone still holding the retired private key can decrypt the file — even after `.sops.yaml` no longer lists them. This is the classic "forgot to run `sops updatekeys` after rotating" footgun.

## Scope of audit

Swept every file matching `*.enc.yaml` for embedded `age1...` recipients and compared against the current `.sops.yaml`:

```
$ for f in $(git ls-files '*.enc.yaml'); do
    grep -oE 'age1[a-z0-9]+' "$f" | sort -u | \
      while read k; do
        case "$k" in
          age14skmde00w0ps6u8asm4rdqwpktr5m5pq84070yzwvjjmcyfnl4ushfn5uq|\
          age1rk6fs67kly3h4zux5za429z3grjtvs8vcunav4sa28pxk738najsk8wgs6) ;;
          *) echo "STALE: $f -> $k" ;;
        esac
      done
  done
STALE: k8s/bases/variables/variables-base-secret.enc.yaml -> age188ez3ur…
```

This was the only finding. Other historical recipients (12 ever in `.sops.yaml` history) have been correctly stripped from every other file.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅ (not affected — recipient-only change)
- `sops -d k8s/bases/variables/variables-base-secret.enc.yaml | head -2` decrypts with the current local key, confirming no plaintext drift.

## Caveat

This does **not** invalidate the rotated key in git history — prior revisions of this file remain decryptable by the old recipient. If the retired key is suspected to have leaked, the underlying secret **values** should also be rotated (handled separately when/if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)