### PR TITLE
chore(security): tighten Renovate trust gates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended", 
+    "config:recommended",
     ":disableDependencyDashboard",
     ":semanticCommitTypeAll(fix)"
   ],
@@ -43,6 +43,69 @@
   "patch": {
     "automerge": true
   },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security",
+      "priority/high"
+    ],
+    "minimumReleaseAge": "0 days",
+    "automerge": false
+  },
+  "packageRules": [
+    {
+      "description": "Security-critical controllers always require manual review, even for patch/minor bumps. A compromised release of any of these would let an attacker bypass admission, exfiltrate secrets, or disable encryption — automerging on a 7-day-old release is not enough trust.",
+      "matchManagers": [
+        "helmv3",
+        "flux",
+        "kubernetes"
+      ],
+      "matchPackageNames": [
+        "/^cilium$/",
+        "/^tetragon$/",
+        "/^kyverno$/",
+        "/^kyverno-policies$/",
+        "/^openbao$/",
+        "/^vault$/",
+        "/^cert-manager$/",
+        "/^trust-manager$/",
+        "/^dex$/",
+        "/^oauth2-proxy$/",
+        "/^kubescape-operator$/",
+        "/^trivy-operator$/",
+        "/^external-secrets$/",
+        "/^spire$/",
+        "/^spire-agent$/",
+        "/^spire-server$/",
+        "/^velero$/",
+        "/^reloader$/"
+      ],
+      "automerge": false,
+      "labels": [
+        "security/review-required"
+      ]
+    },
+    {
+      "description": "Talos machine config and the prod KSail config are infrastructure-trust-critical: a wrong patch can render the cluster unbootable, and a malicious chart bump dragged in via a transitive bump would be very hard to spot. Block automerge on any change under talos*/** or to ksail.prod.yaml.",
+      "matchFileNames": [
+        "talos/**",
+        "talos-local/**",
+        "ksail.prod.yaml",
+        "ksail.yaml"
+      ],
+      "automerge": false,
+      "labels": [
+        "security/review-required"
+      ]
+    },
+    {
+      "description": "Major versions always require manual review. Belt-and-braces — config:recommended already does this, but stating it explicitly survives future preset drift.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    }
+  ],
   "ignorePaths": [
     "k8s/bases/infrastructure/cluster-policies/samples"
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,11 +50,11 @@
       "priority/high"
     ],
     "minimumReleaseAge": "0 days",
-    "automerge": false
+    "automerge": true
   },
   "packageRules": [
     {
-      "description": "Security-critical controllers always require manual review, even for patch/minor bumps. A compromised release of any of these would let an attacker bypass admission, exfiltrate secrets, or disable encryption — automerging on a 7-day-old release is not enough trust.",
+      "description": "Security-critical controllers — labelled so security-driven bumps are visible in the PR feed. Automerge stays ON: CI (system-test on a real Talos+Docker cluster, kubescape NSA scan, gitleaks, zizmor, CodeQL) is the trust gate.",
       "matchManagers": [
         "helmv3",
         "flux",
@@ -80,30 +80,30 @@
         "/^velero$/",
         "/^reloader$/"
       ],
-      "automerge": false,
+      "automerge": true,
       "labels": [
         "security/review-required"
       ]
     },
     {
-      "description": "Talos machine config and the prod KSail config are infrastructure-trust-critical: a wrong patch can render the cluster unbootable, and a malicious chart bump dragged in via a transitive bump would be very hard to spot. Block automerge on any change under talos*/** or to ksail.prod.yaml.",
+      "description": "Talos / KSail config changes — labelled for visibility. Automerge stays ON: CI's system-test boots a real Talos+Docker cluster from the patched config, so a broken machine-config patch fails bring-up before merge.",
       "matchFileNames": [
         "talos/**",
         "talos-local/**",
         "ksail.prod.yaml",
         "ksail.yaml"
       ],
-      "automerge": false,
+      "automerge": true,
       "labels": [
         "security/review-required"
       ]
     },
     {
-      "description": "Major versions always require manual review. Belt-and-braces — config:recommended already does this, but stating it explicitly survives future preset drift.",
+      "description": "Major versions — automerged. CI (full system-test, kubescape NSA scan, manifest validation) is the trust gate.",
       "matchUpdateTypes": [
         "major"
       ],
-      "automerge": false
+      "automerge": true
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of the security-hardening series (Phase 0.7 + 5.4).

> **Posture update after @devantler review:** The original draft of this PR disabled automerge on every new rule (vulnerability alerts, security-critical controllers, talos/ksail paths, major bumps). @devantler reviewed and pushed back — CI (system-test on a real Talos+Docker cluster, kubescape NSA scan, gitleaks, zizmor, CodeQL) is already a sufficient trust gate, and blocking automerge here would add noise without adding security. All four `automerge` settings were flipped to `true` in [`8a74bec7`](https://github.com/devantler-tech/platform/commit/8a74bec7). The rules now exist to **label and route** these bumps for visibility, not to gate the merge.

## What

| Change | Effect |
|---|---|
| `vulnerabilityAlerts` block | CVE bumps labelled `security` + `priority/high`; `minimumReleaseAge: 0` so CVE patches don't wait 7 days; `automerge: true` (CI catches functional + security regressions). |
| `packageRules[]` matching security-critical controllers | cilium / tetragon / kyverno / openbao / vault / cert-manager / trust-manager / dex / oauth2-proxy / kubescape-operator / trivy-operator / external-secrets / spire\* / velero / reloader — labelled `security/review-required` for the PR feed; `automerge: true`. |
| `packageRules[]` matching trust-critical paths | `talos/**`, `talos-local/**`, `ksail.prod.yaml`, `ksail.yaml` — labelled for visibility; `automerge: true`. CI's system-test boots a real Talos+Docker cluster from the patched config, so a broken machine-config patch fails bring-up before merge. |
| Explicit major-bump rule | `automerge: true`. CI is the trust gate. |

## Why

The original policy `minor/patch automerge after a 7-day minimumReleaseAge` is reasonable for ordinary deps but historically had no special-casing for the security control plane. This PR adds explicit *labels* for security-critical bumps so they're surfaced in the PR feed and routed for visibility, while leaving automerge enabled — CI is treated as the trust gate.

The security-critical package list and the path-scoped rule still capture intent: any future automation that needs to special-case these bumps (e.g., a separate notification channel, a different review SLA) can hang off the labels without further config changes.

## Validation

- `python3 -c 'import json; json.load(open(".github/renovate.json"))'` — JSON well-formed.
- Renovate's online schema (`$schema` field) is unchanged; the new fields are all documented at https://docs.renovatebot.com/configuration-options/.

## Notes

- The `matchPackageNames` regex form (`/^name$/`) is the documented Renovate syntax for exact-match without prefix-collision (so `cilium` doesn't match `cilium-cli` or `cilium-operator`).
- The package list is a closed enumeration; adding Tetragon (Phase 3.1) and any future security controller is a one-line addition here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
