### PR TITLE
feat(talos): add kernel hardening sysctls (defense in depth)

### DIFF
--- a/talos/cluster/sysctls.yaml
+++ b/talos/cluster/sysctls.yaml
@@ -1,4 +1,45 @@
 machine:
   sysctls:
+    # Network buffer tuning (Cilium / high-throughput workloads).
     net.core.rmem_max: "7500000"
     net.core.wmem_max: "7500000"
+
+    # ----- Kernel information disclosure -----
+    # Hide kernel pointers from /proc so a local attacker can't easily
+    # locate gadgets for kernel exploits.
+    kernel.kptr_restrict: "2"
+    # Restrict access to dmesg() so an unprivileged process can't read
+    # the kernel log (which often leaks addresses and dev info).
+    kernel.dmesg_restrict: "1"
+    # Restrict ptrace() to direct children only. Stops one compromised
+    # container from attaching a debugger to a neighbour in the same
+    # PID namespace, even when both run as the same UID.
+    kernel.yama.ptrace_scope: "1"
+
+    # ----- BPF hardening -----
+    # Cilium runs with CAP_BPF/CAP_SYS_ADMIN, so it does not rely on
+    # unprivileged eBPF. Disabling unprivileged eBPF closes a class of
+    # local-privilege-escalation primitives without affecting Cilium.
+    kernel.unprivileged_bpf_disabled: "1"
+
+    # ----- L3 sanity: source routing, redirects, martians -----
+    # Source-routed packets let a remote pick the return path; nothing
+    # legitimate on this cluster needs them.
+    net.ipv4.conf.all.accept_source_route: "0"
+    net.ipv4.conf.default.accept_source_route: "0"
+    net.ipv6.conf.all.accept_source_route: "0"
+    net.ipv6.conf.default.accept_source_route: "0"
+    # ICMP redirects let an on-path attacker rewrite the host's routing
+    # table. Cilium uses BPF for routing decisions, never ICMP redirects.
+    net.ipv4.conf.all.accept_redirects: "0"
+    net.ipv4.conf.default.accept_redirects: "0"
+    net.ipv6.conf.all.accept_redirects: "0"
+    net.ipv6.conf.default.accept_redirects: "0"
+    net.ipv4.conf.all.send_redirects: "0"
+    net.ipv4.conf.default.send_redirects: "0"
+    # Smurf amplification: don't reply to broadcast pings.
+    net.ipv4.icmp_echo_ignore_broadcasts: "1"
+    # Log packets with martian (impossible) source addresses; useful for
+    # spotting misconfigured peers / source-spoofing.
+    net.ipv4.conf.all.log_martians: "1"
+    net.ipv4.conf.default.log_martians: "1"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of the security-hardening series (Phase 4.1).

## What

Extends [\`talos/cluster/sysctls.yaml\`](talos/cluster/sysctls.yaml) from a 2-entry network-buffer tweak to a 16-entry kernel-hardening baseline.

| Group | Sysctl | Effect |
|---|---|---|
| Info disclosure | `kernel.kptr_restrict=2` | Hide kernel pointers in /proc |
| | `kernel.dmesg_restrict=1` | Restrict dmesg to root |
| | `kernel.yama.ptrace_scope=1` | Restrict ptrace to direct children |
| BPF | `kernel.unprivileged_bpf_disabled=1` | Block unprivileged eBPF (Cilium runs privileged so unaffected) |
| L3 sanity | `net.ipv{4,6}.conf.{all,default}.accept_source_route=0` | Drop source-routed packets |
| | `net.ipv{4,6}.conf.{all,default}.accept_redirects=0` | Ignore ICMP redirects |
| | `net.ipv4.conf.{all,default}.send_redirects=0` | Don't emit ICMP redirects |
| | `net.ipv4.icmp_echo_ignore_broadcasts=1` | Smurf amplification |
| | `net.ipv4.conf.{all,default}.log_martians=1` | Log spoofed sources |

## Why

These have no functional impact on the workloads running on the cluster but close well-known LPE and on-path-attack primitives. Cheap defense in depth on top of AppArmor + user-namespaces + KubeSpan that's already configured.

## Explicit non-changes

To avoid surprising the Cilium / KubeSpan dataplane, I deliberately did **not** touch:

- `net.ipv4.conf.*.rp_filter` — Cilium manages this per-interface on `cilium_host`; setting it globally to 1 can break BPF host routing.
- `net.core.bpf_jit_harden` — perf impact, marginal extra value once unprivileged BPF is off.
- `kernel.unprivileged_userns_clone` — must stay available because this cluster enables user namespaces via [`talos/cluster/user-namespaces.yaml`](talos/cluster/user-namespaces.yaml).

Local Docker provider is unchanged ([`talos-local/`](talos-local/) has no sysctls patch); these settings only apply to the prod Talos cluster.

## Validation

```
$ yq '.machine.sysctls | keys' talos/cluster/sysctls.yaml | head -3
- net.core.rmem_max
- net.core.wmem_max
- kernel.kptr_restrict

$ kubectl kustomize k8s/clusters/local/  | tail -3   # unaffected, still builds
$ kubectl kustomize k8s/clusters/prod/   | tail -3   # unaffected, still builds
```

\`talosctl validate\` on the patch alone reports the expected "missing cluster/install/machine.ca" errors — that's normal for a partial machine-config patch (the same is true of every other file under \`talos/cluster/\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)