### PR TITLE
feat(cilium): enable transparent WireGuard encryption (prod)

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -94,6 +94,22 @@ spec:
     ipam:
       mode: kubernetes
     kubeProxyReplacement: true
+    # Transparent WireGuard encryption for all pod-to-pod and node-to-node
+    # traffic.  KubeSpan (Talos-layer WireGuard between nodes) is not
+    # enabled in this cluster, so without this setting inter-node pod
+    # traffic would transit the Hetzner private network in cleartext.
+    # SPIRE mutual authentication below provides workload *identity*; this
+    # block provides on-the-wire *encryption*. They are independent and
+    # complementary.
+    #
+    # Requires the kernel WireGuard module (present in the Talos kernel
+    # since 5.6) and kubeProxyReplacement=true (set above).
+    # Disabled in the Docker provider overlay — local-only traffic never
+    # leaves a single Docker container.
+    encryption:
+      enabled: true
+      type: wireguard
+      nodeEncryption: true
     authentication:
       enabled: true
       mutual:

--- a/k8s/providers/docker/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: kube-system
 spec:
   values:
+    # Local Docker provider has a single Talos container — there is no
+    # node-to-node wire, and pod-to-pod traffic stays inside one Linux
+    # network namespace. Disabling encryption and SPIRE mTLS keeps the
+    # local cluster lean and avoids the WireGuard kernel module setup.
+    encryption:
+      enabled: false
     authentication:
       enabled: false
       mutual:

--- a/talos/control-planes/ingress-firewall.yaml
+++ b/talos/control-planes/ingress-firewall.yaml
@@ -5,7 +5,7 @@
 #   - apid (50000) and Kubernetes API (6443): open to all (external management)
 #   - kubelet (10250), trustd (50001): cluster-internal only
 #   - etcd (2379-2380): cluster-internal only (Hetzner assigns IPs dynamically)
-#   - Cilium VXLAN (8472), health (4240), Hubble peer (4244): cluster-internal only
+#   - Cilium VXLAN (8472), WireGuard (51871), health (4240), Hubble peer (4244): cluster-internal only
 #   - NodePort range (30000-32767): cluster-internal (Hetzner Cloud LB)
 #   - Node exporter (9100): cluster-internal (Prometheus scraping)
 #
@@ -76,6 +76,21 @@ name: cni-vxlan-ingress
 portSelector:
   ports:
     - 8472
+  protocol: udp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+# Cilium WireGuard transparent encryption (encryption.type: wireguard).
+# Tunnels VXLAN-encapsulated pod traffic between nodes through cilium_wg0.
+# Default port is UDP 51871; Talos's NetworkDefaultActionConfig: block
+# would otherwise drop inter-node WireGuard packets and break pod-to-pod
+# traffic the moment encryption is enabled.
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cilium-wireguard-ingress
+portSelector:
+  ports:
+    - 51871
   protocol: udp
 ingress:
   - subnet: 10.0.0.0/16

--- a/talos/workers/ingress-firewall.yaml
+++ b/talos/workers/ingress-firewall.yaml
@@ -4,7 +4,7 @@
 # Policy summary (workers are more restrictive than control planes):
 #   - apid (50000): open to all (KSail manages workers via public IPs)
 #   - kubelet (10250): cluster-internal only
-#   - Cilium VXLAN (8472), health (4240), Hubble peer (4244): cluster-internal only
+#   - Cilium VXLAN (8472), WireGuard (51871), health (4240), Hubble peer (4244): cluster-internal only
 #   - NodePort range (30000-32767): cluster-internal (Hetzner Cloud LB)
 #   - Node exporter (9100): cluster-internal (Prometheus scraping)
 #
@@ -44,6 +44,21 @@ name: cni-vxlan-ingress
 portSelector:
   ports:
     - 8472
+  protocol: udp
+ingress:
+  - subnet: 10.0.0.0/16
+---
+# Cilium WireGuard transparent encryption (encryption.type: wireguard).
+# Tunnels VXLAN-encapsulated pod traffic between nodes through cilium_wg0.
+# Default port is UDP 51871; Talos's NetworkDefaultActionConfig: block
+# would otherwise drop inter-node WireGuard packets and break pod-to-pod
+# traffic the moment encryption is enabled.
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cilium-wireguard-ingress
+portSelector:
+  ports:
+    - 51871
   protocol: udp
 ingress:
   - subnet: 10.0.0.0/16


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of the security-hardening series (Phase 1.1).

## What

Enables Cilium WireGuard transparent encryption in the base HelmRelease; turns it back off in the Docker provider overlay.

```diff
+ encryption:
+   enabled: true
+   type: wireguard
+   nodeEncryption: true
```

## Why

The cluster already has SPIRE mutual authentication, but that only verifies workload identity — it does not encrypt the bytes on the wire. Talos KubeSpan is **not** enabled (no `talos/cluster/kubespan.yaml`), so pod-to-pod traffic between nodes currently rides the Hetzner private network in cleartext. Hetzner's "private" network is private in the routing sense but is still shared physical infrastructure.

WireGuard at the CNI layer fills the gap; mutual auth and encryption are independent and complementary.

## Validation

```
$ kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/ \
    | yq 'select(.metadata.name == "cilium") | .spec.values.encryption'
enabled: true
nodeEncryption: true
type: wireguard

$ kubectl kustomize k8s/providers/docker/infrastructure/controllers/ \
    | yq 'select(.metadata.name == "cilium") | .spec.values.encryption.enabled'
false

$ ksail workload validate                            → 255 files validated
$ ksail --config ksail.prod.yaml workload validate   → 255 files validated
```

## Rollout caveats

- **Restart needed:** Cilium agent will roll. PDBs preserve connectivity during the rollout.
- **MTU:** Cilium auto-adjusts the in-pod MTU for the WireGuard overhead (~32B). No manual tuning needed for VXLAN tunneling (the default).
- **Existing flows:** Long-lived TCP connections established before the upgrade will continue unencrypted until they reconnect; new flows pick up encryption immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)