### PR TITLE
feat(gateway): add HSTS preload header to all HTTPRoutes

### DIFF
--- a/k8s/bases/apps/actual-budget/httproute.yaml
+++ b/k8s/bases/apps/actual-budget/httproute.yaml
@@ -23,3 +23,9 @@ spec:
         - name: keda-add-ons-http-interceptor-proxy
           namespace: keda
           port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/apps/fleetdm/httproute.yaml
+++ b/k8s/bases/apps/fleetdm/httproute.yaml
@@ -23,3 +23,9 @@ spec:
         - name: keda-add-ons-http-interceptor-proxy
           namespace: keda
           port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/apps/headlamp/httproute.yaml
+++ b/k8s/bases/apps/headlamp/httproute.yaml
@@ -21,3 +21,9 @@ spec:
         - name: keda-add-ons-http-interceptor-proxy
           namespace: keda
           port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/apps/homepage/httproute.yaml
+++ b/k8s/bases/apps/homepage/httproute.yaml
@@ -17,6 +17,11 @@ spec:
             set:
               - name: X-Auth-Request-Redirect
                 value: https://${domain}/
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload
       backendRefs:
         - name: oauth2-proxy
           namespace: oauth2-proxy

--- a/k8s/bases/apps/whoami/httproute.yaml
+++ b/k8s/bases/apps/whoami/httproute.yaml
@@ -21,3 +21,9 @@ spec:
         - name: keda-add-ons-http-interceptor-proxy
           namespace: keda
           port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/infrastructure/controllers/cilium/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/httproute.yaml
@@ -25,6 +25,11 @@ spec:
             set:
               - name: X-Auth-Request-Redirect
                 value: https://hubble.${domain}/
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload
       backendRefs:
         - name: oauth2-proxy
           namespace: oauth2-proxy

--- a/k8s/bases/infrastructure/controllers/dex/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/httproute.yaml
@@ -14,3 +14,9 @@ spec:
     - backendRefs:
         - name: dex
           port: 5556
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/infrastructure/controllers/flux-operator/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/httproute.yaml
@@ -22,3 +22,9 @@ spec:
     - backendRefs:
         - name: flux-operator
           port: 9080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/httproute.yaml
@@ -14,3 +14,9 @@ spec:
     - backendRefs:
         - name: oauth2-proxy
           port: 80
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/infrastructure/controllers/openbao/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/httproute.yaml
@@ -22,3 +22,9 @@ spec:
     - backendRefs:
         - name: openbao-ui
           port: 8200
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of the security-hardening series (Phase 4.3, HSTS portion).

## What

Every HTTPRoute (except the http→https redirect) now carries a `ResponseHeaderModifier` filter that sets:

```
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
```

- `max-age=63072000` — 2 years (satisfies the [HSTS preload list](https://hstspreload.org) requirement of ≥ 1 year).
- `includeSubDomains` — applies to the whole `*.<domain>` wildcard.
- `preload` — signals intent to add the apex to the Chromium HSTS preload list.

Touched 10 HTTPRoutes (5 infrastructure controllers, 5 apps); skipped the http→https redirect (it has no body, just emits a 301 — HSTS is honoured on the subsequent HTTPS response).

## Why not set it once on the Gateway

Gateway API v1 has **no default-filter mechanism** for a listener — filters live on HTTPRoute rules. Per-route is the only portable option. The patch is structurally identical across every route, so the addition is mechanical.

## Why not also pin TLS 1.3 minVersion here

Cilium Gateway exposes TLS options only via [`CiliumEnvoyConfig`](https://docs.cilium.io/en/v1.19/network/servicemesh/cec/), a vendor-specific lower-level CRD. That is a meaningfully larger change with a higher rollback cost and is tracked as a follow-up. TLS 1.2 with modern Envoy ciphers (the Cilium default) remains acceptable in the interim.

## Validation

```
$ ksail workload validate                            → 255 files validated
$ ksail --config ksail.prod.yaml workload validate   → 255 files validated

$ kubectl kustomize k8s/bases/apps/whoami/ | yq \
    'select(.kind=="HTTPRoute") | .spec.rules'
- backendRefs:
    - name: keda-add-ons-http-interceptor-proxy
      namespace: keda
      port: 8080
  filters:
    - responseHeaderModifier:
        set:
          - name: Strict-Transport-Security
            value: max-age=63072000; includeSubDomains; preload
      type: ResponseHeaderModifier
```

## Operational note

Once stable in prod, submit the apex to <https://hstspreload.org> to land on the preload list. Once preloaded, **rolling back is hard** — browsers will keep enforcing HTTPS-only on the domain for `max-age` (2 years) regardless of what the server says. Don't preload until you're sure the platform is HTTPS-only forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)