### PR TITLE
feat(security): pin non-Helm container images by digest

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: traefik
-          image: docker.io/library/traefik:v3.7
+          image: docker.io/library/traefik:v3.7@sha256:6b9cbca6fac42ab0075f5437d8dc1685cfd188626d8d515839ea94f8b6271c42
           args:
             - --configFile=/etc/traefik/traefik.yaml
           ports:

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -111,7 +111,7 @@ spec:
                 - |
                   chown -R 1000:1000 /run/spire/data
                   chown -R 1000:1000 /tmp/spire-server
-                image: docker.io/library/busybox:1.37.0
+                image: docker.io/library/busybox:1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
                 imagePullPolicy: IfNotPresent
                 name: chown
                 securityContext:

--- a/k8s/bases/infrastructure/vault-backup/cronjob.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: snapshot
-              image: quay.io/openbao/openbao:2.5.3
+              image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
               env:
                 - name: BAO_ADDR
                   value: http://openbao.openbao.svc.cluster.local:8200

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -67,7 +67,7 @@ spec:
       initContainers:
         # --- 1. Auto-init + unseal ---
         - name: vault-init
-          image: quay.io/openbao/openbao:2.5.3
+          image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
           env:
             - name: BAO_ADDR
               value: http://openbao.openbao.svc.cluster.local:8200
@@ -144,7 +144,7 @@ spec:
               fi
         # --- 2. Persist credentials in K8s Secret (only on fresh init) ---
         - name: store-keys
-          image: alpine/k8s:1.36.1
+          image: alpine/k8s:1.36.1@sha256:692239d739589247c4a791205ed9619c28ae85a21286e19a6211c04a62c56668
           volumeMounts:
             - name: shared
               mountPath: /shared
@@ -172,7 +172,7 @@ spec:
               fi
       containers:
         - name: vault-config
-          image: quay.io/openbao/openbao:2.5.3
+          image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
           env:
             - name: BAO_ADDR
               value: http://openbao.openbao.svc.cluster.local:8200

--- a/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - args:
             - -conf
             - /etc/coredns/Corefile
-          image: registry.k8s.io/coredns/coredns:v1.14.3
+          image: registry.k8s.io/coredns/coredns:v1.14.3@sha256:884b72dd6d2f7d367902af420605e0288dffedb0516ce29330423ae3f8f5c6fa
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5

--- a/k8s/providers/docker/infrastructure/controllers/minio/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/minio/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: minio
-          image: quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z
+          image: quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z@sha256:8834ae47a2de3509b83e0e70da9369c24bbbc22de42f2a2eddc530eee88acd1b
           args:
             - server
             - /data
@@ -119,7 +119,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mc
-          image: quay.io/minio/mc:RELEASE.2025-04-08T15-39-49Z
+          image: quay.io/minio/mc:RELEASE.2025-04-08T15-39-49Z@sha256:7e3efb09c22c0882fbf341b9d99f61f94ae6c4c20a06f2f1a2b20ea8993d8952
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Part of the security-hardening series (Phase 2.5).

## What

Pins every container `image:` reference outside upstream-bundled operator manifests and Helm chart defaults by appending `@sha256:<digest>`:

| Image | Used by |
|---|---|
| `docker.io/library/traefik:v3.7` | `auth-proxy/deployment.yaml` |
| `docker.io/library/busybox:1.37.0` | Cilium SPIRE chown workaround |
| `quay.io/openbao/openbao:2.5.3` | `vault-backup`, `vault-config` (x2) |
| `alpine/k8s:1.36.1` | `vault-config` store-keys init |
| `registry.k8s.io/coredns/coredns:v1.14.3` | docker provider coredns |
| `quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z` | docker provider minio |
| `quay.io/minio/mc:RELEASE.2025-04-08T15-39-49Z` | docker provider minio |

Each line becomes `<ref>:<tag>@sha256:<digest>`. Digests resolved with `crane digest <ref>` at commit time.

## Why

Tag-only image references can be silently re-pointed by the registry. Even with `imagePullPolicy: IfNotPresent`, a pod created on a freshly-scheduled node fetches whatever bytes the tag now resolves to — which is not necessarily what the previous pod ran. Digest pinning makes the bytes deterministic.

Renovate still tracks these — its `kubernetes` manager understands digest-pinned images and bumps the digest in lockstep with the tag on each upstream release.

## Explicitly out of scope

- **Upstream-bundled operator manifests** (`k8s/bases/infrastructure/controllers/{cdi,kubevirt}/*-operator.yaml`): these are verbatim copies of the upstream release manifests. Rewriting the image lines defeats the bundle approach and creates merge conflicts on every operator bump. The image tags move with the operator chart version, which is already pinned via Renovate.
- **Images inside HelmRelease `values:` overrides** that come from the chart's defaults: pinning a values override diverges from upstream defaults. Only the Cilium SPIRE busybox workaround qualifies — it's a custom inject, not a chart default — so it gets pinned here.

## Validation

```
$ ksail workload validate                            → 255 files validated
$ ksail --config ksail.prod.yaml workload validate   → 255 files validated
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)