### PR TITLE
fix(fleetdm): create SA in fleetdm namespace for VaultDynamicSecret generator

### DIFF
--- a/k8s/bases/apps/fleetdm/external-secrets-serviceaccount.yaml
+++ b/k8s/bases/apps/fleetdm/external-secrets-serviceaccount.yaml
@@ -1,0 +1,18 @@
+# ServiceAccount used as the JWT subject when ESO's VaultDynamicSecret
+# generator authenticates to OpenBao for fleet's rotated MySQL credential.
+#
+# The generator's spec.provider.auth.kubernetes.serviceAccountRef.namespace
+# field is silently IGNORED by ESO for generator resources (see ESO issue
+# #4629; the cross-namespace SA lookup path is gated to ClusterSecretStore
+# only — runtime/esutils/resolvers/secret_ref.go uses EmptyStoreKind for
+# generators). So the SA must live in the generator's own namespace.
+#
+# This SA exists purely as the JWT subject — no in-cluster RBAC is granted
+# to it. Authorisation happens on the OpenBao side via the
+# `fleetdm-mysql-rotated` Kubernetes auth role bound to this SA, which
+# carries only the `app-fleetdm-db-readonly` policy.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: fleetdm

--- a/k8s/bases/apps/fleetdm/kustomization.yaml
+++ b/k8s/bases/apps/fleetdm/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - httproute.yaml
   - http-scaled-object.yaml
   - external-secrets.yaml
+  - external-secrets-serviceaccount.yaml
   - mysql-static-cred-generator.yaml
   - server-key-external-secret.yaml
   - networkpolicy.yaml

--- a/k8s/bases/apps/fleetdm/mysql-static-cred-generator.yaml
+++ b/k8s/bases/apps/fleetdm/mysql-static-cred-generator.yaml
@@ -1,10 +1,19 @@
 # Reads the OpenBao Database-engine static credential for the fleet MySQL user.
 # ESO's Vault provider supports the KV engine only, so the database engine must
-# be read through a generator. Authenticates the same way as the `openbao`
-# ClusterSecretStore (Kubernetes auth, role `external-secrets`). The mysql
-# ExternalSecret consumes this via `dataFrom` and maps `password` -> the
-# `mysql-password` key. OpenBao rotates this on its static-role schedule; the
-# generator re-reads on each ExternalSecret refresh (validated on ESO v2.5.0).
+# be read through a generator. The generator authenticates to OpenBao with a
+# Kubernetes service account JWT (the `fleetdm-mysql-rotated` Vault auth role)
+# bound to the `external-secrets` SA in THIS namespace. The mysql ExternalSecret
+# consumes this via `dataFrom` and maps `password` -> the `mysql-password` key.
+# OpenBao rotates this on its static-role schedule; the generator re-reads on
+# each ExternalSecret refresh (validated on ESO v2.5.0).
+#
+# The SA must live in the generator's own namespace: ESO's generator codepath
+# uses an "empty store kind" for resolving SA refs and silently ignores
+# `serviceAccountRef.namespace` (cross-namespace SA lookup is gated to
+# ClusterSecretStores — ESO issue #4629, closed not-planned). A dedicated Vault
+# role (`fleetdm-mysql-rotated`) keeps the policy surface tight: it carries
+# only `app-fleetdm-db-readonly`, not the broad policy bundle on the
+# `external-secrets` role used by the ClusterSecretStore.
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: VaultDynamicSecret
 metadata:
@@ -18,7 +27,6 @@ spec:
     auth:
       kubernetes:
         mountPath: "kubernetes"
-        role: "external-secrets"
+        role: "fleetdm-mysql-rotated"
         serviceAccountRef:
           name: "external-secrets"
-          namespace: "external-secrets"

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -375,11 +375,27 @@ spec:
               # --- 5. Create auth roles ---
               echo "Writing Kubernetes auth roles..."
 
-              # ESO needs broad read access for ExternalSecrets + write for PushSecrets
+              # ESO needs broad read access for ExternalSecrets + write for PushSecrets.
+              # This role is bound to the ESO controller's own SA via the
+              # `openbao` ClusterSecretStore and covers KV-engine reads only.
+              # The fleetdm MySQL Database-engine static credential is handled
+              # by a separate, narrowly scoped role below — keep
+              # app-fleetdm-db-readonly off this bundle.
               bao write auth/kubernetes/role/external-secrets \
                 bound_service_account_names=external-secrets \
                 bound_service_account_namespaces=external-secrets \
-                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-fleetdm-db-readonly,app-wedding-readonly,infra-oidc-readonly,vault-seed-write \
+                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,app-fleetdm-readonly,app-wedding-readonly,infra-oidc-readonly,vault-seed-write \
+                ttl=1h
+
+              # Dedicated role for the fleetdm VaultDynamicSecret generator.
+              # The generator authenticates with the `external-secrets` SA in
+              # the fleetdm namespace (the generator's own namespace — ESO
+              # silently ignores serviceAccountRef.namespace for generators,
+              # see ESO #4629). Scoped to the database static-creds read only.
+              bao write auth/kubernetes/role/fleetdm-mysql-rotated \
+                bound_service_account_names=external-secrets \
+                bound_service_account_namespaces=fleetdm \
+                policies=app-fleetdm-db-readonly \
                 ttl=1h
 
               # Snapshot CronJob needs health check read


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Symptom (production)

Since the Phase 1 fleetdm MySQL rotation rollout ([#1606](https://github.com/devantler-tech/platform/pull/1606)) merged, the `apps` Flux Kustomization has been failing its health check every reconcile:

```
HealthCheckFailed   kustomization/apps   health check failed after 20m: timeout waiting for:
  [ExternalSecret/fleetdm/mysql-fleet-rotated status: 'InProgress',
   HelmRelease/fleetdm/fleetdm status: 'InProgress']
```

and the `mysql-fleet-rotated` ExternalSecret has been in `SecretSyncedError` with:

```
error processing spec.dataFrom[0].sourceRef.generatorRef, err: error using
generator: unable to setup Vault client: cannot request Kubernetes service
account token for service account "external-secrets": cannot get Kubernetes
service account "external-secrets": ServiceAccount "external-secrets" not
found
```

Downstream, the fleet Deployment Pod and the `fleet-migration` Pod sit in `CreateContainerConfigError` ("secret `mysql-fleet-rotated` not found"), and `fleet-vulnprocessing` CronJob runs hit the backoff limit.

## Root cause

ESO **silently ignores `serviceAccountRef.namespace`** on generator resources. The cross-namespace SA lookup path in [`providers/v1/vault/auth_kubernetes.go`](https://github.com/external-secrets/external-secrets/blob/main/providers/v1/vault/auth_kubernetes.go) is gated to `ClusterSecretStoreKind` only, and the VaultDynamicSecret generator entry point builds its Vault client with `resolvers.EmptyStoreKind` (which is explicitly not cluster-scoped — see the comment in `runtime/esutils/resolvers/secret_ref.go`).

So the `namespace: external-secrets` we set on the generator's SA ref was a no-op; ESO fell back to the generator's own namespace (`fleetdm`) where no `external-secrets` SA exists.

Confirmed by ESO maintainer in [external-secrets/external-secrets#4629](https://github.com/external-secrets/external-secrets/issues/4629) (closed not-planned) and the maintainer vote at [#4634](https://github.com/external-secrets/external-secrets/issues/4634):

> *Generators are not Cluster Scoped, thus, `namespace` setting is never honored. If you want to use a Generator, you need to treat it like a SecretStore — and have credentials available on the same namespace the Generator exists.*

## Fix

The maintainer-recommended pattern: put the SA in the generator's own namespace and use a Vault role scoped to that SA.

- **New ServiceAccount** `external-secrets` in the `fleetdm` namespace ([external-secrets-serviceaccount.yaml](k8s/bases/apps/fleetdm/external-secrets-serviceaccount.yaml)). It only needs to exist as a JWT subject — no in-cluster RBAC is attached to it.
- **New OpenBao Kubernetes auth role** `fleetdm-mysql-rotated` bound to `fleetdm:external-secrets`, carrying ONLY the `app-fleetdm-db-readonly` policy ([job.yaml:385](k8s/bases/infrastructure/vault-config/job.yaml#L385)). This is more conservative than reusing the broad `external-secrets` role: the fleetdm generator no longer inherits `infra-*`, `app-wedding-readonly`, `vault-seed-write`, etc.
- **Tightened the broad `external-secrets` role**: dropped `app-fleetdm-db-readonly` from its policy bundle, since the only consumer is now the dedicated role.
- **Updated [`mysql-static-cred-generator.yaml`](k8s/bases/apps/fleetdm/mysql-static-cred-generator.yaml)**: `role: external-secrets → fleetdm-mysql-rotated`, dropped the silently-ignored `serviceAccountRef.namespace` field, and refreshed the comment to document the ESO behaviour for the next reader.

## Net effect after Flux reconciles

1. SA `fleetdm:external-secrets` exists → ESO can `TokenRequest` against it.
2. OpenBao role `fleetdm-mysql-rotated` accepts that JWT and grants read on `database/static-creds/fleet`.
3. `mysql-fleet-rotated` ExternalSecret materialises the Secret.
4. `fleet-migration` and `fleet` Pods escape `CreateContainerConfigError`.
5. `apps` Kustomization stops timing out on `HealthCheckFailed`.

## Validation

```
$ ksail workload validate                            → 256 files validated
$ ksail --config ksail.prod.yaml workload validate   → 256 files validated
```

(+1 vs the previous count of 255 = the new SA manifest.)

The vault-config Job is idempotent (`bao write` overwrites the existing role, and the new role is written separately), so this is safe to apply on a running cluster — no `bao delete` needed for the policy that was dropped from the bundle, since the policy itself is unchanged, only the binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)