### PR TITLE
fix(fleetdm): point vulnprocessing CronJob at rotated MySQL secret

### DIFF
--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -135,6 +135,32 @@ spec:
                               secretKeyRef:
                                 name: mysql-fleet-rotated
                                 key: mysql-password
+          # The hourly vulnerability-processing CronJob also reads from MySQL.
+          # Without this override every run fails with `Error 1045 Access denied`
+          # because the chart-rendered CronJob points at the stale `mysql` Secret
+          # while OpenBao has rotated the actual fleet user password (the rotated
+          # value lives in `mysql-fleet-rotated`, same as the Deployment uses).
+          - target:
+              kind: CronJob
+              name: fleet-vulnprocessing
+            patch: |
+              apiVersion: batch/v1
+              kind: CronJob
+              metadata:
+                name: fleet-vulnprocessing
+              spec:
+                jobTemplate:
+                  spec:
+                    template:
+                      spec:
+                        containers:
+                          - name: fleet-vulnprocessing
+                            env:
+                              - name: FLEET_MYSQL_PASSWORD
+                                valueFrom:
+                                  secretKeyRef:
+                                    name: mysql-fleet-rotated
+                                    key: mysql-password
           - target:
               kind: Deployment
               name: fleet


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

The hourly `fleet-vulnprocessing` CronJob has been failing on every run with:

```
level=warn msg="could not connect to db" cron=vulnerabilities
err="Error 1045 (28000): Access denied for user 'fleet'@'10.244.1.222' (using password: YES)"
```

`#1606` (OpenBao Database-engine static-role rotation of the `fleet` MySQL user) wired the rotated password into:

- the `fleet` Deployment (`fleet` container + `fleet-db-init` initContainer)
- the one-shot `fleet-migration` Job

but left the chart-rendered `fleet-vulnprocessing` CronJob still pointing at the KV-bootstrap `mysql` Secret, which is now stale. Every hour at HH:00 the CronJob spawns, fails auth, and exhausts `backoffLimit` retries before being TTL'd.

## Fix

Add a strategic-merge `postRenderer` patch targeting `CronJob/fleet-vulnprocessing` that overrides `FLEET_MYSQL_PASSWORD` to read from `mysql-fleet-rotated` (same source the Deployment and migration Job already use).

Surgical — single env override, no logic change.

## Validation

- `ksail workload validate` → `256 files validated` (local)
- `ksail --config ksail.prod.yaml workload validate` → `256 files validated`
- Captured prod failure logs match the rotated-credential hypothesis; the chart's main `fleet` Deployment (which uses `mysql-fleet-rotated`) is healthy and reaching MySQL.

## Evidence

Captured during the 16:00 UTC 2026-05-28 run via background watcher:

```
=== fleet-vulnprocessing-29666400-tpfpl ===
…
ts=2026-05-28T16:04:05Z level=warn msg="could not connect to db" cron=vulnerabilities
  err="Error 1045 (28000): Access denied for user 'fleet'@'10.244.1.222' (using password: YES)"
```

Same failure on three sequential pods (`-ldmbk`, `-nwpgf`, `-tpfpl`); cluster auth-success on the long-running `fleet-…-gxvb8` pod (different secret source) confirms the user/grant is fine — only this CronJob is reading the wrong Secret.
