### PR TITLE
fix(opencost): treat custom pricing as USD/month and lift memory limit

### DIFF
--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -42,42 +42,51 @@ spec:
       # Hetzner Cloud custom pricing — CX33 monthly cap decomposed into
       # per-resource-unit USD costs. CX33 spec verified live with
       # `kubectl get nodes`: 4 vCPU, 7916176 KiB RAM (8 GB nominal), 80 GB NVMe.
-      # Price source: Hetzner price-adjustment doc, effective 2026-04-01:
-      #   https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/
-      #   CX33 cap = €6.49 / server / month  → $7.01 at EUR/USD ≈ 1.08
-      #   Volumes = €0.0572 / GB / month     → $0.0618 / GB / month
+      # Price source: Hetzner Cloud Pricing API (2026-05, location fsn1, net
+      # of VAT — gross is +25% but VAT is reclaimable / location-dependent and
+      # tracking it in OpenCost would conflate compute cost with tax overhead):
+      #   curl -H "Authorization: Bearer $HCLOUD_TOKEN" \
+      #        https://api.hetzner.cloud/v1/pricing
+      #     CX33 cap = €6.49 / server / month   (hourly €0.0104)
+      #     Volumes  = €0.0572 / GB / month
+      #     Egress   = €1.00 / TB overage  (€0.001 / GB; 20 TiB incl. per server)
+      # FX: ECB EUR→USD reference rate 2026-05-27 = 1.1637.
       #
       # IMPORTANT: OpenCost interprets CPU / spotCPU / RAM / spotRAM / GPU / storage
       # in the costModel ConfigMap as USD PER MONTH and divides by HoursPerMonth=730
       # to get an hourly rate (opencost providerconfig.go:188, customprovider.go:95).
       # Network egress fields are passed through as-is (USD per GB transferred).
       #
-      # 50/50 CPU-RAM split of the $7.01/server/month server cost (Hetzner does
-      # not publish a CPU/RAM breakdown — this is an allocation convention):
-      #   CPU: $7.01 × 0.5 / 4 vCPU ≈ $0.876 / vCPU-month
-      #   RAM: $7.01 × 0.5 / 8 GB   ≈ $0.438 / GB-month
+      # Derivation:
+      #   €6.49/server/month × 1.1637 = $7.5524/server/month
+      #   50/50 CPU-RAM split (Hetzner does not publish a breakdown — convention):
+      #     CPU: $7.5524 × 0.5 / 4 vCPU ≈ $0.9441 / vCPU-month
+      #     RAM: $7.5524 × 0.5 / 8 GB   ≈ $0.4720 / GB-month
+      #   Volume: €0.0572 × 1.1637 ≈ $0.0666 / GB-month
+      #   Egress: €0.001  × 1.1637 ≈ $0.001164 / GB
       #
       # End-to-end sanity check (1 vCPU for 1 hour):
-      #   ConfigMap CPU = 0.876 → OpenCost / 730 = $0.00120 / vCPU-hour
-      #   Real cost     = (€6.49 × 0.5 / 4 vCPU / 730 hr) × 1.08 = $0.00120 / vCPU-hour ✓
+      #   ConfigMap CPU = 0.9441 → OpenCost / 730 = $0.001293 / vCPU-hour
+      #   Real cost     = (€6.49 × 0.5 / 4 vCPU / 730 hr) × 1.1637
+      #                 =  €0.001112 × 1.1637 = $0.001294 / vCPU-hour ✓
       # https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart
       customPricing:
         enabled: true
         createConfigmap: true
         provider: custom
         costModel:
-          description: "Hetzner Cloud CX33 — 4 vCPU / 8 GB / 80 GB NVMe (50/50 CPU-RAM split, USD/month)"
-          CPU: 0.876
+          description: "Hetzner Cloud CX33 — 4 vCPU / 8 GB / 80 GB NVMe (50/50 CPU-RAM split, USD/month net of VAT)"
+          CPU: 0.9441
           spotCPU: 0
-          RAM: 0.438
+          RAM: 0.4720
           spotRAM: 0
           GPU: 0
-          storage: 0.0618
+          storage: 0.0666
           # Egress: passed through as USD per GB transferred; CX33 includes
-          # 20 TB/month free, overage ≈ $0.001/GB on Hetzner Cloud.
-          zoneNetworkEgress: 0.001
-          regionNetworkEgress: 0.001
-          internetNetworkEgress: 0.001
+          # 20 TiB/month free, overage ≈ €1.00/TB = $0.001164/GB.
+          zoneNetworkEgress: 0.001164
+          regionNetworkEgress: 0.001164
+          internetNetworkEgress: 0.001164
 
       exporter:
         replicas: 1

--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -29,7 +29,7 @@ spec:
   #
   # Lightweight FinOps cost allocation. Points at the existing
   # kube-prometheus-stack Prometheus and uses custom pricing derived from
-  # Hetzner Cloud CX33 hourly rates (€0.0117/hr for 3 vCPU / 8 GB RAM).
+  # Hetzner Cloud CX33 rates (€0.0117/hr for 3 vCPU / 8 GB RAM).
   values:
     opencost:
       prometheus:
@@ -40,8 +40,17 @@ spec:
           url: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
 
       # Hetzner Cloud custom pricing — CX33 rates decomposed into
-      # per-resource-unit hourly USD costs (EUR/USD ≈ 1.09).
-      # CX33: €0.0117/hr → $0.01275/hr, 50/50 CPU-RAM split.
+      # per-resource-unit USD costs (EUR/USD ≈ 1.09).
+      # CX33: €0.0117/hr → $0.01275/hr → $9.31/month per server, 50/50 CPU-RAM split.
+      #
+      # IMPORTANT: OpenCost interprets CPU / spotCPU / RAM / spotRAM / GPU / storage
+      # in the costModel ConfigMap as USD PER MONTH and divides by HoursPerMonth=730
+      # to get an hourly rate (opencost providerconfig.go:188, customprovider.go:95).
+      # Network egress fields are passed through as-is (USD per GB transferred).
+      # Per-server monthly: $9.31 / 2 = $4.655 each for CPU and RAM.
+      #   CPU: $4.655 / 3 vCPU ≈ $1.5517 / vCPU-month
+      #   RAM: $4.655 / 8 GB   ≈ $0.5819 / GB-month
+      #   storage: Hetzner Cloud Volume ≈ €0.044/GB-month → ≈ $0.048 / GB-month
       # https://www.hetzner.com/cloud#pricing
       # https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart
       customPricing:
@@ -49,13 +58,15 @@ spec:
         createConfigmap: true
         provider: custom
         costModel:
-          description: "Hetzner Cloud CX33 — 3 vCPU / 8 GB / 80 GB NVMe (50/50 CPU-RAM split)"
-          CPU: 0.002125
+          description: "Hetzner Cloud CX33 — 3 vCPU / 8 GB / 80 GB NVMe (50/50 CPU-RAM split, USD/month)"
+          CPU: 1.5517
           spotCPU: 0
-          RAM: 0.000797
+          RAM: 0.5819
           spotRAM: 0
           GPU: 0
-          storage: 0.00008
+          storage: 0.048
+          # Egress: passed through as USD per GB transferred; CX33 includes
+          # 20 TB/month free, overage ≈ $0.001/GB on Hetzner Cloud.
           zoneNetworkEgress: 0.001
           regionNetworkEgress: 0.001
           internetNetworkEgress: 0.001
@@ -66,8 +77,12 @@ spec:
           requests:
             cpu: 10m
             memory: 55Mi
+          # 256Mi OOM-killed when Headlamp issued the 14d allocation queries —
+          # the cost-model engine holds the full window in memory while
+          # aggregating. 512Mi gives ~7× headroom over idle (~75 Mi) and is
+          # still well under the chart's 1Gi default.
           limits:
-            memory: 256Mi
+            memory: 512Mi
 
       ui:
         enabled: true

--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -25,6 +25,45 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: opencost
+  postRenderers:
+    # Zero-downtime, gate-clean rollout. The chart default (maxUnavailable: 1 on
+    # a single replica) kills the old pod the instant the new one is created;
+    # kubelet then fires one last readiness probe ~1s after Cilium tears down
+    # the dead pod's route, emitting `Unhealthy: …:9003/healthz: connect: no
+    # route to host`. That one-shot teardown warning trips the merge-queue
+    # deploy gate (.github/actions/check-event-warnings) even though it is
+    # harmless. Two mitigations:
+    #   1. maxUnavailable: 0 — surge the new pod to Ready before the old is
+    #      terminated (matches the homepage/headlamp convention).
+    #   2. preStop.sleep — keep the opencost container serving :9003 for 15s
+    #      after it is marked for deletion, so kubelet's probes during drain
+    #      land on a live endpoint instead of a torn-down route. Native sleep
+    #      action (GA since k8s 1.30; cluster is 1.32) — no shell needed in the
+    #      distroless image.
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: opencost
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: opencost
+              spec:
+                strategy:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 1
+                    maxUnavailable: 0
+                template:
+                  spec:
+                    containers:
+                      - name: opencost
+                        lifecycle:
+                          preStop:
+                            sleep:
+                              seconds: 15
   # https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/values.yaml
   #
   # Lightweight FinOps cost allocation. Points at the existing

--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -29,7 +29,7 @@ spec:
   #
   # Lightweight FinOps cost allocation. Points at the existing
   # kube-prometheus-stack Prometheus and uses custom pricing derived from
-  # Hetzner Cloud CX33 rates (€0.0117/hr for 3 vCPU / 8 GB RAM).
+  # Hetzner Cloud CX33 rates (€6.49/month for 4 vCPU / 8 GB / 80 GB).
   values:
     opencost:
       prometheus:
@@ -39,32 +39,40 @@ spec:
           enabled: true
           url: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
 
-      # Hetzner Cloud custom pricing — CX33 rates decomposed into
-      # per-resource-unit USD costs (EUR/USD ≈ 1.09).
-      # CX33: €0.0117/hr → $0.01275/hr → $9.31/month per server, 50/50 CPU-RAM split.
+      # Hetzner Cloud custom pricing — CX33 monthly cap decomposed into
+      # per-resource-unit USD costs. CX33 spec verified live with
+      # `kubectl get nodes`: 4 vCPU, 7916176 KiB RAM (8 GB nominal), 80 GB NVMe.
+      # Price source: Hetzner price-adjustment doc, effective 2026-04-01:
+      #   https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/
+      #   CX33 cap = €6.49 / server / month  → $7.01 at EUR/USD ≈ 1.08
+      #   Volumes = €0.0572 / GB / month     → $0.0618 / GB / month
       #
       # IMPORTANT: OpenCost interprets CPU / spotCPU / RAM / spotRAM / GPU / storage
       # in the costModel ConfigMap as USD PER MONTH and divides by HoursPerMonth=730
       # to get an hourly rate (opencost providerconfig.go:188, customprovider.go:95).
       # Network egress fields are passed through as-is (USD per GB transferred).
-      # Per-server monthly: $9.31 / 2 = $4.655 each for CPU and RAM.
-      #   CPU: $4.655 / 3 vCPU ≈ $1.5517 / vCPU-month
-      #   RAM: $4.655 / 8 GB   ≈ $0.5819 / GB-month
-      #   storage: Hetzner Cloud Volume ≈ €0.044/GB-month → ≈ $0.048 / GB-month
-      # https://www.hetzner.com/cloud#pricing
+      #
+      # 50/50 CPU-RAM split of the $7.01/server/month server cost (Hetzner does
+      # not publish a CPU/RAM breakdown — this is an allocation convention):
+      #   CPU: $7.01 × 0.5 / 4 vCPU ≈ $0.876 / vCPU-month
+      #   RAM: $7.01 × 0.5 / 8 GB   ≈ $0.438 / GB-month
+      #
+      # End-to-end sanity check (1 vCPU for 1 hour):
+      #   ConfigMap CPU = 0.876 → OpenCost / 730 = $0.00120 / vCPU-hour
+      #   Real cost     = (€6.49 × 0.5 / 4 vCPU / 730 hr) × 1.08 = $0.00120 / vCPU-hour ✓
       # https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart
       customPricing:
         enabled: true
         createConfigmap: true
         provider: custom
         costModel:
-          description: "Hetzner Cloud CX33 — 3 vCPU / 8 GB / 80 GB NVMe (50/50 CPU-RAM split, USD/month)"
-          CPU: 1.5517
+          description: "Hetzner Cloud CX33 — 4 vCPU / 8 GB / 80 GB NVMe (50/50 CPU-RAM split, USD/month)"
+          CPU: 0.876
           spotCPU: 0
-          RAM: 0.5819
+          RAM: 0.438
           spotRAM: 0
           GPU: 0
-          storage: 0.048
+          storage: 0.0618
           # Egress: passed through as USD per GB transferred; CX33 includes
           # 20 TB/month free, overage ≈ $0.001/GB on Hetzner Cloud.
           zoneNetworkEgress: 0.001

--- a/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/opencost/helm-release.yaml
@@ -93,10 +93,13 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 55Mi
+            # Observed steady-state ~75Mi (kubectl top). Request 128Mi so the
+            # scheduler reserves real baseline and the pod isn't first to be
+            # evicted under node memory pressure.
+            memory: 128Mi
           # 256Mi OOM-killed when Headlamp issued the 14d allocation queries —
           # the cost-model engine holds the full window in memory while
-          # aggregating. 512Mi gives ~7× headroom over idle (~75 Mi) and is
+          # aggregating. 512Mi gives ~4× headroom over the request and is
           # still well under the chart's 1Gi default.
           limits:
             memory: 512Mi


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Headlamp's OpenCost panel stopped reporting costs on prod. Two issues were stacked.

### 1. Custom pricing was off by a factor of ~730

The OpenCost helm chart's `customPricing.costModel` fields (`CPU`, `RAM`, `GPU`, `storage`, `spotCPU`, `spotRAM`) are interpreted as **USD per month** and divided by `HoursPerMonth = 730` to derive an hourly rate. Our values were authored as hourly, so OpenCost reported `node_cpu_hourly_cost = 3e-06` (`0.002125 / 730 ≈ 2.91e-6`). Allocation queries returned values like `$0.00227` for kube-system over 14 days, which Headlamp rounds to `$0.00` — "no cost data". Conversion is hardcoded in [`providerconfig.go:188-210`](https://github.com/opencost/opencost/blob/develop/pkg/cloud/provider/providerconfig.go#L188-L210); chart [defaults](https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/values.yaml) (`CPU: 1.25`, `RAM: 0.50`) confirm the monthly convention.

### 2. The exporter was OOMKilled while serving Headlamp's 14d query

256 MiB limit; Headlamp's `window=14d&aggregate=namespace` query holds the window in memory → exit 137 mid-response → intermittent 499s and an empty panel.

## What changed

> Pricing values were revised to use Hetzner-Pricing-API figures + the ECB FX rate; the table reflects the **final** values in the branch.

| | before | after | source of "after" |
|---|---|---|---|
| `costModel.CPU` (USD/vCPU/month) | 0.002125 (hourly!) | **0.9441** | €6.49/mo ÷ 4 vCPU × 0.5 × 1.1637 |
| `costModel.RAM` (USD/GB/month) | 0.000797 (hourly!) | **0.4720** | €6.49/mo ÷ 8 GB × 0.5 × 1.1637 |
| `costModel.storage` (USD/GB/month) | 0.00008 (hourly!) | **0.0666** | Volume €0.0572/GB × 1.1637 |
| `costModel.*NetworkEgress` (USD/GB) | 0.001 | **0.001164** | €1.00/TB overage × 1.1637 |
| `exporter.resources.requests.memory` | 55Mi | **128Mi** | above observed ~75Mi idle |
| `exporter.resources.limits.memory` | 256Mi | **512Mi** | ~4× request; chart default is 1Gi |
| rollout `strategy.maxUnavailable` | 1 (chart default) | **0** (+ `preStop.sleep: 15`) | see "Merge-queue deploy gate" below |

Hetzner figures are net of VAT, pulled live from `GET https://api.hetzner.cloud/v1/pricing` (fsn1): CX33 = €6.49/server/month, Volume = €0.0572/GB-month, egress = €1.00/TB. FX = ECB EUR→USD reference 2026-05-27 = **1.1637**. CX33 spec (4 vCPU / 8 GB / 80 GB) verified via `kubectl get nodes`. 50/50 CPU-RAM split is an allocation convention.

**End-to-end check (1 vCPU for 1 hour):** ConfigMap CPU `0.9441` → `/730` = `$0.001293/vCPU-hr`; real = `(€6.49 × 0.5 / 4 / 730) × 1.1637 = $0.001294/vCPU-hr` ✓

### Merge-queue deploy gate (`check-event-warnings`)

The merge-queue *Deploy to Prod* job deploys to real prod, waits 90s, and fails on any `Warning` event in the window. This PR's OpenCost config change rolls the pod, and the chart-default `maxUnavailable:1` on a single replica kills the old pod the instant the new one is created — kubelet then fires one last readiness probe ~1s after Cilium removes the dead pod's route → `Unhealthy: …:9003/healthz: connect: no route to host`, tripping the gate. Mitigated with a postRenderer: `maxUnavailable:0` (surge new→Ready before old terminates) + `preStop.sleep:15` (keep the container serving `:9003` during drain so probes land on a live endpoint; native sleep action, GA k8s 1.30, cluster is 1.32).

> The homepage probe warnings seen in earlier merge-queue runs of this PR are a **separate, platform-wide** issue (every PR's deploy gate hits them), fixed by #1636 (`initialDelaySeconds`). Not this PR's concern.

## Validation

`ksail workload validate` on both `clusters/local` and `clusters/prod` (256 files each). Strategy + `preStop.sleep` accepted by the live 1.32 API via `kubectl apply --dry-run=server`. Bug reproduced read-only on prod before the fix (`node_cpu_hourly_cost = 3e-06`, OOMKilled exit 137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)