### PR TITLE
fix(oauth2-proxy): raise upstream_timeout to 90s for scale-to-zero cold starts

### DIFF
--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -83,6 +83,12 @@ spec:
         whitelist_domains = ["${domain}", ".${domain}"]
         redirect_url = "https://oauth2-proxy.${domain}/oauth2/callback"
         upstreams = [ "http://auth-proxy.oauth2-proxy.svc.cluster.local:80" ]
+        # upstream_timeout — max time to await upstream response headers
+        # (default 30s). Raised to 90s so KEDA scale-to-zero apps behind this
+        # proxy (notably hubble-ui, which cold-starts via auth-proxy → the KEDA
+        # HTTP interceptor) have room to wake before SSO returns a 504. Kept
+        # under Cloudflare's ~100s edge timeout so oauth2-proxy answers first.
+        upstream_timeout = "90s"
         skip_provider_button = true
         reverse_proxy = true
     ingress:


### PR DESCRIPTION
## Problem

Clicking **Hubble** from the homepage returns a Cloudflare **504 Gateway time-out** (`hubble.platform.devantler.tech`). Hubble UI is KEDA scale-to-zero, and its request path is the longest of any app:

```
Cloudflare → Cilium Gateway → oauth2-proxy (SSO) → auth-proxy (Traefik) → KEDA HTTP interceptor → scale hubble-ui 0→1 → wait Ready
```

The oauth2-proxy SSO log for the failing click shows the smoking gun:

```
[2026/05/28 17:52:39] hubble.platform.devantler.tech GET / ... 504 15 30.005   ← ned@devantler.tech (auth OK)
[2026/05/28 17:54:12] error_page.go:91 Error proxying to upstream server: net/http: timeout awaiting response headers
```

Auth succeeded; oauth2-proxy then timed out **at exactly 30.005s** awaiting upstream response headers. `--upstream-timeout` / `upstream_timeout` defaults to **30s**, which is shorter than the cold-start budget when the cluster is under contention (the 504 landed inside a ~17:31–18:08 restart/eviction wave: VPA evictions, `auth-proxy`/Traefik restart at 17:50, homepage 502-flapping). headlamp/whoami don't hit this because they route **straight to the KEDA interceptor**, bypassing the 30s SSO cap; Hubble is the only scale-to-zero app behind oauth2-proxy.

## Fix

Set `upstream_timeout = "90s"` in the oauth2-proxy `configFile`.

- 90s gives a slow cold start (incl. a possible Cluster Autoscaler node add or cold image pull) room to complete.
- Kept **under Cloudflare's ~100s edge timeout** so oauth2-proxy responds before the edge cuts the connection.
- Stakater Reloader (`deploymentAnnotations: configmap.reloader.stakater.com/reload`) rolls oauth2-proxy automatically when the rendered ConfigMap changes — no manual restart needed once Flux applies.

Verified the option name/format against oauth2-proxy v7.15.2 docs: `upstream_timeout` is a top-level legacy config-file key (valid alongside `upstreams`, `email_domains`, …), Go-duration value.

## Timeout ladder — verified the rest of the chain won't pre-empt 90s

Confirmed against the deployed components that nothing downstream gives up before oauth2-proxy's new 90s, and nothing upstream cuts it off too early:

- **KEDA interceptor** (`http-add-on-interceptor:0.14.0`, chart `keda-add-ons-http` 0.14.1): per `interceptor/config/timeouts.go` @ v0.14.0, readiness wait = `0s` = **unbounded** ("gives the full request budget to cold starts"; the 30s fallback default applies only when a fallback service is set — hubble-ui has none), total request deadline = `0s` = none, response-header timeout = `300s`. The live interceptor overrides none of these. → **won't pre-empt 90s; no interceptor change needed.**
- **Traefik (`auth-proxy`)**: no `responseHeaderTimeout` configured (default = none). → won't pre-empt.
- **Cloudflare**: ~100s edge timeout > 90s. → oauth2-proxy answers first.

## Validation

- `ksail workload validate` → **256 files validated** ✅
- `ksail --config ksail.prod.yaml workload validate` → **256 files validated** ✅
- `kubectl kustomize k8s/clusters/local/` and `…/prod/` build ✅; change renders into the rendered HelmRelease `configFile`.

## Notes

- Read-only investigation on prod; no live-cluster changes made. This lands via Flux on merge/release.
- Residual case timeout-tuning **cannot** cover: a cold start that needs a Cluster Autoscaler node add (>~100s) will still exceed Cloudflare's edge timeout. For that, pin `hubble-ui` `minReplicas: 1` or pre-warm — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)