### PR TITLE
fix(cd): bump cosign + syft SHA256 to match pinned versions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -146,7 +146,7 @@ jobs:
           # SHA256 of cosign-linux-amd64 for the version above.
           # Update alongside COSIGN_VERSION (Renovate bumps the version
           # only; the digest must follow in the same PR — intentional).
-          COSIGN_SHA256: "1f6c194dd0891eb345b436bb71ff9f996768355f5e0ce02dde88567029ac2188"
+          COSIGN_SHA256: "c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
         run: |
           set -euo pipefail
           curl -fsSL \
@@ -187,7 +187,7 @@ jobs:
           # renovate: datasource=github-releases depName=anchore/syft extractVersion=^v(?<version>.+)$
           SYFT_VERSION: "1.44.0"
           # SHA256 of syft_<ver>_linux_amd64.tar.gz for the version above.
-          SYFT_SHA256: "689e12c5cbf67521ce61b9c126068f9eaabe1223e77971b2fede50033ff6b5cc"
+          SYFT_SHA256: "0e91737aee2b5baf1d255b959630194a302335d848ff97bb07921eb6205b5f5a"
           # Indirected through env to keep the template expansion out
           # of the shell script body (zizmor: code-injection via
           # template-expansion).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why CD has been failing on `main`

Every CD run since [v1.4.0](https://github.com/devantler-tech/platform/actions/runs/26582412550) (last success) has failed in the **🖋️ Sign OCI manifest with cosign (keyless)** step with:

```
sha256sum: WARNING: 1 computed checksum did NOT match
/tmp/cosign: FAILED
```

Latest failing run: [#26591485520](https://github.com/devantler-tech/platform/actions/runs/26591485520).

### Root cause

Renovate auto-merged three PRs in quick succession that bumped pinned binary versions but **didn't update the corresponding pinned SHA256**:

| PR | Bump | SHA in `cd.yaml` | Real upstream |
|---|---|---|---|
| #1632 | syft `1.20.0 → 1.44.0` | `689e12c5…b5cc` (stale) | `0e91737a…b5f5a` |
| #1633 | cosign `2.5.0 → 2.6.3` | (superseded) | — |
| #1634 | cosign `2.6.3 → 3.0.6` | `1f6c194d…c2188` (stale) | `c956e5df…f4c74` |

The workflow comment is explicit about the policy:

```yaml
# Update alongside COSIGN_VERSION (Renovate bumps the version
# only; the digest must follow in the same PR — intentional).
```

…but nothing actually enforced it, and Renovate auto-merge let all three through.

Cosign fails first, so the syft step has only been skipped (never executed). It would fail the same way once cosign is fixed — that's why this PR bumps both digests in one go.

## Verification

Real digests pulled live from the upstream checksum manifests:

- `cosign_checksums.txt` for [`sigstore/cosign@v3.0.6`](https://github.com/sigstore/cosign/releases/tag/v3.0.6) → `c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74  cosign-linux-amd64`
- `syft_1.44.0_checksums.txt` for [`anchore/syft@v1.44.0`](https://github.com/anchore/syft/releases/tag/v1.44.0) → `0e91737aee2b5baf1d255b959630194a302335d848ff97bb07921eb6205b5f5a  syft_1.44.0_linux_amd64.tar.gz`

No cluster validation needed — only `.github/workflows/cd.yaml` changes, and the next tag deploy is the real test.

## Follow-ups (not in this PR)

**Earlier draft of this section claimed Renovate has native `currentDigest`/`digest` support for `github-releases` datasources that would let it update version + SHA atomically. That's wrong — `digest` in Renovate maps to OCI image digests (`docker` datasource) and git commit SHAs (`git-*` datasources), not to the sha256 of an arbitrary release asset. There is no Renovate-native way to track `cosign-linux-amd64`'s file digest.**

The structural fix is to stop using raw release-asset downloads and let an official installer action handle the binary integrity check internally. That's what [#1641](https://github.com/devantler-tech/platform/pull/1641) does — it switches cosign + syft to `sigstore/cosign-installer` / `anchore/sbom-action`, eliminating both `*_SHA256` env vars while keeping `*_VERSION` Renovate-tracked.

Either this PR alone or [#1641](https://github.com/devantler-tech/platform/pull/1641) alone unblocks CD. The two conflict (same lines), so the maintainer picks one:

- **Merge #1640 first** → CD recovers with the minimal patch → [#1641](https://github.com/devantler-tech/platform/pull/1641) rebases on top (trivial conflict) and removes the manual-SHA contract for good.
- **Merge [#1641](https://github.com/devantler-tech/platform/pull/1641) first** → close this PR as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
