### PR TITLE
refactor(cd): use installer actions for cosign and syft

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -128,6 +128,20 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
 
+      - name: ⚙️ Install cosign
+        # sigstore/cosign-installer is the official installer action — it
+        # downloads cosign for the requested release and verifies its own
+        # Sigstore signature against Fulcio + Rekor (keyless), so there is
+        # no per-version SHA256 to track in this repo. Bump cosign by
+        # editing COSIGN_VERSION below; Renovate proposes the bump via the
+        # custom regex manager in .github/renovate.json.
+        env:
+          # renovate: datasource=github-releases depName=sigstore/cosign extractVersion=^v(?<version>.+)$
+          COSIGN_VERSION: "3.0.6"
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v${{ env.COSIGN_VERSION }}'
+
       - name: 🖋️ Sign OCI manifest with cosign (keyless)
         # Signs the platform OCI artifact published by `ksail workload push`
         # using Sigstore keyless signing: Fulcio mints a short-lived cert
@@ -135,31 +149,15 @@ jobs:
         # signature in its append-only transparency log. There is no
         # private key on disk -- the security policy lives in the
         # verifier's matchOIDCIdentity regex (planned for a follow-up).
+        id: cosign-sign
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           # COSIGN_EXPERIMENTAL was retired in cosign 2.x; keyless is now
           # the default when --key is omitted.
           COSIGN_YES: "true"
-          # renovate: datasource=github-releases depName=sigstore/cosign extractVersion=^v(?<version>.+)$
-          COSIGN_VERSION: "3.0.6"
-          # SHA256 of cosign-linux-amd64 for the version above.
-          # Update alongside COSIGN_VERSION (Renovate bumps the version
-          # only; the digest must follow in the same PR — intentional).
-          COSIGN_SHA256: "c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
         run: |
           set -euo pipefail
-          curl -fsSL \
-            "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64" \
-            -o /tmp/cosign
-          # Verify the binary BEFORE installing as root. Without this,
-          # a compromised release asset would land on the runner under
-          # /usr/local/bin and run as part of the signing chain.
-          echo "${COSIGN_SHA256}  /tmp/cosign" | sha256sum -c -
-          chmod +x /tmp/cosign
-          sudo install /tmp/cosign /usr/local/bin/cosign
-          rm /tmp/cosign
-          cosign version
           # Login to GHCR so cosign can resolve and sign the manifest pushed
           # in the previous step. The signature is uploaded back to GHCR
           # alongside the artifact.
@@ -175,39 +173,34 @@ jobs:
           DIGEST=$(cosign manifest digest "${REF}")
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
           echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
-        id: cosign-sign
+
+      - name: 🔐 Login to GHCR (for syft)
+        # anchore/sbom-action shells out to syft to pull the OCI manifest's
+        # descriptor + layers. The action has no registry-credentials input,
+        # so docker login must run first — same pattern syft uses on its own.
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: 📋 Generate SBOM (CycloneDX)
-        # Uses syft to enumerate every package/binary in the OCI manifest
-        # artifact published in the previous step. Output is CycloneDX
-        # JSON, which is the format attest-sbom expects.
+        # anchore/sbom-action is the official installer wrapper for syft —
+        # it manages syft's binary integrity itself, so no per-version
+        # SHA256 to track here either. Bump syft by editing SYFT_VERSION
+        # below; Renovate proposes the bump via the custom regex manager.
+        # Output is CycloneDX JSON, which is the format attest-sbom expects.
+        # `upload-artifact: false` matches today's behaviour (no workflow
+        # artifact); the SBOM is attested to the registry in the next step.
         env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
           # renovate: datasource=github-releases depName=anchore/syft extractVersion=^v(?<version>.+)$
           SYFT_VERSION: "1.44.0"
-          # SHA256 of syft_<ver>_linux_amd64.tar.gz for the version above.
-          SYFT_SHA256: "0e91737aee2b5baf1d255b959630194a302335d848ff97bb07921eb6205b5f5a"
-          # Indirected through env to keep the template expansion out
-          # of the shell script body (zizmor: code-injection via
-          # template-expansion).
-          OCI_DIGEST: ${{ steps.cosign-sign.outputs.digest }}
-        run: |
-          set -euo pipefail
-          curl -fsSL \
-            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
-            -o /tmp/syft.tar.gz
-          echo "${SYFT_SHA256}  /tmp/syft.tar.gz" | sha256sum -c -
-          sudo tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
-          rm /tmp/syft.tar.gz
-          syft version
-          # Auth so syft can pull the OCI manifest descriptor + layers.
-          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
-          syft scan --output cyclonedx-json=sbom.cdx.json \
-            "ghcr.io/devantler-tech/platform/manifests@${OCI_DIGEST}"
-          # Sanity: SBOM file should be non-empty and parseable JSON.
-          test -s sbom.cdx.json
-          jq -e '.bomFormat == "CycloneDX"' sbom.cdx.json >/dev/null
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/devantler-tech/platform/manifests@${{ steps.cosign-sign.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          syft-version: 'v${{ env.SYFT_VERSION }}'
+          upload-artifact: false
 
       - name: 🪪 Attest SBOM (Sigstore via cosign keyless)
         # Records the SBOM as a Sigstore in-toto attestation against the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Reopens [#1641](https://github.com/devantler-tech/platform/pull/1641) (closed after rebasing on the post-[#1640](https://github.com/devantler-tech/platform/pull/1640) main; force-push to the old branch wasn't available).

## Why

[#1640](https://github.com/devantler-tech/platform/pull/1640) was the minimal fix for the broken CD pipeline — it bumped two pinned SHA256 digests that Renovate version-only bumps left stale. The underlying problem is structural: the contract documented in the workflow comment ("Renovate bumps the version only; the digest must follow in the same PR — intentional") relied on a human noticing, and Renovate auto-merge kept slipping past it.

This PR removes the contract entirely by switching both binaries to their **official installer actions**, which manage binary integrity themselves:

| Action | What it replaces | Integrity check |
|---|---|---|
| [`sigstore/cosign-installer@v4.1.2`](https://github.com/sigstore/cosign-installer) | curl + sha256sum + sudo install of `cosign-linux-amd64` | Keyless-verifies the cosign binary against Fulcio + Rekor on every run |
| [`anchore/sbom-action@v0.24.0`](https://github.com/anchore/sbom-action) | curl + sha256sum + tar of `syft_*.tar.gz`, plus the raw `syft scan` invocation | Installer manages syft's binary integrity; we just pass `syft-version` |

Both actions are themselves SHA-pinned (matching the repo's existing convention for `actions/checkout`, `actions/attest-sbom`, etc.).

## What this preserves

- **`COSIGN_VERSION` / `SYFT_VERSION` env vars stay**, with the same `# renovate:` annotations. The custom regex manager in `.github/renovate.json` (which already targets `*_VERSION` env vars) keeps proposing bumps for both, and those bumps are now single-value — no second value to forget.
- **All existing signing behaviour:** keyless cosign sign + recursive, GHCR registry login, digest capture in `steps.cosign-sign.outputs.digest`, the same SBOM at `sbom.cdx.json` consumed by `actions/attest-sbom`, the same SLSA provenance attestation, same OIDC permissions.
- **No new `docker/login-action` dependency** — kept the bare `docker login` shell step (split out so the registry credentials are visible in one place rather than re-used inside an action input).

## What this removes

- `COSIGN_SHA256` and `SYFT_SHA256` env vars and their explanatory comments (both were updated in [#1640](https://github.com/devantler-tech/platform/pull/1640); this PR removes them entirely as part of the refactor).
- The `curl + sha256sum -c + sudo install` blocks for both tools.
- The defensive `jq -e '.bomFormat == "CycloneDX"' sbom.cdx.json` sanity check — `anchore/sbom-action` either succeeds (and writes a valid file) or fails the step; the home-rolled defence was insurance against a home-rolled syft invocation silently emitting garbage, which the action doesn't do.

Net: `cd.yaml` is **−45 / +38 lines** (same as the pre-rebase diff).

## Verification

Workflow-only change. YAML parses (`ruby -ryaml -e 'YAML.load_file'` → OK). Both action commits are the upstream-published commits for their respective tags:

- `sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6` → `refs/tags/v4.1.2`
- `anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610` → `refs/tags/v0.24.0`

Real validation is the next `v*` tag deploy — CD has no static cluster-free way to test the signing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
