### PR TITLE
fix(cd): replace removed-in-v3 cosign command for digest capture

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -170,7 +170,13 @@ jobs:
           # Capture the digest so subsequent SBOM + provenance attestation
           # steps reference the exact bytes that were signed, not whatever
           # the tag happens to point at by the time those steps run.
-          DIGEST=$(cosign manifest digest "${REF}")
+          # cosign 3.0 removed the `cosign manifest digest` subcommand --
+          # calling it now prints the top-level Usage text, which the
+          # GITHUB_OUTPUT writer below rejects with "Invalid format 'Usage:'".
+          # docker buildx imagetools is preinstalled on ubuntu-latest and
+          # reuses the ~/.docker/config.json that `cosign login` above
+          # populates, so it's a drop-in replacement with no extra install.
+          DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
           echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why CD is still failing

[#1640](https://github.com/devantler-tech/platform/pull/1640) and [#1642](https://github.com/devantler-tech/platform/pull/1642) unblocked the cosign **install** + **sign** steps, but the next line in the same script also fails on cosign v3:

```yaml
DIGEST=$(cosign manifest digest "${REF}")
```

**cosign 3.0 removed the `cosign manifest digest` subcommand.** Calling it now prints the top-level Usage help text to stdout. That multi-line blob gets captured into `$DIGEST` and echoed into `$GITHUB_OUTPUT` as:

```
digest=Usage: cosign sign [flags]
cosign sign signs the supplied artifact
...
```

The runner's output-file parser sees the second line (`cosign sign signs...`) as invalid format and aborts the step with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format 'Usage:'
```

Latest failing run: [#26599722405](https://github.com/devantler-tech/platform/actions/runs/26599722405) on tag v1.7.1 (oauth2-proxy timeout bump). Every subsequent `v*` tag deploy hits the same wall.

## Fix

Drop the cosign call and resolve the digest via `docker buildx imagetools inspect`:

```diff
- DIGEST=$(cosign manifest digest "${REF}")
+ DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{.Manifest.Digest}}')
```

- `docker` + `docker buildx` are preinstalled on `ubuntu-latest`, so no extra tool install / SHA pin.
- `cosign login ghcr.io` runs earlier in the same step and writes `~/.docker/config.json`, which is exactly what `docker buildx imagetools` reads for registry auth — same credentials, same auth surface.
- The `--format '{{.Manifest.Digest}}'` template prints the index manifest's digest as `sha256:…`, which is the format both `actions/attest-sbom` and `actions/attest-build-provenance` expect for their `subject-digest:` input.

## Verification

Workflow-only change, +7/−1 in `cd.yaml` (one substantive line plus a 6-line comment explaining the cosign-3 removal). YAML parses (`ruby -ryaml -e 'YAML.load_file'` → OK).

Real validation is the next `v*` tag deploy — CD has no static way to test the signing path. If the maintainer wants to verify before tagging, `workflow_dispatch` is not currently enabled on `cd.yaml`, but pushing a throwaway `v0.0.0-test` tag (and detaching it on success) would exercise the path end-to-end against the real prod cluster.

## Follow-ups (not in this PR)

`cosign sign` still emits this warning every run, and it's a real future-breakage:

```
WARNING: Image reference ghcr.io/devantler-tech/platform/manifests:latest uses a tag, not a digest, to identify the image to sign.
    ... The ability to refer to images by tag will be removed in a future release.
```

The natural fix is to resolve the digest **before** signing (via the same `docker buildx imagetools inspect` we now use) and pass `REF@DIGEST` to `cosign sign`. That removes the warning, eliminates the tag→digest TOCTOU between resolve and sign, and saves one tag lookup. I kept this PR minimal — one fix per PR — but happy to open the reorder as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
