### PR TITLE
refactor(cd): resolve OCI digest before signing, then sign by digest

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -158,27 +158,26 @@ jobs:
           COSIGN_YES: "true"
         run: |
           set -euo pipefail
-          # Login to GHCR so cosign can resolve and sign the manifest pushed
-          # in the previous step. The signature is uploaded back to GHCR
-          # alongside the artifact.
+          # Login to GHCR so cosign + docker can read/write the manifest
+          # pushed in the previous step. `cosign login` writes
+          # ~/.docker/config.json, which docker buildx imagetools also reads.
           echo "${GHCR_TOKEN}" | cosign login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
-          REF="ghcr.io/devantler-tech/platform/manifests:latest"
-          # cosign sign by tag resolves to the current digest internally,
-          # producing a digest-bound signature that survives future tag
-          # mutations.
+          REF_TAG="ghcr.io/devantler-tech/platform/manifests:latest"
+          # Resolve the tag → digest BEFORE signing so that (a) cosign signs
+          # exactly the bytes we resolved -- no tag→digest TOCTOU if a
+          # concurrent deploy mutates the tag between this resolve and the
+          # sign call, (b) cosign stops warning about tag-based references
+          # and we stay forward-compatible with the cosign roadmap that
+          # removes tag-based signing entirely, and (c) cosign skips its
+          # own internal tag→digest lookup -- one fewer registry round-trip.
+          # docker buildx imagetools is preinstalled on ubuntu-latest; the
+          # cosign-native equivalent (`cosign manifest digest`) was removed
+          # in cosign v3.0.
+          DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')
+          REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"
           cosign sign --yes --recursive "${REF}"
-          # Capture the digest so subsequent SBOM + provenance attestation
-          # steps reference the exact bytes that were signed, not whatever
-          # the tag happens to point at by the time those steps run.
-          # cosign 3.0 removed the `cosign manifest digest` subcommand --
-          # calling it now prints the top-level Usage text, which the
-          # GITHUB_OUTPUT writer below rejects with "Invalid format 'Usage:'".
-          # docker buildx imagetools is preinstalled on ubuntu-latest and
-          # reuses the ~/.docker/config.json that `cosign login` above
-          # populates, so it's a drop-in replacement with no extra install.
-          DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
-          echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${REF_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: 🔐 Login to GHCR (for syft)
         # anchore/sbom-action shells out to syft to pull the OCI manifest's

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -170,7 +170,13 @@ jobs:
           # Capture the digest so subsequent SBOM + provenance attestation
           # steps reference the exact bytes that were signed, not whatever
           # the tag happens to point at by the time those steps run.
-          DIGEST=$(cosign manifest digest "${REF}")
+          # cosign 3.0 removed the `cosign manifest digest` subcommand --
+          # calling it now prints the top-level Usage text, which the
+          # GITHUB_OUTPUT writer below rejects with "Invalid format 'Usage:'".
+          # docker buildx imagetools is preinstalled on ubuntu-latest and
+          # reuses the ~/.docker/config.json that `cosign login` above
+          # populates, so it's a drop-in replacement with no extra install.
+          DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
           echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

[#1643](https://github.com/devantler-tech/platform/pull/1643) fixes the runtime breakage (cosign 3.0 removed `cosign manifest digest`) but leaves a warning visible on every prod deploy:

```
WARNING: Image reference ghcr.io/devantler-tech/platform/manifests:latest uses a tag, not a digest, to identify the image to sign.
    ... The ability to refer to images by tag will be removed in a future release.
```

That's a forward-compat hazard — cosign's roadmap commits to making this an error — and it also masks a real correctness bug: today the digest capture happens **after** signing, so if a concurrent prod deploy mutates `:latest` between cosign's internal tag→digest resolve and our `docker buildx imagetools inspect`, we sign one digest and attest a different one. Both `actions/attest-sbom` and `actions/attest-build-provenance` would then bind their attestations to an artifact whose cosign signature lives on a different sha256 — silently broken supply chain.

## Fix

Swap the order so we resolve the digest **first**, then pass `REF@DIGEST` to `cosign sign`:

```diff
- REF="ghcr.io/devantler-tech/platform/manifests:latest"
- cosign sign --yes --recursive "${REF}"
- DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{.Manifest.Digest}}')
+ REF_TAG="ghcr.io/devantler-tech/platform/manifests:latest"
+ DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')
+ REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"
+ cosign sign --yes --recursive "${REF}"
```

Net wins:

1. **No TOCTOU.** cosign signs exactly the bytes we resolved; the SBOM and SLSA attestations downstream bind to the same `sha256:…`.
2. **Warning gone.** Forward-compatible with cosign dropping tag signing.
3. **One fewer registry round-trip.** Signing by digest skips cosign's internal tag lookup.

## What this preserves

- `outputs.digest` — still the same `sha256:<hex>` string consumed by `actions/attest-sbom`, `actions/attest-build-provenance`, and the `anchore/sbom-action` `image:` input concat.
- `outputs.ref` — still the tag-form ref. Nothing inside this repo reads it today (`grep -rn "cosign-sign.outputs.ref" .github` → 0 hits), but I left it in place as a stable output surface; removing dead exports is a separate concern.
- `--recursive` — still works against a digest-pinned ref (cosign descends into the index's per-platform manifests regardless of how the index itself was addressed).

## Stacking on #1643

This branch was cut from `claude/cd-cosign3-fix` so GitHub initially shows both commits:

1. `fix(cd): replace removed-in-v3 cosign command for digest capture` (from [#1643](https://github.com/devantler-tech/platform/pull/1643))
2. `refactor(cd): resolve OCI digest before signing, then sign by digest` (this PR)

When [#1643](https://github.com/devantler-tech/platform/pull/1643) merges into main, this PR's diff vs main collapses to just commit 2 — no rebase needed, no force-push. If for some reason you'd rather merge this PR first, it subsumes [#1643](https://github.com/devantler-tech/platform/pull/1643) (the broken `cosign manifest digest` line is gone from the new run block entirely); close [#1643](https://github.com/devantler-tech/platform/pull/1643) as superseded.

## Verification

Workflow-only change, +17/−18 in `cd.yaml` (mostly comment rewrite — the executable change is the reorder and the REF/REF_TAG split). YAML parses (`ruby -ryaml -e 'YAML.load_file'` → OK). No new tools, no new actions.

Real validation is the next `v*` tag deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
