### PR TITLE
chore(cd): pre-create ~/.docker/config.json instead of CLI logins

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -142,6 +142,41 @@ jobs:
         with:
           cosign-release: 'v${{ env.COSIGN_VERSION }}'
 
+      - name: 🔐 Configure GHCR auth (cosign + buildx + syft)
+        # Pre-create ~/.docker/config.json instead of `cosign login` /
+        # `docker login` so neither emits the "credentials stored
+        # unencrypted in '/home/runner/.docker/config.json'" warning every
+        # run. The on-disk format is byte-identical to what those CLI
+        # commands would have written (base64 of "actor:token") -- the
+        # warning is cosmetic noise on an ephemeral runner that's destroyed
+        # after the job. Writing the auth here once also lets us drop the
+        # per-tool login commands from the steps below: cosign, docker
+        # buildx imagetools, and syft (via anchore/sbom-action) all resolve
+        # GHCR credentials through the standard OCI keychain, which reads
+        # this same file.
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p ~/.docker
+          # Build the auth blob in a command substitution so it never
+          # reaches stdout.
+          AUTH=$(printf '%s:%s' "${GITHUB_ACTOR}" "${GHCR_TOKEN}" | base64 -w0)
+          # Register the derived value as a workflow mask so any future
+          # accidental log output (e.g. from a `set -x` added during
+          # debugging) is redacted -- GitHub's automatic secret masking
+          # only matches the raw GHCR_TOKEN literal, not the base64 of
+          # "actor:token" derived from it.
+          echo "::add-mask::${AUTH}"
+          # jq is preinstalled on ubuntu-latest; --arg avoids any shell
+          # quoting issue if the token ever contains a JSON-special char.
+          jq -n --arg auth "${AUTH}" \
+            '{auths: {"ghcr.io": {auth: $auth}}}' \
+            > ~/.docker/config.json
+          chmod 600 ~/.docker/config.json
+
       - name: 🖋️ Sign OCI manifest with cosign (keyless)
         # Signs the platform OCI artifact published by `ksail workload push`
         # using Sigstore keyless signing: Fulcio mints a short-lived cert
@@ -151,17 +186,13 @@ jobs:
         # verifier's matchOIDCIdentity regex (planned for a follow-up).
         id: cosign-sign
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           # COSIGN_EXPERIMENTAL was retired in cosign 2.x; keyless is now
-          # the default when --key is omitted.
+          # the default when --key is omitted. GHCR credentials come from
+          # ~/.docker/config.json populated by the "Configure GHCR auth"
+          # step above; cosign reads them through the OCI keychain.
           COSIGN_YES: "true"
         run: |
           set -euo pipefail
-          # Login to GHCR so cosign + docker can read/write the manifest
-          # pushed in the previous step. `cosign login` writes
-          # ~/.docker/config.json, which docker buildx imagetools also reads.
-          echo "${GHCR_TOKEN}" | cosign login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
           REF_TAG="ghcr.io/devantler-tech/platform/manifests:latest"
           # Resolve the tag → digest BEFORE signing so that (a) cosign signs
           # exactly the bytes we resolved -- no tag→digest TOCTOU if a
@@ -178,15 +209,6 @@ jobs:
           cosign sign --yes --recursive "${REF}"
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
           echo "ref=${REF_TAG}" >> "${GITHUB_OUTPUT}"
-
-      - name: 🔐 Login to GHCR (for syft)
-        # anchore/sbom-action shells out to syft to pull the OCI manifest's
-        # descriptor + layers. The action has no registry-credentials input,
-        # so docker login must run first — same pattern syft uses on its own.
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: 📋 Generate SBOM (CycloneDX)
         # anchore/sbom-action is the official installer wrapper for syft —

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -158,27 +158,26 @@ jobs:
           COSIGN_YES: "true"
         run: |
           set -euo pipefail
-          # Login to GHCR so cosign can resolve and sign the manifest pushed
-          # in the previous step. The signature is uploaded back to GHCR
-          # alongside the artifact.
+          # Login to GHCR so cosign + docker can read/write the manifest
+          # pushed in the previous step. `cosign login` writes
+          # ~/.docker/config.json, which docker buildx imagetools also reads.
           echo "${GHCR_TOKEN}" | cosign login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
-          REF="ghcr.io/devantler-tech/platform/manifests:latest"
-          # cosign sign by tag resolves to the current digest internally,
-          # producing a digest-bound signature that survives future tag
-          # mutations.
+          REF_TAG="ghcr.io/devantler-tech/platform/manifests:latest"
+          # Resolve the tag → digest BEFORE signing so that (a) cosign signs
+          # exactly the bytes we resolved -- no tag→digest TOCTOU if a
+          # concurrent deploy mutates the tag between this resolve and the
+          # sign call, (b) cosign stops warning about tag-based references
+          # and we stay forward-compatible with the cosign roadmap that
+          # removes tag-based signing entirely, and (c) cosign skips its
+          # own internal tag→digest lookup -- one fewer registry round-trip.
+          # docker buildx imagetools is preinstalled on ubuntu-latest; the
+          # cosign-native equivalent (`cosign manifest digest`) was removed
+          # in cosign v3.0.
+          DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')
+          REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"
           cosign sign --yes --recursive "${REF}"
-          # Capture the digest so subsequent SBOM + provenance attestation
-          # steps reference the exact bytes that were signed, not whatever
-          # the tag happens to point at by the time those steps run.
-          # cosign 3.0 removed the `cosign manifest digest` subcommand --
-          # calling it now prints the top-level Usage text, which the
-          # GITHUB_OUTPUT writer below rejects with "Invalid format 'Usage:'".
-          # docker buildx imagetools is preinstalled on ubuntu-latest and
-          # reuses the ~/.docker/config.json that `cosign login` above
-          # populates, so it's a drop-in replacement with no extra install.
-          DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
-          echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${REF_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: 🔐 Login to GHCR (for syft)
         # anchore/sbom-action shells out to syft to pull the OCI manifest's

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -170,7 +170,13 @@ jobs:
           # Capture the digest so subsequent SBOM + provenance attestation
           # steps reference the exact bytes that were signed, not whatever
           # the tag happens to point at by the time those steps run.
-          DIGEST=$(cosign manifest digest "${REF}")
+          # cosign 3.0 removed the `cosign manifest digest` subcommand --
+          # calling it now prints the top-level Usage text, which the
+          # GITHUB_OUTPUT writer below rejects with "Invalid format 'Usage:'".
+          # docker buildx imagetools is preinstalled on ubuntu-latest and
+          # reuses the ~/.docker/config.json that `cosign login` above
+          # populates, so it's a drop-in replacement with no extra install.
+          DIGEST=$(docker buildx imagetools inspect "${REF}" --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
           echo "ref=${REF}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Every prod CD run logs this twice:

```
WARNING! Your credentials are stored unencrypted in '/home/runner/.docker/config.json'.
Configure a credential helper to remove this warning. See
https://docs.docker.com/go/credential-store/
```

— once from `cosign login` and once from `docker login` (the syft auth step [#1642](https://github.com/devantler-tech/platform/pull/1642) split out). The on-disk format is the same base64 of `actor:token` those CLIs would have written; the warning is just docker nagging on every invocation. On an ephemeral GitHub-hosted runner that's destroyed at job end, a credential helper has no security upside — it's noise.

## Fix

Replace both login calls with a single `Configure GHCR auth` step that writes `~/.docker/config.json` directly via `jq`. The standard OCI keychain (used by cosign, docker buildx imagetools, and syft via `anchore/sbom-action`) then resolves GHCR creds from that file without the warning.

```diff
+ - name: 🔐 Configure GHCR auth (cosign + buildx + syft)
+   env:
+     GITHUB_ACTOR: ${{ github.actor }}
+     GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+   run: |
+     set -euo pipefail
+     umask 077
+     mkdir -p ~/.docker
+     AUTH=$(printf '%s:%s' "${GITHUB_ACTOR}" "${GHCR_TOKEN}" | base64 -w0)
+     echo "::add-mask::${AUTH}"
+     jq -n --arg auth "${AUTH}" '{auths: {"ghcr.io": {auth: $auth}}}' \
+       > ~/.docker/config.json
+     chmod 600 ~/.docker/config.json

  - name: 🖋️ Sign OCI manifest with cosign (keyless)
    env:
-     GITHUB_ACTOR: ${{ github.actor }}
-     GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
      COSIGN_YES: "true"
    run: |
      set -euo pipefail
-     echo "${GHCR_TOKEN}" | cosign login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
      REF_TAG="..."
      ...

- - name: 🔐 Login to GHCR (for syft)
-   env:
-     GITHUB_ACTOR: ${{ github.actor }}
-     GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-   run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
```

Net `cd.yaml`: **+38 / −16** (most of the +38 is comments explaining why we're bypassing the CLI login).

## Defence-in-depth

GitHub's automatic secret masking only matches the literal `GHCR_TOKEN` value in logs, not values *derived* from it. So `base64("actor:token")` would leak if (say) a future `set -x` got added during debugging. The step calls `echo "::add-mask::${AUTH}"` immediately after computing AUTH, registering the derived value as a mask so any subsequent log line containing it gets redacted to `***`. `umask 077` + explicit `chmod 600` on the config file complete the local-disk side.

## Stacking on #1644

Branched from `claude/cd-cosign3-sign-by-digest` so the PR initially shows two commits:

1. `refactor(cd): resolve OCI digest before signing, then sign by digest` (from [#1644](https://github.com/devantler-tech/platform/pull/1644))
2. `chore(cd): pre-create ~/.docker/config.json instead of CLI logins` (this PR)

When [#1644](https://github.com/devantler-tech/platform/pull/1644) merges into main, this PR's diff vs main collapses to just commit 2. If you want to merge this one first, it subsumes [#1644](https://github.com/devantler-tech/platform/pull/1644) entirely (this PR's sign step uses the reordered shape); [#1644](https://github.com/devantler-tech/platform/pull/1644) can be closed as superseded.

## Verification

Workflow-only change. YAML parses (`ruby -ryaml -e 'YAML.load_file'` → OK). No new actions, no new tools (jq is preinstalled on `ubuntu-latest`). Real validation is the next `v*` tag deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
