### PR TITLE
fix(flux): spread controllers across workers to prevent GitOps deadlock

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -38,3 +38,28 @@ spec:
           - op: add
             path: /spec/template/spec/containers/0/args/-
             value: --requeue-dependency=5s
+      # Spread the four Flux controllers across worker nodes. They are
+      # single-replica Deployments that all carry app.kubernetes.io/part-of=flux,
+      # so a per-controller topology spread keyed on that label distributes the
+      # set (skew <= 1) instead of letting the scheduler stack them on one node.
+      # On 2026-05-28 kustomize-controller landed on prod-worker-2 when that
+      # node's Cilium ClusterIP datapath degraded after an OOMKill; it then
+      # crash-looped on "dial tcp 10.96.0.1:443: i/o timeout" and GitOps
+      # reconciliation stalled — so the fix for the underlying OOM could not be
+      # applied (a deadlock GitOps cannot self-heal from). Keeping the
+      # controllers spread means a single bad worker cannot decapitate
+      # reconciliation. Soft (ScheduleAnyway) so it never blocks scheduling on
+      # the capacity-constrained 3-worker cluster.
+      - target:
+          kind: Deployment
+          labelSelector: app.kubernetes.io/part-of=flux
+        patch: |
+          - op: add
+            path: /spec/template/spec/topologySpreadConstraints
+            value:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/part-of: flux


### PR DESCRIPTION
## Problem

The four Flux controllers (`source-controller`, `kustomize-controller`, `helm-controller`, `notification-controller`) are single-replica Deployments with **no topology spread**, so the scheduler is free to stack them on one worker.

During the 2026-05-28/29 prod instability, `kustomize-controller` and `flux-operator` were both on `prod-worker-2` when that node's Cilium ClusterIP datapath degraded after an OOMKill. `kustomize-controller` then crash-looped on:

```
Get "https://10.96.0.1:443/api": dial tcp 10.96.0.1:443: i/o timeout
```

…and GitOps reconciliation stalled. Because reconciliation was down, the **already-merged fix for the underlying OOM (#1649) could not be applied** — Cilium/SPIRE stayed in BestEffort QoS, the cluster stayed broken, and the `CD` deploy failed its health gate. A single bad worker decapitated reconciliation: a deadlock GitOps cannot self-heal from.

## Fix

Add a **soft** `topologySpreadConstraint` to every controller via the prod `FluxInstance.spec.kustomize.patches`:

- `maxSkew: 1`, `topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`
- `labelSelector` keyed on `app.kubernetes.io/part-of=flux` — since each controller is single-replica, keying on the shared label spreads the *set* across nodes (≈2/1/1 over three workers) rather than spreading replicas of one Deployment.

`ScheduleAnyway` (soft) means it expresses a preference and **never blocks scheduling** on the capacity-constrained 3-worker cluster.

## Why not flux-operator too

`flux-operator` is also single-replica, but it already carries a chart-managed `nodeAffinity` (`kubernetes.io/os=linux`) that an `affinity` override would clobber, and its downtime does **not** stop the controllers from reconciling (it only reconciles the `FluxInstance` CR itself). Left out deliberately to keep this change focused and low-risk.

## Validation

- `kubectl kustomize .../flux-instance/` builds; the rendered `FluxInstance` carries the patch.
- Proved the JSON6902 patch actually injects `topologySpreadConstraints` by applying the identical patch to a sample `part-of: flux` Deployment in a standalone kustomize build (the `FluxInstance`'s inner patches are applied by flux-operator at runtime, not by `kubectl kustomize`, so this was verified out-of-band).
- `kubectl kustomize k8s/clusters/local/` still builds (prod-only change).

## Scope

Preventative (blast-radius reduction). Does not resolve the active outage on its own — that needs `prod-worker-2`'s Cilium datapath rebuilt so reconciliation recovers first.