### PR TITLE
fix(cilium): keep spire-server off the Flux-controller node (soft anti-affinity)

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -153,6 +153,25 @@ spec:
                   memory: 128Mi
             # TODO: Remove workaround when SPIRE no longer fails to start (https://github.com/cilium/cilium/issues/40533)
             server:
+              # spire-server is a single replica and the cluster's identity
+              # root: if its node fails, every spire-agent loses its upstream
+              # (dial spire-server ClusterIP -> i/o timeout) and Cilium mutual
+              # auth degrades cluster-wide. Prefer to keep it off whatever
+              # worker runs the Flux controllers, so a single node loss can't
+              # take out BOTH workload identity AND GitOps reconciliation at
+              # once — the combination that turned the 2026-05-28 incident into
+              # a deadlock (reconciliation was needed to apply the fix, but was
+              # down on the same failed node). Soft (preferred) so the single
+              # replica always schedules even when every node hosts a Flux pod.
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 100
+                      podAffinityTerm:
+                        topologyKey: kubernetes.io/hostname
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/part-of: flux
               resources:
                 requests:
                   cpu: 50m


### PR DESCRIPTION
## Problem

`spire-server` is a **single replica** and the cluster's identity root. If its node fails, every `spire-agent` loses its upstream:

```
create attestation client: failed to dial dns:///spire-server:8081 ... dial tcp 10.96.193.18:8081: i/o timeout
```

…all six `spire-agent` pods crash-loop and Cilium mutual auth degrades cluster-wide.

During the 2026-05-28/29 incident, `spire-server` shared `prod-worker-2` with `kustomize-controller`. When that node's Cilium ClusterIP datapath degraded after an OOMKill, **workload identity *and* GitOps reconciliation went down together** — and reconciliation was exactly what was needed to apply the fix (#1649). One node loss took out two critical subsystems at once, which is what made recovery a deadlock.

## Fix

Add a **soft** (`preferredDuringSchedulingIgnoredDuringExecution`, weight 100) `podAntiAffinity` so `spire-server` prefers a worker that is **not** running the Flux controllers (`app.kubernetes.io/part-of=flux`), decorrelating the identity SPOF from the GitOps control plane.

Soft, so the single replica **always schedules** even when every node hosts a Flux pod — never risks leaving the cluster with no identity. Pairs with #1659 (which spreads the Flux controllers): together they push identity and reconciliation onto different workers.

## Validation

- Confirmed the Cilium **1.19.4** chart renders `authentication.mutual.spire.install.server.affinity` into the spire-server StatefulSet (`templates/spire/server/statefulset.yaml` line 114), so the value takes effect (not a silent no-op).
- `kubectl kustomize` of the base cilium dir renders the `podAntiAffinity`; the **docker** controllers overlay still builds with `spire.enabled: false` (prod-only, inert locally — no merge conflict).
- Both `k8s/clusters/local/` and `k8s/clusters/prod/` build.

## Scope

Preventative (decorrelation / blast-radius reduction), placed in the base alongside the SPIRE server config added in #1649. Does not resolve the active outage on its own — that needs `prod-worker-2`'s datapath rebuilt so reconciliation recovers.