### PR TITLE
feat(cluster-policies): require workloads to spread across nodes

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -95,7 +95,7 @@ patches:
       - op: replace
         path: /spec/rules/0/mutate/patchStrategicMerge/spec/template/spec/+(affinity)/+(podAntiAffinity)/+(preferredDuringSchedulingIgnoredDuringExecution)/0/podAffinityTerm/labelSelector/matchExpressions/0/values/0
         value: "{{request.object.spec.template.metadata.labels.\"app.kubernetes.io/name\"}}"
-  # --- Topology spread: remove label gate, add StatefulSet, hostname key, ScheduleAnyway, exclude kube-system ---
+  # --- Topology spread: remove label gate, add StatefulSet, hostname key, DoNotSchedule, exclude kube-system ---
   - target:
       kind: ClusterPolicy
       name: spread-pods
@@ -125,7 +125,16 @@ patches:
         value: "kubernetes.io/hostname"
       - op: replace
         path: /spec/rules/0/mutate/patchStrategicMerge/spec/template/spec/+(topologySpreadConstraints)/0/whenUnsatisfiable
-        value: "ScheduleAnyway"
+        value: "DoNotSchedule"
+      # Scope skew per ReplicaSet revision so rolling updates don't deadlock under
+      # DoNotSchedule (surge pods of the new revision would otherwise count against
+      # the old revision's skew). Requires k8s >=1.27 (GA in 1.34). For StatefulSets
+      # the pod-template-hash key is absent, so k8s ignores it and falls back to the
+      # labelSelector — fine, since StatefulSet updates roll one pod at a time.
+      - op: add
+        path: /spec/rules/0/mutate/patchStrategicMerge/spec/template/spec/+(topologySpreadConstraints)/0/matchLabelKeys
+        value:
+          - pod-template-hash
       - op: replace
         path: /spec/rules/0/mutate/patchStrategicMerge/spec/template/spec/+(topologySpreadConstraints)/0/labelSelector
         value:


### PR DESCRIPTION
## What

The `spread-pods` ClusterPolicy is synced verbatim from upstream `kyverno/policies` by [`.github/workflows/sync-cluster-policies.yaml`](.github/workflows/sync-cluster-policies.yaml) and adapted for this cluster via a Kustomize patch in [`k8s/bases/infrastructure/cluster-policies/kustomization.yaml`](k8s/bases/infrastructure/cluster-policies/kustomization.yaml). This change hardens that patch so spreading workloads across nodes is **strictly required** rather than best-effort:

- `whenUnsatisfiable: ScheduleAnyway` → **`DoNotSchedule`** — every `Deployment`/`StatefulSet` (outside `kube-system`, carrying an `app.kubernetes.io/name` label) must spread across nodes (`topologyKey: kubernetes.io/hostname`, `maxSkew: 1`).
- Added **`matchLabelKeys: [pod-template-hash]`**.

## Why

`DoNotSchedule` + `maxSkew: 1` on its own deadlocks rolling updates: during a rollout the new revision's surge pod is counted against the old revision's pods, so it can't be placed. `matchLabelKeys: [pod-template-hash]` scopes the skew calculation per ReplicaSet revision, keeping rollouts flowing while enforcement stays strict.

- Requires Kubernetes ≥ 1.27 (GA in 1.34). This cluster runs k8s ~1.34 via Talos `v1.12.4`, so it is on by default.
- StatefulSets have no `pod-template-hash` label; Kubernetes ignores absent keys and falls back to the label selector — fine, since StatefulSet updates roll one pod at a time.

## Reviewer notes

- The change is confined to the **Kustomize patch**; the upstream-synced sample (`samples/other/spread-pods-across-topology/`) is untouched, so it keeps receiving upstream updates for free.
- **Behavioral impact:** pods can now go `Pending` if they genuinely cannot spread (e.g. a worker is drained/down on the 3-worker local cluster and a multi-replica app needs a distinct node). Single-replica apps are unaffected; rollouts are protected by `matchLabelKeys`.
- Workloads without an `app.kubernetes.io/name` label are skipped (the policy needs it to group replicas) — unchanged behavior.
- Companion `insert-pod-antiaffinity` policy left soft (preferred) — topology spread is now the hard enforcer.

## Validation

- `ksail workload validate` — local + prod, 256 files each, exit 0
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
