### PR TITLE
fix(prod): pin kubernetesVersion to v1.32.0 so cluster update doesn't roll to ksail's incompatible default

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -51,9 +51,17 @@ spec:
     # workers; autoscaler-created nodes are compute-only.
     # The Cluster Autoscaler manages additional workers dynamically.
     # Temporarily held at 3 (matching the 3 healthy nodes) while the
-    # cluster is stabilized / right-sized; a 4th worker was blocked from
-    # joining by a k8s-version pin gap. Restore to 4 once resourced.
+    # cluster is stabilized / right-sized. (A 4th worker previously failed
+    # to join because of the missing Kubernetes version pin — now fixed via
+    # kubernetesVersion below.) Restore to 4 once resourced.
     workers: 3
+    # Pin Kubernetes to the version the cluster already runs so
+    # 'ksail cluster update' doesn't roll nodes to ksail's newer default
+    # (currently 1.36.0), which Talos v1.12.4 rejects with
+    # "kubelet image is not valid: version of Kubernetes ... is too new".
+    # Talos v1.12.4 supports Kubernetes up to 1.35.x; bump this deliberately
+    # in lockstep with the Talos version rather than letting the default drift.
+    kubernetesVersion: v1.32.0
     talos:
       # Pin Talos to match the ISO so 'ksail cluster update' doesn't attempt
       # an unwanted in-place upgrade to ksail's default version.


### PR DESCRIPTION
## Problem

The prod deploy in the **merge queue** failed (surfaced on #1667, but it blocks *every* queued PR — `ci.yaml`'s `merge_group` job runs `ksail --config ksail.prod.yaml cluster update` against prod):

```
⚠ Config update failed on <worker> (worker): apply worker config: failed to apply configuration:
  * kubelet image is not valid: version of Kubernetes 1.36.0 is too new to be used with Talos 1.12.4
```

Control planes applied fine ("no reboot"); only the **workers** failed.

## Root cause

`ksail.prod.yaml` pins Talos (`v1.12.4`) and the ISO, but **never pinned `spec.cluster.kubernetesVersion`**. With no pin, KSail uses its built-in default — which has since advanced to **1.36.0**, beyond what Talos `v1.12.4` supports (≤ 1.35.x).

On `cluster update` KSail's **control-plane** path clamps `1.36.0 → 1.35.0` (the `defaulting to compatible Kubernetes 1.35.0` warning), but the **worker** path does not clamp, so Talos rejects the worker config. This is the same *"k8s-version pin gap"* noted in the `workers:` comment that previously blocked a 4th worker from joining — it was never actually pinned (`git log -S kubernetesVersion` on this file is empty).

It only began failing recently because KSail's default Kubernetes version drifted past the Talos `v1.12.4` ceiling.

## Fix

Pin `spec.cluster.kubernetesVersion: v1.32.0` — the version **all 6 nodes already run** (`kubectl get nodes` → `v1.32.0`, Talos `v1.12.4`). Consequences:

- `cluster update` makes **no in-place Kubernetes change** (zero node churn) — it just stops KSail from rolling nodes toward an incompatible default.
- Mirrors the existing Talos version pin and its stated rationale ("so `ksail cluster update` doesn't attempt an unwanted in-place upgrade to ksail's default version").
- Future Kubernetes bumps become deliberate, in lockstep with the Talos version.

No worker-count change here (still `3`, held per the stabilization work); this pin is the prerequisite that unblocks restoring the 4th worker later.

## Validation

- `ksail --config ksail.prod.yaml workload validate` — config loads with **no version warning** (previously `⚠ Kubernetes 1.36.0 is too new…`); all kustomizations validate.
- `kubectl kustomize k8s/clusters/prod/` and `…/local/` both build.

Once merged, #1667 (and any other queued PR) will re-run the prod `cluster update` against the pinned version and pass.