### PR TITLE
fix(ascoachingogvaner): correct homepage display name

### DIFF
--- a/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml
@@ -29,7 +29,7 @@ spec:
           name: ascoachingogvaner
           annotations:
             gethomepage.dev/enabled: "true"
-            gethomepage.dev/name: AS Coaching og Væren
+            gethomepage.dev/name: AS - Coaching, vaner og ro
             gethomepage.dev/description: Personal/business static site.
             gethomepage.dev/group: Customer Sites
             gethomepage.dev/icon: mdi-account-tie


### PR DESCRIPTION
## What

Corrects the display name of the first customer site on the **gethomepage** dashboard:

- Before: `AS Coaching og Væren`
- After: `AS - Coaching, vaner og ro`

## Why

The previous title was incorrect. `AS - Coaching, vaner og ro` is the correct business name.

## Where

The site content is served statically from an external OCI artifact, so the dashboard title isn't part of the site itself — it's a `gethomepage.dev/name` annotation injected by the Hetzner (prod) overlay onto the `ascoachingogvaner` Flux `Kustomization`:

[`k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml`](k8s/providers/hetzner/apps/ascoachingogvaner/patches/kustomization-patch.yaml)

Flux applies that patch to the HTTPRoute pulled from the OCI artifact, which is how gethomepage auto-discovers the entry. This is a prod-only tenant (the Docker/local overlay excludes it).

## Validation

- `kubectl kustomize k8s/clusters/local/` — builds ✅
- `kubectl kustomize k8s/clusters/prod/` — builds ✅
- `kubectl kustomize k8s/providers/hetzner/apps/` — builds ✅; rendered output confirms the corrected `gethomepage.dev/name` on the `ascoachingogvaner` Kustomization patch (parses cleanly as a plain string despite the comma/hyphen, so no quoting needed).
- No remaining references to the old name anywhere in the repo.

## Reviewer notes

Display-only change; no functional or runtime impact. The new title appears on the dashboard once merged and Flux reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
