### PR TITLE
chore(homepage): remove Monitoring section and reorder dashboard groups

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -26,26 +26,26 @@ data:
     layout:
       Kubernetes:
         icon: si-talos-#FF7300
-      Device Management:
-        icon: mdi-cellphone-cog
-      Diagnostics:
-        icon: mdi-stethoscope
+      Observability:
+        icon: si-grafana
       Security:
         icon: mdi-shield-lock
-      Finance:
-        icon: mdi-finance
-      Personal Sites:
-        icon: mdi-web
-      Customer Sites:
-        icon: mdi-briefcase-account
+      Diagnostics:
+        icon: mdi-stethoscope
+      Device Management:
+        icon: mdi-cellphone-cog
       Cloud:
         icon: si-hetzner
       Network:
         icon: si-cloudflare
-      Monitoring:
-        icon: si-grafana
+      Finance:
+        icon: mdi-finance
       Analytics:
         icon: si-googleanalytics
+      Personal Sites:
+        icon: mdi-web
+      Customer Sites:
+        icon: mdi-briefcase-account
   kubernetes.yaml: |
     mode: cluster
     gateway: true
@@ -93,11 +93,6 @@ data:
             icon: google-analytics
             href: https://analytics.google.com
             description: Web analytics service.
-    - Monitoring:
-        - Grafana:
-            icon: grafana
-            href: https://devantler.grafana.net
-            description: Central hub for monitoring my infrastructure.
   bookmarks.yaml: |
     - Personal:
         - Personal Site:


### PR DESCRIPTION
## What

Reorganizes the [homepage](https://gethomepage.dev) dashboard config (`k8s/bases/apps/homepage/config-map.yaml`):

- **Removes the "Monitoring" section** — the external Grafana Cloud link (`devantler.grafana.net`), dropped from both `services.yaml` and the `layout:` block.
- **Adds the previously-missing "Observability" group** to `layout:` — the self-hosted Grafana/Prometheus/Alertmanager/OpenCost stack (defined via HTTPRoute annotations) was not listed, so it had been rendering in alphabetical fallback order with a generic icon. It now has an explicit position (#2) and the `si-grafana` icon.
- **Reorders groups** so platform administration/management leads by frequency of use, and personal/customer sites come last.

New group order:

| # | Group |
|---|-------|
| 1 | Kubernetes |
| 2 | Observability |
| 3 | Security |
| 4 | Diagnostics |
| 5 | Device Management |
| 6 | Cloud |
| 7 | Network |
| 8 | Finance |
| 9 | Analytics |
| 10 | Personal Sites |
| 11 | Customer Sites |

## Why

The external Grafana Cloud "Monitoring" entry is superseded by the self-hosted **Observability** stack, so it was dead weight on the dashboard. While reordering, the layout was brought back in sync with the actual groups (it referenced the now-removed "Monitoring" but omitted "Observability").

## Reviewer notes

- This removes the **only** link to external Grafana Cloud from the dashboard. That's intentional given the self-hosted observability direction, but flagging it in case a quick-jump link is still wanted (could be re-added under a different group name).
- Group ordering for "most commonly used" is a judgment call — easy to tweak.
- No functional/runtime change beyond the homepage UI; `services.yaml` group order (Cloud → Network → Analytics) already matches the new layout, so only the Monitoring entry was removed there.

## Validation

Both overlays build clean:

- `kubectl kustomize k8s/clusters/local/` → OK
- `kubectl kustomize k8s/clusters/prod/` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)