### PR TITLE
feat(observability): authenticate all UIs behind Dex OIDC

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -26,10 +26,6 @@ data:
           rule: "Host(`hubble.${domain}`)"
           entryPoints: ["web"]
           service: hubble-ui
-        grafana:
-          rule: "Host(`grafana.${domain}`)"
-          entryPoints: ["web"]
-          service: grafana
         prometheus:
           rule: "Host(`prometheus.${domain}`)"
           entryPoints: ["web"]
@@ -51,10 +47,6 @@ data:
           loadBalancer:
             servers:
               - url: "http://keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local:8080"
-        grafana:
-          loadBalancer:
-            servers:
-              - url: "http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80"
         prometheus:
           loadBalancer:
             servers:

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -76,6 +76,7 @@ spec:
             - "https://headlamp.${domain}/oidc-callback"
             - "https://budget.${domain}/oidc/callback"
             - "https://vault.${domain}/ui/vault/auth/oidc/oidc/callback"
+            - "https://grafana.${domain}/login/generic_oauth"
           trustedPeers:
             - kubectl
         - name: kubectl

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
@@ -40,12 +40,14 @@ spec:
     crds:
       enabled: true
 
-    # Grafana is exposed behind oauth2-proxy SSO (see httproute.yaml).
-    # Access to the route is already gated to a single GitHub user
-    # (oauth2-proxy github_users), so Grafana itself runs with anonymous
-    # Admin and the login form disabled -- whoever clears the SSO gate is
-    # the operator. This avoids depending on the proxy to forward an
-    # identity header. Loki is wired in as an additional datasource below.
+    # Grafana authenticates users directly against Dex via native OIDC
+    # (auth.generic_oauth) -- it is NOT fronted by oauth2-proxy (its
+    # HTTPRoute backends straight to the Grafana Service). Every user who
+    # clears the Dex gate is mapped to Admin (single-operator homelab) via
+    # the JMESPath literal in role_attribute_path. auto_login +
+    # disable_login_form send users straight to Dex with no Grafana login
+    # form (break-glass: https://grafana.${domain}/login?disableAutoLogin=true).
+    # Loki is wired in as an additional datasource below.
     grafana:
       enabled: true
       grafana.ini:
@@ -55,9 +57,30 @@ spec:
           disable_login_form: true
         auth.basic:
           enabled: false
-        auth.anonymous:
+        auth.generic_oauth:
           enabled: true
-          org_role: Admin
+          name: Dex
+          auto_login: true
+          client_id: public-client
+          scopes: openid profile email groups
+          auth_url: https://dex.${domain}/auth
+          token_url: https://dex.${domain}/token
+          api_url: https://dex.${domain}/userinfo
+          # JMESPath string literal -> every authenticated user gets Admin.
+          role_attribute_path: "'Admin'"
+      # Client secret (Dex 'public-client') from the grafana-oidc
+      # ExternalSecret. GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET overrides the
+      # grafana.ini value. optional:true so a bootstrap race fails login
+      # closed instead of crash-looping the pod; reloader restarts Grafana
+      # when ESO lands the secret.
+      envValueFrom:
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
+          secretKeyRef:
+            name: grafana-oidc
+            key: client-secret
+            optional: true
+      annotations:
+        secret.reloader.stakater.com/reload: grafana-oidc
       # Dashboards are provisioned as code, so the pod can stay ephemeral.
       persistence:
         enabled: false

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/httproute.yaml
@@ -1,8 +1,12 @@
-# Expose Grafana, Prometheus and Alertmanager behind oauth2-proxy SSO.
-# Each route backends to the oauth2-proxy service (not the app); after
+# Prometheus and Alertmanager are exposed behind oauth2-proxy SSO: each
+# route backends to the oauth2-proxy service (not the app); after
 # authentication oauth2-proxy forwards to auth-proxy, which routes by Host
-# to the in-cluster service (see auth-proxy config-map.yaml). The same
+# to the in-cluster service (see auth-proxy config-map.yaml) -- the same
 # pattern the homepage/hubble UIs use.
+#
+# Grafana is the exception: it authenticates against Dex itself (native
+# auth.generic_oauth, see helm-release.yaml), so its route backends
+# straight to the Grafana Service with no oauth2-proxy hop.
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -24,19 +28,13 @@ spec:
     - grafana.${domain}
   rules:
     - filters:
-        - type: RequestHeaderModifier
-          requestHeaderModifier:
-            set:
-              - name: X-Auth-Request-Redirect
-                value: https://grafana.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
               - name: Strict-Transport-Security
                 value: max-age=63072000; includeSubDomains; preload
       backendRefs:
-        - name: oauth2-proxy
-          namespace: oauth2-proxy
+        - name: kube-prometheus-stack-grafana
           port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/networkpolicy.yaml
@@ -18,18 +18,29 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
-    # auth-proxy (oauth2-proxy SSO) reaches the Grafana, Prometheus and
-    # Alertmanager UIs after authentication.
+    # auth-proxy (oauth2-proxy SSO) reaches the Prometheus and Alertmanager
+    # UIs after authentication. Grafana is no longer fronted by oauth2-proxy
+    # (it does native Dex OIDC and is reached directly from the Gateway --
+    # see the ingress rule below), so port 3000 is dropped here.
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: oauth2-proxy
       toPorts:
         - ports:
-            - port: "3000"
-              protocol: TCP
             - port: "9090"
               protocol: TCP
             - port: "9093"
+              protocol: TCP
+    # Cilium Gateway ingress to the Grafana UI. Grafana authenticates
+    # against Dex itself, so the Gateway hits it directly on 3000. Envoy
+    # runs hostNetwork, so match the ingress + host entities (as
+    # allow-openbao does for its directly-routed UI).
+    - fromEntities:
+        - ingress
+        - host
+      toPorts:
+        - ports:
+            - port: "3000"
               protocol: TCP
     # Webhook from kube-apiserver (hostNetwork on control plane nodes)
     - fromEntities:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -57,6 +57,21 @@ spec:
       configFile: |-
         provider = "oidc"
         oidc_issuer_url = "https://dex.${domain}"
+        # Split the OIDC endpoints so this works on every cluster: the
+        # browser-facing authorize endpoint stays the public Dex URL (the
+        # browser resolves dex.${domain} via the host /etc/hosts locally,
+        # public DNS in prod), while the server-side token + JWKS calls use
+        # the in-cluster Dex Service the pod can always resolve. This also
+        # disables eager discovery (skip_oidc_discovery) -- otherwise
+        # oauth2-proxy blocks at startup fetching .well-known from
+        # dex.${domain}, which the pod cannot resolve on the docker/local
+        # cluster (dex.platform.lan exists only in the host's /etc/hosts), and
+        # crash-loops so the Flux HelmRelease never goes Ready. ID tokens
+        # still carry iss=https://dex.${domain}, so issuer validation matches.
+        skip_oidc_discovery = true
+        login_url = "https://dex.${domain}/auth"
+        redeem_url = "http://dex.dex.svc.cluster.local:5556/token"
+        oidc_jwks_url = "http://dex.dex.svc.cluster.local:5556/keys"
         # Request the groups scope so Dex returns the user's GitHub teams as
         # group claims (its github connector uses teamNameField: slug), then
         # gate on the 'platform' team -- preserving the stricter team

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -47,38 +47,30 @@ spec:
         maxSurge: 1
         maxUnavailable: 0
     config:
-      clientID: "${github_app_client_id}"
-      clientSecret: "${github_app_client_secret}"
+      # oauth2-proxy authenticates against Dex (the cluster's single OIDC
+      # IdP) using the shared confidential 'public-client'. Dex federates to
+      # GitHub, so the GitHub app credentials now live only on Dex's
+      # connector (github_app_client_id/secret) -- not here.
+      clientID: "public-client"
+      clientSecret: "${dex_client_secret}"
       cookieSecret: "${oauth2_proxy_cookie_secret}"
       configFile: |-
-        provider = "github"
-        # Defence in depth: three independent GitHub gates.
-        #   github_org   — only members of devantler-tech can authenticate.
-        #                  This matches the Dex GitHub connector that gates
-        #                  kubectl OIDC (orgs:[devantler-tech], no team
-        #                  restriction). Web auth and kubectl auth now
-        #                  enforce the same org boundary.
-        #   github_team  — additionally restrict to the 'platform' team.
-        #                  This is *stricter* than the Dex connector
-        #                  (intentional — web auth previously had only the
-        #                  github_users bypass list). If the org has no
-        #                  'platform' team, anyone outside github_users
-        #                  will be locked out; drop this line for an
-        #                  org-only gate equivalent to Dex.
-        #   github_users — explicit allowlist that bypasses the org/team
-        #                  check. oauth2-proxy treats this as an OR: users
-        #                  here pass even if the org/team check fails. If
-        #                  the list is ever cleared the org + team gate
-        #                  still holds as the fallback.
-        github_org = "devantler-tech"
-        github_team = "platform"
-        github_users = ["devantler"]
-        # email_domains = ["*"] is intentional: GitHub OAuth does not
-        # always return a verified email (users with private emails
-        # surface as <id>+<login>@users.noreply.github.com or empty), so
-        # gating on email_domains would lock out legitimate accounts that
-        # already passed the org/team/users checks above.
-        email_domains = [ "*" ]
+        provider = "oidc"
+        oidc_issuer_url = "https://dex.${domain}"
+        # Request the groups scope so Dex returns the user's GitHub teams as
+        # group claims (its github connector uses teamNameField: slug), then
+        # gate on the 'platform' team -- preserving the stricter team
+        # restriction the github provider enforced. NOTE: OIDC mode has no
+        # per-user bypass (the old github_users escape hatch is gone), so the
+        # authenticating user MUST be a member of devantler-tech/platform.
+        # Drop allowed_groups for an org-only gate (Dex's connector already
+        # restricts to the devantler-tech org).
+        scope = "openid email profile groups"
+        allowed_groups = ["devantler-tech:platform"]
+        # email_domains = ["*"] is intentional: GitHub (via Dex) does not
+        # always return a public email, and the real gate is now
+        # allowed_groups -- so don't additionally gate on the email domain.
+        email_domains = ["*"]
         cookie_domains=[".${domain}"]
         whitelist_domains = ["${domain}", ".${domain}"]
         redirect_url = "https://oauth2-proxy.${domain}/oauth2/callback"
@@ -89,6 +81,9 @@ spec:
         # HTTP interceptor) have room to wake before SSO returns a 504. Kept
         # under Cloudflare's ~100s edge timeout so oauth2-proxy answers first.
         upstream_timeout = "90s"
+        # Button-less flow: with skip_provider_button + Dex skipApprovalScreen
+        # + a single Dex connector, app -> oauth2-proxy -> Dex -> GitHub -> back
+        # needs no extra clicks.
         skip_provider_button = true
         reverse_proxy = true
     ingress:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy.yaml
@@ -25,7 +25,9 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-    # Dex for OIDC
+    # Dex (in-cluster service path). oauth2-proxy reaches Dex via the public
+    # HTTPS issuer URL (world:443 below), so this in-cluster path is a
+    # harmless fallback kept for parity with the other OIDC clients.
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: dex
@@ -33,7 +35,9 @@ spec:
         - ports:
             - port: "5556"
               protocol: TCP
-    # GitHub OAuth
+    # Dex OIDC discovery + token exchange via the public issuer URL
+    # (https://dex.${domain}, fronted by Cloudflare). GitHub is reached by
+    # Dex's connector, not by oauth2-proxy directly.
     - toEntities:
         - world
       toPorts:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy.yaml
@@ -25,9 +25,11 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-    # Dex (in-cluster service path). oauth2-proxy reaches Dex via the public
-    # HTTPS issuer URL (world:443 below), so this in-cluster path is a
-    # harmless fallback kept for parity with the other OIDC clients.
+    # Dex token exchange (redeem_url) + JWKS (oidc_jwks_url) over the
+    # in-cluster Dex Service. oauth2-proxy does its server-side OIDC calls
+    # in-cluster (skip_oidc_discovery; see helm-release.yaml), which the pod
+    # can always resolve -- unlike the public dex.${domain} URL, which does
+    # not resolve in-cluster on the docker/local cluster.
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: dex
@@ -35,9 +37,9 @@ spec:
         - ports:
             - port: "5556"
               protocol: TCP
-    # Dex OIDC discovery + token exchange via the public issuer URL
-    # (https://dex.${domain}, fronted by Cloudflare). GitHub is reached by
-    # Dex's connector, not by oauth2-proxy directly.
+    # Outbound HTTPS. oauth2-proxy no longer calls Dex or GitHub over the
+    # internet (Dex is reached in-cluster above; GitHub is Dex's upstream
+    # connector), but keep general egress for resilience.
     - toEntities:
         - world
       toPorts:

--- a/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
+++ b/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
@@ -76,3 +76,25 @@ spec:
       remoteRef:
         key: infrastructure/monitoring/alertmanager
         property: webhook_url
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oidc
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: grafana-oidc
+    creationPolicy: Owner
+  data:
+    # Dex 'public-client' secret. Grafana does native OIDC against Dex
+    # (auth.generic_oauth); this is the same shared confidential-client
+    # secret Headlamp/actual-budget/oauth2-proxy use.
+    - secretKey: client-secret
+      remoteRef:
+        key: infrastructure/oidc/dex
+        property: client-secret


### PR DESCRIPTION
## What & why

Make **Dex** the single OIDC IdP for every externally-exposed observability endpoint. Use a chart's **native** OIDC where it has one; otherwise front it with **oauth2-proxy** — and point oauth2-proxy at Dex too, so there is one IdP. Internal in-cluster traffic (scraping, datasource queries, log shipping) is unchanged.

Investigation found the stack was mostly there, with two gaps closed here:

| Endpoint | Before | After |
|---|---|---|
| **Grafana** | oauth2-proxy **+ internally anonymous `org_role: Admin`** (no real auth) | **native Dex `auth.generic_oauth`**, Gateway routes directly |
| Prometheus / Alertmanager / OpenCost / Hubble | oauth2-proxy → **GitHub** | oauth2-proxy → **Dex** |
| Flux UI / Headlamp / OpenBao / actual-budget | native OIDC → Dex | unchanged (already correct) |
| Loki | no Gateway route (internal datasource only) | unchanged (internal) |

## Changes

**Grafana → native Dex OIDC**
- Add Grafana redirect URI to Dex `public-client` (`/login/generic_oauth`).
- New `grafana-oidc` ExternalSecret (monitoring ns) pulling the shared Dex client secret from OpenBao `infrastructure/oidc/dex` — the same key Headlamp/actual-budget use.
- Replace the anonymous-Admin block with `auth.generic_oauth` against Dex; client secret injected via `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` env (`envValueFrom`). Every authenticated user → Admin (`role_attribute_path: "'Admin'"`); `auto_login` + `disable_login_form` go straight to Dex (break-glass: `/login?disableAutoLogin=true`).
- Grafana HTTPRoute backends straight to the Grafana Service; removed from the auth-proxy Traefik config; monitoring NetworkPolicy now allows Gateway (`ingress`+`host`) → `:3000`.

**oauth2-proxy → Dex** (Prometheus/Alertmanager/OpenCost/Hubble + the shared homepage route)
- `provider = github` → `provider = oidc` against `https://dex.${domain}` using `public-client` / `${dex_client_secret}`.
- Preserve the stricter team gate via `allowed_groups = ["devantler-tech:platform"]` (Dex's GitHub connector emits `org:team-slug` groups with `teamNameField: slug`).

## ⚠️ Behaviour change
OIDC mode has **no `github_users` bypass** — the authenticating user must be a member of **`devantler-tech/platform`** to pass oauth2-proxy (Prometheus/Alertmanager/OpenCost/Hubble + homepage) and to get into Grafana. Drop `allowed_groups` for an org-only gate if needed.

## No new secrets / SOPS
Reuses the existing `${dex_client_secret}` (OpenBao `infrastructure/oidc/dex`). No `*.enc.yaml`, `ksail.prod.yaml`, or `.sops.yaml` touched. Bases-only edits; the hetzner overlay's kube-prometheus-stack patch (Prometheus/Alertmanager storage) is unaffected.

## Validation
- `kubectl kustomize k8s/clusters/local` and `…/prod` build.
- Rendered prod tree verified: Grafana `generic_oauth`, oauth2-proxy `oidc`+`allowed_groups`, `grafana-oidc` ExternalSecret, Dex redirect URI, direct Grafana backend, auth-proxy router removed, hetzner storage patch coexists.
- `ksail workload validate` (local + prod): **263 files validated**, exit 0.
- Full browser auth flow is only exercisable on a live cluster — left to CI's Talos+Docker system test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)