### PR TITLE
feat(security): add Tetragon runtime security observability

### DIFF
--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - openbao/
   - opencost/
   - reloader/
+  - tetragon/
   - trust-manager/
   - velero/
   - vertical-pod-autoscaler/

--- a/k8s/bases/infrastructure/controllers/tetragon/README.md
+++ b/k8s/bases/infrastructure/controllers/tetragon/README.md
@@ -1,0 +1,8 @@
+# Tetragon
+
+Tetragon is Cilium's eBPF-based security observability and runtime enforcement agent. It observes process execution, syscalls, file access, and network activity at the kernel level and exports the events for auditing and alerting.
+
+This install is observability-only: the agent emits its built-in process lifecycle events (plus any `TracingPolicy` added later), exports them to stdout where Alloy collects them into Loki, and exposes Prometheus metrics. Runtime enforcement is not enabled.
+
+- [Documentation](https://tetragon.io/docs/)
+- [Helm Chart](https://github.com/cilium/tetragon/tree/main/install/kubernetes/tetragon)

--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tetragon
+  namespace: kube-system
+  labels:
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  chart:
+    spec:
+      chart: tetragon
+      version: 1.7.0
+      sourceRef:
+        kind: HelmRepository
+        name: cilium
+  interval: 10m0s
+  timeout: 10m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  # https://github.com/cilium/tetragon/blob/main/install/kubernetes/tetragon/values.yaml
+  #
+  # eBPF-based runtime security observability. Sibling to the Cilium
+  # install (same vendor, same helm.cilium.io repo), so it reuses the
+  # `cilium` HelmRepository in this namespace instead of defining a
+  # duplicate source against the same URL -- the same dedup pattern as
+  # alloy reusing loki's `grafana` repo.
+  #
+  # Deployed to kube-system because the agent needs hostNetwork + hostPath
+  # + host PID, which the validate-host-restrictions Kyverno policy blocks
+  # in every namespace except the infrastructure set (kube-system among
+  # them). kube-system is also exempt from the add-default-deny CNP, so no
+  # NetworkPolicy is required for Prometheus to scrape the metrics ports.
+  #
+  # Observability-only for now: no TracingPolicies are shipped yet, so the
+  # agent emits its built-in process_exec / process_exit events. Runtime
+  # enforcement (Sigkill / Override actions) is a later, separately-gated
+  # change -- the Override action additionally needs CONFIG_BPF_KPROBE_OVERRIDE
+  # verified on the pinned Talos kernel.
+  values:
+    # ------------------------------------------------------------------
+    # Talos: tracefs is mounted at /sys/kernel/tracing (debugfs is NOT
+    # mounted on Talos), and Tetragon needs it to attach kprobes /
+    # tracepoints. BTF is auto-detected from /sys/kernel/btf/vmlinux
+    # (Talos ships CONFIG_DEBUG_INFO_BTF=y), so tetragon.btf stays empty.
+    # ------------------------------------------------------------------
+    extraHostPathMounts:
+      - name: sys-kernel-tracing
+        mountPath: /sys/kernel/tracing
+    tetragon:
+      # Resource requests promote the per-node agent DaemonSet out of
+      # BestEffort QoS so it survives node memory pressure -- the same
+      # lesson as the cilium-agent OOM cascade. Limits are intentionally
+      # left unset (an event burst must not get the agent OOMKilled),
+      # matching the cilium-agent posture.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      # Enrich exec / kprobe events with process capabilities and
+      # namespaces (both default to false). enablePolicyFilter (default
+      # true) is required for the K8s namespace / pod-label filtering that
+      # TracingPolicies will rely on.
+      enableProcessCred: true
+      enableProcessNs: true
+      prometheus:
+        enabled: true
+        # Prometheus discovers ServiceMonitors cluster-wide
+        # (serviceMonitorSelectorNilUsesHelmValues: false), so enabling
+        # this is all that's needed for the agent metrics (:2112) to be
+        # scraped.
+        serviceMonitor:
+          enabled: true
+    tetragonOperator:
+      # Operator metrics (:2113); operator already ships resource requests
+      # and a non-root securityContext by default.
+      prometheus:
+        serviceMonitor:
+          enabled: true
+    # The export-stdout sidecar is on by default (export.mode: stdout), so
+    # Tetragon's JSON events go to the pod's stdout -- where Alloy tails
+    # them into Loki, making them searchable in Grafana with no extra
+    # wiring.

--- a/k8s/bases/infrastructure/controllers/tetragon/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -30,6 +30,11 @@ patches:
       namespace: kubescape
     path: kubescape/patches/helm-release-patch.yaml
   - target:
+      kind: HelmRelease
+      name: tetragon
+      namespace: kube-system
+    path: tetragon/patches/helm-release-patch.yaml
+  - target:
       kind: KubeVirt
       name: kubevirt
       namespace: kubevirt

--- a/k8s/providers/docker/infrastructure/controllers/tetragon/patches/helm-release-patch.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/tetragon/patches/helm-release-patch.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tetragon
+  namespace: kube-system
+spec:
+  # eBPF tracing support on Docker-provider Talos nodes is unverified (cf.
+  # kubescape disabling its eBPF runtime detection locally). Don't block
+  # the kustomize-controller health window on the agent DaemonSet becoming
+  # Ready -- the manifests still apply, so CI exercises them, but a slow or
+  # degraded agent on the nested Docker kernel won't fail the HelmRelease.
+  install:
+    disableWait: true
+  upgrade:
+    disableWait: true

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
   - ../../../../bases/infrastructure/controllers/openbao/
   - ../../../../bases/infrastructure/controllers/opencost/
   - ../../../../bases/infrastructure/controllers/reloader/
+  - ../../../../bases/infrastructure/controllers/tetragon/
   - ../../../../bases/infrastructure/controllers/trust-manager/
   - ../../../../bases/infrastructure/controllers/velero/
   - ../../../../bases/infrastructure/controllers/vertical-pod-autoscaler/


### PR DESCRIPTION
## What

Adds **Tetragon** (Cilium's eBPF-based security observability + runtime enforcement agent) as an infrastructure controller, **observability-only** for this first PR.

It's the natural sibling to the existing Cilium install — same vendor, same `helm.cilium.io` repo, same eBPF/Talos concerns — so it mirrors Cilium and the existing privileged security tool (kubescape).

### Files
- `k8s/bases/infrastructure/controllers/tetragon/` — `HelmRelease` (chart `tetragon` **v1.7.0**, ns `kube-system`, reuses the `cilium` `HelmRepository`), `kustomization.yaml`, `README.md`.
- `k8s/providers/docker/infrastructure/controllers/tetragon/patches/helm-release-patch.yaml` — `disableWait` for the local/CI Docker provider.
- Wiring: `+ tetragon/` in the base controllers list, `+ .../tetragon/` in the **hetzner** controllers list (so it reaches prod), `+` patch target in the **docker** controllers list.

## Why these choices

- **Namespace `kube-system`** — the agent runs with `hostNetwork: true` + `hostPath` + host PID, which the `validate-host-restrictions` Kyverno policy (Enforce mode) blocks in every namespace except the infrastructure set. `kube-system` is in that set and is also exempt from `add-default-deny`, so **no NetworkPolicy or Kyverno change is required**. It's also where Cilium itself lives and what Tetragon's docs recommend.
- **BestEffort QoS trap** — the chart ships `tetragon.resources: {}`, which would land the per-node agent in BestEffort QoS (first to be evicted under node memory pressure). Set requests (100m / 256Mi); limits left unset, matching the cilium-agent posture (an event burst must not OOMKill the agent).
- **Talos** — tracefs lives at `/sys/kernel/tracing` (debugfs is not mounted on Talos), so it's added via `extraHostPathMounts`. BTF is auto-detected from `/sys/kernel/btf/vmlinux` (Talos ships `CONFIG_DEBUG_INFO_BTF=y`).
- **Observability integration is automatic** — `export-stdout` sidecar (on by default) → Alloy → Loki (searchable in Grafana); `ServiceMonitor`s enabled for agent (`:2112`) and operator (`:2113`), discovered cluster-wide by Prometheus.
- **Docker/CI** — eBPF tracing support on Docker-provider Talos nodes is unverified (kubescape disables its eBPF runtime detection there for the same reason), so `disableWait: true` keeps CI from blocking on DaemonSet readiness. Manifests still apply, so CI exercises them.

## Reviewer notes

- ⚠️ **Prod memory:** this adds a per-node DaemonSet (~256Mi request × nodes) **+ operator** to prod **during the active right-sizing effort** (workers held at 3; kubevirt/cdi disabled to free memory). If you'd rather not add memory pressure yet, drop the one line `- ../../../../bases/infrastructure/controllers/tetragon/` from `k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml` to ship local/CI-only first, then enable prod once right-sizing settles.
- The CI Talos+Docker system test is the real check for whether the agent comes up healthy on Docker-Talos. If it crash-loops there, the fallback is to relocate the controller to the hetzner-only provider tree (like `hcloud-*` / `longhorn`).
- **No TracingPolicies** are shipped yet, so the agent emits its built-in `process_exec` / `process_exit` events. CRDs are installed by the Tetragon operator (chart default `installMethod: operator`).

## Validation

| Check | Local | Prod |
|---|---|---|
| `ksail workload validate` | ✅ 264 files | ✅ 264 files |
| `kubectl kustomize` cluster overlay | ✅ | ✅ |
| Rendered `HelmRelease` | ✅ `disableWait` applied | ✅ no `disableWait`, ServiceMonitor on, Talos mount present |

## Follow-ups (separate PRs)

- **PR 2** — curated observe-only `TracingPolicy` resources (sensitive-file access, privileged-binary exec, unexpected egress); optional Grafana dashboard + agent-down `PrometheusRule`.
- **PR 3** — runtime enforcement (`Sigkill` / `Override` actions), **gated on** verifying `CONFIG_BPF_KPROBE_OVERRIDE` on the pinned Talos kernel.
