### PR TITLE
feat(security): add opt-in Tetragon enforcement for system-file integrity

### DIFF
--- a/k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml
+++ b/k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml
@@ -1,0 +1,65 @@
+---
+# ENFORCING TracingPolicy: SIGKILLs any process that attempts to WRITE to
+# system / binary directories (a classic tampering / persistence pattern).
+#
+# OPT-IN, ZERO DEFAULT BLAST RADIUS:
+#   spec.podSelector matches only pods carrying the label
+#   `tetragon.devantler.tech/enforce-file-integrity: "true"`. With no pod
+#   labelled, this policy enforces on nothing. Requires the policy filter,
+#   which is enabled on the agent (tetragon.enablePolicyFilter: true).
+#
+# This deliberately does NOT enforce on /var/log or /dev/log (legitimate
+# log writes) and does NOT enforce on file *reads* -- system daemons read
+# /etc/shadow etc. legitimately. Reads are covered observe-only by
+# monitor-sensitive-file-access.yaml.
+#
+# Rollout: add the label to one workload's pods, watch the observe policy
+# in Loki to confirm no legitimate writes would be killed, then widen.
+#
+# Action choice: `Sigkill` is a post-hook signal and does NOT require any
+# special kernel config. The stronger `Override` action (fail the syscall
+# before it executes) requires CONFIG_BPF_KPROBE_OVERRIDE -- verify that on
+# the pinned Talos kernel before switching to Override.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: enforce-protect-system-files
+spec:
+  podSelector:
+    matchLabels:
+      tetragon.devantler.tech/enforce-file-integrity: "true"
+  kprobes:
+    - call: "security_file_permission"
+      syscall: false
+      return: true
+      args:
+        - index: 0
+          type: "file" # (struct file *) used for getting the path
+        - index: 1
+          type: "int" # 0x04 is MAY_READ, 0x02 is MAY_WRITE
+      returnArg:
+        index: 0
+        type: "int"
+      selectors:
+        - matchArgs:
+            - index: 0
+              operator: "Prefix"
+              values:
+                - "/etc"
+                - "/boot"
+                - "/lib"
+                - "/lib64"
+                - "/bin"
+                - "/usr/lib"
+                - "/usr/local/lib"
+                - "/usr/local/sbin"
+                - "/usr/local/bin"
+                - "/usr/bin"
+                - "/usr/sbin"
+                - "/root/.ssh"
+            - index: 1
+              operator: "Equal"
+              values:
+                - "2" # MAY_WRITE
+          matchActions:
+            - action: Sigkill

--- a/k8s/bases/infrastructure/tracing-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/tracing-policies/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - monitor-sensitive-file-access.yaml
+  - enforce-protect-system-files.yaml


### PR DESCRIPTION
> 📚 **Stacked on #1689** (base branch: `claude/tetragon-tracingpolicies`), which is stacked on #1688. Merge in order: #1688 → #1689 → this.

## What

PR 3 (final) of the Tetragon rollout — adds **runtime enforcement**, designed to be safe by construction.

`k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml` — a `TracingPolicy` that **`Sigkill`s** any process writing to system / binary directories (`/etc`, `/usr/bin`, `/lib`, `/lib64`, `/boot`, `/usr/local/*`, `/root/.ssh`, …), a classic tampering / persistence pattern.

## Safe by construction

- **Opt-in, zero default blast radius:** `spec.podSelector` matches only pods labelled `tetragon.devantler.tech/enforce-file-integrity: "true"`. With nothing labelled, this policy enforces on **nothing**. (Works via the agent policy filter enabled in PR 1.)
- **Writes only** — reads are left to PR 2's observe policy, because system daemons legitimately read `/etc/shadow`, `/etc/sudoers`, etc. Killing on read would be catastrophic.
- **Excludes `/var/log` and `/dev/log`** to avoid killing legitimate logging even for opted-in pods.

## Rollout path

1. Merge; nothing changes (no pods labelled).
2. Label one workload's pods, watch PR 2's observe events in Loki to confirm no legitimate writes would be killed.
3. Widen the label as confidence grows.

## Sigkill vs Override

`Sigkill` is a post-hook signal and needs **no special kernel config**. The stronger `Override` action (fail the syscall *before* it runs) requires `CONFIG_BPF_KPROBE_OVERRIDE` — verify that on the pinned Talos kernel before switching. This is documented inline in the policy.

## Validation

| Check | Local | Prod |
|---|---|---|
| `ksail workload validate` | ✅ 266 files | ✅ 266 files |
| `kubectl kustomize` provider infra overlay | ✅ 2 TracingPolicies | ✅ 2 TracingPolicies |
