### PR TITLE
feat(observability): ship kube-apiserver audit log to Loki

### DIFF
--- a/k8s/bases/infrastructure/controllers/alloy/audit-collector.yaml
+++ b/k8s/bases/infrastructure/controllers/alloy/audit-collector.yaml
@@ -1,0 +1,130 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy-audit
+  namespace: monitoring
+  labels:
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  # Needs Loki's push endpoint; reuses the `grafana` HelmRepository and the
+  # monitoring namespace defined by the loki release.
+  dependsOn:
+    - name: loki
+      namespace: monitoring
+  interval: 5m
+  timeout: 10m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: alloy
+      version: 1.8.2
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+  # A SECOND, dedicated Alloy DaemonSet whose only job is to ship the
+  # kube-apiserver AUDIT log to Loki. It is deliberately separate from the main
+  # `alloy` pod-log shipper for two reasons:
+  #
+  #   1. Scope. The audit log only exists on CONTROL-PLANE nodes, at the
+  #      Talos-managed host path /var/log/audit/kube — Talos' `KubernetesAuditLogDir`
+  #      on the EPHEMERAL partition (audit logging is on by default; the prod
+  #      policy is enriched in talos/cluster/audit-logging.yaml). So this runs
+  #      ONLY on control planes (nodeSelector + control-plane toleration), while
+  #      the main alloy DaemonSet stays on the workers.
+  #   2. Privilege. The API server writes those files root-owned and mode 0600,
+  #      so the reader must run as root / with CAP_DAC_READ_SEARCH. Isolating that
+  #      here keeps the main pod-log alloy unprivileged.
+  #
+  # Why ship it at all: the audit trail otherwise lives ONLY on a node's
+  # EPHEMERAL partition — so it is lost whenever a (cattle) node is rebuilt, and
+  # cannot be queried centrally. Shipping to Loki makes it durable across
+  # rebuilds and visible in Grafana next to everything else. (It survives plain
+  # apiserver restarts already; node rebuilds are the gap.)
+  #
+  # The root + hostPath profile is permitted by design: `monitoring` is exempt
+  # from the Kyverno PSS / host-restriction policies and is listed in the
+  # kubescape `infrastructure-privileged` ClusterSecurityException.
+  values:
+    controller:
+      type: daemonset
+      # Control-plane nodes only — that is where the audit log lives.
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      volumes:
+        extra:
+          # Read-only host mount of the Talos-managed audit log directory.
+          # DirectoryOrCreate (not Directory) so the pod still starts cleanly on
+          # the off chance the dir isn't present yet — the file match below then
+          # simply finds nothing rather than wedging the pod in ContainerCreating.
+          - name: kube-audit-log
+            hostPath:
+              path: /var/log/audit/kube
+              type: DirectoryOrCreate
+    alloy:
+      # Pure file forwarding — no clustering needed.
+      clustering:
+        enabled: false
+      # Run as root with only CAP_DAC_READ_SEARCH (to read the root-owned 0600
+      # audit files); everything else dropped. `monitoring` is policy-exempt, so
+      # this profile is allowed.
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - DAC_READ_SEARCH
+      mounts:
+        extra:
+          - name: kube-audit-log
+            mountPath: /var/log/audit/kube
+            readOnly: true
+      extraEnv:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+      configMap:
+        content: |
+          // Tail the Talos-managed kube-apiserver audit log. The `*.log` glob
+          // catches the active audit.log plus any rotated audit-*.log files.
+          // Inert where no such file exists (so it's a no-op off control planes).
+          local.file_match "kube_audit" {
+            path_targets = [{
+              __path__ = "/var/log/audit/kube/*.log",
+              job      = "kube-audit",
+              node     = sys.env("NODE_NAME"),
+            }]
+          }
+
+          loki.source.file "kube_audit" {
+            targets    = local.file_match.kube_audit.targets
+            forward_to = [loki.write.default.receiver]
+          }
+
+          loki.write "default" {
+            endpoint {
+              url = "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+            }
+          }
+    # No ServiceMonitor — this is a single-purpose forwarder, not a scrape target.
+    serviceMonitor:
+      enabled: false

--- a/k8s/bases/infrastructure/controllers/alloy/audit-collector.yaml
+++ b/k8s/bases/infrastructure/controllers/alloy/audit-collector.yaml
@@ -104,12 +104,18 @@ spec:
           memory: 128Mi
       configMap:
         content: |
-          // Tail the Talos-managed kube-apiserver audit log. The `*.log` glob
-          // catches the active audit.log plus any rotated audit-*.log files.
-          // Inert where no such file exists (so it's a no-op off control planes).
+          // Tail the Talos-managed kube-apiserver audit log. The `audit*` glob
+          // catches the active audit.log AND its rotated backups under either
+          // naming scheme: the apiserver's built-in lumberjack rotation
+          // (--audit-log-max*) writes `audit-<timestamp>.log`, and logrotate-style
+          // `audit.log.N` if anything external ever rotates it. A plain `*.log`
+          // would miss logrotate backups; `audit.log*` would miss lumberjack's —
+          // `audit*` covers both, so a restart after a rotation re-discovers the
+          // backups and doesn't drop events. Inert where no such file exists (a
+          // no-op off control planes).
           local.file_match "kube_audit" {
             path_targets = [{
-              __path__ = "/var/log/audit/kube/*.log",
+              __path__ = "/var/log/audit/kube/audit*",
               job      = "kube-audit",
               node     = sys.env("NODE_NAME"),
             }]

--- a/k8s/bases/infrastructure/controllers/alloy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/alloy/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - audit-collector.yaml


### PR DESCRIPTION
## What

Adds a dedicated **`alloy-audit`** DaemonSet ([`audit-collector.yaml`](k8s/bases/infrastructure/controllers/alloy/audit-collector.yaml)) that tails the kube-apiserver audit log and ships it to the existing Loki.

## Why

The audit log ([`talos/cluster/audit-logging.yaml`](talos/cluster/audit-logging.yaml)) is written to `/var/log/audit/kube` — Talos' `KubernetesAuditLogDir`, on each control-plane node's **EPHEMERAL** partition. The main [`alloy`](k8s/bases/infrastructure/controllers/alloy/helm-release.yaml) shipper only tails **pod** logs via the K8s API and runs on workers, so the security audit trail (who changed RBAC, who touched a Secret, every workload mutation) was never centralised:

- it lives only on the node, so it's **lost when a cattle node is rebuilt**, and
- it can't be queried in Grafana next to everything else.

It survives plain apiserver restarts already (EPHEMERAL ≠ container fs); **node rebuilds are the gap**, and that's what shipping to Loki closes.

## Design notes (why a *second* Alloy)

| Decision | Reason |
| --- | --- |
| **Dedicated DaemonSet**, not the main alloy | The audit files are root-owned `0600`, so the reader needs root / `CAP_DAC_READ_SEARCH`. Isolating that keeps the main pod-log shipper unprivileged. |
| **Control-plane only** (`nodeSelector` + toleration) | The audit log only exists there. |
| **No Talos change** | Talos *already* host-backs `/var/log/audit/kube`. Adding `apiServer.extraVolumes` for it would be a **duplicate mount → apiserver crash**. Confirmed via Talos' `KubernetesAuditLogDir` constant + "audit on by default" KB. |
| **No new NetworkPolicy** | `allow-monitoring` uses an empty `endpointSelector`, so it already grants this pod intra-namespace egress to Loki + DNS. |
| **root + hostPath allowed** | `monitoring` is excluded from the Kyverno PSS/host-restriction policies and listed in the kubescape `infrastructure-privileged` exception. |

## Validation

- ✅ `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` — **264 files validated** each.
- ✅ `kubectl kustomize k8s/bases/infrastructure/controllers/` builds; the rendered `alloy-audit` carries the control-plane nodeSelector, the `/var/log/audit/kube` mount, `DAC_READ_SEARCH`, and the `kube-audit` file source.
- The local Talos+Docker **system test exercises this** (Talos enables audit logging by default, so the local control plane has the dir + file) — it's the runtime check for the Alloy/River config and pod health.

## To verify on the cluster (reviewer)

1. After reconcile, `alloy-audit` pods are `Running` on control-plane nodes only.
2. In Grafana/Loki, `{job="kube-audit"}` returns events.
3. If (2) is empty but pods are healthy, the collector likely can't read the files — adjust its `securityContext` (the apiserver's audit file owner/mode is the variable here).

### Known minor behaviour

Alloy's read positions live in the pod's default (emptyDir) storage, so a collector restart re-reads the current audit file from the start (bounded by the 100 MB rotation size) — some duplicate lines in Loki after a restart. Acceptable; can be made durable later with a host-backed positions dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)