### PR TITLE
fix(observability): route Grafana OIDC token exchange to in-cluster Dex

### DIFF
--- a/k8s/bases/infrastructure/controllers/dex/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/networkpolicy.yaml
@@ -32,6 +32,17 @@ spec:
               protocol: TCP
             - port: "5558"
               protocol: TCP
+    # OIDC token + userinfo exchange from Grafana (native auth.generic_oauth).
+    # Same in-cluster path as headlamp/oauth2-proxy: Grafana's server-side
+    # calls hit the Dex Service directly and arrive with the monitoring pod
+    # identity, so they must be allowed explicitly here.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "5556"
+              protocol: TCP
   egress:
     # Kube API for reading secrets
     - toEntities:

--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
@@ -63,9 +63,19 @@ spec:
           auto_login: true
           client_id: public-client
           scopes: openid profile email groups
+          # Split the OIDC endpoints so this works on every cluster (mirrors
+          # oauth2-proxy): the browser-facing authorize endpoint stays the
+          # public Dex URL (the browser resolves dex.${domain} via the host
+          # /etc/hosts locally, public DNS in prod), while the server-side
+          # token + userinfo calls use the in-cluster Dex Service the Grafana
+          # pod can always resolve. dex.${domain} does NOT resolve via
+          # in-cluster CoreDNS on the docker/local cluster, so targeting the
+          # public URL here fails the back-channel token exchange with
+          # "Failed to get token from provider". The dex NetworkPolicy allows
+          # the matching monitoring->5556 ingress.
           auth_url: https://dex.${domain}/auth
-          token_url: https://dex.${domain}/token
-          api_url: https://dex.${domain}/userinfo
+          token_url: http://dex.dex.svc.cluster.local:5556/token
+          api_url: http://dex.dex.svc.cluster.local:5556/userinfo
           # JMESPath string literal -> every authenticated user gets Admin.
           role_attribute_path: "'Admin'"
       # Client secret (Dex 'public-client') from the grafana-oidc


### PR DESCRIPTION
## What

Fix Grafana "Sign in with Dex" failing with **"Login failed — Failed to get token from provider"**.

Two changes, both mirroring what oauth2-proxy already does:

- **`kube-prometheus-stack/helm-release.yaml`** — split Grafana's `auth.generic_oauth` endpoints: `auth_url` stays the public Dex URL (browser-facing), while the server-side `token_url`/`api_url` now target the in-cluster Dex Service `http://dex.dex.svc.cluster.local:5556`.
- **`dex/networkpolicy.yaml`** — add a `monitoring → dex:5556` ingress rule to `allow-dex`.

## Why

Grafana was switched to native Dex OIDC in #1687, but — unlike oauth2-proxy in that same PR — it kept two latent defects that only surface at the **back-channel token exchange** (the browser front-channel login worked, which is why the symptom is "Failed to get token from provider" rather than a redirect failure):

1. **DNS.** `token_url`/`api_url` pointed at `https://dex.${domain}`, which the Grafana pod **cannot resolve via in-cluster CoreDNS** — `dex.platform.lan` exists only in the host's `/etc/hosts` on the docker/local cluster. This is the exact wall oauth2-proxy hit in #1687 and was fixed for with `skip_oidc_discovery` + in-cluster `redeem_url`/`oidc_jwks_url`; Grafana never got the equivalent split.
2. **NetworkPolicy.** `allow-dex` enumerates which namespaces may reach Dex for token exchange (`headlamp`, `oauth2-proxy`) but omitted `monitoring`, so the cluster's default-deny would block Grafana's in-cluster call even after the DNS fix.

Ruled out: client-secret mismatch — `grafana-oidc` already sources the shared `infrastructure/oidc/dex` `client-secret`, the same one Dex's `public-client` uses.

## Reviewer notes

- `auth_url` deliberately stays public (the **browser** resolves `dex.${domain}` via `/etc/hosts` locally and public DNS in prod); only the two server-side calls move in-cluster.
- This also makes prod use the in-cluster path instead of hairpinning to the LB — same rationale called out for oauth2-proxy in #1687.
- **Out of scope but related:** `actual-budget` (`discoveryUrl: https://dex.${domain}/.well-known/...`) and OpenBao (`oidc_discovery_url="https://dex.${domain}"`) do server-side OIDC against the same public URL and aren't in Dex's ingress allowlist, so they likely share this latent failure on local. Not touched here — worth a separate verification/PR.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `.../prod/` — build clean
- `ksail workload validate` (local) and `ksail --config ksail.prod.yaml workload validate` — **263 files validated** each

🤖 Generated with [Claude Code](https://claude.com/claude-code)
