### PR TITLE
perf(observability): discover Prometheus targets via EndpointSlice

### DIFF
--- a/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kube-prometheus-stack/helm-release.yaml
@@ -130,6 +130,17 @@ spec:
         ruleSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         scrapeConfigSelectorNilUsesHelmValues: false
+        # Discover targets through EndpointSlices rather than the default
+        # core/v1 Endpoints API. ServiceMonitor discovery inherently lists
+        # *every* endpoint in a monitor's target namespace and keeps only the
+        # matching Service, dropping the rest -- so a large "dropped" count on
+        # Prometheus' Service Discovery page is expected, not a fault (each of
+        # the ~14 monitors in this namespace scans ~50 endpoints). EndpointSlice
+        # is the scalable, operator-recommended SD role: it trims the apiserver
+        # watch + relabel churn behind those drops and future-proofs against the
+        # core/v1 Endpoints deprecation (k8s 1.33). It does not (and need not)
+        # lower the dropped count -- that is just how ServiceMonitors select.
+        serviceDiscoveryRole: EndpointSlice
         # External labels so the webhook payload identifies the source
         # cluster.
         externalLabels:


### PR DESCRIPTION
## What

Switch Prometheus' service-discovery role from the default core/v1 `Endpoints` to `EndpointSlice` (`prometheus.prometheusSpec.serviceDiscoveryRole: EndpointSlice`).

## Why — investigation

The Prometheus **Service Discovery** page reports a large number of *dropped* targets. I investigated against live prod:

| Metric | Value |
|---|---|
| Active targets | 40 (all healthy, `up`) |
| Dropped targets | 689 |
| SD errors in logs | none |

**Root cause — this is expected, not a fault.** The Prometheus Operator generates one `role: endpoints` scrape job per ServiceMonitor, scoped to the monitor's target namespace. Each job lists *every* endpoint-address-port in that namespace and `keep`s only the ones whose Service matches the monitor's selector — everything else is reported as "dropped". So:

- ~14 ServiceMonitors in `monitoring`, each scanning ~50 namespace-local endpoints (node-exporter ×6, alertmanager mesh/reloader ports, Loki memberlist, prometheus-operated, …) → the bulk of the 689.
- A few in `kube-system` (~48 each: kubelet ×12, hubble-peer ×12, kube-dns aliasing coredns ×6, cilium-envoy ×6, …).

Discovery is **correctly namespace-scoped**, not cluster-wide: the cluster has 86 `Endpoints` objects total, yet each pool drops only ~50 (its own namespace's size). If it were scanning cluster-wide, drops would be far higher.

**The dropped count is inherent to how ServiceMonitors select targets and cannot be lowered without dropping metrics we actually want.** What *is* worth fixing is the cost of all that discover-then-drop work.

## The fix

`serviceDiscoveryRole: EndpointSlice` is the scalable, operator-recommended SD role. It:

- trims the apiserver watch + relabel churn behind the drops, and
- future-proofs against the core/v1 `Endpoints` API deprecation (Kubernetes 1.33).

It does **not** (and need not) change the dropped count shown on the SD page.

## Safety

- Operator-managed **kubelet** and **coredns** `Endpoints` are already mirrored to `EndpointSlices` (verified on prod: `kube-prometheus-stack-kubelet-thxn5`, `kube-prometheus-stack-coredns-dfhl4`), so those targets keep being discovered.
- **No** chart in this repo uses custom relabelings referencing `__meta_kubernetes_endpoints_*` labels, so nothing breaks when the operator regenerates its relabel rules with endpointslice meta labels.

## Validation

- `ksail workload validate` — 263 files ✔ (local)
- `ksail --config ksail.prod.yaml workload validate` — 263 files ✔ (prod)

## Note

If decluttering the SD page itself is ever desired, `keepDroppedTargets` bounds how many dropped targets Prometheus retains/shows — at the cost of hiding info useful for debugging new ServiceMonitors. Deliberately not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
