### PR TITLE
fix(tetragon): right-size agent memory request to fit prod workers

### DIFF
--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -59,10 +59,19 @@ spec:
       # lesson as the cilium-agent OOM cascade. Limits are intentionally
       # left unset (an event burst must not get the agent OOMKilled),
       # matching the cilium-agent posture.
+      #
+      # memory is sized to observed prod usage (agents run 64-105Mi), not
+      # a round guess. The original 256Mi did not fit the request-saturated
+      # prod workers (~97% of allocatable already requested), so one
+      # DaemonSet pod stayed Pending ("Insufficient memory") -- and because
+      # Helm waits for full DaemonSet readiness, that single pod wedged the
+      # entire prod reconcile (HelmRelease stuck InProgress -> Kustomization
+      # HealthCheckFailed). 128Mi stays comfortably Burstable (preserving
+      # the anti-BestEffort intent) while fitting the available budget.
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 128Mi
       # Enrich exec / kprobe events with process capabilities and
       # namespaces (both default to false). enablePolicyFilter (default
       # true) is required for the K8s namespace / pod-label filtering that


### PR DESCRIPTION
## Symptom

The merge-queue **prod deploy** has been failing (~3h), blocking every PR in the queue:

```
infrastructure-controllers: HealthCheckFailed — timeout waiting for:
  [HelmRelease/kube-system/tetragon status: 'InProgress']
kube-system/tetragon: Progressing — Running 'install' action with timeout of 10m0s
```

CI didn't catch this: the docker provider patch sets `disableWait`, so local/CI reconciliation never gates on Tetragon DaemonSet readiness — only the hetzner (prod) path does.

## Root cause (live prod)

The Tetragon agent DaemonSet can't fully roll out — one pod is stuck `Pending`:

```
0/6 nodes are available: 1 Insufficient memory, 5 node(s) didn't satisfy NodeAffinity
```

| Fact | Value |
|---|---|
| Target node | `prod-worker-3` |
| worker-3 memory **requests** | ~97% of allocatable (~159Mi free) |
| worker-3 memory **actual use** | 67% |
| Tetragon pod **request** | 256Mi |
| Tetragon **actual** use | 64–105Mi |

worker-3 is request-saturated, and Tetragon's 256Mi request (~2.5× its real footprint) is ~97Mi too big to fit. A DaemonSet pins each pod to its node via NodeAffinity, so the other 5 nodes "don't satisfy" — this pod belongs to worker-3, which is full. Helm's wait-for-DaemonSet-readiness then turns one unschedulable pod into a full prod-pipeline failure (controllers → infrastructure → apps).

## Fix

Right-size the agent memory request **256Mi → 128Mi**:

- comfortably above observed peak (105Mi), so it stays **Burstable** — preserving the deliberate anti-BestEffort-QoS posture; limit stays unset, and
- fits worker-3's available request budget, so all 6 DaemonSet pods schedule and the install completes.

This is the request-inflation lever, not added capacity.

## Validation

- `ksail workload validate` — 264 files ✔ (local)
- `ksail --config ksail.prod.yaml workload validate` — 264 files ✔ (prod)
- Rendered hetzner overlay shows `memory: 128Mi`.

## Note

worker-3 will still sit ~99% requested after this — it just fits. The systemic fix is freeing the inflated requests across the workers (tracked separately under the prod right-sizing effort). This PR is the minimal change to unblock the prod deploy queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
