### PR TITLE
fix(observability): right-size tetragon memory request to fit prod

### DIFF
--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -66,9 +66,12 @@ spec:
       # ample RAM actually free -- request inflation, not real pressure).
       # The node-pinned DaemonSet pod stayed Pending ("Insufficient
       # memory"), so the HelmRelease never reached the Ready state Flux
-      # waits on and the prod deploy timed out. 128Mi fits every node,
-      # stays Burstable (out of BestEffort), and -- with no memory limit
-      # -- carries no OOMKill risk.
+      # waits on and the prod deploy timed out. 128Mi fits every node and
+      # stays Burstable (out of BestEffort). With no memory limit, lowering
+      # the request neither caps the agent's actual usage nor adds a
+      # limit-driven OOMKill; it only shrinks the scheduling reservation
+      # (the pod stays subject to node-pressure eviction like any other,
+      # acceptable here given the real RAM headroom).
       resources:
         requests:
           cpu: 100m

--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -59,10 +59,20 @@ spec:
       # lesson as the cilium-agent OOM cascade. Limits are intentionally
       # left unset (an event burst must not get the agent OOMKilled),
       # matching the cilium-agent posture.
+      #
+      # Memory request right-sized 256Mi -> 128Mi: live prod agents use
+      # only 63-128Mi, and the 256Mi reservation no longer fit a
+      # request-saturated prod worker (~158Mi free for requests despite
+      # ample RAM actually free -- request inflation, not real pressure).
+      # The node-pinned DaemonSet pod stayed Pending ("Insufficient
+      # memory"), so the HelmRelease never reached the Ready state Flux
+      # waits on and the prod deploy timed out. 128Mi fits every node,
+      # stays Burstable (out of BestEffort), and -- with no memory limit
+      # -- carries no OOMKill risk.
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 128Mi
       # Enrich exec / kprobe events with process capabilities and
       # namespaces (both default to false). enablePolicyFilter (default
       # true) is required for the K8s namespace / pod-label filtering that


### PR DESCRIPTION
## What

Lower the Tetragon agent DaemonSet's memory **request** from 256Mi to 128Mi (base HelmRelease). CPU request unchanged.

## Why

Tetragon ([#1688](https://github.com/devantler-tech/platform/pull/1688)) has been jamming the **merge queue**: every prod (`merge_group`) deploy since it merged failed — #1692, #1696, #1698 — with `kube-system/tetragon: Running 'install' action with timeout of 10m0s` cascading `infrastructure-controllers → infrastructure → apps` to `DependencyNotReady`.

Root cause (confirmed by read-only `kubectl` on prod):

- The agent DaemonSet was stuck **5/6** — the pod node-pinned to `prod-worker-3` was `Pending`: `0/6 nodes available: 1 Insufficient memory, 5 didn't satisfy NodeAffinity`.
- `prod-worker-3` sits at **97% memory _requests_** (~158Mi free) but only **65% actual usage** (~2.5 GiB RAM physically free) — request inflation, not real pressure.
- Tetragon requested **256Mi** but its agents actually use **63–128Mi** (~2–4× inflated). 256Mi couldn't fit worker-3's ~158Mi request headroom, so the pod never scheduled; prod has no `disableWait` patch, so the helm install blocked on 6/6 readiness and timed out.

Right-sizing to **128Mi** fits every node (restores 6/6, lets the install complete naturally), stays Burstable (out of BestEffort), and — no memory limit is set — carries no OOMKill risk.

## Reviewer notes

- **Unblocks the merge queue:** once prod reconciles tetragon to 6/6, the deploy passes and queued PRs (including the unrelated Grafana-OIDC #1698) can merge.
- Chose right-sizing over a hetzner `disableWait` patch deliberately, so tetragon keeps full per-node coverage rather than silently skipping worker-3.
- The broader cluster-wide request inflation (requests ~95% vs usage ~20–65%) is a separate, larger effort.

## Validation

- `kubectl kustomize` local + prod — build clean
- `ksail workload validate` local + prod — **264 files validated** each

🤖 Generated with [Claude Code](https://claude.com/claude-code)
