### PR TITLE
fix(tetragon): right-size agent memory request 256Mi -> 160Mi

### DIFF
--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -62,7 +62,11 @@ spec:
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          # Right-sized 256Mi -> 160Mi: the agent uses ~63-124Mi in practice, and
+          # 256Mi failed to schedule on a request-saturated prod worker (97% mem
+          # requests), stranding the DaemonSet at 5/6 and hanging the HelmRelease's
+          # install wait, which stalled the infrastructure-controllers -> apps chain.
+          memory: 160Mi
       # Enrich exec / kprobe events with process capabilities and
       # namespaces (both default to false). enablePolicyFilter (default
       # true) is required for the K8s namespace / pod-label filtering that


### PR DESCRIPTION
## Problem

The merge-queue **🚀 Deploy to Prod** has been failing for every PR since tetragon (#1688) landed:

```
✗ infrastructure-controllers — kube-system/tetragon: Running 'install' action with timeout of 10m0s
✗ infrastructure / apps: DependencyNotReady
```

Live read-only diagnosis on prod: the tetragon DaemonSet is stuck **5/6** — the pod node-pinned to `prod-worker-3` is `Pending`:

```
0/6 nodes are available: 1 Insufficient memory, 5 node(s) didn't satisfy NodeAffinity
prod-worker-3  memory requests: 7297820922 (97%)   (MemoryPressure=False)
```

`prod-worker-3` is **request-saturated** (97% of allocatable requested, while actual usage is far lower — the known request-inflation pattern). tetragon requests **256Mi**, which doesn't fit, so its pod never schedules → the DaemonSet never reaches full availability → the HelmRelease's install wait hangs at its 10m timeout → `infrastructure-controllers` (`wait: true`) times out → `infrastructure`/`apps` cascade to `DependencyNotReady`. A best-effort observability agent ends up jamming the whole prod Flux chain.

## Fix

Right-size the agent's memory **request** `256Mi → 160Mi` in the base HelmRelease. Observed agent usage is **~63–124Mi** across prod nodes, so 160Mi keeps headroom while fitting the saturated worker (~210Mi free). The agent has **no memory limit**, so a lower request only affects scheduling/QoS — it cannot cause an OOMKill.

This restores the DaemonSet to 6/6, lets the HelmRelease go Ready, and unblocks the prod merge-queue deploy for all PRs.

## Validation

- `kubectl kustomize` of the hetzner and docker controllers overlays build; tetragon renders `memory: 160Mi`.
- `ksail workload validate` (schema-aware, Flux substitution) passes for local and prod.

## Notes

- Base change, so it applies to all providers (160Mi is reasonable everywhere; docker already uses `disableWait`).
- Residual risk (out of scope here, by request): a best-effort agent can still block the infra→apps chain if a worker re-saturates. Adding `install/upgrade.disableWait: true` on hetzner (as docker already has) would decouple it — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
