### PR TITLE
feat(prod): restore baseline worker count to 4

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -50,7 +50,7 @@ spec:
     # Longhorn requires dedicated Hetzner Cloud Volumes on static
     # workers; autoscaler-created nodes are compute-only.
     # The Cluster Autoscaler manages additional workers dynamically.
-    # Restored to 4 — the kubernetesVersion pin below unblocks the 4th worker.
+    # Restored to 4 — unblocked by the kubernetesVersion pin below and the KSail >= 7.23.4 scale-up fix.
     workers: 4
     # Pin Kubernetes to the version the cluster already runs so
     # 'ksail cluster update' doesn't roll nodes to ksail's newer default

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -50,13 +50,8 @@ spec:
     # Longhorn requires dedicated Hetzner Cloud Volumes on static
     # workers; autoscaler-created nodes are compute-only.
     # The Cluster Autoscaler manages additional workers dynamically.
-    # Temporarily held at 3 (matching the 3 healthy nodes) while the
-    # cluster is stabilized / right-sized. (A 4th worker previously failed
-    # to join because of the missing Kubernetes version pin — now fixed
-    # via kubernetesVersion below.) Restore to 4 once resourced -- the
-    # always-on observability tier (Grafana, Loki, persistent
-    # Prometheus/Alertmanager) is what motivates the eventual bump.
-    workers: 3
+    # Restored to 4 — the kubernetesVersion pin below unblocks the 4th worker.
+    workers: 4
     # Pin Kubernetes to the version the cluster already runs so
     # 'ksail cluster update' doesn't roll nodes to ksail's newer default
     # (currently 1.36.0), which Talos v1.12.4 rejects with


### PR DESCRIPTION
## What

Restore `spec.cluster.workers` from `3` → `4` in `ksail.prod.yaml`, reversing the temporary hold added in #1671.

## Why

#1671 held the baseline at `workers: 3` to stabilise the cluster, because a 4th worker couldn't join. The two root causes are now fixed:

- **k8s version drift** — ksail defaulted the desired Kubernetes version to `1.36.0`, which Talos `v1.12.4` rejects. Now pinned via `kubernetesVersion: v1.32.0` (#1673), already on `main`.
- **ksail scale-up hostname bug** — newly-added Hetzner workers came up with a generic `talos-xxxx` hostname (couldn't register) and then a duplicate-hostname config Talos rejected. Fixed in **ksail 7.23.4** (devantler-tech/ksail#4962, #4969 → #4974).

## Validation

`ksail --config ksail.prod.yaml cluster update --dry-run` on ksail 7.23.4 + latest `main`:
- Only change detected: `cluster.workers 3 → 4` (in-place)
- No `machine.config` drift; `kubernetesVersion: v1.32.0` pin honoured (no "defaulting to 1.36" warning)

## ⚠️ Merge gating — Hetzner cx33 capacity

The 4th worker only provisions when **cx33 capacity is available** in `fsn1` / `nbg1` / `hel1` (primary + fallbacks). As of now it has been **out across all three for an extended period** (sustained Intel-cx shortage).

Merging triggers a CD prod deploy (`ksail cluster update`). If cx33 is still unavailable at merge time, the deploy fails at the worker-availability check — **no harm to the running cluster (stays at 3 workers), but the CD run goes red.** Recommend holding merge until cx33 restocks (or merge and let a subsequent deploy pick it up once capacity returns).

Draft per repo convention.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
