### PR TITLE
ci(cluster-policies): adopt negation-aware sync filter; file-scope .policyignore

### DIFF
--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   sync-policies:
-    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@d6c7133cb8cb13189b97993aeb3f4d120f27479d # v5.4.1
+    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@cc177a46c8ffb899ad1c0bd506be203fa0d7b0c4 # unreleased: reusable-workflows#277 (.policyignore ! negation fix); re-pin to tag once merged
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   sync-policies:
-    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@cc177a46c8ffb899ad1c0bd506be203fa0d7b0c4 # unreleased: reusable-workflows#277 (.policyignore ! negation fix); re-pin to tag once merged
+    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@1661334c8fa709b1663f6168677f65073250d83d # v5.4.4
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:

--- a/.policyignore
+++ b/.policyignore
@@ -8,7 +8,7 @@ argo*
 aws*
 best-practices-cel*
 best-practices*
-!best-practices/add-ns-quota
+!best-practices/add-ns-quota/add-ns-quota.yaml
 castai*
 cert-manager*
 cleanup*
@@ -29,8 +29,8 @@ nginx*
 openshift*
 other-cel*
 other*
-!other/create-pod-antiaffinity
-!other/spread-pods-across-topology
+!other/create-pod-antiaffinity/create-pod-antiaffinity.yaml
+!other/spread-pods-across-topology/spread-pods-across-topology.yaml
 pod-security-cel*
 pod-security*
 psa-cel*


### PR DESCRIPTION
## What

Adopt the released fix for the **Sync Cluster Policies** filter and adapt `.policyignore`:

- **Pin bump** — `sync-cluster-policies.yaml` → `reusable-workflows` **v5.4.4**, which makes the `.policyignore` filter honor gitignore-style `!` negation ([reusable-workflows#277](https://github.com/devantler-tech/reusable-workflows/pull/277)).
- **File-scoped negations** — the three whitelist lines now target the exact policy manifests instead of their directories:
  ```diff
  -!best-practices/add-ns-quota
  +!best-practices/add-ns-quota/add-ns-quota.yaml
  -!other/create-pod-antiaffinity
  +!other/create-pod-antiaffinity/create-pod-antiaffinity.yaml
  -!other/spread-pods-across-topology
  +!other/spread-pods-across-topology/spread-pods-across-topology.yaml
  ```

## Why

The old reusable-workflow filtered `.policyignore` with a `find -path … -exec rm -rf` loop that has no notion of `!` negation, so the whitelist lines were silent no-ops and the broad `best-practices*`/`other*` lines deleted the three upstream policies the cluster-policies kustomization references — leaving dangling resources that broke `kustomize build` (the perpetually-red sync PR #1589).

With negation now working, a **directory-level** `!` would re-include the dir's `artifacthub-pkg.yml` / `.chainsaw-test/` / `.kyverno-test/` siblings (non-k8s YAML). **File-scoped** negations keep only the policy manifest.

## Validation

Ran v5.4.4's actual `run:` blocks against a fresh `kyverno/policies` sparse clone with this exact `.policyignore`:

- Synced output is **byte-identical to the current `samples/`** → the next sync is a zero-diff no-op and **#1589 auto-closes**.
- `kubectl kustomize` of `clusters/local` and `clusters/prod` both build (neither changed file is a manifest).
- `actionlint` clean.

## Notes

- This PR touches only `.github/**` and `.policyignore`, so the Talos+Docker **system test is skipped** by design (no `k8s/**` change).
- After merge, the sync runs on the daily schedule — trigger **Sync Cluster Policies** via `workflow_dispatch` to close #1589 immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
