### PR TITLE
feat(security): disable kubescape runtimeDetection in favor of Tetragon

### DIFF
--- a/docs/runtime-security.md
+++ b/docs/runtime-security.md
@@ -5,22 +5,24 @@ stops malicious behaviour *while workloads are running*, as opposed to blocking
 it at admission ([Kyverno](../k8s/bases/infrastructure/cluster-policies/)) or
 hardening it at the OS layer ([Talos](../talos/)).
 
-It exists mainly to answer one recurring question: **why do we run two
-eBPF-based runtime sensors — Kubescape's node-agent *and* Tetragon — instead of
-picking one?** The short answer is that they are not the same kind of tool;
-the long answer is below.
+The platform runs **one** eBPF runtime engine — **Tetragon** — for both
+detection and enforcement, and keeps **Kubescape** as a **posture platform**
+(config / CVE / compliance scanning) with its node-agent runtime sensor
+**disabled**. This document explains that split: what each tool owns, how
+Tetragon covers the runtime threats Kubescape's node-agent used to flag, and
+what we consciously traded away by consolidating onto one runtime sensor.
 
-> Guiding principle: **detection and enforcement are different jobs, and the
-> best tool for each is different.** We accept one deliberate overlap (two
-> eBPF agents) to get both done well, and we write down the conditions under
-> which we'd revisit that.
+> Guiding principle: **detection and enforcement are different jobs, but one
+> well-targeted engine can do both.** We previously ran two eBPF sensors and
+> documented the conditions under which we'd narrow to one — this is that
+> change.
 
 ---
 
 ## The runtime stack at a glance
 
-Runtime security here is layered. The two eBPF sensors are the headline, but
-they sit inside a wider set of controls:
+Runtime security here is layered. Tetragon is the headline runtime engine, but
+it sits inside a wider set of controls:
 
 | Layer | Control | What it does at runtime |
 | --- | --- | --- |
@@ -28,131 +30,122 @@ they sit inside a wider set of controls:
 | Syscall filter | **seccomp `RuntimeDefault`** (mutated + enforced by [Kyverno](../k8s/bases/infrastructure/cluster-policies/best-practices/validate-pod-security.yaml)) | Blocks the dangerous-syscall tail every container gets by default |
 | Kernel hardening | **sysctls** ([`talos/cluster/sysctls.yaml`](../talos/cluster/sysctls.yaml)) | `kptr_restrict`, `ptrace_scope`, unprivileged-eBPF off, etc. — shrinks the local-privesc surface |
 | Network | **Cilium + Hubble** | L3–L7 flow visibility and default-deny [CiliumNetworkPolicy](../k8s/bases/infrastructure/cluster-policies/best-practices/add-default-deny.yaml) per namespace |
-| Runtime detection | **Kubescape node-agent** | Learned-behaviour anomaly detection, correlated with config/CVE/compliance posture |
-| Runtime enforcement | **Tetragon** | Declarative kernel-hook policies that **terminate the offending process** (SIGKILL) on a policy match |
+| Runtime detection **+ enforcement** | **Tetragon** | Declarative kernel-hook `TracingPolicy` resources: observe threat behaviours (→ Loki) and optionally **terminate the offending process** (SIGKILL) on a match |
+| Posture | **Kubescape** | Config scan (CIS/NSA/MITRE), image-CVE inventory, compliance — **runtime node-agent disabled** |
 | Forensics | **API audit log** ([`talos/cluster/audit-logging.yaml`](../talos/cluster/audit-logging.yaml)) | Who-did-what record of control-plane mutations |
 
-This document focuses on the two middle-to-bottom rows — the eBPF sensors.
+This document focuses on the Tetragon row and the Kubescape posture row.
 
 ---
 
-## The two sensors
+## The two tools
 
-### Kubescape node-agent — *detection, tied to posture*
+### Tetragon — *the runtime engine (detection + enforcement)*
 
-Enabled in [`kubescape/helm-release.yaml`](../k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml):
+Installed under `k8s/bases/infrastructure/controllers/tetragon/`, with policies
+under `k8s/bases/infrastructure/tracing-policies/`. Delivered across
+[#1688](https://github.com/devantler-tech/platform/pull/1688) (install +
+observability), [#1689](https://github.com/devantler-tech/platform/pull/1689)
+(observe-only `TracingPolicy` set), and
+[#1690](https://github.com/devantler-tech/platform/pull/1690) (opt-in
+enforcement).
+
+Two properties make it a good single runtime engine:
+
+1. **Precise, declarative kernel hooks.** A `TracingPolicy` targets specific
+   kprobes/tracepoints/syscalls (an LSM hook, a file path, `finit_module`,
+   `ptrace`) with low overhead, rather than profiling everything. That keeps the
+   event volume into Loki proportional to *threat-relevant* activity instead of
+   all activity.
+2. **Enforcement.** A `TracingPolicy` can carry a `SIGKILL` action that
+   **terminates the offending process** as soon as Tetragon observes a match.
+   This is *post-event* termination — the triggering syscall may already have
+   completed, so it kills the **process**, it does not block the call.
+   (Tetragon's `Override` action can block the syscall itself where the kernel
+   supports it; this platform uses SIGKILL — see #1690.) It is opt-in per
+   workload via a pod label, so it starts safe.
+
+Tetragon events are exported to stdout and shipped to Loki by Alloy, and its
+metrics are scraped by Prometheus.
+
+What it does **not** do: it has no notion of compliance frameworks, image CVEs,
+or a *learned* baseline of "normal" — it observes and enforces the rules *you
+write*, nothing more. That gap is the trade we accept (below).
+
+### Kubescape — *posture, runtime sensor off*
+
+Configured in [`kubescape/helm-release.yaml`](../k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml):
 
 ```yaml
 capabilities:
   configurationScan: enable   # CIS / NSA / MITRE compliance
   continuousScan: enable
   vulnerabilityScan: enable   # image CVEs (kubevuln)
-  runtimeDetection: enable    # ← the eBPF node-agent
+  runtimeDetection: disable   # ← node-agent runtime sensor OFF (Tetragon owns runtime)
 hostScanner:
-  enabled: true
-nodeAgent:
-  config:
-    hostSensor:
-      enabled: true
+  enabled: true               # host CIS checks — posture, not runtime
 ```
 
-Kubescape is a **posture platform** that happens to ship a runtime sensor. Its
-node-agent builds a learned profile of each workload's normal syscall/file/
-network behaviour and flags deviations — and, crucially, it reports those
-deviations **in the same pane as** the config-scan results, the image-CVE
-inventory, and the CIS/NSA/MITRE compliance frameworks. That correlation is the
-point: "this container is doing something unusual *and* it has a known-exploitable
-CVE *and* it violates control C-00xx" is a far stronger signal than any of those
-alone.
-
-What it does **not** do: it is **detection-only**. It will tell you a process
-misbehaved; it will not stop it.
-
-### Tetragon — *enforcement and precise kernel observability*
-
-Being introduced via the stacked PRs
-[#1688](https://github.com/devantler-tech/platform/pull/1688) (install +
-observability), [#1689](https://github.com/devantler-tech/platform/pull/1689)
-(observe-only `TracingPolicy` for sensitive files), and
-[#1690](https://github.com/devantler-tech/platform/pull/1690) (opt-in
-enforcement). Lives under
-`k8s/bases/infrastructure/controllers/tetragon/` and
-`k8s/bases/infrastructure/tracing-policies/`.
-
-Tetragon is a **purpose-built runtime engine**. Two things make it
-complementary rather than redundant:
-
-1. **Enforcement.** A `TracingPolicy` can carry a `SIGKILL` action that
-   **terminates the offending process** as soon as Tetragon observes a matching
-   event (e.g. a write to a protected system path). This is *post-event*
-   termination — the triggering syscall may already have completed, so it kills
-   the **process**, it does not block the call. (Tetragon's `Override` action can
-   block the syscall itself where the kernel supports it; this platform uses
-   SIGKILL — see #1690.) Either way it does something a detection-only tool
-   can't: it stops the workload rather than just alerting. Opt-in per workload
-   (via a pod label) so it starts safe.
-2. **Precise, declarative kernel hooks.** `TracingPolicy` targets specific
-   kprobes/tracepoints (a syscall, an LSM hook, a file path) with low overhead,
-   rather than profiling everything. That makes it the right tool for narrow,
-   high-value invariants like "no one rewrites `/etc` or the kubelet binary."
-
-What it does **not** do: it has no notion of compliance frameworks, image CVEs,
-or a learned baseline of "normal" — it enforces and observes the rules *you
-write*, nothing more.
+Kubescape remains the **posture platform**: it scans cluster and host
+configuration against compliance frameworks and inventories image CVEs. What it
+no longer does here is **runtime threat detection** — its node-agent built a
+learned per-workload behaviour profile and flagged deviations, correlated with
+the config/CVE/compliance view. That capability is now off; see the trade below.
 
 ---
 
-## Why both, and not one
+## Why one runtime engine, and how parity is kept
 
-| If we kept only… | We would lose |
+Running two eBPF sensors meant two sets of probes on every node (real memory on
+the memory-constrained prod nodes) and overlapping syscall visibility consumed
+for two different purposes. Consolidating onto Tetragon removes the second
+sensor. The risk in doing so is **losing detection coverage**, so each concrete
+threat behaviour Kubescape's node-agent flagged is now covered explicitly:
+
+| Runtime threat behaviour | Now covered by |
 | --- | --- |
-| **Tetragon** | Compliance/CVE/posture correlation, learned-behaviour anomaly detection, the single-pane Kubescape view — i.e. *"is this CVE actually reachable at runtime?"* |
-| **Kubescape node-agent** | **Enforcement** — killing an offending process (SIGKILL) on a match (with `Override` available for true syscall-blocking) — and expressive low-overhead kernel-hook policies for system-file integrity |
+| Sensitive-file read / system-dir write | Tetragon [`monitor-sensitive-file-access`](../k8s/bases/infrastructure/tracing-policies/monitor-sensitive-file-access.yaml) (#1689) |
+| Process execution visibility | Tetragon built-in `process_exec` / `process_exit` (#1688) |
+| Kernel module load / unload (rootkits) | Tetragon [`monitor-privileged-operations`](../k8s/bases/infrastructure/tracing-policies/monitor-privileged-operations.yaml) (#1689) |
+| Process injection (`ptrace`) | Tetragon `monitor-privileged-operations` (#1689) |
+| Privilege / identity transitions (`setuid`/`setgid`) | Tetragon `monitor-privileged-operations` (#1689) |
+| System-file tampering — **active blocking** | Tetragon [`enforce-protect-system-files`](../k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml) (opt-in SIGKILL, #1690) |
+| Network flows / egress | **Cilium + Hubble** (already a separate layer — never was Kubescape's job here) |
 
-They sit at opposite ends of the detect → enforce spectrum:
+Net result: detection coverage of concrete behaviours is **maintained or
+improved** (enforcement is new), on a single runtime engine.
 
-```
-        Kubescape node-agent                         Tetragon
-   ┌────────────────────────────┐        ┌────────────────────────────┐
-   │ broad, learned, correlated │        │ narrow, declared, enforcing│
-   │ "something looks wrong AND  │        │ "this exact thing is        │
-   │  it maps to a known risk"   │   vs.  │  forbidden — kill it now"   │
-   │ detection only              │        │ detection + enforcement     │
-   └────────────────────────────┘        └────────────────────────────┘
-```
+### What we traded away (be honest about it)
 
-Consolidating onto either one would either give up the ability to **block**
-attacks (Kubescape-only) or give up **posture-correlated detection**
-(Tetragon-only). For a platform that is going public, we want both.
+Consolidation is not free. These Kubescape node-agent capabilities are **not**
+replicated by Tetragon and are gone until/unless we re-enable it:
 
----
+- **Learned-behaviour anomaly detection.** Tetragon matches rules you write; it
+  has no baseline of "normal" per workload, so genuinely novel/unknown bad
+  behaviour that doesn't trip an explicit policy won't be flagged.
+- **Posture-correlated runtime alerts.** Kubescape's single-pane *"this
+  container is misbehaving AND has an exploitable CVE AND violates control
+  C-00xx"* correlation no longer exists — Kubescape still scans config/CVE/
+  compliance, but no longer joins that to live runtime behaviour.
+- **Malware signature matching** (the node-agent's malware capability).
 
-## The cost we accept
-
-- **Two sets of eBPF programs** are loaded on every node (each sensor attaches
-  its own probes). That is real memory and a little CPU per node. On the
-  memory-constrained prod nodes this is bounded but not free — see
-  [`docs/node-autoscaling.md`](node-autoscaling.md) and the resource
-  right-sizing work for the budget context.
-- **Overlapping syscall visibility.** Both sensors can see `exec`/`open` events.
-  We accept the duplication because each consumes those events for a different
-  purpose (anomaly baseline vs. policy match).
+These are deliberate trade-offs for a single runtime engine plus enforcement,
+on memory-constrained nodes. Mitigations: the explicit `TracingPolicy` set
+above covers the high-value behaviours, Cilium/Hubble covers network, and the
+policy set can grow.
 
 ---
 
 ## When to revisit this decision
 
-This is a *deliberate* overlap, not a permanent one. Reopen it if either of
-these becomes true:
+Re-enable Kubescape `capabilities.runtimeDetection` (accepting the second eBPF
+sensor and its memory cost) if either becomes true:
 
-1. **Node memory pressure becomes acute.** The first lever is to narrow the
-   **heavier** sensor: set Kubescape `capabilities.runtimeDetection: disable`
-   (keeping its config-scan, image-CVE, and compliance scanning, which are its
-   real differentiators) and let **Tetragon own all runtime**. This trades
-   posture-correlated anomaly detection for a smaller footprint.
-2. **Tetragon's detection matures** — if observe-only `TracingPolicy` coverage
-   (plus any future anomaly tooling around it) grows to cover the cases we rely
-   on Kubescape's node-agent for, consolidating onto Tetragon becomes the
-   simpler architecture.
+1. **Learned-behaviour / posture-correlated detection becomes worth the cost** —
+   e.g. an incident slips past the explicit `TracingPolicy` set that an anomaly
+   baseline would have caught, and prod node memory has headroom for a second
+   sensor.
+2. **The explicit policy set proves too coarse** and maintaining parity by hand
+   (one policy per threat) becomes more work than running the learned sensor.
 
-Until one of those holds, **both run, by design.**
+Until then, **Tetragon owns runtime; Kubescape owns posture.**

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -30,13 +30,20 @@ spec:
       configurationScan: enable
       continuousScan: enable
       vulnerabilityScan: enable
-      runtimeDetection: enable
+      # Runtime threat detection is owned by Tetragon now (see
+      # docs/runtime-security.md and k8s/bases/infrastructure/tracing-policies/).
+      # Kubescape stays as the posture platform -- config/CVE/compliance
+      # scanning, its real differentiators -- and we drop its node-agent so the
+      # cluster runs a single eBPF runtime sensor. This is the documented
+      # "revisit" path #1 in docs/runtime-security.md: it trades Kubescape's
+      # learned-behaviour anomaly detection for Tetragon's explicit, low-overhead
+      # TracingPolicies (file integrity, privileged ops) plus enforcement.
+      runtimeDetection: disable
+    # Host configuration scanning (CIS/NSA host checks) is posture, not runtime,
+    # so it stays enabled. The node-agent runtime host sensor is intentionally
+    # not configured -- runtimeDetection above is off.
     hostScanner:
       enabled: true
-    nodeAgent:
-      config:
-        hostSensor:
-          enabled: true
     # Hetzner CSI provisions a minimum 10Gi volume; match the PVC request
     # to avoid Helm upgrade failures from PVC shrink rejection.
     persistence:


### PR DESCRIPTION
> ⛔ **MERGE-ORDER DEPENDENCY — do not merge before [#1689](https://github.com/devantler-tech/platform/pull/1689).**
> This turns **off** Kubescape's runtime threat detection. #1689 adds the Tetragon `TracingPolicy` set that replaces it. Merging this first would leave a runtime-detection gap (Tetragon would have only built-in exec events). **Order: #1689 → (#1690) → this.** #1690 (enforcement) is a bonus, not required for detection parity.

## What

Disables the second eBPF runtime sensor. Kubescape's node-agent runtime threat detection is turned off; **Tetragon becomes the sole runtime engine** (detection + enforcement). Kubescape stays as the **posture platform** (config / CVE / compliance scanning, host CIS checks — all kept).

```diff
 capabilities:
   configurationScan: enable
   continuousScan: enable
   vulnerabilityScan: enable
-  runtimeDetection: enable
+  runtimeDetection: disable
-nodeAgent:
-  config:
-    hostSensor:
-      enabled: true
```

Plus a full rewrite of [`docs/runtime-security.md`](docs/runtime-security.md) from "why two sensors" to "Tetragon owns runtime, Kubescape owns posture."

## Why this doesn't lessen security (parity matrix)

Every concrete runtime threat behaviour Kubescape's node-agent flagged is now covered explicitly:

| Threat behaviour | Now covered by |
| --- | --- |
| Sensitive-file read / system-dir write | Tetragon `monitor-sensitive-file-access` (#1689) |
| Process execution visibility | Tetragon built-in `process_exec`/`exit` (#1688, merged) |
| Kernel module load/unload (rootkits) | Tetragon `monitor-privileged-operations` (#1689) |
| Process injection (`ptrace`) | Tetragon `monitor-privileged-operations` (#1689) |
| Privilege transitions (`setuid`/`setgid`) | Tetragon `monitor-privileged-operations` (#1689) |
| System-file tampering — **active blocking** | Tetragon `enforce-protect-system-files` (#1690, opt-in SIGKILL) — *new capability kubescape never had* |
| Network flows / egress | Cilium + Hubble (separate layer, unchanged) |

Detection of concrete behaviours is **maintained**, and enforcement is **added**.

## What we trade away (honest)

Not replicable by Tetragon's rule-based model, and gone until/unless re-enabled:
- **Learned-behaviour anomaly detection** (no per-workload "normal" baseline).
- **Posture-correlated runtime alerts** (Kubescape still scans config/CVE/compliance, but no longer joins that to live runtime behaviour).
- **Malware-signature matching.**

These are the documented trade-offs (see the rewritten doc → "When to revisit"). The driver is one runtime sensor on memory-constrained prod nodes.

## Validation

| Check | Result |
| --- | --- |
| `ksail workload validate` (local + prod) | ✅ |
| `kubectl kustomize` both overlays | ✅ render `runtimeDetection: disable` |

## Note

Kubescape's `vulnerabilityScan` relevancy may still run a lightweight node-agent; if you want the node-agent **fully** gone for max resource savings, that's a follow-up (disable relevancy). This PR does the literal runtime-detection switch.
