### PR TITLE
fix(observability): raise loki memory limit to 1Gi to stop OOMKills

### DIFF
--- a/k8s/bases/infrastructure/controllers/loki/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/loki/helm-release.yaml
@@ -76,9 +76,17 @@ spec:
       resources:
         requests:
           cpu: 50m
-          memory: 128Mi
+          # 128Mi -> 256Mi: shipping the kube-apiserver audit log to Loki
+          # (#1696) raised steady-state ingest; VPA now recommends ~728Mi.
+          # A warmer floor covers cold start before VPA's Initial-mode
+          # recommendation re-applies on pod (re)creation.
+          memory: 256Mi
         limits:
-          memory: 512Mi
+          # 512Mi -> 1Gi: the old cap sat below the VPA target (~728Mi), so
+          # VPA (controlledValues: RequestsOnly) could not raise the request
+          # past the limit and Loki was OOMKilled. 1Gi clears the target with
+          # headroom for further audit-log ingest growth.
+          memory: 1Gi
     # Single-binary mode only -- zero out the scalable-topology targets.
     backend:
       replicas: 0


### PR DESCRIPTION
## Problem

`loki-0` is being **OOMKilled** in prod. Live read-only measurement (`admin@prod`, 2026-06-02):

- VPA target for the `loki` container: **~728Mi**
- Pod pinned at **request 512Mi / limit 512Mi** (Guaranteed QoS)
- `lastState.terminated.reason: OOMKilled`, `restartCount: 1`

**Root cause:** shipping the kube-apiserver audit log to Loki (#1696) raised steady-state ingest, pushing Loki past the old 512Mi limit. `auto-vpa` runs with `controlledValues: RequestsOnly`, so VPA raises the *request* toward its target but never touches the *limit* — and a request can't exceed the limit. Loki was therefore capped below its known need and couldn't self-heal.

## Change

`k8s/bases/infrastructure/controllers/loki/helm-release.yaml` — `singleBinary.resources`:

| | before | after |
|---|---|---|
| `limits.memory` | 512Mi | **1Gi** |
| `requests.memory` | 128Mi | **256Mi** |

- **Limit → 1Gi** clears the ~728Mi VPA target with headroom for further audit-log ingest growth.
- **Request → 256Mi** warms the cold-start floor before VPA's `Initial`-mode recommendation re-applies on pod recreation (the HelmRelease change itself recreates the pod).

This is the urgent point-fix. A companion PR addresses the systemic cause (limits not tracking VPA) cluster-wide.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` build.
- hetzner + docker provider overlays build; loki renders `limits.memory: 1Gi`, `requests.memory: 256Mi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
