### PR TITLE
fix(resources): let VPA manage limits (RequestsAndLimits) to prevent OOMKills

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -44,7 +44,15 @@ spec:
               containerPolicies:
                 - containerName: "*"
                   controlledResources: ["cpu", "memory"]
-                  controlledValues: RequestsOnly
+                  # RequestsAndLimits (not RequestsOnly): VPA also scales each
+                  # container's limit in proportion to the request it sets,
+                  # preserving the authored limit:request ratio. Under
+                  # RequestsOnly the limit stayed fixed, so any workload whose
+                  # VPA target outgrew its static memory limit was capped below
+                  # its known need and OOMKilled (e.g. loki once audit-log
+                  # ingest grew). The request is still bounded by maxAllowed
+                  # below; CPU limits only loosen (less throttling, no OOM).
+                  controlledValues: RequestsAndLimits
                   minAllowed:
                     # CPU floor lowered 50m->15m: live data showed 87 containers
                     # pinned at the 50m floor using avg 4.4m — VPA was floored,
@@ -95,7 +103,15 @@ spec:
               containerPolicies:
                 - containerName: "*"
                   controlledResources: ["cpu", "memory"]
-                  controlledValues: RequestsOnly
+                  # RequestsAndLimits (not RequestsOnly): VPA also scales each
+                  # container's limit in proportion to the request it sets,
+                  # preserving the authored limit:request ratio. Under
+                  # RequestsOnly the limit stayed fixed, so any workload whose
+                  # VPA target outgrew its static memory limit was capped below
+                  # its known need and OOMKilled (e.g. loki once audit-log
+                  # ingest grew). The request is still bounded by maxAllowed
+                  # below; CPU limits only loosen (less throttling, no OOM).
+                  controlledValues: RequestsAndLimits
                   minAllowed:
                     # CPU floor lowered 50m->15m: live data showed 87 containers
                     # pinned at the 50m floor using avg 4.4m — VPA was floored,
@@ -140,7 +156,15 @@ spec:
               containerPolicies:
                 - containerName: "*"
                   controlledResources: ["cpu", "memory"]
-                  controlledValues: RequestsOnly
+                  # RequestsAndLimits (not RequestsOnly): VPA also scales each
+                  # container's limit in proportion to the request it sets,
+                  # preserving the authored limit:request ratio. Under
+                  # RequestsOnly the limit stayed fixed, so any workload whose
+                  # VPA target outgrew its static memory limit was capped below
+                  # its known need and OOMKilled (e.g. loki once audit-log
+                  # ingest grew). The request is still bounded by maxAllowed
+                  # below; CPU limits only loosen (less throttling, no OOM).
+                  controlledValues: RequestsAndLimits
                   minAllowed:
                     # CPU floor lowered 50m->15m: live data showed 87 containers
                     # pinned at the 50m floor using avg 4.4m — VPA was floored,

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -41,10 +41,17 @@ patches:
       - op: replace
         path: /spec/rules/0/generate/data/spec/hard
         value:
+          # Quota only the REQUESTS dimension. auto-vpa.yaml runs VPA with
+          # controlledValues: RequestsAndLimits, so VPA raises container LIMITS
+          # dynamically (ratio-preserving). A static limits.cpu/limits.memory
+          # quota would then reject the very rollouts VPA triggers once limits
+          # rise -- an unrecoverable evict-then-can't-recreate loop -- and
+          # monitoring already sat at 96% of limits.cpu=16. requests.* still
+          # govern aggregate reserved capacity (each pod's request is bounded by
+          # VPA maxAllowed), which is the dimension that actually reserves node
+          # resources; limits are burst ceilings VPA now owns per pod.
           requests.cpu: "8"
           requests.memory: 16Gi
-          limits.cpu: "16"
-          limits.memory: 32Gi
       - op: add
         path: /spec/rules/1/exclude
         value:


### PR DESCRIPTION
## Problem

Requests are well right-sized in this cluster — VPA is healthy and its updater is applying recommendations (confirmed live: `EvictedByVPA` events firing, requests tracking VPA targets). The **unaddressed dimension is memory limits.**

`auto-vpa` generated every VPA with `controlledValues: RequestsOnly`, so VPA raises the *request* toward its recommendation but never touches the *limit*. A request can't exceed its limit, so when the recommendation outgrows the container's static memory limit the workload is **capped below its known need and OOMKilled** — and VPA can't self-heal.

Live read-only measurement (`admin@prod`, 2026-06-02) — workloads where the VPA memory **target already exceeds the limit**:

| VPA wants > limit | workload | status |
|---|---|---|
| 728 > 512Mi | monitoring/loki | **actively OOMKilled** |
| 422 > 256Mi | monitoring/grafana | at risk |
| 137 > 128Mi | monitoring/alloy | at risk |
| 100 > 64Mi | ascoachingogvaner, 3× keda-add-ons-http | at risk |
| 100 > 32Mi | kubelet-serving-cert-approver | at risk |

## Change

**1. `auto-vpa.yaml` — flip `controlledValues: RequestsOnly` → `RequestsAndLimits`** in all three rules (Deployment / StatefulSet / DaemonSet). VPA now scales the limit in proportion to the request it sets, **preserving each container's authored `limit:request` ratio**, so limits stay ahead of the recommended request. Fixes the whole class systemically (and future workloads), not one at a time.

**2. `cluster-policies/kustomization.yaml` — quota only `requests.*`, drop `limits.*` from the `add-ns-quota` ResourceQuota.** (Addresses the review feedback below.) With VPA now raising *limits* dynamically, a static `limits.cpu: 16` / `limits.memory: 32Gi` namespace quota would reject the rollouts VPA itself triggers once limits rise — an unrecoverable evict-then-can't-recreate loop. **Live data: `monitoring` was already at 15.5/16 `limits.cpu` (96%)**, so any upward CPU-limit movement there would break admission. `requests.cpu: 8` / `requests.memory: 16Gi` are kept — that's the dimension that actually reserves node capacity (and each pod's request is bounded by VPA `maxAllowed`), so aggregate cost governance is preserved; limits are burst ceilings VPA now owns per pod. No LimitRange `max` exists, so the quota was the only admission blocker.

## Trade-offs / safety

- **Request** is still bounded by VPA `maxAllowed` (3 CPU / 6Gi for Deploy+STS, 1 CPU / 1Gi for DaemonSets), so scheduling can't over-commit.
- **CPU limits only loosen** (higher throttle ceiling) — never causes an OOM.
- **Memory limits become dynamic** rather than a fixed ceiling; for the realistic ratios here (≤4:1) they scale sanely. Node memory-pressure eviction remains the backstop.
- **StatefulSets** keep `updateMode: Initial` (no mid-flight eviction → no Multi-Attach outage), so their limits adjust on the next natural restart.

## Companion PR

[#1708](https://github.com/devantler-tech/platform/pull/1708) is the urgent point-fix raising loki's explicit limit to 1Gi for immediate relief (StatefulSet `Initial` mode means loki won't pick up this policy change until its next restart). This PR prevents recurrence cluster-wide.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/cluster-policies/` builds; renders `controlledValues: RequestsAndLimits` ×3 / `RequestsOnly` ×0, and the generated ResourceQuota has **0** `limits.cpu`/`limits.memory` (requests.* only).
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` build.
- `kubectl apply --dry-run=client` on `auto-vpa.yaml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
