### PR TITLE
feat(security): add Tetragon enforcement as a complement to Kubescape

### DIFF
--- a/docs/runtime-security.md
+++ b/docs/runtime-security.md
@@ -70,17 +70,15 @@ misbehaved; it will not stop it.
 
 ### Tetragon — *enforcement and precise kernel observability*
 
-Being introduced via the stacked PRs
-[#1688](https://github.com/devantler-tech/platform/pull/1688) (install +
-observability), [#1689](https://github.com/devantler-tech/platform/pull/1689)
-(observe-only `TracingPolicy` for sensitive files), and
-[#1690](https://github.com/devantler-tech/platform/pull/1690) (opt-in
-enforcement). Lives under
-`k8s/bases/infrastructure/controllers/tetragon/` and
+Installed via [#1688](https://github.com/devantler-tech/platform/pull/1688)
+(agent + operator), with its enforcement policy under
 `k8s/bases/infrastructure/tracing-policies/`.
 
-Tetragon is a **purpose-built runtime engine**. Two things make it
-complementary rather than redundant:
+Tetragon's job here is the one thing Kubescape's node-agent cannot do:
+**enforcement**. We deliberately do **not** use Tetragon to duplicate
+Kubescape's runtime *detection* (anomaly profiling, sensitive-file/exec/network
+visibility, posture correlation) — that is Kubescape's domain and it does it
+better. Tetragon adds:
 
 1. **Enforcement.** A `TracingPolicy` can carry a `SIGKILL` action that
    **terminates the offending process** as soon as Tetragon observes a matching
@@ -88,17 +86,19 @@ complementary rather than redundant:
    termination — the triggering syscall may already have completed, so it kills
    the **process**, it does not block the call. (Tetragon's `Override` action can
    block the syscall itself where the kernel supports it; this platform uses
-   SIGKILL — see #1690.) Either way it does something a detection-only tool
-   can't: it stops the workload rather than just alerting. Opt-in per workload
-   (via a pod label) so it starts safe.
+   SIGKILL.) It does something a detection-only tool can't: it stops the
+   workload rather than just alerting. The policy
+   ([`enforce-protect-system-files.yaml`](../k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml))
+   is **opt-in per workload** via a pod label, so it starts safe — zero blast
+   radius until a workload opts in.
 2. **Precise, declarative kernel hooks.** `TracingPolicy` targets specific
-   kprobes/tracepoints (a syscall, an LSM hook, a file path) with low overhead,
-   rather than profiling everything. That makes it the right tool for narrow,
-   high-value invariants like "no one rewrites `/etc` or the kubelet binary."
+   kprobes/tracepoints (a syscall, an LSM hook, a file path) with low overhead.
+   That makes it the right tool for narrow, high-value *invariants you enforce*,
+   like "no one rewrites `/etc` or a system binary."
 
-What it does **not** do: it has no notion of compliance frameworks, image CVEs,
-or a learned baseline of "normal" — it enforces and observes the rules *you
-write*, nothing more.
+What it does **not** do: no compliance frameworks, image CVEs, or a learned
+"normal" baseline — and, **by choice, no standalone detection policies** (that
+would duplicate Kubescape). It enforces the rules *you write*.
 
 ---
 
@@ -142,17 +142,19 @@ attacks (Kubescape-only) or give up **posture-correlated detection**
 
 ## When to revisit this decision
 
-This is a *deliberate* overlap, not a permanent one. Reopen it if either of
-these becomes true:
+Running two eBPF sensors is a *deliberate* overlap — **Kubescape for detection,
+Tetragon for the enforcement Kubescape lacks** — not a permanent one. Reopen it
+if either becomes true:
 
-1. **Node memory pressure becomes acute.** The first lever is to narrow the
-   **heavier** sensor: set Kubescape `capabilities.runtimeDetection: disable`
-   (keeping its config-scan, image-CVE, and compliance scanning, which are its
-   real differentiators) and let **Tetragon own all runtime**. This trades
-   posture-correlated anomaly detection for a smaller footprint.
-2. **Tetragon's detection matures** — if observe-only `TracingPolicy` coverage
-   (plus any future anomaly tooling around it) grows to cover the cases we rely
-   on Kubescape's node-agent for, consolidating onto Tetragon becomes the
-   simpler architecture.
+1. **Kubescape gains comparable enforcement.** Tetragon exists here specifically
+   because Kubescape's node-agent is detection-only. If Kubescape (or whatever
+   posture platform we run) ships process-killing / syscall-blocking enforcement
+   we trust, Tetragon's reason to exist shrinks to its precise kernel-hook
+   policies — at which point dropping Tetragon and letting Kubescape own all
+   runtime becomes the simpler architecture.
+2. **Node memory pressure becomes acute.** Two sensors cost memory per node. The
+   preferred lever is to trim **Tetragon** to only the enforcement policies in
+   active use — *not* to disable Kubescape's runtime detection, which is the
+   capability we lean on most (use Kubescape as much as possible).
 
-Until one of those holds, **both run, by design.**
+Until one of those holds, **both run: Kubescape detects, Tetragon enforces.**

--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -44,6 +44,15 @@ spec:
   # change -- the Override action additionally needs CONFIG_BPF_KPROBE_OVERRIDE
   # verified on the pinned Talos kernel.
   values:
+    # CRDs (TracingPolicy, ...) are rendered by the chart and applied by Flux
+    # (the helm.toolkit.fluxcd.io/crds label above) at release install, instead
+    # of the chart default of the operator installing them at runtime. This
+    # makes the CRD deterministically present before the `infrastructure` Flux
+    # layer (dependsOn infrastructure-controllers, wait:true) applies the
+    # enforce-protect-system-files TracingPolicy -- avoiding a CRD-not-found
+    # race on first reconcile.
+    crds:
+      installMethod: helm
     # ------------------------------------------------------------------
     # Talos: tracefs is mounted at /sys/kernel/tracing (debugfs is NOT
     # mounted on Talos), and Tetragon needs it to attach kprobes /

--- a/k8s/bases/infrastructure/kustomization.yaml
+++ b/k8s/bases/infrastructure/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - gateway/
   - http-scaled-objects/
   - security-exceptions/
+  - tracing-policies/
   - vault-config/
   - vault-backup/
   - vault-seed/

--- a/k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml
+++ b/k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml
@@ -1,0 +1,72 @@
+---
+# ENFORCING TracingPolicy: SIGKILLs any process that attempts to WRITE to
+# system / binary directories (a classic tampering / persistence pattern).
+#
+# This is Tetragon's role on the platform: ENFORCEMENT -- the capability
+# Kubescape's node-agent lacks. Runtime *detection* (anomaly profiling,
+# sensitive-file/exec/network visibility, posture correlation) is owned by
+# Kubescape; Tetragon is not used to duplicate it. See docs/runtime-security.md.
+#
+# OPT-IN, ZERO DEFAULT BLAST RADIUS:
+#   spec.podSelector matches only pods carrying the label
+#   `tetragon.devantler.tech/enforce-file-integrity: "true"`. With no pod
+#   labelled, this policy enforces on nothing. Requires the policy filter,
+#   which is enabled on the agent (tetragon.enablePolicyFilter: true).
+#
+# Scope: writes only (system daemons legitimately *read* /etc/shadow etc.), and
+# /var/log + /dev/log are intentionally excluded (legitimate log writes).
+#
+# Rollout: add the label to one workload's pods, watch Kubescape runtime
+# detection (and Tetragon's own events in Loki) to confirm no legitimate writes
+# would be killed, then widen.
+#
+# Action choice: `Sigkill` is a post-hook signal and needs no special kernel
+# config. The stronger `Override` action (fail the syscall before it executes)
+# requires CONFIG_BPF_KPROBE_OVERRIDE -- verify on the pinned Talos kernel
+# before switching to Override.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: enforce-protect-system-files
+spec:
+  podSelector:
+    matchLabels:
+      tetragon.devantler.tech/enforce-file-integrity: "true"
+  kprobes:
+    - call: "security_file_permission"
+      syscall: false
+      return: true
+      args:
+        - index: 0
+          type: "file" # (struct file *) used for getting the path
+        - index: 1
+          type: "int" # 0x04 is MAY_READ, 0x02 is MAY_WRITE
+      returnArg:
+        index: 0
+        type: "int"
+      selectors:
+        - matchArgs:
+            - index: 0
+              operator: "Prefix"
+              values:
+                - "/etc"
+                - "/boot"
+                - "/lib"
+                - "/lib64"
+                - "/bin"
+                - "/usr/lib"
+                - "/usr/local/lib"
+                - "/usr/local/sbin"
+                - "/usr/local/bin"
+                - "/usr/bin"
+                - "/usr/sbin"
+                - "/root/.ssh"
+            - index: 1
+              # Bitmask, not exact match: fires when the MAY_WRITE (0x2) bit is
+              # set, including combined read+write opens (0x6). Equal "2" would
+              # miss O_RDWR opens -- a real enforcement-evasion gap.
+              operator: "Mask"
+              values:
+                - "2" # MAY_WRITE bit
+          matchActions:
+            - action: Sigkill

--- a/k8s/bases/infrastructure/tracing-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/tracing-policies/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - enforce-protect-system-files.yaml


### PR DESCRIPTION
## What

Re-aligns the Tetragon work to the decision: **use Kubescape as much as possible (it stays the primary runtime detector + posture platform), and have Tetragon complement it only where Kubescape falls short — enforcement.**

- Adds the opt-in enforcing `TracingPolicy` [`enforce-protect-system-files`](k8s/bases/infrastructure/tracing-policies/enforce-protect-system-files.yaml): **SIGKILL** on writes to system/binary dirs (`/etc`, `/usr/bin`, `/lib`, `/boot`, `/root/.ssh`, …), gated by the pod label `tetragon.devantler.tech/enforce-file-integrity=true` → **zero blast radius** until a workload opts in.
- `crds.installMethod: helm` on the Tetragon HelmRelease so the `TracingPolicy` CRD is present before the `infrastructure` layer applies the policy (no first-reconcile race).
- Wires `tracing-policies/` into the base infrastructure kustomization.
- Rewrites `docs/runtime-security.md` to the Kubescape-primary / Tetragon-enforcement framing.

## What is intentionally NOT here

- **No standalone Tetragon detection policies.** Runtime *detection* (anomaly profiling, sensitive-file/exec visibility, posture/CVE correlation) is Kubescape's job and stays with Kubescape. Duplicating it in Tetragon would be redundant.
- **Kubescape `runtimeDetection` stays `enable`** (this PR doesn't touch kubescape).

## Security-correctness note

The enforce policy matches the write bit with **`Mask "2"`**, not `Equal "2"` — an `Equal` match would miss `O_RDWR` opens (access mask `0x6`), letting a process write to a protected path while evading the SIGKILL. (Same class of bug Copilot flagged on the now-superseded #1689; carried the fix forward, where for *enforcement* it actually matters.)

## Supersedes / closes

This consolidates and replaces the stacked Tetragon-policy PRs:
- **Supersedes #1690** — enforcement, consolidated here (off current `main`, so no stale-stack rebase needed).
- **Supersedes #1689** — its observe-only detection policies are dropped as redundant with Kubescape (the `crds.installMethod: helm` change is carried here).
- **Abandons #1707** — disabling Kubescape `runtimeDetection` is the opposite of this decision.

(#1688 — the Tetragon install — is already merged and unchanged.)

## Validation

| Check | Result |
| --- | --- |
| `ksail workload validate` (local + prod) | ✅ 266 files |
| `kubectl kustomize` both overlays | ✅ 1 TracingPolicy (enforce), kubescape `runtimeDetection: enable` unchanged |
