### PR TITLE
fix(resources): right-size cilium-envoy and operator memory to live usage

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -79,10 +79,15 @@ spec:
           enabled: false
     operator:
       replicas: ${cilium_replicas:=2}
+      # memory 256Mi -> 128Mi: live prod usage is 36-77Mi across both
+      # replicas (2026-06-03). 128Mi keeps the operator in Burstable QoS
+      # (request > 0 -- the BestEffort escape that matters) with ~1.7x
+      # headroom over the observed peak. The operator runs on the
+      # control-plane nodes, so this frees control-plane memory requests.
       resources:
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 128Mi
       podDisruptionBudget:
         enabled: true
         minAvailable: 1
@@ -115,7 +120,13 @@ spec:
       resources:
         requests:
           cpu: 50m
-          memory: 128Mi
+          # memory 128Mi -> 64Mi: the standalone cilium-envoy DaemonSet uses
+          # only 17-29Mi per node in live prod (2026-06-03). 64Mi keeps it in
+          # Burstable QoS (still out of BestEffort, so it survives node memory
+          # pressure -- the protection this block exists for) with >2x headroom
+          # over peak, while freeing ~64Mi of reserved-unused request on every
+          # node (~256Mi across the workers, which sat at 98-99% memory requests).
+          memory: 64Mi
     # Transparent WireGuard encryption for all pod-to-pod and node-to-node
     # traffic.  KubeSpan (Talos-layer WireGuard between nodes) is not
     # enabled in this cluster, so without this setting inter-node pod


### PR DESCRIPTION
## Summary

Right-sizes the two over-provisioned **cilium** memory requests to match live prod usage, reclaiming reserved-unused memory on a cluster that is running hot.

| Component | Request (before → after) | Live usage (2026-06-03) | Headroom | Runs on |
|---|---|---|---|---|
| `cilium-envoy` (DaemonSet) | `128Mi → 64Mi` | 17–29Mi / node | >2× peak | every node (≈256Mi freed across 4 workers) |
| `cilium-operator` (2 replicas) | `256Mi → 128Mi` | 36–77Mi total | ~1.7× peak | control planes |

CPU and limits are unchanged. `cilium-agent` (512Mi) and SPIRE (128Mi) floors are left untouched.

## Why

Investigation of the right-sizing implementation found it is **mature and working**: VPA (`auto-vpa` Kyverno policy, `RequestsAndLimits`) manages everything outside `kube-system`, and the recent #1708 / #1709 fixes resolved the OOMKill gap (verified live — zero OOMKills). The request side is otherwise **exhausted**: VPA-managed workloads sit at peak-based targets, and the other large `kube-system` requests (cilium-agent, SPIRE) are deliberate QoS floors that must not shrink.

Meanwhile the cluster is under genuine memory pressure — workers 1–3 at **98–99% memory requests**, with recent `FailedScheduling: Insufficient memory` on grafana/headlamp. The Cluster Autoscaler currently **cannot add capacity** (Hetzner rejects both pools with `invalid input in field 'user_data'`); that fix lives in `ksail.prod.yaml` / KSail and is out of scope for this repo.

cilium-envoy/operator were the only safely-reclaimable items left: both keep **Burstable QoS** (`request > 0` — the BestEffort-escape that keeps the datapath alive under node memory pressure), losing only the reserved magnitude while retaining >2× / ~1.7× headroom over observed peaks.

## Validation

- `ksail workload validate` (local) — ✔ 266 files
- `ksail --config ksail.prod.yaml workload validate` (prod) — ✔ 266 files
- `kubectl kustomize` builds: hetzner + docker provider controllers, and `clusters/{local,prod}` — all OK; rendered values confirmed (envoy 64Mi, operator 128Mi, agent/SPIRE unchanged).

## Notes / follow-up

- Applying this triggers a rolling restart of the cilium-envoy DaemonSet + cilium-operator (normal cilium rollout).
- **Root cause of the capacity crunch is the broken autoscaler** (`user_data` rejection in `ksail.prod.yaml`/KSail) — not fixable here. Recommend addressing it where it lives so the cluster can self-heal capacity again rather than relying on the manually-added `prod-worker-4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
