### PR TITLE
fix(homepage): relax liveness/readiness probe timeout under node pressure

### DIFF
--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -74,6 +74,24 @@ spec:
                   periodSeconds: 5
                   timeoutSeconds: 3
                   failureThreshold: 12  # 60s grace beyond initial delay
+              # Once the startupProbe succeeds, liveness/readiness take over
+              # with the chart's tight timeoutSeconds: 1. When a replica lands
+              # on a CPU-pressured node its event loop is briefly starved and
+              # GET / can't answer within 1s, so liveness fails 3×10s and
+              # SIGTERMs an otherwise-healthy pod (observed in steady state:
+              # 4 restarts, exitCode 0 / Completed, 119Mi of 512Mi — not an
+              # OOMKill). Relax the timeout, and make liveness slower to act,
+              # so transient starvation doesn't restart a healthy pod; a
+              # genuinely hung container is still caught within ~60s.
+              - op: add
+                path: /spec/template/spec/containers/0/livenessProbe/timeoutSeconds
+                value: 5
+              - op: add
+                path: /spec/template/spec/containers/0/livenessProbe/failureThreshold
+                value: 6
+              - op: add
+                path: /spec/template/spec/containers/0/readinessProbe/timeoutSeconds
+                value: 5
           # Flicker fix: with replicaCount=2 and the chart's default ClusterIP
           # service, the Kubernetes widget's poll for node/cluster CPU/memory
           # round-robins between two pods that each maintain their own


### PR DESCRIPTION
## Problem

Investigating recurring `Unhealthy` warning events on prod surfaced `homepage-5746b7679b-2k6v4` (on `prod-worker-3`) being restarted by its **liveness probe** — 4 restarts, all with `lastState.terminated.reason: Completed`, `exitCode: 0` (graceful SIGTERM from the kubelet), at steady-state uptime (4h+), using only **119Mi of its 512Mi** limit. So it is **not** an OOMKill — it is a healthy pod being killed by an over-aggressive probe.

Root cause: the upstream chart hardcodes liveness/readiness with `timeoutSeconds: 1`. The existing post-renderer added a `startupProbe` that only gates the ~13s **cold-start** window; once it passes, the tight 1s probes take over. When a replica lands on a CPU-pressured node, homepage's (Node.js) event loop is briefly starved and `GET /` can't answer within 1s → liveness fails 3×10s → SIGTERM → restart. The sibling replica on a less-pressured node (`prod-worker-2`) has 0 restarts.

## Fix

Extend the existing Deployment post-renderer to relax the steady-state probes:

| Probe | Field | Before | After |
|-------|-------|--------|-------|
| liveness | `timeoutSeconds` | 1 | 5 |
| liveness | `failureThreshold` | 3 | 6 |
| readiness | `timeoutSeconds` | 1 | 5 |

A genuinely hung container is still restarted within ~60s; transient CPU starvation no longer kills a healthy pod.

## Scope

This addresses the probe fragility only. The underlying driver — **memory/CPU request inflation on workers 1–3** (~97–99% of memory *requested* vs ~64–70% *used*, which is also why pods spill onto newly-added nodes) — is tracked separately under the ongoing VPA/right-sizing work and is out of scope here.

## Validation

- `kubectl kustomize k8s/providers/hetzner/apps` — builds; the three patch ops render into the homepage HelmRelease with the expected paths/values.
- `kubectl kustomize k8s/providers/docker/apps` — builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
