### PR TITLE
feat(autoscaling): right-size kube-system workloads via VPA (drop exclusion)

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -7,14 +7,19 @@
 # control-plane pods (kube-apiserver/etcd/scheduler/controller-manager) are
 # bare Pods, not Deployment/StatefulSet/DaemonSet, so they never match.
 #
-# EVICTION CAVEAT: the InPlacePodVerticalScaling feature gate is alpha and
-# off on this k8s 1.32 cluster, so updateMode InPlaceOrRecreate falls back
-# to Recreate -- VPA applies a recommendation by EVICTING the pod. For the
+# IN-PLACE RESIZE (no eviction) requires k8s >= 1.33, where the
+# InPlacePodVerticalScaling feature gate is beta and ON by default. VPA here
+# is already 1.6 (its own InPlaceOrRecreate gate defaults on since 1.5) and
+# the rules below already set updateMode InPlaceOrRecreate, so nothing else
+# needs to change -- the cluster just has to run >= 1.33.
+#
+# On k8s < 1.33 the gate is alpha/off, so InPlaceOrRecreate falls back to
+# Recreate: VPA applies a recommendation by EVICTING the pod. For the
 # kube-system DaemonSets (cilium / spire-agent) that is a brief per-node
 # datapath blip as each pod restarts, one node at a time; spire-server
-# (StatefulSet) uses updateMode Initial and is never evicted. Enable
-# InPlacePodVerticalScaling (Talos kubelet + apiserver feature gate) to make
-# these resizes non-disruptive.
+# (StatefulSet) uses updateMode Initial and is never evicted. Until prod is
+# upgraded to >= 1.33 (target 1.34; Talos 1.12 supports k8s 1.30-1.35),
+# expect a one-time round of such evictions as VPA applies its initial recs.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -1,4 +1,20 @@
 # TODO: Upstream `auto-vpa.yaml` to Kyverno policies repository.
+#
+# kube-system is intentionally NOT excluded: its controllers (cilium,
+# cilium-envoy, spire-agent, coredns, metrics-server, hubble, hcloud
+# ccm/csi, tetragon, cluster-autoscaler) carry ~10Gi of hand-tuned request
+# floors that VPA can right-size to observed usage instead. Static
+# control-plane pods (kube-apiserver/etcd/scheduler/controller-manager) are
+# bare Pods, not Deployment/StatefulSet/DaemonSet, so they never match.
+#
+# EVICTION CAVEAT: the InPlacePodVerticalScaling feature gate is alpha and
+# off on this k8s 1.32 cluster, so updateMode InPlaceOrRecreate falls back
+# to Recreate -- VPA applies a recommendation by EVICTING the pod. For the
+# kube-system DaemonSets (cilium / spire-agent) that is a brief per-node
+# datapath blip as each pod restarts, one node at a time; spire-server
+# (StatefulSet) uses updateMode Initial and is never evicted. Enable
+# InPlacePodVerticalScaling (Talos kubelet + apiserver feature gate) to make
+# these resizes non-disruptive.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -10,7 +26,9 @@ metadata:
     policies.kyverno.io/subject: Deployment,StatefulSet,DaemonSet
     policies.kyverno.io/description: >-
       Generates a VerticalPodAutoscaler for every Deployment, StatefulSet,
-      and DaemonSet outside kube-system. VPA controls both CPU and memory
+      and DaemonSet in every namespace, including kube-system, so the
+      cluster's control-plane add-ons and datapath controllers are
+      right-sized to observed usage too. VPA controls both CPU and memory
       to ensure workloads do not over-request resources. KEDA-managed
       workloads use HTTP request rate (not CPU) for horizontal scaling,
       so VPA CPU management does not conflict.
@@ -21,10 +39,6 @@ spec:
         resources:
           kinds:
             - Deployment
-      exclude:
-        resources:
-          namespaces:
-            - kube-system
       generate:
         apiVersion: autoscaling.k8s.io/v1
         kind: VerticalPodAutoscaler
@@ -74,10 +88,6 @@ spec:
         resources:
           kinds:
             - StatefulSet
-      exclude:
-        resources:
-          namespaces:
-            - kube-system
       generate:
         apiVersion: autoscaling.k8s.io/v1
         kind: VerticalPodAutoscaler
@@ -133,10 +143,6 @@ spec:
         resources:
           kinds:
             - DaemonSet
-      exclude:
-        resources:
-          namespaces:
-            - kube-system
       generate:
         apiVersion: autoscaling.k8s.io/v1
         kind: VerticalPodAutoscaler


### PR DESCRIPTION
## Summary

Removes the `kube-system` exclusion from the `auto-vpa` Kyverno policy so VPA right-sizes kube-system controllers like every other namespace. kube-system is the cluster's largest namespace (~10Gi of requests) and was the only one VPA didn't manage — its values were hand-tuned static floors.

Now VPA-managed: `cilium`, `cilium-envoy`, `spire-agent`, `tetragon`, `hcloud-csi-node` (DaemonSets); `coredns`, `metrics-server`, `hubble-relay/ui`, `cilium-operator`, `hcloud-ccm`, `hcloud-csi-controller`, `cluster-autoscaler`, `tetragon-operator` (Deployments); `spire-server` (StatefulSet).

## Why

Investigation found the request side was "exhausted" only because kube-system — the biggest consumer — sat outside VPA. Letting VPA manage it is the natural way to right-size those ~10Gi of hand-tuned floors to actual usage (e.g. cilium-envoy 128Mi→~64Mi, coredns 70Mi→~64Mi) and keep them tracking real demand over time, rather than maintaining the numbers by hand.

## Safety analysis

- **No quota collision.** `add-ns-quota` already excludes kube-system, so there is no `ResourceQuota`/`LimitRange` for VPA's adjusted requests/limits to fight (the #1709 failure mode does not apply here).
- **Static control-plane pods are untouched.** kube-apiserver / etcd / scheduler / controller-manager are bare `Pod`s (kubelet static pods), not Deployment/StatefulSet/DaemonSet — they never match the policy rules.
- **spire-server never evicts.** The StatefulSet rule uses `updateMode: Initial`, so spire-server only picks up recommendations on a natural restart.
- **`minReplicas: 1` + existing PDBs** (coredns, cilium-operator, hubble-relay) bound how much VPA can disrupt at once.

## ⚠️ Eviction caveat (please read before promoting to ready)

`InPlacePodVerticalScaling` is **alpha and disabled** on this k8s 1.32 cluster (verified: `kubernetes_feature_enabled{name="InPlacePodVerticalScaling"} 0`). So `updateMode: InPlaceOrRecreate` falls back to **Recreate** — VPA applies a recommendation by **evicting** the pod.

For the kube-system **DaemonSets** (`cilium`, `spire-agent`) this means a brief per-node datapath blip as each pod restarts (one node at a time). Per the cilium HelmRelease notes, an evicted spire-agent can momentarily stall the co-located cilium-agent. Expect a one-time round of evictions as VPA applies its initial recommendations, then steady state.

**Recommended follow-up:** enable the `InPlacePodVerticalScaling` feature gate (Talos kubelet + apiserver, in `talos/`) so these resizes happen in place with no restarts. I can prepare that as a separate PR if you want it landed first.

## Relationship to #1713

[#1713](https://github.com/devantler-tech/platform/pull/1713) statically right-sizes cilium-envoy (→64Mi) and cilium-operator (→128Mi). With this PR, VPA manages those same containers dynamically, so #1713's values become sensible **initial / floor** values that VPA refines from (cilium-envoy lands on the 64Mi `minAllowed` floor either way). They're complementary; merge order doesn't matter.

## Validation

- `ksail workload validate` (local) — ✔ 266 files
- `ksail --config ksail.prod.yaml workload validate` (prod) — ✔ 266 files
- `kubectl kustomize` builds: cluster-policies base + `clusters/{local,prod}` — all OK; rendered ClusterPolicy confirmed to have no namespace exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
