### PR TITLE
feat(cluster): upgrade prod Kubernetes 1.32 -> 1.33.12 for in-place VPA resize

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -53,10 +53,10 @@ spec:
     # Restored to 4 — unblocked by the kubernetesVersion pin below and the KSail >= 7.23.4 scale-up fix.
     workers: 4
     # Pin Kubernetes deliberately so 'ksail cluster update' doesn't roll nodes
-    # to ksail's newer default (currently 1.36.0), which Talos v1.12.4 rejects:
-    # "kubelet image is not valid: version of Kubernetes ... is too new".
-    # Talos v1.12.4 supports Kubernetes 1.30-1.35; bump in lockstep with Talos
-    # rather than letting the default drift.
+    # to ksail's newer default when that default outruns what the pinned Talos
+    # version supports (rejected with "kubelet image is not valid: version of
+    # Kubernetes ... is too new"). Talos v1.12.4 supports Kubernetes 1.30-1.35;
+    # bump in lockstep with Talos rather than letting the default drift.
     #
     # Bumped 1.32.0 -> 1.33.12 to enable in-place Pod resize: the
     # InPlacePodVerticalScaling feature gate is beta and ON by default from

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -52,13 +52,19 @@ spec:
     # The Cluster Autoscaler manages additional workers dynamically.
     # Restored to 4 — unblocked by the kubernetesVersion pin below and the KSail >= 7.23.4 scale-up fix.
     workers: 4
-    # Pin Kubernetes to the version the cluster already runs so
-    # 'ksail cluster update' doesn't roll nodes to ksail's newer default
-    # (currently 1.36.0), which Talos v1.12.4 rejects with
+    # Pin Kubernetes deliberately so 'ksail cluster update' doesn't roll nodes
+    # to ksail's newer default (currently 1.36.0), which Talos v1.12.4 rejects:
     # "kubelet image is not valid: version of Kubernetes ... is too new".
-    # Talos v1.12.4 supports Kubernetes up to 1.35.x; bump this deliberately
-    # in lockstep with the Talos version rather than letting the default drift.
-    kubernetesVersion: v1.32.0
+    # Talos v1.12.4 supports Kubernetes 1.30-1.35; bump in lockstep with Talos
+    # rather than letting the default drift.
+    #
+    # Bumped 1.32.0 -> 1.33.12 to enable in-place Pod resize: the
+    # InPlacePodVerticalScaling feature gate is beta and ON by default from
+    # k8s 1.33, so VPA (already 1.6 with updateMode InPlaceOrRecreate) resizes
+    # pods -- including the kube-system datapath now under auto-vpa -- in place
+    # instead of evicting them. Upgrade one minor at a time (1.32 -> 1.33); a
+    # follow-up moves to 1.34 since 1.33 reaches EOL 2026-06-28.
+    kubernetesVersion: v1.33.12
     talos:
       # Pin Talos to match the ISO so 'ksail cluster update' doesn't attempt
       # an unwanted in-place upgrade to ksail's default version.


### PR DESCRIPTION
## Summary

Bumps the prod `kubernetesVersion` pin **v1.32.0 → v1.33.12** so the `InPlacePodVerticalScaling` feature gate (Beta and **on by default from k8s 1.33**) is enabled. With it, VPA right-sizes pods **in place** instead of evicting them.

This is the hardening for **[#1715](https://github.com/devantler-tech/platform/pull/1715)** (kube-system under auto-vpa). It's the *only* change needed — everything else is already in place:

| Piece | Required | Status |
|---|---|---|
| VPA ≥ 1.4 with in-place support | yes | ✅ running 1.6.0 |
| VPA `InPlaceOrRecreate` gate | on | ✅ default-on since VPA 1.5 |
| Policy `updateMode: InPlaceOrRecreate` | set | ✅ already set (all 3 rules) |
| k8s `InPlacePodVerticalScaling` gate | k8s ≥ 1.33 | ✅ **this PR** |

## Why it matters

Without in-place resize, VPA applies a recommendation by **evicting** the pod. On the kube-system datapath DaemonSets (`cilium` / `spire-agent`) that's a brief per-node blip. On ≥ 1.33 those resizes happen live, with no restart — so kube-system VPA management becomes non-disruptive.

## Validation

- **Talos v1.12.4 supports Kubernetes [1.30–1.35](https://docs.siderolabs.com/talos/v1.12/getting-started/support-matrix)** — 1.33 is comfortably in range.
- `ksail --config ksail.prod.yaml workload validate` → ✔ **278 files** validated against v1.33.12.

## Rollout & sequencing

- Applied via `ksail cluster update` (CD on release, or manually), which rolls the control plane + kubelets **one minor at a time**.
- **Apply this before promoting #1715** so kube-system VPA is in-place from the start (otherwise expect a one-time eviction round on 1.32).
- **Follow-up:** [1.33 EOLs Jun 28, 2026](https://kubernetes.io/releases/patch-releases/) — a follow-up PR will bump to **1.34** (Talos 1.12 supports ≤ 1.35). In-place resize stays on (default-on for 1.33+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
