### PR TITLE
fix(deps): update flux-operator to 0.50.0

### DIFF
--- a/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: flux-operator
-      version: 0.48.0
+      version: 0.50.0
       sourceRef:
         kind: HelmRepository
         name: flux-operator


### PR DESCRIPTION
## What

Bump the `flux-operator` HelmRelease from `0.48.0` → `0.50.0` to match the version KSail seeds at bootstrap (`pkg/svc/installer/flux/Dockerfile`, currently `0.50.0`).

## Why

KSail installs the flux-operator imperatively at create/update time (its pinned `0.50.0`), and this repo's HelmRelease is the steady-state owner reconciled by Flux afterward. With the HelmRelease pinned two minors behind (`0.48.0`), every `ksail cluster create`/`update` installs `0.50.0` and Flux then reconciles it back **down** to `0.48.0` — an avoidable version flap. Aligning to `0.50.0` removes it.

## Heads-up: Renovate appears stalled on this dependency

Renovate's `flux` manager last bumped this HelmRelease on **2026-04-21** (`0.48.0`, #1422) — *with* the OCI `HelmRepository` already in place, so OCI is not the blocker. Since then `0.49.0` and `0.50.0` have published and cleared the configured `minimumReleaseAge: 7 days`, yet no Renovate PR was opened (minor automerge is enabled). This manual bump is a stopgap; the stall itself is worth investigating. Note `:disableDependencyDashboard` is set in `renovate.json`, which hides stuck/errored updates — temporarily re-enabling the dashboard would surface what Renovate thinks it's doing.

## Durable fix (separate)

The root cause is dual ownership of the Flux operator/instance versions between KSail (bootstrap seed) and this repo (GitOps steady state). Tracked for a proper fix in KSail: **devantler-tech/ksail#5007** (seed-if-absent + defer to a repo-provided `FluxInstance`).

## Scope

- Operator **chart** version only. The `FluxInstance` `distribution.version` (`2.8.x`) is intentionally left unchanged — different concern (the Flux distribution, not the operator).

## Validation

```
kubectl kustomize k8s/clusters/local/     # OK
kubectl kustomize k8s/clusters/prod/      # OK
kubectl kustomize k8s/providers/docker/infrastructure/controllers/    # OK — renders flux-operator 0.50.0
kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/   # OK — renders flux-operator 0.50.0
```

The full Talos+Docker system test runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
