### PR TITLE
ci(renovate): track flux-operator chart version deterministically

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,19 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) extractVersion=(?<extractVersion>\\S+)\\s+[A-Z][A-Z0-9_]*_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track the flux-operator OCI Helm chart version in its HelmRelease via the docker datasource. The built-in `flux` manager silently stopped proposing flux-operator bumps after 0.48.0 (2026-04-21) even though 0.49.0/0.50.0 published, letting the version drift from the chart KSail seeds at bootstrap. This regex manager tracks ghcr.io/controlplaneio-fluxcd/charts/flux-operator deterministically (same datasource that bumps Dockerfile FROM tags elsewhere) so it cannot silently drift again.",
+      "fileMatch": [
+        "^k8s/bases/infrastructure/controllers/flux-operator/helm-release\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "chart:\\s*flux-operator\\s+version:\\s*(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/controlplaneio-fluxcd/charts/flux-operator",
+      "versioningTemplate": "semver"
     }
   ],
   "minor": {
@@ -53,6 +66,17 @@
     "automerge": true
   },
   "packageRules": [
+    {
+      "description": "flux-operator is tracked by the dedicated regex customManager above (the built-in `flux` manager stalled on it). Disable the `flux` manager for this chart so the two managers cannot open duplicate PRs if the flux manager later resumes.",
+      "matchManagers": [
+        "flux"
+      ],
+      "matchPackageNames": [
+        "flux-operator",
+        "ghcr.io/controlplaneio-fluxcd/charts/flux-operator"
+      ],
+      "enabled": false
+    },
     {
       "description": "Security-critical controllers — labelled so security-driven bumps are visible in the PR feed. Automerge stays ON: CI (system-test on a real Talos+Docker cluster, kubescape NSA scan, gitleaks, zizmor, CodeQL) is the trust gate.",
       "matchManagers": [


### PR DESCRIPTION
## What

Add a deterministic Renovate **regex `customManager`** that tracks the `flux-operator` OCI Helm chart version in its `HelmRelease` via the `docker` datasource, plus a `packageRule` that disables the built-in `flux` manager for this one chart (so the two managers can't open duplicate PRs).

## Why — the built-in `flux` manager silently stalled on this dependency

Investigation (latest `main` of both repos):

- Renovate is **healthy** on this repo — it bumped cilium, loki, openbao, opencost, kube-prometheus-stack, etc. as recently as the last day.
- But it has **not proposed a `flux-operator` bump since `0.48.0` (2026-04-21, #1422)**, even though `0.49.0` and `0.50.0` published and cleared the 7-day `minimumReleaseAge`. The stall is **specific to `flux-operator`**, which is one of only ~3 OCI-registry HelmReleases here and the only one that releases frequently.
- Result: the chart drifted two minors behind the version KSail seeds at bootstrap, causing a version flap on every `ksail cluster create`/`update` (see #1717 for the immediate realignment).

Rather than chase an unobservable flux-manager/OCI-resolution bug, this pins tracking to a **deterministic mechanism**: the `docker` datasource against `ghcr.io/controlplaneio-fluxcd/charts/flux-operator` — the exact registry path that already powered the earlier `fix(deps): update flux-operator docker tag` PRs and that bumps Dockerfile `FROM` tags across the org. It can't silently stop the way the flux manager did.

## Why not Dependabot

This repo would prefer Dependabot, but Dependabot **cannot** track a Flux `HelmRelease` chart version: it has no Helm or Flux ecosystem, its `docker` ecosystem only scans Dockerfiles/compose (not a `version:` field in a CR), and it has **no regex/custom manager**. The only Dependabot-compatible route is a placeholder `Dockerfile` whose tag a CI job rewrites back into the YAML — a brittle build step for a declarative GitOps repo (KSail can use that trick only because it has a Go `go:embed` + regex at compile time). Renovate's regex manager is the clean, native fit.

## Changes

- `customManagers[]`: new regex manager scoped to `k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml`, datasource `docker`, depName `ghcr.io/controlplaneio-fluxcd/charts/flux-operator`, `semver` versioning.
- `packageRules[]`: disable manager `flux` for `flux-operator` (anti-duplicate guard).

Minor/patch/major automerge already apply globally, so future operator bumps follow the repo's existing "CI is the trust gate, automerge on" policy.

## Validation

```
npx renovate-config-validator .github/renovate.json   # INFO: Config validated successfully
```

## Notes / follow-ups

- Interplay with **#1717** (manual `0.48.0 → 0.50.0` bump): independent files, no conflict. Merge #1717 for the immediate fix; once this lands, Renovate owns subsequent bumps. (If this merges first, Renovate will raise the same `0.50.0` bump and #1717 can be closed.)
- The durable cross-repo ownership fix is tracked in **devantler-tech/ksail#5007**.
- This config sets `:disableDependencyDashboard`, which is what hid the stall for ~6 weeks. Re-enabling the dependency dashboard is the best general safeguard against a future silent stall — left out of scope here, but worth considering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
