### PR TITLE
ci(renovate): re-enable the dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,9 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":disableDependencyDashboard",
     ":semanticCommitTypeAll(fix)"
   ],
+  "dependencyDashboard": true,
   "assigneesFromCodeOwners": true,
   "minimumReleaseAge": "7 days",
   "flux": {


### PR DESCRIPTION
## What

Re-enable the Renovate **Dependency Dashboard**: drop the `:disableDependencyDashboard` preset and set `"dependencyDashboard": true` explicitly.

## Why

The dashboard was disabled, which is exactly what let a Renovate stall go unnoticed: the `flux-operator` HelmRelease silently stopped receiving bumps after `0.48.0` (2026-04-21) and drifted two minors behind while every other Helm release kept updating — invisible for ~6 weeks because there was no dashboard surfacing pending/errored/stuck updates.

The Dependency Dashboard is a single tracking issue that lists what Renovate intends to do, what's awaiting `minimumReleaseAge`, and crucially **what errored or is otherwise stuck**. Turning it back on makes a future silent stall observable instead of something you only find by manually comparing versions.

## Context

- Companion to #1718, which makes `flux-operator` tracking deterministic. That fixes the *one* dependency we already caught; this restores visibility for the *next* one.
- Set explicitly (`"dependencyDashboard": true`) rather than just removing the preset, so the intent is loud and the disable preset isn't re-added by reflex.

## Effect

Renovate will open/maintain one issue titled **"Dependency Dashboard"**. No change to update/automerge behavior.

## Validation

```
npx renovate-config-validator .github/renovate.json   # INFO: Config validated successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
