### PR TITLE
fix(ci): retarget skills update to renamed update-agent-skills workflow

### DIFF
--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -1,4 +1,4 @@
-name: Update Copilot Skills
+name: Update Agent Skills
 on:
   workflow_dispatch:
   schedule:
@@ -11,11 +11,11 @@ concurrency:
 permissions: {}
 
 jobs:
-  update-copilot-skills:
+  update-agent-skills:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/reusable-workflows/.github/workflows/update-copilot-skills.yaml@d6c7133cb8cb13189b97993aeb3f4d120f27479d # v5.4.1
+    uses: devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml@d4d382168eeef3d08606ed7c6fb2671e3d4170fc # v5.5.2
     with:
       dir: .agents/skills
       # Create the update PR with a GitHub App token so it triggers this


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
The daily scheduled **Update Skills** workflow has **failed every day since at least 2026-05-31** ([latest run](https://github.com/devantler-tech/platform/actions/runs/26870480480)) — a silent breakage no jobs/logs surface clearly.

## Root cause
The reusable workflow was renamed `update-copilot-skills.yaml` → `update-agent-skills.yaml` ([reusable-workflows#246](https://github.com/devantler-tech/reusable-workflows/pull/246), agent-neutral skills rename). platform's `update-skills.yaml` still pins the **old path** at `v5.4.1` (`d6c7133`), where that file **404s**, so GitHub can't resolve the called workflow → *"workflow file issue"*.

This is the same missed consumer-propagation that broke ksail's equivalent workflow (fixed in [ksail#5008](https://github.com/devantler-tech/ksail/pull/5008)).

## Fix
- Retarget to `update-agent-skills.yaml`, pinned to **v5.5.2** (`d4d3821`).
- Align workflow `name:` and job id to the agent-neutral naming.
- `use-app-token: true`, the `APP_PRIVATE_KEY` secret, and `dir: .agents/skills` are all still supported at v5.5.2 (verified) — interface unchanged.

## Validation
- Confirmed `update-agent-skills.yaml` exists at the pinned SHA and exposes `dir` + `use-app-token` inputs and the `APP_PRIVATE_KEY` secret.
- `actionlint` clean.