### PR TITLE
feat(cluster): upgrade prod Kubernetes 1.33 -> 1.34.8 (off soon-EOL 1.33)

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -58,13 +58,13 @@ spec:
     # Kubernetes ... is too new"). Talos v1.12.4 supports Kubernetes 1.30-1.35;
     # bump in lockstep with Talos rather than letting the default drift.
     #
-    # Bumped 1.32.0 -> 1.33.12 to enable in-place Pod resize: the
-    # InPlacePodVerticalScaling feature gate is beta and ON by default from
-    # k8s 1.33, so VPA (already 1.6 with updateMode InPlaceOrRecreate) resizes
-    # pods -- including the kube-system datapath now under auto-vpa -- in place
-    # instead of evicting them. Upgrade one minor at a time (1.32 -> 1.33); a
-    # follow-up moves to 1.34 since 1.33 reaches EOL 2026-06-28.
-    kubernetesVersion: v1.33.12
+    # In-place Pod resize (InPlacePodVerticalScaling, beta and ON by default
+    # from k8s 1.33) lets VPA -- already 1.6 with updateMode InPlaceOrRecreate
+    # -- resize pods, including the kube-system datapath now under auto-vpa, in
+    # place instead of evicting them. Upgraded one minor at a time
+    # (1.32 -> 1.33 -> 1.34); landed on 1.34 because 1.33 reached EOL
+    # 2026-06-28. Talos v1.12.4's ceiling is Kubernetes 1.35.
+    kubernetesVersion: v1.34.8
     talos:
       # Pin Talos to match the ISO so 'ksail cluster update' doesn't attempt
       # an unwanted in-place upgrade to ksail's default version.

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -62,7 +62,7 @@ spec:
     # from k8s 1.33) lets VPA -- already 1.6 with updateMode InPlaceOrRecreate
     # -- resize pods, including the kube-system datapath now under auto-vpa, in
     # place instead of evicting them. Upgraded one minor at a time
-    # (1.32 -> 1.33 -> 1.34); landed on 1.34 because 1.33 reached EOL
+    # (1.32 -> 1.33 -> 1.34); landed on 1.34 because 1.33 reaches EOL
     # 2026-06-28. Talos v1.12.4's ceiling is Kubernetes 1.35.
     kubernetesVersion: v1.34.8
     talos:


### PR DESCRIPTION
## Summary

Second hop of the planned **1.32 → 1.33 → 1.34** upgrade. #1716 already landed **1.33.12** (and merged to `main`); this moves prod off **1.33 (EOL 2026-06-28)** onto the supported **v1.34.8**. In-place Pod resize (`InPlacePodVerticalScaling`) stays beta/default-on, so VPA keeps right-sizing kube-system **in place** (no evictions).

Clean single-minor delta against `main` (1.33.12 → 1.34.8).

## Validation

- Talos v1.12.4 supports Kubernetes [1.30–1.35](https://docs.siderolabs.com/talos/v1.12/getting-started/support-matrix) — 1.34 is in range (1.35 is the ceiling).
- v1.34.8 is the [latest 1.34 patch](https://kubernetes.io/releases/patch-releases/) (2026-05-12).
- `ksail --config ksail.prod.yaml workload validate` → ✔ **278 files** on v1.34.8.

## ⚠️ Apply only when the cluster is healthy

A k8s minor upgrade triggers a **node roll**. #1716's roll exposed the cluster's fragility (a reprovisioned worker-4 came back mis-named → CCM couldn't initialize it → memory pressure left source-controller briefly unschedulable, failing the first deploy attempt). Before promoting this:
1. Confirm **worker-4 provisioning is solid** (the mis-named-node / KSail user_data issue) so the roll has scheduling headroom.
2. Merge the **memory-relief PRs (#1713, #1715)** so workers aren't at 98–99% requests during the roll.

Otherwise this upgrade can reproduce that node-roll scheduling failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
