### PR TITLE
fix(homepage): set explicit CPU limit to stop CFS throttling

### DIFF
--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -114,6 +114,32 @@ spec:
   # https://github.com/M0NsTeRRR/helm-charts/blob/main/charts/homepage/values.yaml
   values:
     replicaCount: ${homepage_replicas:=2}
+    # Homepage is a single-threaded Next.js server: it idles near ~3m CPU but
+    # bursts hard on every load — server-rendering the page, polling ~14
+    # service statuses against kube-apiserver, and aggregating the cluster /
+    # node Kubernetes widget. With no explicit block it inherits the namespace
+    # LimitRange's default CPU limit of 500m, and auto-vpa (controlledValues:
+    # RequestsAndLimits) preserves that stingy default limit:request ratio, so
+    # the limit stays pinned near 500m and can never grow to absorb a burst.
+    # Measured result: the container was CFS-throttled in 35-60% of scheduled
+    # periods, starving the event loop — the "GET / can't answer within 1s"
+    # stall the probe tuning below was only working around, and the real cause
+    # of the dashboard feeling slow.
+    #
+    # Author resources explicitly (Kyverno add-resource-defaults uses +(key)
+    # anchors, so these win and stay scanner-visible). Pin the CPU request to
+    # the auto-vpa minAllowed floor (15m) on purpose: VPA keeps the request
+    # there, and because it preserves the authored limit:request ratio the
+    # generous 2-core limit survives its proportional scaling. CPU is
+    # compressible and the namespace ResourceQuota caps requests, not limits,
+    # so a 2-core ceiling reserves nothing while it idles.
+    resources:
+      requests:
+        cpu: 15m
+        memory: 192Mi
+      limits:
+        cpu: "2"
+        memory: 512Mi
     config:
       allowedHosts:
         - ${domain}


### PR DESCRIPTION
## Summary

Homepage felt slow because its container is **CPU CFS-throttled in 35–60% of scheduled periods** on prod — not a code, network, or auth problem. This authors an explicit, generous CPU limit so a bursty single-threaded UI stops starving its own event loop.

## Root cause (measured on prod, read-only)

Homepage pods are healthy and idle on average (2–3m CPU, ~100Mi RAM, 0 restarts), yet the kubelet cAdvisor metrics show heavy throttling:

| Pod (node) | CFS periods | Throttled periods | Throttle ratio |
|---|---|---|---|
| worker-2 | 3653 | 2189 | **59.9%** |
| worker-3 | 1585 | 559 | **35.3%** |

- The container runs with a **500m CPU limit it never authored** — it comes from the namespace `default-limitrange` default. `auto-vpa` then runs `controlledValues: RequestsAndLimits`, which preserves that default 33:1 limit:request ratio anchored to the 15m request floor, so the limit is permanently pinned near 500m and can never grow to absorb a burst.
- Homepage is a single-threaded Next.js server. On each load it server-renders, polls ~14 service statuses against kube-apiserver, and aggregates the cluster/node Kubernetes widget. Those bursts blow past 500m within the 100ms CFS window and get parked — exactly the *"GET / can't answer within 1s"* event-loop starvation the existing probe tuning was only working around.

## Fix

Author an explicit `resources` block on the Homepage container:

- `requests.cpu: 15m` — deliberately at the `auto-vpa` `minAllowed` floor, so VPA keeps the request there and the limit ratio below survives its proportional scaling.
- `limits.cpu: "2"` — was effectively 500m; 2 cores removes throttling for one JS thread while staying a sane ceiling. CPU is compressible and the namespace ResourceQuota caps **requests, not limits**, so this reserves nothing at idle.
- Memory: request nudged to 192Mi (≈ the live VPA target, so it's stable under VPA); limit unchanged at 512Mi (peak observed 116Mi).

`add-resource-defaults` uses `+(key)` anchors, so the explicit values win and stay visible to static scanners.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `.../prod/` build.
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` — **279 files validated** each.

## Out of scope (noted, not fixed here)

- The Cilium egress policy has no internet rule, so Homepage's `api.github.com` release check (`hideVersion: true` does not stop the call) hangs ~8s on the TCP connect timeout intermittently. It's client-side/async so it doesn't block render, but it is a real defect worth a follow-up.
- Several service status dots show "down" for legitimately scale-to-zero apps (hubble-ui, whoami, headlamp, actual-budget) or disabled ones (fleetdm), generating recurring `no pods found` log spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
