### PR TITLE
feat(cluster): cost-tiered CX autoscaler pools (cx23/33/43/53)

### DIFF
--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -17,11 +17,11 @@ KSail (static baseline)
 └── 3 static workers (cx33, 4 vCPU / 8 GB, guaranteed minimum, Longhorn storage nodes)
 
 Cluster Autoscaler (dynamic workers, managed by KSail)
-├── Pool: autoscale-cx23 → 0-1 × CX23 (2 vCPU, 4 GB)
-├── Pool: autoscale-cx33 → 0-1 × CX33 (4 vCPU, 8 GB)
-├── Pool: autoscale-cx43 → 0-1 × CX43 (8 vCPU, 16 GB)
-├── Pool: autoscale-cx53 → 0-1 × CX53 (16 vCPU, 32 GB)
-├── maxNodesTotal: 10 (6 base + up to 4 autoscaler nodes)
+├── Pool: autoscale-cx23 → 0-4 × CX23 (2 vCPU, 4 GB)
+├── Pool: autoscale-cx33 → 0-4 × CX33 (4 vCPU, 8 GB)
+├── Pool: autoscale-cx43 → 0-4 × CX43 (8 vCPU, 16 GB)
+├── Pool: autoscale-cx53 → 0-4 × CX53 (16 vCPU, 32 GB)
+├── maxNodesTotal: 10 (6 base + up to 4 autoscaler nodes — caps the total)
 └── Expander: LeastWaste
 ```
 
@@ -76,22 +76,22 @@ spec:
             serverType: cx23
             location: fsn1
             min: 0
-            max: 1
+            max: 4
           - name: autoscale-cx33
             serverType: cx33
             location: fsn1
             min: 0
-            max: 1
+            max: 4
           - name: autoscale-cx43
             serverType: cx43
             location: fsn1
             min: 0
-            max: 1
+            max: 4
           - name: autoscale-cx53
             serverType: cx53
             location: fsn1
             min: 0
-            max: 1
+            max: 4
 ```
 
 | Field | Default | Description |
@@ -108,12 +108,20 @@ spec:
 
 ### Cost guardrails
 
-- **Hard max per pool** — `pools[].max` caps each pool independently.
+- **Hard max per pool** — `pools[].max` caps each pool independently. Set to
+  `4` so any single CX type can serve a full burst (e.g. 4× cx23) instead of
+  forcing larger types; `maxNodesTotal` still caps the autoscaler **total** at
+  4, so this changes only the type distribution, never the node count.
 - **Hard max total** — `maxNodesTotal` caps the **total cluster node count**
-  (CPs + static workers + autoscaler workers). Set to `10` (3 CPs + 3
-  workers = 6 base, plus up to 4 autoscaler nodes — one per CX pool, each
-  capped at 1). It must stay ≥ the static baseline, or the autoscaler treats
-  the cluster as already full and never scales up.
+  (CPs + static workers + autoscaler workers). Set to `10` (3 CPs + 3 workers
+  = 6 base + up to 4 autoscaler nodes). It must stay ≥ the static baseline, or
+  the autoscaler treats the cluster as already full and never scales up. **This
+  is the real cap on autoscaler growth.**
+- **serverLimit** (`spec.provider.hetzner.serverLimit`) — a KSail
+  config-validation guard, **not** a runtime cap and not passed to the
+  autoscaler. KSail validates `CP + workers + min(maxNodesTotal, Σ pool.max) ≤
+  serverLimit`, so with per-pool `max: 4` it is set to `16` (`3 + 3 + min(10,
+  16)`). The live cluster never exceeds `maxNodesTotal` (10).
 - **Expander** — `LeastWaste` (current) picks the node group left with the
   least idle capacity after scheduling — the cheapest adequate type in a
   linearly-priced family. (`Price` is unsupported on Hetzner.)

--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -21,7 +21,7 @@ Cluster Autoscaler (dynamic workers, managed by KSail)
 ├── Pool: autoscale-cx33 → 0-4 × CX33 (4 vCPU, 8 GB)
 ├── Pool: autoscale-cx43 → 0-4 × CX43 (8 vCPU, 16 GB)
 ├── Pool: autoscale-cx53 → 0-4 × CX53 (16 vCPU, 32 GB)
-├── maxNodesTotal: 10 (6 base + up to 4 autoscaler nodes — caps the total)
+├── maxNodesTotal: 4 (autoscaler-only budget: account cap 10 − 6 baseline)
 └── Expander: LeastWaste
 ```
 
@@ -69,7 +69,7 @@ spec:
       node:
         enabled: true
         expander: LeastWaste
-        maxNodesTotal: 10
+        maxNodesTotal: 4
         scaleDownUnneededTime: "10m"
         pools:
           - name: autoscale-cx23
@@ -98,7 +98,7 @@ spec:
 |-------|---------|-------------|
 | `enabled` | `false` | Enable/disable node autoscaling |
 | `expander` | `LeastWaste` | Node selection strategy: `LeastWaste`, `LeastNodes`, `Random` (`Price` is unsupported on Hetzner — no pricing API) |
-| `maxNodesTotal` | `0` (unlimited) | Hard ceiling on total cluster nodes (all types) |
+| `maxNodesTotal` | `0` (unlimited) | Intended: max autoscaler nodes, excluding the static baseline (see [ksail#5017](https://github.com/devantler-tech/ksail/issues/5017)) |
 | `scaleDownUnneededTime` | `10m` | Time before an underutilized node is eligible for removal |
 | `pools[].name` | — | DNS-1123 pool identifier |
 | `pools[].serverType` | — | Hetzner server type (e.g., `cx23`, `cx33`) |
@@ -112,16 +112,17 @@ spec:
   `4` so any single CX type can serve a full burst (e.g. 4× cx23) instead of
   forcing larger types; `maxNodesTotal` still caps the autoscaler **total** at
   4, so this changes only the type distribution, never the node count.
-- **Hard max total** — `maxNodesTotal` caps the **total cluster node count**
-  (CPs + static workers + autoscaler workers). Set to `10` (3 CPs + 3 workers
-  = 6 base + up to 4 autoscaler nodes). It must stay ≥ the static baseline, or
-  the autoscaler treats the cluster as already full and never scales up. **This
-  is the real cap on autoscaler growth.**
-- **serverLimit** (`spec.provider.hetzner.serverLimit`) — a KSail
-  config-validation guard, **not** a runtime cap and not passed to the
-  autoscaler. KSail validates `CP + workers + min(maxNodesTotal, Σ pool.max) ≤
-  serverLimit`, so with per-pool `max: 4` it is set to `16` (`3 + 3 + min(10,
-  16)`). The live cluster never exceeds `maxNodesTotal` (10).
+- **Autoscaler budget** — `maxNodesTotal` is the max number of nodes the
+  autoscaler may add, **excluding** the static baseline. Set to `4` (Hetzner
+  account cap `10` − 6 static). ⚠️ KSail currently passes this straight to
+  cluster-autoscaler's `--max-nodes-total`, which counts *all* nodes, so until
+  [ksail#5017](https://github.com/devantler-tech/ksail/issues/5017) lands the
+  runtime sees `4 < 6` and will not scale; the intended value is set here in
+  preparation for that fix.
+- **serverLimit** (`spec.provider.hetzner.serverLimit`) — the Hetzner account
+  hard cap (`10`), which also serves as KSail's config-validation guard:
+  `CP + workers + min(maxNodesTotal, Σ pool.max) ≤ serverLimit` (`3 + 3 + 4 =
+  10`).
 - **Expander** — `LeastWaste` (current) picks the node group left with the
   least idle capacity after scheduling — the cheapest adequate type in a
   linearly-priced family. (`Price` is unsupported on Hetzner.)

--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -17,9 +17,11 @@ KSail (static baseline)
 └── 3 static workers (cx33, 4 vCPU / 8 GB, guaranteed minimum, Longhorn storage nodes)
 
 Cluster Autoscaler (dynamic workers, managed by KSail)
-├── Pool: autoscale-small  → 0-1 × CX23 (2 vCPU, 4 GB)
-├── Pool: autoscale-medium → 0-2 × CX33 (4 vCPU, 8 GB)
-├── maxNodesTotal: 10 (3 CPs + 3 workers + headroom for autoscaler nodes)
+├── Pool: autoscale-cx23 → 0-1 × CX23 (2 vCPU, 4 GB)
+├── Pool: autoscale-cx33 → 0-1 × CX33 (4 vCPU, 8 GB)
+├── Pool: autoscale-cx43 → 0-1 × CX43 (8 vCPU, 16 GB)
+├── Pool: autoscale-cx53 → 0-1 × CX53 (16 vCPU, 32 GB)
+├── maxNodesTotal: 10 (6 base + up to 4 autoscaler nodes)
 └── Expander: LeastWaste
 ```
 
@@ -28,8 +30,10 @@ Cluster Autoscaler (dynamic workers, managed by KSail)
   configurable cooldown.
 - **Vertical scaling** — multiple node pools with different server types.
   The `LeastWaste` expander picks the pool left with the least idle CPU and
-  memory after scheduling the pending pod (`Price`, which biases toward the
-  cheapest pool, is also available). See
+  memory after scheduling the pending pod — the cheapest adequate type in a
+  linearly-priced family. (`Price` is **not supported on Hetzner**: the
+  cluster-autoscaler hcloud provider implements no pricing API, so KSail
+  rejects it and the autoscaler crashes on startup.) See
   [cluster-autoscaler FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 - **KSail integration** — KSail installs the Cluster Autoscaler Helm chart,
   generates the worker config secret (`cluster-autoscaler-config`), and
@@ -68,22 +72,32 @@ spec:
         maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:
-          - name: autoscale-small
+          - name: autoscale-cx23
             serverType: cx23
             location: fsn1
             min: 0
             max: 1
-          - name: autoscale-medium
+          - name: autoscale-cx33
             serverType: cx33
             location: fsn1
             min: 0
-            max: 2
+            max: 1
+          - name: autoscale-cx43
+            serverType: cx43
+            location: fsn1
+            min: 0
+            max: 1
+          - name: autoscale-cx53
+            serverType: cx53
+            location: fsn1
+            min: 0
+            max: 1
 ```
 
 | Field | Default | Description |
 |-------|---------|-------------|
 | `enabled` | `false` | Enable/disable node autoscaling |
-| `expander` | `LeastWaste` | Node selection strategy: `Price`, `LeastWaste`, `LeastNodes`, `Random` |
+| `expander` | `LeastWaste` | Node selection strategy: `LeastWaste`, `LeastNodes`, `Random` (`Price` is unsupported on Hetzner — no pricing API) |
 | `maxNodesTotal` | `0` (unlimited) | Hard ceiling on total cluster nodes (all types) |
 | `scaleDownUnneededTime` | `10m` | Time before an underutilized node is eligible for removal |
 | `pools[].name` | — | DNS-1123 pool identifier |
@@ -97,11 +111,12 @@ spec:
 - **Hard max per pool** — `pools[].max` caps each pool independently.
 - **Hard max total** — `maxNodesTotal` caps the **total cluster node count**
   (CPs + static workers + autoscaler workers). Set to `10` (3 CPs + 3
-  workers = 6 base, plus up to 3 autoscaler nodes from the current pool caps
-  of 1 small + 2 medium).
+  workers = 6 base, plus up to 4 autoscaler nodes — one per CX pool, each
+  capped at 1). It must stay ≥ the static baseline, or the autoscaler treats
+  the cluster as already full and never scales up.
 - **Expander** — `LeastWaste` (current) picks the node group left with the
-  least idle capacity after scheduling; `Price` instead picks the cheapest
-  eligible group.
+  least idle capacity after scheduling — the cheapest adequate type in a
+  linearly-priced family. (`Price` is unsupported on Hetzner.)
 - **Scale-down** — underutilized nodes are removed after 10 minutes.
 
 ### Adding more pools

--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -21,7 +21,7 @@ Cluster Autoscaler (dynamic workers, managed by KSail)
 ├── Pool: autoscale-cx33 → 0-4 × CX33 (4 vCPU, 8 GB)
 ├── Pool: autoscale-cx43 → 0-4 × CX43 (8 vCPU, 16 GB)
 ├── Pool: autoscale-cx53 → 0-4 × CX53 (16 vCPU, 32 GB)
-├── maxNodesTotal: 4 (autoscaler-only budget: account cap 10 − 6 baseline)
+├── maxNodesTotal: 10 (total cluster nodes incl. baseline: 6 static + 4 autoscaler)
 └── Expander: LeastWaste
 ```
 
@@ -69,7 +69,7 @@ spec:
       node:
         enabled: true
         expander: LeastWaste
-        maxNodesTotal: 4
+        maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:
           - name: autoscale-cx23
@@ -98,7 +98,7 @@ spec:
 |-------|---------|-------------|
 | `enabled` | `false` | Enable/disable node autoscaling |
 | `expander` | `LeastWaste` | Node selection strategy: `LeastWaste`, `LeastNodes`, `Random` (`Price` is unsupported on Hetzner — no pricing API) |
-| `maxNodesTotal` | `0` (unlimited) | Intended: max autoscaler nodes, excluding the static baseline (see [ksail#5017](https://github.com/devantler-tech/ksail/issues/5017)) |
+| `maxNodesTotal` | `0` (unlimited) | Hard ceiling on total cluster nodes, including the static baseline (see [ksail#5017](https://github.com/devantler-tech/ksail/issues/5017)) |
 | `scaleDownUnneededTime` | `10m` | Time before an underutilized node is eligible for removal |
 | `pools[].name` | — | DNS-1123 pool identifier |
 | `pools[].serverType` | — | Hetzner server type (e.g., `cx23`, `cx33`) |
@@ -110,19 +110,19 @@ spec:
 
 - **Hard max per pool** — `pools[].max` caps each pool independently. Set to
   `4` so any single CX type can serve a full burst (e.g. 4× cx23) instead of
-  forcing larger types; `maxNodesTotal` still caps the autoscaler **total** at
-  4, so this changes only the type distribution, never the node count.
-- **Autoscaler budget** — `maxNodesTotal` is the max number of nodes the
-  autoscaler may add, **excluding** the static baseline. Set to `4` (Hetzner
-  account cap `10` − 6 static). ⚠️ KSail currently passes this straight to
-  cluster-autoscaler's `--max-nodes-total`, which counts *all* nodes, so until
-  [ksail#5017](https://github.com/devantler-tech/ksail/issues/5017) lands the
-  runtime sees `4 < 6` and will not scale; the intended value is set here in
-  preparation for that fix.
+  forcing larger types; the `maxNodesTotal` total ceiling still caps the
+  autoscaler at 4 (`10 − 6` baseline), so this changes only the type
+  distribution, never the node count.
+- **Total node ceiling** — `maxNodesTotal` caps the **total cluster node
+  count, including** the static baseline. Set to `10` (6 static + up to 4
+  autoscaler). It is passed straight to cluster-autoscaler's
+  `--max-nodes-total`, so the runtime already enforces this total.
 - **serverLimit** (`spec.provider.hetzner.serverLimit`) — the Hetzner account
-  hard cap (`10`), which also serves as KSail's config-validation guard:
-  `CP + workers + min(maxNodesTotal, Σ pool.max) ≤ serverLimit` (`3 + 3 + 4 =
-  10`).
+  hard cap (`10`). Under the in-progress KSail change
+  ([ksail#5017](https://github.com/devantler-tech/ksail/issues/5017)) the
+  autoscaler validation becomes `maxNodesTotal ≤ serverLimit` (`10 ≤ 10`);
+  until it ships, the old validation (`CP + workers + min(maxNodesTotal, Σ
+  pool.max)`) rejects this config, so the KSail change must land first.
 - **Expander** — `LeastWaste` (current) picks the node group left with the
   least idle capacity after scheduling — the cheapest adequate type in a
   linearly-priced family. (`Price` is unsupported on Hetzner.)

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -185,8 +185,8 @@ spec:
                     cpu: "15m"
                     memory: "64Mi"
                   # Lower upper bound than Deployments/StatefulSets: a DaemonSet
-                  # pod must schedule on EVERY node, including autoscale-small
-                  # cx23 workers (2 vCPU / 4 GB). Bound it to fit a cx23 next to
+                  # pod must schedule on EVERY node, including autoscale-cx23
+                  # workers (2 vCPU / 4 GB). Bound it to fit a cx23 next to
                   # the other per-node agents; this still covers the heaviest
                   # auto-VPA'd DaemonSet observed (kubescape node-agent ~0.7Gi).
                   maxAllowed:

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -19,23 +19,56 @@ spec:
     # autoscaler.node.enabled is set. KSail installs, configures, and
     # reconciles the autoscaler — no Flux manifests needed. Initial
     # static node counts still apply on `cluster create`.
+    #
+    # Cost-optimized overflow: one pool per cost-optimized Hetzner x86
+    # shared-vCPU type (the CX line), so the autoscaler can pick the smallest
+    # *adequate* node for whatever can't schedule on the static workers. Sizes
+    # double cleanly per step (cx23 2c/4G → cx33 4c/8G → cx43 8c/16G →
+    # cx53 16c/32G; ~€4.99/€8.11/€14.99/€28.11 gross/mo in fsn1). All pools
+    # scale to zero (min: 0) so idle capacity costs nothing; the static
+    # workers are the guaranteed baseline and the only Longhorn storage nodes
+    # (autoscaler nodes are compute-only). CAX/ARM is cheaper but needs an ARM
+    # Talos image — not applicable to this x86 cluster.
+    #
+    # expander: LeastWaste — selects the node group leaving the least idle
+    # CPU/memory, i.e. the cheapest adequate type in this linearly-priced
+    # family. "Price" would be the direct cost optimizer, but the Hetzner
+    # cluster-autoscaler provider does not implement the pricing API, so KSail
+    # rejects Price+Hetzner (and the autoscaler would crash on startup);
+    # LeastWaste is the supported cost-targeting choice.
+    #
+    # maxNodesTotal: 3 is the real ceiling — serverLimit defaults to 10 and
+    # controlPlanes(3) + workers(4) + autoscaler must stay <= it, leaving 3.
+    # Per-pool max is the same 3 so any single type can absorb the whole
+    # budget; the global cap binds. To grow this, raise serverLimit too, and
+    # only within the Hetzner project's actual server limit.
     autoscaler:
       node:
         enabled: true
         expander: LeastWaste
-        maxNodesTotal: 10
+        maxNodesTotal: 3
         scaleDownUnneededTime: "10m"
         pools:
-          - name: autoscale-small
+          - name: autoscale-cx23
             serverType: cx23
             location: fsn1
             min: 0
-            max: 1
-          - name: autoscale-medium
+            max: 3
+          - name: autoscale-cx33
             serverType: cx33
             location: fsn1
             min: 0
-            max: 2
+            max: 3
+          - name: autoscale-cx43
+            serverType: cx43
+            location: fsn1
+            min: 0
+            max: 3
+          - name: autoscale-cx53
+            serverType: cx53
+            location: fsn1
+            min: 0
+            max: 3
     # These components are installed by ksail. There is a known race on
     # Hetzner clusters between ksail's metrics-server install and Flux's
     # kubelet-serving-cert-approver install (required because Talos

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -37,25 +37,25 @@ spec:
     # rejects Price+Hetzner (and the autoscaler would crash on startup);
     # LeastWaste is the supported cost-targeting choice.
     #
-    # maxNodesTotal is the autoscaler-only budget: the max number of nodes the
-    # autoscaler may ADD, excluding the static baseline. 4 = Hetzner account cap
-    # (10) - 6 static (3 control-planes + 3 workers). Each pool max is also 4,
-    # so any single CX type can fill the whole budget (e.g. 4x cx23) or any mix;
-    # the budget caps the autoscaler total at 4 regardless of type. Matches
-    # KSail's config validation: controlPlanes + workers + min(maxNodesTotal,
-    # Σ pool.max) <= serverLimit (3 + 3 + 4 = 10).
+    # maxNodesTotal is the HARD CEILING ON TOTAL CLUSTER NODES, INCLUDING the
+    # static baseline. 10 = the Hetzner account cap: 6 static (3 control-planes
+    # + 3 workers) + up to 4 autoscaler nodes. KSail passes it to
+    # cluster-autoscaler --max-nodes-total, which counts every node, so this
+    # total framing already matches the runtime. Each pool max is 4, so any
+    # single CX type can fill the 4-node autoscaler headroom (or any mix); the
+    # cluster total stays <= 10.
     #
-    # ⚠️ Upstream bug ksail#5017: KSail currently passes maxNodesTotal straight
-    # to cluster-autoscaler's --max-nodes-total, which counts EVERY node
-    # (baseline + autoscaler) — so until that fix lands the runtime sees 4 < 6
-    # static and refuses to scale. The intended value (4) is set here in
-    # preparation for the fix; the autoscaler is in any case currently blocked
-    # by the user_data limit (ksail#5015), so this is not a new regression.
+    # NB KSail's config validation is being changed (ksail#5017) to expect
+    # maxNodesTotal as this total (validate maxNodesTotal <= serverLimit). Until
+    # that ships, the old validation computes controlPlanes + workers +
+    # min(maxNodesTotal, Σ pool.max) = 3 + 3 + 10 = 16 and would reject this, so
+    # the KSail change must land before this deploys. (Scale-up is in any case
+    # currently blocked by the user_data limit, ksail#5015.)
     autoscaler:
       node:
         enabled: true
         expander: LeastWaste
-        maxNodesTotal: 4
+        maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:
           - name: autoscale-cx23
@@ -125,9 +125,9 @@ spec:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   provider:
     hetzner:
-      # Hetzner account hard cap: at most 10 servers total. Doubles as KSail's
-      # config-validation guard: controlPlanes + workers + min(maxNodesTotal,
-      # Σ pool.max) <= serverLimit, i.e. 3 + 3 + min(4, 16) = 10.
+      # Hetzner account hard cap: at most 10 servers total. Under the in-progress
+      # KSail change (ksail#5017) the autoscaler validation becomes
+      # maxNodesTotal <= serverLimit (10 <= 10). See the autoscaler block.
       serverLimit: 10
       controlPlaneServerType: cx33
       workerServerType: cx33

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -37,38 +37,38 @@ spec:
     # rejects Price+Hetzner (and the autoscaler would crash on startup);
     # LeastWaste is the supported cost-targeting choice.
     #
-    # maxNodesTotal: 3 is the real ceiling — serverLimit defaults to 10 and
-    # controlPlanes(3) + workers(4) + autoscaler must stay <= it, leaving 3.
-    # Per-pool max is the same 3 so any single type can absorb the whole
+    # maxNodesTotal: 4 is the real ceiling — serverLimit defaults to 10 and
+    # controlPlanes(3) + workers(3) + autoscaler must stay <= it, leaving 4.
+    # Per-pool max is the same 4 so any single type can absorb the whole
     # budget; the global cap binds. To grow this, raise serverLimit too, and
     # only within the Hetzner project's actual server limit.
     autoscaler:
       node:
         enabled: true
         expander: LeastWaste
-        maxNodesTotal: 3
+        maxNodesTotal: 4
         scaleDownUnneededTime: "10m"
         pools:
           - name: autoscale-cx23
             serverType: cx23
             location: fsn1
             min: 0
-            max: 3
+            max: 4
           - name: autoscale-cx33
             serverType: cx33
             location: fsn1
             min: 0
-            max: 3
+            max: 4
           - name: autoscale-cx43
             serverType: cx43
             location: fsn1
             min: 0
-            max: 3
+            max: 4
           - name: autoscale-cx53
             serverType: cx53
             location: fsn1
             min: 0
-            max: 3
+            max: 4
     # These components are installed by ksail. There is a known race on
     # Hetzner clusters between ksail's metrics-server install and Flux's
     # kubelet-serving-cert-approver install (required because Talos

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -37,25 +37,25 @@ spec:
     # rejects Price+Hetzner (and the autoscaler would crash on startup);
     # LeastWaste is the supported cost-targeting choice.
     #
-    # maxNodesTotal is the HARD CEILING ON TOTAL CLUSTER NODES (control-planes
-    # + static workers + autoscaler) — KSail passes it straight to the
-    # cluster-autoscaler --max-nodes-total, which counts EVERY node, so it must
-    # exceed the static baseline or scale-up is blocked outright. 10 = 6 static
-    # (3 control-planes + 3 workers) + up to 4 autoscaler nodes. THIS is the
-    # real cap on autoscaler growth (+4).
+    # maxNodesTotal is the autoscaler-only budget: the max number of nodes the
+    # autoscaler may ADD, excluding the static baseline. 4 = Hetzner account cap
+    # (10) - 6 static (3 control-planes + 3 workers). Each pool max is also 4,
+    # so any single CX type can fill the whole budget (e.g. 4x cx23) or any mix;
+    # the budget caps the autoscaler total at 4 regardless of type. Matches
+    # KSail's config validation: controlPlanes + workers + min(maxNodesTotal,
+    # Σ pool.max) <= serverLimit (3 + 3 + 4 = 10).
     #
-    # Per-pool max is 4 (not 1): each CX type may supply up to 4 nodes, so a
-    # burst can be served entirely by the cheapest adequate type (e.g. 4x cx23)
-    # or any mix — maxNodesTotal still caps the autoscaler total at 4, so this
-    # only changes the type distribution, never the count. (serverLimit is
-    # raised to 16 purely to satisfy KSail's config validation, which sums
-    # min(maxNodesTotal, Σ pool.max) onto the static baseline; see provider
-    # block. To grow real capacity, raise maxNodesTotal within that limit.)
+    # ⚠️ Upstream bug ksail#5017: KSail currently passes maxNodesTotal straight
+    # to cluster-autoscaler's --max-nodes-total, which counts EVERY node
+    # (baseline + autoscaler) — so until that fix lands the runtime sees 4 < 6
+    # static and refuses to scale. The intended value (4) is set here in
+    # preparation for the fix; the autoscaler is in any case currently blocked
+    # by the user_data limit (ksail#5015), so this is not a new regression.
     autoscaler:
       node:
         enabled: true
         expander: LeastWaste
-        maxNodesTotal: 10
+        maxNodesTotal: 4
         scaleDownUnneededTime: "10m"
         pools:
           - name: autoscale-cx23
@@ -125,12 +125,10 @@ spec:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   provider:
     hetzner:
-      # Config-validation guard ONLY (not a runtime cap; not passed to the
-      # autoscaler). KSail's check is controlPlanes + workers +
-      # min(maxNodesTotal, Σ pool.max) <= serverLimit = 3 + 3 + min(10, 16) =
-      # 16, so this must be >= 16 to accept per-pool max 4. The live cluster
-      # still never exceeds maxNodesTotal (10) — see the autoscaler block.
-      serverLimit: 16
+      # Hetzner account hard cap: at most 10 servers total. Doubles as KSail's
+      # config-validation guard: controlPlanes + workers + min(maxNodesTotal,
+      # Σ pool.max) <= serverLimit, i.e. 3 + 3 + min(4, 16) = 10.
+      serverLimit: 10
       controlPlaneServerType: cx33
       workerServerType: cx33
       location: fsn1

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -38,13 +38,19 @@ spec:
     # LeastWaste is the supported cost-targeting choice.
     #
     # maxNodesTotal is the HARD CEILING ON TOTAL CLUSTER NODES (control-planes
-    # + static workers + autoscaler nodes): KSail passes it straight to the
-    # cluster-autoscaler --max-nodes-total, which counts EVERY node, so it
-    # must exceed the static baseline or scale-up is blocked outright. 10 =
-    # 6 static (3 control-planes + 3 workers) + up to 4 autoscaler nodes, and
-    # equals the Hetzner serverLimit (default 10). Each pool is capped at 1,
-    # so the 4 pools add at most 4 nodes; to grow headroom raise both
-    # maxNodesTotal and serverLimit together, within the Hetzner project limit.
+    # + static workers + autoscaler) — KSail passes it straight to the
+    # cluster-autoscaler --max-nodes-total, which counts EVERY node, so it must
+    # exceed the static baseline or scale-up is blocked outright. 10 = 6 static
+    # (3 control-planes + 3 workers) + up to 4 autoscaler nodes. THIS is the
+    # real cap on autoscaler growth (+4).
+    #
+    # Per-pool max is 4 (not 1): each CX type may supply up to 4 nodes, so a
+    # burst can be served entirely by the cheapest adequate type (e.g. 4x cx23)
+    # or any mix — maxNodesTotal still caps the autoscaler total at 4, so this
+    # only changes the type distribution, never the count. (serverLimit is
+    # raised to 16 purely to satisfy KSail's config validation, which sums
+    # min(maxNodesTotal, Σ pool.max) onto the static baseline; see provider
+    # block. To grow real capacity, raise maxNodesTotal within that limit.)
     autoscaler:
       node:
         enabled: true
@@ -56,22 +62,22 @@ spec:
             serverType: cx23
             location: fsn1
             min: 0
-            max: 1
+            max: 4
           - name: autoscale-cx33
             serverType: cx33
             location: fsn1
             min: 0
-            max: 1
+            max: 4
           - name: autoscale-cx43
             serverType: cx43
             location: fsn1
             min: 0
-            max: 1
+            max: 4
           - name: autoscale-cx53
             serverType: cx53
             location: fsn1
             min: 0
-            max: 1
+            max: 4
     # These components are installed by ksail. There is a known race on
     # Hetzner clusters between ksail's metrics-server install and Flux's
     # kubelet-serving-cert-approver install (required because Talos
@@ -119,6 +125,12 @@ spec:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
   provider:
     hetzner:
+      # Config-validation guard ONLY (not a runtime cap; not passed to the
+      # autoscaler). KSail's check is controlPlanes + workers +
+      # min(maxNodesTotal, Σ pool.max) <= serverLimit = 3 + 3 + min(10, 16) =
+      # 16, so this must be >= 16 to accept per-pool max 4. The live cluster
+      # still never exceeds maxNodesTotal (10) — see the autoscaler block.
+      serverLimit: 16
       controlPlaneServerType: cx33
       workerServerType: cx33
       location: fsn1

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -37,38 +37,41 @@ spec:
     # rejects Price+Hetzner (and the autoscaler would crash on startup);
     # LeastWaste is the supported cost-targeting choice.
     #
-    # maxNodesTotal: 4 is the real ceiling — serverLimit defaults to 10 and
-    # controlPlanes(3) + workers(3) + autoscaler must stay <= it, leaving 4.
-    # Per-pool max is the same 4 so any single type can absorb the whole
-    # budget; the global cap binds. To grow this, raise serverLimit too, and
-    # only within the Hetzner project's actual server limit.
+    # maxNodesTotal is the HARD CEILING ON TOTAL CLUSTER NODES (control-planes
+    # + static workers + autoscaler nodes): KSail passes it straight to the
+    # cluster-autoscaler --max-nodes-total, which counts EVERY node, so it
+    # must exceed the static baseline or scale-up is blocked outright. 10 =
+    # 6 static (3 control-planes + 3 workers) + up to 4 autoscaler nodes, and
+    # equals the Hetzner serverLimit (default 10). Each pool is capped at 1,
+    # so the 4 pools add at most 4 nodes; to grow headroom raise both
+    # maxNodesTotal and serverLimit together, within the Hetzner project limit.
     autoscaler:
       node:
         enabled: true
         expander: LeastWaste
-        maxNodesTotal: 4
+        maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:
           - name: autoscale-cx23
             serverType: cx23
             location: fsn1
             min: 0
-            max: 4
+            max: 1
           - name: autoscale-cx33
             serverType: cx33
             location: fsn1
             min: 0
-            max: 4
+            max: 1
           - name: autoscale-cx43
             serverType: cx43
             location: fsn1
             min: 0
-            max: 4
+            max: 1
           - name: autoscale-cx53
             serverType: cx53
             location: fsn1
             min: 0
-            max: 4
+            max: 1
     # These components are installed by ksail. There is a known race on
     # Hetzner clusters between ksail's metrics-server install and Flux's
     # kubelet-serving-cert-approver install (required because Talos


### PR DESCRIPTION
## What

Replace the two prod autoscaler pools with **one pool per cost-optimized Hetzner x86 CX type**, so the cluster-autoscaler can pick the smallest *adequate* node for whatever can't schedule on the static workers.

| Pool | Type | vCPU / RAM | min | max | ~€/mo (fsn1, gross) |
|---|---|---|---|---|---|
| `autoscale-cx23` | cx23 | 2c / 4 GB | 0 | 4 | 4.99 |
| `autoscale-cx33` | cx33 | 4c / 8 GB | 0 | 4 | 8.11 |
| `autoscale-cx43` | cx43 | 8c / 16 GB | 0 | 4 | 14.99 |
| `autoscale-cx53` | cx53 | 16c / 32 GB | 0 | 4 | 28.11 |

Previously: `autoscale-small` (cx23, max 1) + `autoscale-medium` (cx33, max 2).

## Why these choices

- **`expander: LeastWaste` (unchanged).** `Price` would be the direct cost optimizer, but the cluster-autoscaler hcloud provider implements no pricing API — KSail rejects `Price`+Hetzner and the autoscaler would crash. `LeastWaste` is the supported cost-targeting choice (cheapest *adequate* type across this linearly-priced family).
- **`min: 0` everywhere** → scale-to-zero, no idle cost. Static workers stay the guaranteed baseline and the only Longhorn storage nodes (autoscaler nodes are compute-only).
- **`maxNodesTotal: 10` = total cluster nodes, including the static baseline** (6 static = 3 CP + 3 workers, + up to 4 autoscaler). It is passed straight to cluster-autoscaler's `--max-nodes-total`, which counts every node, so the runtime already enforces this total.
- **`max: 4` per pool.** Each CX type may supply up to 4 nodes, so a burst can be served entirely by the cheapest adequate type (e.g. 4× cx23) or any mix — the 10-node total ceiling still caps the autoscaler at 4 (`10 − 6`), so this changes only the *type distribution*, never the count.
- **`serverLimit: 10`** = the Hetzner account hard cap.

## Validation

Config-only change to `ksail.prod.yaml` (+ doc updates). Validated with yq + jq; both kustomize overlays build:

- ✅ `expander` ∈ enum and `== LeastWaste`; pool fields conform; names match the kebab pattern; all `min == 0`.
- ✅ Runtime: `--max-nodes-total = maxNodesTotal = 10` → 4 autoscaler nodes on top of 6 static.
- ✅ `kubectl kustomize k8s/clusters/{prod,local}/` both build.

## ⚠️ Requires the in-progress KSail validation change before it can deploy

`maxNodesTotal` is being redefined in KSail to mean the **total** cluster node count including the baseline ([devantler-tech/ksail#5017](https://github.com/devantler-tech/ksail/issues/5017)) — matching the existing `--max-nodes-total` runtime. The new validation will be `maxNodesTotal ≤ serverLimit` (`10 ≤ 10` ✓). **Until that change ships, KSail's *current* validation computes `CP + workers + min(maxNodesTotal, Σ pool.max) = 3 + 3 + min(10, 16) = 16 > serverLimit(10)` and rejects this config**, so the KSail change must be deployed before this PR merges/deploys.

Separately, actual scale-up is still gated by the `user_data` > 32 KiB limit ([devantler-tech/ksail#5015](https://github.com/devantler-tech/ksail/issues/5015)) — KSail embeds the full Talos worker config into `HCLOUD_CLOUD_INIT` (~39.8 KB). Orthogonal to pool count. The existing `cluster_autoscaler_failed_scale_ups_total[15m] > 0` alert will catch failures.

## Notes

- Branch contains main's `baseline 3, and autoscale for rest` commit (3 control-planes + 3 workers), so this PR leaves `workers` untouched and changes only the autoscaler block + provider `serverLimit` (+ docs).
- Updated `docs/node-autoscaling.md` (architecture, config example, cost guardrails) and a comment in `auto-vpa.yaml` that referenced the old `autoscale-small` pool.
- Touches the protected `ksail.prod.yaml` — done at the maintainer's explicit request. Affects live prod infra on the next `ksail --config ksail.prod.yaml cluster update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
