### PR TITLE
fix(homepage): disable GitHub update check blocked by egress policy

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -18,6 +18,17 @@ data:
     statusStyle: dot
     iconStyle: gradient
     hideVersion: true
+    # Disable Homepage's built-in GitHub release check. The cluster egress
+    # NetworkPolicy (networkpolicy.yaml) intentionally allows no internet
+    # access, so the check — GET api.github.com/repos/gethomepage/homepage/
+    # releases, fired by the Version component — is dropped by Cilium and
+    # hangs ~8s on the TCP connect timeout before failing, wasting an
+    # event-loop slot on this single-threaded server. This is separate from
+    # hideVersion (which only hides the footer display); hideVersion alone did
+    # not stop the call in prod, so disable the check at its source. Gates the
+    # useSWR("/api/releases") key in the Version component, so it holds even
+    # if hideVersion is later set false to show the version again.
+    disableUpdateCheck: true
     target: _blank
     # Layout order also controls render order on the page. Groups not listed
     # here still appear (Homepage falls back to alphabetical) but get a generic


### PR DESCRIPTION
## Summary

Stops Homepage's built-in GitHub release check from hanging ~8s against the cluster's locked-down egress policy. Follow-up to the CPU-throttling fix in #1727 (separate concern → separate PR).

## Root cause

The `allow-homepage` CiliumNetworkPolicy (`k8s/bases/apps/homepage/networkpolicy.yaml`) allows egress only to kube-apiserver, intra-namespace, and kube-dns — no internet. Homepage's Version component fires `useSWR("/api/releases")`, whose server-side handler calls `https://api.github.com/repos/gethomepage/homepage/releases`. Cilium drops it, so it hangs for the full ~8s TCP connect timeout before erroring:

```
<httpProxy> Error calling https://api.github.com/repos/gethomepage/homepage/releases...
Error: connect ETIMEDOUT 140.82.121.5:443
```

`hideVersion: true` (already set since #1608) only hides the footer display — it did **not** stop the call in prod (the timeout was observed on a pod running with `hideVersion` active).

## Fix

Add `disableUpdateCheck: true` to `settings.yaml` — the homepage setting purpose-built to disable the GitHub check. It nulls the SWR key inside the Version component:

```
version.jsx:30  useSWR(latestRelease || disableUpdateCheck ? null : "/api/releases")
```

so the call never fires, independent of `hideVersion` (so it holds even if the version display is turned back on later).

Chose this over allowing `api.github.com` egress (there is a `toFQDNs` precedent in the Dex policy): you set `hideVersion: true`, so the version is unwanted — stopping a call whose result is hidden is cleaner than opening an egress hole for it, and keeps the locked-down posture.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `.../prod/` build.
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` — **279 files validated** each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
