### PR TITLE
chore: dedupe auth-proxy removal TODO to a single component tracker

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -1,4 +1,3 @@
-# TODO: Remove auth-proxy when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
@@ -1,4 +1,3 @@
-# TODO: Remove auth-proxy when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
@@ -1,4 +1,4 @@
-# TODO: Remove auth-proxy when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
+# TODO: Remove this auth-proxy component when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
@@ -1,4 +1,3 @@
-# TODO: Remove auth-proxy when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/k8s/bases/infrastructure/controllers/auth-proxy/service.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/service.yaml
@@ -1,4 +1,3 @@
-# TODO: Remove auth-proxy when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

All five `auth-proxy` base manifests carried the **identical** comment:

```
# TODO: Remove auth-proxy when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
```

The shared `TODOs` workflow (`scan-for-todo-comments` → `create-issues-from-todos` → upstream `alstr/todo-to-issue-action`) opens **one issue per occurrence**, so a multi-occurrence TODO produces duplicate issues with the same title. When such a TODO is later removed, the upstream close path takes its ambiguous-match branch and **crashes** the workflow with `KeyError: 'web_url'` — the portfolio-wide failure mode tracked in [devantler-tech/actions#222](https://github.com/devantler-tech/actions/issues/222). `platform` still carried the latent 5-occurrence trigger.

## Change

Mirror the proven fix from [platform-template#16](https://github.com/devantler-tech/platform-template/pull/16):

- Keep the tracker **once**, on `kustomization.yaml`, reworded to component scope (`Remove this auth-proxy component when …`).
- Drop the duplicate comment from `config-map.yaml`, `deployment.yaml`, `networkpolicy.yaml`, `service.yaml`.

Comment-only; no resource behaviour changes.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `…/prod/` both build (119 lines each, unchanged).
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` both pass (✔ 279 files).

## Notes / trade-offs

- This is a base-level **comment hygiene** change that applies to all consumers (not a per-environment customization), consistent with the bases-immutable intent and matching how platform-template#16 edited its bases.
- It mitigates the actions#222 crash for `platform` specifically; the upstream `web_url`→`html_url` root cause is still tracked in actions#222 (mitigation option 2). Closing the same dedup gap here keeps the portfolio consistent.