### PR TITLE
feat(homepage): theme dashboard to match devantler.tech

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -159,21 +159,139 @@ data:
             - icon: si-nuget-#1088d6
               href: https://www.nuget.org
   docker.yaml: ""
-  # Backdrop replaces the previous remote Unsplash background image — no
-  # cross-origin asset, no cold-load flash. A slate-950 base plus two soft
-  # radial auras (blue top-left, violet bottom-right) gives a modern
-  # ambient-mesh feel without any image to download or composite. Applied
-  # to html+body so it covers the viewport even on tall scrollable pages,
-  # and `background-attachment: fixed` keeps the gradient anchored while
-  # cards scroll over it.
+  # Theme: mirror https://devantler.tech on the dashboard. devantler.tech is an
+  # Astro Starlight site whose signature is a "Matrix" neon-green accent
+  # (#39ff14) over a dark near-black base, with frosted-glass cards that glow
+  # green and lift on hover, green section accents, and green selection/focus.
+  # We reproduce that purely in CSS — no background.image, because (a) the
+  # cluster egress NetworkPolicy blocks external assets and (b) a remote image
+  # caused a cold-load flash. cardBlur stays unset: the theme already paints a
+  # translucent card fill (dark:bg-white/5 ≈ devantler's rgba(255,255,255,.045)
+  # glass), so the glass look comes from a faint border + glow here rather than
+  # backdrop-filter (which has nothing high-frequency behind it to blur).
+  # color:slate (settings.yaml) already matches devantler's blue-tinted gray
+  # family, so only the accent layer changes below. gethomepage hooks used:
+  # html/body, .service-card, .bookmark, .service-group-name /
+  # .bookmark-group-name, #information-widgets, scoped to #layout-groups /
+  # #services / #bookmarks so they win over the chart's Tailwind utilities.
   custom.css: |
+    :root {
+      --dt-accent: #39ff14;                     /* Matrix neon green */
+      --dt-accent-high: #7aff6e;                /* lighter, more legible green */
+      --dt-glow-subtle: rgba(57, 255, 20, 0.10);
+      --dt-card-border: rgba(255, 255, 255, 0.10);
+      --dt-card-border-hover: rgba(57, 255, 20, 0.45);
+    }
+
+    /* Page backdrop: devantler's dark near-black base with two soft green
+       "Matrix" auras (replaces the previous blue/violet auras). Painted on
+       html+body so it covers tall scrollable pages; fixed so cards scroll
+       over a stable backdrop. */
     html,
     body {
-      background-color: rgb(2, 6, 23);
+      background-color: #0b0e14;
       background-image:
-        radial-gradient(at 18% 12%, rgba(59, 130, 246, 0.18), transparent 55%),
-        radial-gradient(at 82% 88%, rgba(168, 85, 247, 0.14), transparent 55%);
+        radial-gradient(at 18% 12%, rgba(57, 255, 20, 0.10), transparent 55%),
+        radial-gradient(at 82% 88%, rgba(57, 255, 20, 0.06), transparent 60%);
       background-attachment: fixed;
       background-repeat: no-repeat;
+    }
+
+    /* Neon-green text selection + keyboard focus ring, matching devantler.tech. */
+    ::selection {
+      background: rgba(57, 255, 20, 0.25);
+    }
+    *:focus-visible {
+      outline: 2px solid var(--dt-accent);
+      outline-offset: 2px;
+    }
+
+    /* Service & bookmark cards: the theme already paints a translucent glass
+       fill; add a faint border at rest and a green glow + lift on hover —
+       devantler's card interaction. Scoped to the group containers so these
+       override the chart's Tailwind utilities regardless of stylesheet order. */
+    #layout-groups .service-card,
+    #services .service-card,
+    #layout-groups .bookmark > a,
+    #bookmarks .bookmark > a {
+      border: 1px solid var(--dt-card-border);
+      box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.25),
+        inset 0 1px 0 rgba(255, 255, 255, 0.03);
+      transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+    }
+    #layout-groups .service-card:hover,
+    #services .service-card:hover,
+    #layout-groups .bookmark > a:hover,
+    #bookmarks .bookmark > a:hover {
+      border-color: var(--dt-card-border-hover);
+      box-shadow:
+        0 4px 24px var(--dt-glow-subtle),
+        inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      transform: translateY(-2px);
+    }
+    /* Nudge the title toward the lighter green on hover (devantler link hover). */
+    #layout-groups .service-card:hover .service-name,
+    #services .service-card:hover .service-name,
+    #layout-groups .bookmark > a:hover .bookmark-name,
+    #bookmarks .bookmark > a:hover .bookmark-name {
+      color: var(--dt-accent-high);
+    }
+
+    /* Section headers: keep the theme's light-gray text (as devantler's h2s do)
+       and add a short green accent underline — a calmer take on devantler's
+       gradient <hr> dividers. */
+    .service-group-name,
+    .bookmark-group-name {
+      padding-bottom: 0.3rem;
+      background-image: linear-gradient(to right, var(--dt-accent), transparent);
+      background-size: 2.75rem 2px;
+      background-position: 0 100%;
+      background-repeat: no-repeat;
+    }
+
+    /* Top widgets bar: a hairline separator + soft green halo on the logo,
+       echoing devantler's glass header and glowing hero avatar. */
+    #information-widgets {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      padding-bottom: 0.85rem;
+      margin-bottom: 0.25rem;
+    }
+    #information-widgets img {
+      border-radius: 12px;
+      box-shadow: 0 0 16px rgba(57, 255, 20, 0.22);
+    }
+
+    /* Thin, dark scrollbar with a green thumb. */
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: rgba(57, 255, 20, 0.30) transparent;
+    }
+    ::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+    ::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: rgba(57, 255, 20, 0.25);
+      border: 2px solid transparent;
+      border-radius: 9999px;
+      background-clip: content-box;
+    }
+    ::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(57, 255, 20, 0.45);
+      background-clip: content-box;
+    }
+
+    /* Respect reduced-motion: the only transitions are card hovers. */
+    @media (prefers-reduced-motion: reduce) {
+      #layout-groups .service-card,
+      #services .service-card,
+      #layout-groups .bookmark > a,
+      #bookmarks .bookmark > a {
+        transition: none;
+      }
     }
   custom.js: ""


### PR DESCRIPTION
## What

Re-themes the Platform dashboard ([gethomepage](https://gethomepage.dev)) to match my personal site **[devantler.tech](https://devantler.tech)**. Only `k8s/bases/apps/homepage/config-map.yaml`'s `custom.css` block changes; `settings.yaml` is untouched.

## Why

The dashboard's backdrop was a generic **blue/violet** ambient mesh on slate — it didn't follow my theming. devantler.tech (an Astro Starlight site) has a distinct identity: a **"Matrix" neon-green accent (`#39ff14`)** over a dark near-black base, frosted-glass cards that **glow green and lift on hover**, green section accents, and green selection/focus. This brings the dashboard in line with it.

## Changes (`custom.css`)

- **Background** → dark near-black `#0b0e14` with two soft **green** radial auras (replacing blue/violet).
- **Cards** (`.service-card`, `.bookmark > a`) → faint border at rest; **green border + glow + 2px lift + green title** on hover. The translucent glass fill was already the homepage dark default (`bg-white/5` ≈ devantler's `rgba(255,255,255,.045)`).
- **Section headers** (`.service-group-name` / `.bookmark-group-name`) → short green accent underline, echoing devantler's gradient `<hr>` dividers.
- **Neon-green** text selection, `:focus-visible` ring, scrollbar, and a soft halo on the logo. Honors `prefers-reduced-motion`.

CSS hooks were taken from gethomepage source (stable semantic classes), scoped to `#layout-groups` / `#services` / `#bookmarks` so they win over the chart's Tailwind utilities.

## Why no `settings.yaml` change

- `color: slate` already matches devantler's blue-tinted gray (`hsl(224°)`) family — greener palettes would tint all the neutral chrome.
- `background.image` stays unset: the cluster egress NetworkPolicy blocks external assets and a remote image previously caused a cold-load flash.
- `cardBlur` stays unset: `backdrop-filter` has no high-frequency content behind it to blur (no image), so the glass look comes from the translucent fill + border instead.

## Validation

- `ksail workload validate` → ✔ 279 files validated
- ConfigMap client dry-run → `configmap/homepage configured (dry run)`
- `kubectl kustomize` builds clean for both `k8s/clusters/local/` and `k8s/clusters/prod/`

> Note: this is a pure CSS/string change inside an existing ConfigMap — no schema or topology impact. Rendering is client-side, so there's no runtime cost on the single-threaded homepage pod. The system test in CI will exercise the real render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
