### PR TITLE
fix(cluster-policies): exempt monitoring from the default ResourceQuota

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -35,6 +35,18 @@ patches:
                   - kube-public
                   - kube-node-lease
                   - flux-system
+                  # Platform observability stack. monitoring runs the
+                  # node-exporter and alloy DaemonSets, which must schedule a pod
+                  # on EVERY node -- including autoscaler-provisioned ones -- and
+                  # carries a VPA-governed footprint that legitimately exceeds the
+                  # generic tenant quota. A hard requests.memory ResourceQuota
+                  # here rejects those DaemonSet pods (and the kube-prometheus-stack
+                  # Helm pre-upgrade hook Job) on any new node, which stalls the
+                  # HelmRelease and the infrastructure-controllers Flux
+                  # Kustomization cluster-wide. Exempt it like the other
+                  # platform-owned namespaces; its sizing is VPA-owned, not
+                  # quota-bounded. The LimitRange (rule 1) still applies.
+                  - monitoring
       - op: add
         path: /spec/rules/0/generate/generateExisting
         value: true


### PR DESCRIPTION
## Symptom

Live prod warning events, all cascading from one cause:

```
monitoring   FailedCreate     daemonset/alloy ... forbidden: exceeded quota: default-resourcequota
monitoring   FailedCreate     daemonset/kube-prometheus-stack-prometheus-node-exporter ... exceeded quota
monitoring   FailedCreate     job/kube-prometheus-stack-admission-create ... exceeded quota (158x)
monitoring   RollbackFailed   helmrelease/kube-prometheus-stack
flux-system  HealthCheckFailed kustomization/infrastructure-controllers
```

The autoscaler node `autoscale-cx23` had **no** `node-exporter`/`alloy` pod
(every other node did): `alloy` DaemonSet `DESIRED 4 / CURRENT 3`,
`node-exporter` `DESIRED 7 / CURRENT 6`.

## Root cause

The Kyverno `add-ns-quota` policy generates a hard `requests.memory=16Gi`
ResourceQuota into every namespace **except** the platform/system ones
(`kube-system`, `kube-public`, `kube-node-lease`, `flux-system`). The
`monitoring` namespace was wrongly treated as a tenant, but it:

- runs the `node-exporter` and `alloy` **DaemonSets**, which must place a pod on
  **every** node — including autoscaler-provisioned ones. DaemonSet pods get no
  exemption from ResourceQuota admission, so a full namespace quota blocks them
  cluster-wide on scale-up;
- carries a **VPA-governed** observability footprint that legitimately exceeds
  the generic tenant cap.

When the cluster autoscaled a new node, the quota rejected the DaemonSet pods
**and** the kube-prometheus-stack Helm pre-upgrade hook Job for it. That stalled
the HelmRelease (`UpgradeFailed` → `RollbackFailed`, because the rollback waits
on the node-exporter DaemonSet) and the `infrastructure-controllers` Flux
Kustomization (`HealthCheckFailed`).

The fault was **amplified** by the quota controller's `used` value wedging at
`17124312638` (15.95/16Gi) while the real sum of all 19 running pods'
`requests.memory` was only **4.78 GiB** — i.e. the namespace was nowhere near its
true footprint, yet admission was blocked.

## Fix

Add `monitoring` to the `generate-resourcequota` exclude list, exempting it like
the other platform-owned namespaces. Its sizing is VPA-owned, not quota-bounded.

- Surgical: only the **ResourceQuota** (rule 0) is changed. The **LimitRange**
  (rule 1) still applies, so default container requests/limits are unchanged.
- With `generateExisting: true` + `synchronize: true`, Kyverno should garbage-
  collect the now-orphaned `default-resourcequota` in `monitoring`, which also
  clears the wedged `used` accounting and unblocks the DaemonSets + Helm hook.

> **Operational note (post-merge):** if Kyverno does not auto-remove the existing
> object, a one-time `kubectl delete resourcequota -n monitoring default-resourcequota`
> resets the stale accounting and lets Flux finish reconciling.

## Validation

- `kubectl kustomize k8s/clusters/{local,prod}/` — both build.
- `ksail workload validate` (local) and `ksail --config ksail.prod.yaml workload validate` — **279 files validated** each.
- Rendered policy confirms `monitoring` exempt from rule 0 only; rule 1 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
