### PR TITLE
feat(longhorn): expose UI behind Dex SSO and surface on homepage

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -33,12 +33,15 @@ data:
     # Layout order also controls render order on the page. Groups not listed
     # here still appear (Homepage falls back to alphabetical) but get a generic
     # icon — keep this in sync with the gethomepage.dev/group annotations on
-    # the HTTPRoutes under k8s/bases/apps/** and the service entries below.
+    # the HTTPRoutes under k8s/bases/apps/** and k8s/**/infrastructure/** (incl.
+    # provider overlays, e.g. Longhorn on Hetzner) and the service entries below.
     layout:
       Kubernetes:
         icon: si-talos-#FF7300
       Observability:
         icon: si-grafana
+      Storage:
+        icon: mdi-harddisk
       Security:
         icon: mdi-shield-lock
       Diagnostics:

--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -37,6 +37,15 @@ data:
           rule: "Host(`opencost.${domain}`)"
           entryPoints: ["web"]
           service: opencost
+        # Hetzner-only: Longhorn is deployed solely on prod. On local/CI the
+        # backend (longhorn-frontend.longhorn-system) does not exist, but this
+        # router is inert there -- no HTTPRoute sends longhorn.${domain} to
+        # oauth2-proxy, so it is never matched (matches how base policies
+        # already scope the prod-only longhorn-system namespace).
+        longhorn:
+          rule: "Host(`longhorn.${domain}`)"
+          entryPoints: ["web"]
+          service: longhorn
       services:
         homepage:
           loadBalancer:
@@ -58,3 +67,7 @@ data:
           loadBalancer:
             servers:
               - url: "http://opencost.opencost.svc.cluster.local:9090"
+        longhorn:
+          loadBalancer:
+            servers:
+              - url: "http://longhorn-frontend.longhorn-system.svc.cluster.local:80"

--- a/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
@@ -56,6 +56,16 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
+    # Longhorn UI upstream (Hetzner-only). longhorn-frontend forwards to the
+    # longhorn-ui pod on container port 8000; inert on local/CI where the
+    # longhorn-system namespace is absent.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: longhorn-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
     # DNS resolution
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
@@ -21,6 +21,12 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: opencost
+    # Hetzner-only: the Longhorn UI HTTPRoute (longhorn-system) backends to the
+    # oauth2-proxy Service for SSO. Inert on local/CI where longhorn-system has
+    # no HTTPRoute.
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: longhorn-system
   to:
     - group: ""
       kind: Service

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/httproute.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/httproute.yaml
@@ -1,0 +1,44 @@
+# Expose the Longhorn UI behind oauth2-proxy SSO (the same forward-auth
+# pattern the other admin UIs use -- Hubble, Prometheus, Alertmanager,
+# OpenCost). The Longhorn frontend ships no built-in authentication, so SSO at
+# the gateway is the only access control: the route backends to oauth2-proxy
+# (not longhorn-frontend); after authentication oauth2-proxy forwards to
+# auth-proxy, which routes longhorn.${domain} by Host to the longhorn-frontend
+# Service (see k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml).
+# The gethomepage.dev annotations surface it on the dashboard under "Storage".
+# Hetzner-only: Longhorn is deployed solely on prod (k8s/providers/hetzner).
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Longhorn
+    gethomepage.dev/description: Distributed block storage and volume management.
+    gethomepage.dev/group: Storage
+    gethomepage.dev/icon: longhorn.png
+spec:
+  parentRefs:
+    - name: platform
+      namespace: kube-system
+      sectionName: https
+  hostnames:
+    - longhorn.${domain}
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://longhorn.${domain}/
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload
+      backendRefs:
+        - name: oauth2-proxy
+          namespace: oauth2-proxy
+          port: 80

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - helm-repository.yaml
   - helm-release.yaml
   - networkpolicy.yaml
+  - httproute.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/networkpolicy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/networkpolicy.yaml
@@ -23,6 +23,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: monitoring
+    # Longhorn UI reached via auth-proxy (oauth2-proxy SSO) after
+    # authentication. longhorn-frontend forwards to the longhorn-ui pod, which
+    # serves on container port 8000 (Service longhorn-frontend: 80 -> 8000).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
   egress:
     # Kube API
     - toEntities:


### PR DESCRIPTION
## What

Exposes the **Longhorn UI** behind the cluster's Dex SSO and surfaces it on the homepage under a new **Storage** group. Previously the Longhorn dashboard had no route, so it wasn't reachable from the homepage at all.

## Why

The Longhorn frontend ships **no built-in authentication**. It now sits behind the same forward-auth path every other admin UI uses, so the only way to reach it externally is `https://longhorn.${domain}` after authenticating against Dex (membership in `devantler-tech/platform`). The `longhorn-frontend` Service stays `ClusterIP` — no bypass.

```
HTTPRoute → oauth2-proxy (Dex SSO) → auth-proxy (Traefik host fan-out) → longhorn-frontend
```

## Changes

**Prod-only** (Longhorn is deployed only on Hetzner):
- **New** `longhorn/httproute.yaml` — `longhorn.${domain}` → `oauth2-proxy`, with `X-Auth-Request-Redirect` + HSTS headers and `gethomepage.dev/*` annotations (`group: Storage`, `icon: longhorn.png`); registered in the longhorn kustomization.
- `longhorn/networkpolicy.yaml` — ingress allow from the `oauth2-proxy` namespace to the `longhorn-ui` pod port **8000**.

**Base** (inert on local/CI, which has no `longhorn-system` namespace — consistent with how base `cluster-policies/` and `security-exceptions/` already scope that namespace):
- `auth-proxy/config-map.yaml` — Traefik `longhorn` router + service → `longhorn-frontend.longhorn-system.svc:80`.
- `auth-proxy/networkpolicy.yaml` — egress to `longhorn-system:8000`.
- `oauth2-proxy/reference-grant.yaml` — allow the `longhorn-system` HTTPRoute to backend the `oauth2-proxy` Service.
- `homepage/config-map.yaml` — add the `Storage` layout group (icon `mdi-harddisk`) between Observability and Security.

## Reviewer notes

- **Cilium L4 policy uses the pod/targetPort, not the Service port** — proven by the existing homepage rule (egress `3000` while routing to `homepage.svc:80`). Hence `8000` in the NetworkPolicies but `:80` in the Traefik upstream URL (`longhorn-frontend` is `80 → 8000`).
- **Base carries the router/egress/reference-grant on purpose.** A Hetzner full-replace patch of auth-proxy's `dynamic.yaml` string can't merge and would silently drift from base; keeping the entries in base is single-source and inert where `longhorn-system` is absent. The Storage group renders only where a Longhorn tile is discovered (prod).
- **No gateway/cert/DNS changes** — the wildcard `*.${domain}` cert, the unrestricted `https` listener (`from: All`), and prod wildcard DNS already cover the new subdomain.
- auth-proxy remains the SSO fan-out until Cilium ships native forward-auth (cilium#23797) — this follows the existing pattern, it doesn't extend the component's lifetime.

## Validation

`ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` both pass — **280 files, exit 0** — explicitly covering `longhorn/httproute.yaml` and `longhorn/networkpolicy.yaml`. Both provider overlays build (`kubectl kustomize`); the Longhorn HTTPRoute renders for prod only and is absent from the Docker/local build.

> CI runs the full Talos + Docker system test on this PR; the new route is inert there (no `longhorn-system`), so local bring-up is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
