### PR TITLE
fix(hubble): allow auth-proxy to reach the KEDA interceptor for cold-start

### DIFF
--- a/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
@@ -6,9 +6,25 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    # Gateway ingress to interceptor proxy
+    # Gateway ingress to interceptor proxy. Apps routed straight from the
+    # Cilium Gateway to the interceptor (whoami, headlamp, actual-budget)
+    # arrive with the reserved "ingress" identity.
     - fromEntities:
         - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # auth-proxy ingress to interceptor proxy. Hubble UI needs SSO, so its
+    # cold-start path is Gateway -> oauth2-proxy -> auth-proxy -> interceptor.
+    # The client reaching :8080 is therefore the auth-proxy pod, not the
+    # "ingress" identity above. Without this rule the request is silently
+    # dropped by default-deny, the interceptor never sees it, hubble-ui never
+    # scales from zero, and the request hangs until the edge returns a 504.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+            app: auth-proxy
       toPorts:
         - ports:
             - port: "8080"


### PR DESCRIPTION
## Symptom

Opening Hubble from the homepage hangs and eventually returns a Cloudflare **504 Gateway time-out** for `hubble.platform.devantler.tech`.

## Root cause

Hubble UI is a KEDA **scale-to-zero** app, and it's the only such app fronted by SSO. Its request path is:

```
Cloudflare → Cilium Gateway → oauth2-proxy (Dex) → auth-proxy (Traefik) → KEDA HTTP interceptor → hubble-ui
```

The other scale-to-zero apps (whoami, headlamp, actual-budget) route **straight** from the Gateway to the interceptor, so they reach it with Cilium's reserved `ingress` identity.

The `keda` namespace's default-deny `CiliumNetworkPolicy` (`allow-keda`) only permitted ingress to the interceptor on `:8080` from that `ingress` identity. **The `auth-proxy` pod was never an allowed source**, so Hubble's requests were silently dropped at the keda namespace (a Cilium drop is a black-hole, not a reject). Consequences, all observed on the live cluster:

- The interceptor **never** logged a Hubble cold-start (whoami/headlamp/actual-budget log them constantly).
- hubble-ui **never** scaled from zero — **no node has ever cached the hubble-ui images**.
- The connection hung ~100s → Cloudflare 504.

The matching **egress** allow (`auth-proxy → interceptor`, in `allow-auth-proxy`) already existed — only the **ingress** side on the keda namespace was missing. The earlier `oauth2-proxy upstream_timeout` bump to 90s (#1639) couldn't help, because the packet never reached the interceptor.

## Fix

Add one ingress rule to `allow-keda` permitting the `auth-proxy` pod (namespace `oauth2-proxy`) to reach the interceptor on `:8080`. The next hop (`interceptor → hubble-ui:8081`) is already allowed by `allow-hubble-ui`, so this is the only missing piece.

## Validation

- `kubectl kustomize` builds for both provider controller overlays (`providers/hetzner/infrastructure/controllers`, `providers/docker/infrastructure/controllers`).
- `ksail workload validate` passes — **279 files validated**.
- Ruled out (read-only, live `admin@prod`): memory pressure (hubble-ui is BestEffort; real usage 57–73%), admission (no enforcing Kyverno on pods, no PSA on kube-system), Service wiring (selector + port correct), readiness (static nginx).

## Rollout note

This reaches prod via the normal Flux delivery (tag / merge-queue deploy), not instantly on merge. To confirm the fix live before/after merge, apply the single rule and click Hubble — a pod should cold-start within seconds and the image will cache on its node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
