### PR TITLE
ci: exempt internal devantler-tech deps from Renovate cooldown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -128,6 +128,16 @@
         "major"
       ],
       "automerge": true
+    },
+    {
+      "description": "Internal devantler-tech dependencies are trusted (our own code) — bump immediately with no release-age cooldown (e.g. the KSAIL_VERSION custom-manager dep devantler-tech/ksail).",
+      "matchPackageNames": [
+        "devantler-tech/**",
+        "github.com/devantler-tech/**",
+        "ghcr.io/devantler-tech/**",
+        "@devantler-tech/**"
+      ],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
## What

Adds a Renovate `packageRules` entry setting `minimumReleaseAge: "0 days"` for internal deps (matches `devantler-tech/**` — including the `KSAIL_VERSION` custom-manager dep `devantler-tech/ksail` that is currently held 7 days — plus the `github.com/`, `ghcr.io/`, and `@devantler-tech/` forms).

## Why

We trust our own code (CI is the gate), so internal `devantler-tech/*` bumps shouldn't wait in cooldown like third-party deps — they should land immediately.

Companion to devantler-tech/monorepo#1782 (portfolio-wide pass across every repo's Dependabot/Renovate config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
