### PR TITLE
ci(coroot): skip the Coroot kind in workload validate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,10 @@ jobs:
         with:
           distribution: Talos
           provider: Docker
-          ksail-version: "7.25.0"
+          # 7.26.0 adds `workload validate --skip-kinds` / spec.workload.validation.skipKinds,
+          # which ksail.yaml uses to skip the Coroot CR (its CRDs-catalog schema is stale).
+          # Manual pin (the curl KSAIL_VERSION pins below are the Renovate-tracked ones).
+          ksail-version: "7.26.0"
           init: "false"
           validate: "true"
           scan: "true"

--- a/ksail.yaml
+++ b/ksail.yaml
@@ -32,7 +32,7 @@ spec:
     kustomizationFile: clusters/local
     validation:
       # Skip the Coroot CR (coroot.com/v1) during `ksail workload validate`: its
-      # datreeio CRDs-catalog schema is stale (additionalProperties:false, missing
+      # datreeio CRDs-catalog schema is stale (additionalProperties: false, missing
       # newer fields like nodeAgent/clickhouse), so kubeconform rejects valid
       # manifests. Requires ksail >= 7.26.0 (the --skip-kinds / skipKinds feature).
       skipKinds:

--- a/ksail.yaml
+++ b/ksail.yaml
@@ -30,4 +30,11 @@ spec:
   workload:
     sourceDirectory: k8s
     kustomizationFile: clusters/local
+    validation:
+      # Skip the Coroot CR (coroot.com/v1) during `ksail workload validate`: its
+      # datreeio CRDs-catalog schema is stale (additionalProperties:false, missing
+      # newer fields like nodeAgent/clickhouse), so kubeconform rejects valid
+      # manifests. Requires ksail >= 7.26.0 (the --skip-kinds / skipKinds feature).
+      skipKinds:
+        - Coroot
 


### PR DESCRIPTION
## What

Make `ksail workload validate` (the System Test's validate step) tolerate the **Coroot CR** introduced in #1742, by skipping the `Coroot` kind:

- `ksail.yaml` — add `spec.workload.validation.skipKinds: [Coroot]`.
- `.github/workflows/ci.yaml` — bump the `ksail-cluster` action's `ksail-version` input `7.25.0` → `7.26.0` (the release that adds the `--skip-kinds` / `skipKinds` feature, devantler-tech/ksail#5048).

## Why

#1742 (replace kube-prometheus-stack with Coroot) was **merged with a failing System Test** — `ksail workload validate` rejects the `coroot.com/v1` CR because its datreeio CRDs-catalog schema is stale (`additionalProperties: false`, missing newer fields like `nodeAgent`/`clickhouse`), so kubeconform fails valid manifests. That leaves **main's System Test red on every future k8s-path PR** until validation can skip the kind. This PR is the agreed follow-up.

## ⚠️ Gated on the ksail 7.26.0 release

`skipKinds` requires the ksail binary that ships it. devantler-tech/ksail#5048 is **merged to main but not yet released** (latest is v7.25.0; the next release is a `feat` minor → **v7.26.0**). Until v7.26.0 is published, this PR's **System Test will fail at the install step** (the action `gh release download v7.26.0` 404s). Once v7.26.0 is out, **re-run the System Test** (or push) and it will go green.

## Scope — only the validation pin is bumped

There are three ksail pins; only the one that runs validation is changed:

| Pin | Job | Bumped? |
|---|---|---|
| `ci.yaml` `ksail-version` (action input) | System Test → `workload validate` (local overlay) | ✅ → 7.26.0 |
| `ci.yaml` `KSAIL_VERSION` (curl) | merge_group prod `workload push` | ❌ left for Renovate |
| `cd.yaml` `KSAIL_VERSION` (curl) | tag prod deploy `workload push` | ❌ left for Renovate |

The two curl pins are Renovate-managed behind a deliberate `minimumReleaseAge: 7 days` soak, and the prod `workload push` does **not** validate manifests (no `validateOnPush` in `ksail.prod.yaml`) — so they don't need 7.26.0. Bumping them here would bypass the soak and pull the new cluster fixes (ksail#5046/#5035) into prod prematurely. Renovate will bump them in its own reviewable PR. **No protected-file change is needed.**

## Validation

- `kubectl kustomize k8s/clusters/local/` and `…/prod/` both build.
- `ksail.yaml` structure verified against the ksail config schema (`spec.workload.validation.skipKinds`).
- Authoritative check is the System Test itself, which is green once 7.26.0 is available.
