### PR TITLE
fix(coroot): set spec.timeout on the operator HelmRelease

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/helm-release.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.toolkit.fluxcd.io/remediation: enabled
 spec:
   interval: 10m0s
+  timeout: 10m
   install:
     crds: CreateReplace
     remediation:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`infrastructure-controllers` reconciliation is wedged on the live cluster. The `enforce-flux-best-practices` Kyverno `ClusterPolicy` runs in **Enforce** mode and denies the `coroot-operator` HelmRelease at admission:

```
HelmRelease/coroot/coroot-operator dry-run failed: admission webhook
"validate.kyverno.svc-fail" denied the request ... resource
HelmRelease/coroot/coroot-operator was blocked due to the following policies

enforce-flux-best-practices:
  helmrelease-recommended-settings: 'validation error: Flux HelmRelease must set
  the recommended reliability fields ... rule helmrelease-recommended-settings
  failed at path /spec/timeout/'
```

## Root cause

The `helmrelease-recommended-settings` rule requires `spec.interval`, `spec.timeout`, install + upgrade remediation retries, and `spec.upgrade.remediation.remediateLastFailure: true`. The `coroot-operator` HelmRelease introduced in #1742 set every required field **except `spec.timeout`**, so it passed review but is denied at admission now that the policy is in `Enforce` mode.

It was the **only** HelmRelease in the repo missing `timeout` — every other one already sets it (`10m` is the near-universal value).

## Fix

Add `timeout: 10m` to the base `coroot-operator` HelmRelease, matching the repo-wide convention. One line:

```diff
 spec:
   interval: 10m0s
+  timeout: 10m
   install:
```

## Validation

- `kubectl kustomize k8s/clusters/local/` — builds ✅
- `kubectl kustomize k8s/clusters/prod/` — builds ✅
- Rendered `coroot-operator` HelmRelease (both `docker` and `hetzner` provider overlays) now carries all the fields the policy requires: `interval`, `timeout`, install `retries: -1`, upgrade `retries: -1`, and `remediateLastFailure: true`.
