### PR TITLE
chore(local): deploy no apps by default in the docker overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ ksail workload push
 ksail workload reconcile
 ```
 
-By default the local cluster brings up **only the platform infrastructure — no apps**; infrastructure UIs are reachable via the `hosts` file's `*.platform.lan` → `127.0.0.1` mappings (e.g. `dex.platform.lan`, `flux.platform.lan`). Apps are opt-in: enable the ones you want to test by uncommenting them in the docker apps overlay's copy-paste enable-list (`k8s/providers/docker/apps/kustomization.yaml`) and re-running `ksail workload push` + `ksail workload reconcile`. Only then do their routes respond — the apex `https://platform.lan` (served by the homepage app) and per-app subdomains such as `headlamp.platform.lan` or `whoami.platform.lan`.
+By default the local cluster brings up **only the platform infrastructure — no apps**; infrastructure UIs are reachable via the `hosts` file's `*.platform.lan` → `127.0.0.1` mappings (e.g. `dex.platform.lan`, `flux.platform.lan`). Apps are opt-in: to enable one, replace `resources: []` in the docker apps overlay (`k8s/providers/docker/apps/kustomization.yaml`) with the entries you want — its comments carry a copy-paste template, including the `patches:` block needed for `actual-budget`/`headlamp` — then re-run `ksail workload push` + `ksail workload reconcile`. Only then do their routes respond — the apex `https://platform.lan` (served by the homepage app) and per-app subdomains such as `headlamp.platform.lan` or `whoami.platform.lan`.
 
 **Cleanup:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ ksail workload push
 ksail workload reconcile
 ```
 
-Local services are reachable at `https://platform.lan` and the per-app subdomains listed in the `hosts` file (e.g. `headlamp.platform.lan`, `whoami.platform.lan`), which map to `127.0.0.1`.
+By default the local cluster brings up **only the platform infrastructure — no apps**; infrastructure UIs are reachable via the `hosts` file's `*.platform.lan` → `127.0.0.1` mappings (e.g. `dex.platform.lan`, `flux.platform.lan`). Apps are opt-in: enable the ones you want to test by uncommenting them in the docker apps overlay's copy-paste enable-list (`k8s/providers/docker/apps/kustomization.yaml`) and re-running `ksail workload push` + `ksail workload reconcile`. Only then do their routes respond — the apex `https://platform.lan` (served by the homepage app) and per-app subdomains such as `headlamp.platform.lan` or `whoami.platform.lan`.
 
 **Cleanup:**
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ksail workload push
 ksail workload reconcile
 ```
 
-Ports 80 and 443 are automatically mapped to localhost via `extraPortMappings` in `ksail.yaml`. Once the cluster is running, access services at `https://platform.lan` (requires host entries from the `hosts` file).
+Ports 80 and 443 are automatically mapped to localhost via `extraPortMappings` in `ksail.yaml`. By default the local cluster runs only the platform infrastructure; apps are opt-in — enable the ones you want by uncommenting them in `k8s/providers/docker/apps/kustomization.yaml`, then re-run `ksail workload push && ksail workload reconcile`. Reach the deployed services at their `*.platform.lan` hostnames (the `hosts` file maps these to `127.0.0.1`).
 
 To tear down:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ksail workload push
 ksail workload reconcile
 ```
 
-Ports 80 and 443 are automatically mapped to localhost via `extraPortMappings` in `ksail.yaml`. By default the local cluster runs only the platform infrastructure; apps are opt-in — enable the ones you want by uncommenting them in `k8s/providers/docker/apps/kustomization.yaml`, then re-run `ksail workload push && ksail workload reconcile`. Reach the deployed services at their `*.platform.lan` hostnames (the `hosts` file maps these to `127.0.0.1`).
+Ports 80 and 443 are automatically mapped to localhost via `extraPortMappings` in `ksail.yaml`. By default the local cluster runs only the platform infrastructure; apps are opt-in — to enable one, replace `resources: []` in `k8s/providers/docker/apps/kustomization.yaml` with the entries you want (its comments include a copy-paste template), then re-run `ksail workload push && ksail workload reconcile`. Reach the deployed services at their `*.platform.lan` hostnames (the `hosts` file maps these to `127.0.0.1`).
 
 To tear down:
 

--- a/k8s/providers/docker/apps/kustomization.yaml
+++ b/k8s/providers/docker/apps/kustomization.yaml
@@ -1,24 +1,37 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-  # wedding-app & ascoachingogvaner excluded: prod-only tenants needing GHCR, CNPG, and longhorn
-  # fleetdm excluded: heavy app (MySQL + Redis + migration) that consistently
-  #   times out in Docker CI due to controller scheduling delays; Docker overlay
-  #   uses substantially different config (standalone DBs, default storageClass)
-  #   so CI coverage is not representative of production anyway
-  - ../../../bases/apps/actual-budget/
-  - ../../../bases/apps/headlamp/
-  - ../../../bases/apps/homepage/
-  - ../../../bases/apps/whoami/
-patches:
-  - target:
-      kind: HelmRelease
-      name: actual-budget
-      namespace: actual-budget
-    path: actual-budget/patches/helm-release-patch.yaml
-  - target:
-      kind: HelmRelease
-      name: headlamp
-      namespace: headlamp
-    path: headlamp/patches/helm-release-patch.yaml
+# The local (Docker) cluster deploys NO apps by default — a local bring-up only
+# needs the platform infrastructure, and most local testing doesn't exercise the
+# apps. Apps are therefore opt-in for local testing.
+#
+# To enable one or more apps locally, replace `resources: []` below with the
+# entries you want (and add the matching `patches:` block for any app that has
+# one — currently actual-budget and headlamp), then run:
+#   ksail workload push && ksail workload reconcile
+#
+# Available apps (copy the lines you need):
+#   resources:
+#     - ../../../bases/apps/actual-budget/   # also add the actual-budget patch below
+#     - ../../../bases/apps/headlamp/        # also add the headlamp patch below
+#     - ../../../bases/apps/homepage/
+#     - ../../../bases/apps/whoami/
+#
+#   patches:
+#     - target:
+#         kind: HelmRelease
+#         name: actual-budget
+#         namespace: actual-budget
+#       path: actual-budget/patches/helm-release-patch.yaml
+#     - target:
+#         kind: HelmRelease
+#         name: headlamp
+#         namespace: headlamp
+#       path: headlamp/patches/helm-release-patch.yaml
+#
+# Not available on the local cluster (intentionally excluded):
+#   wedding-app, ascoachingogvaner — prod-only tenants (need GHCR, CNPG, longhorn)
+#   fleetdm                        — heavy app (MySQL + Redis + migration) that
+#                                    consistently times out in Docker CI; its
+#                                    Docker config would differ from prod anyway
+resources: []


### PR DESCRIPTION
## What

Stop deploying applications to the local (Docker) cluster by default. The docker apps overlay (`k8s/providers/docker/apps/kustomization.yaml`) now builds to an empty `resources: []`, with a self-documenting **commented enable-list / copy-paste template** above it so a maintainer can turn on individual apps when testing locally.

## Why

A local bring-up only needs the platform infrastructure — the apps (actual-budget, headlamp, homepage, whoami) are rarely exercised locally and add cold image-pull and scheduling time to every `ksail cluster create`. Making them opt-in keeps the default local environment lean while leaving every app one uncomment away.

## How to enable an app locally

Replace `resources: []` with the entries you want (and add the matching `patches:` block for `actual-budget` / `headlamp`), then `ksail workload push && ksail workload reconcile`. The full template, including the patches, lives in the file's comments.

## Scope / blast radius

- **Only** `k8s/providers/docker/apps/kustomization.yaml` changed — the local overlay.
- The shared base (`k8s/bases/apps/`) and the **hetzner/prod** overlay are untouched, so production deploys are unaffected.
- The prod-only exclusion rationale (wedding-app, ascoachingogvaner, fleetdm) is preserved in the comments.

## Implementation note

Kustomize rejects a null/commented-out `resources:` key with `"kustomization.yaml is empty"`, and `[]` can't coexist with uncommented block items — so the file keeps an explicit `resources: []` plus a copy-paste template block rather than per-line uncommenting, which is the footgun-free way to have both a valid build and an easy enable path.

## Validation

- `kubectl kustomize k8s/providers/docker/apps/` → 0 docs (no apps, intended).
- `kubectl kustomize k8s/clusters/local/` → unchanged (Flux wiring).
- `kubectl kustomize k8s/clusters/prod/` and `k8s/providers/hetzner/apps/` → unchanged.
- `ksail workload validate` → `providers/docker/apps validated ✔`. The one reported failure is `providers/hetzner/infrastructure` on the Coroot CRD schema (`notificationIntegrations`) — a prod path not touched here and a pre-existing stale-catalog-schema issue, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
