### PR TITLE
fix(coroot): set notificationIntegrations.baseURL to unblock prod reconcile

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -54,6 +54,14 @@ spec:
             key: key
           description: bundled node-agent + cluster-agent
       notificationIntegrations:
+        # Required by the Coroot CRD whenever any notificationIntegrations are
+        # set (`spec.projects[].notificationIntegrations.baseURL`, pattern
+        # ^https?://.+$). Coroot interpolates it into the `.URL` template
+        # variable used in the Slack templates below, so incident/alert links
+        # deep-link back to the affected app in this instance. Same host the
+        # HTTPRoute + auth-proxy serve the UI on; `${domain}` is substituted by
+        # Flux from the per-cluster variables-cluster ConfigMap.
+        baseURL: https://coroot.${domain}
         webhook:
           url: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}
           incidents: true


### PR DESCRIPTION
## Problem

Prod Flux reconciliation is wedged. On the live cluster:

```
flux-system  infrastructure  False  Coroot/coroot/coroot dry-run failed (Invalid):
  Coroot.coroot.com "coroot" is invalid:
  [spec.projects[0].notificationIntegrations.baseURL: Required value, ...]
flux-system  apps            False  dependency 'flux-system/infrastructure' is not ready
```

The `infrastructure` Kustomization fails its server-side dry-run every 2 minutes and never
applies the `Coroot` CR (the live CR is `NotFound`). Because `apps` `dependsOn`
`infrastructure`, the whole `apps` layer is blocked behind it.

## Root cause

The Coroot CRD makes `spec.projects[].notificationIntegrations.baseURL` **required** whenever
any `notificationIntegrations` are present (schema: `required: [baseURL]`, pattern
`^https?://.+$`, _"The URL of Coroot instance (required). Used for generating links in
notifications."_).

The hetzner overlay
([`coroot-patch.yaml`](k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml))
wires a **prod-only** Slack `webhook` integration but never set `baseURL`, so the CR is
structurally invalid and the apiserver rejects it at dry-run.

This is **prod-only** because the base CR
([`coroot.yaml`](k8s/bases/infrastructure/coroot/coroot.yaml)) has no `projects` block at all —
the docker (local/CI) overlay therefore has no `notificationIntegrations`, the field isn't
required there, and the System Test passes. Only the hetzner overlay trips it.

## Fix

Set `baseURL: https://coroot.${domain}` on the prod `notificationIntegrations` block — the same
host the Coroot HTTPRoute and auth-proxy already serve the UI on. Flux substitutes `${domain}`
from the per-cluster `variables-cluster` ConfigMap (`platform.devantler.tech`), the same
mechanism the adjacent `${alertmanager_webhook_url}` already relies on. Coroot interpolates
`baseURL` into the `.URL` template variable, so the existing Slack incident/alert templates now
produce links that deep-link back to the affected app.

## Validation (static + live read-only)

- `kubectl kustomize k8s/providers/hetzner/infrastructure/` builds; rendered prod CR carries
  `notificationIntegrations.baseURL: https://coroot.${domain}`.
- `kubectl kustomize k8s/providers/docker/infrastructure/` builds; local CR still has **no**
  `projects`/`notificationIntegrations` (stays quiet by design — unchanged).
- **Server-side dry-run** of the rendered prod CR (with `${domain}`/`${alertmanager_webhook_url}`
  substituted) against the live cluster now succeeds — the exact operation that was failing:
  `coroot.coroot.com/coroot created (server dry run)`.

Once merged and pushed to GHCR, `infrastructure` will apply the Coroot CR and go Ready, which
unblocks `apps`.

### Note (not in scope of this PR)

The `apps` health condition also shows a **stale** `Job/umami/umami-provision-tenants status:
'Failed'` — but that is frozen from an older revision (`apps` hasn't reconciled since it's
blocked), the Job no longer exists on the cluster, and umami itself is currently healthy (both
pods `Running` `1/1`, last restart 13h ago). The idempotent provision Job should re-run and
complete once `apps` unblocks; flagging it only as something to watch after this lands.
