### PR TITLE
fix(coroot): use a resolvable Homepage icon for Coroot

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -39,7 +39,8 @@ data:
       Kubernetes:
         icon: si-talos-#FF7300
       Observability:
-        icon: coroot
+        # `coroot` is not in any icon set Homepage resolves; use an MDI icon.
+        icon: mdi-chart-line
       Storage:
         icon: mdi-harddisk
       Security:

--- a/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
@@ -15,7 +15,12 @@ metadata:
     gethomepage.dev/name: Coroot
     gethomepage.dev/description: Metrics, logs, traces, profiling and alerts.
     gethomepage.dev/group: Observability
-    gethomepage.dev/icon: coroot.png
+    # Coroot isn't in the dashboard-icons / selfh.st / simple-icons sets Homepage
+    # resolves, so `coroot.png` 404s and the card renders blank. Point at Coroot's
+    # upstream brand SVG instead — the same upstream-URL pattern this repo already
+    # uses for the Cilium and OpenBao routes. Homepage fetches icons client-side,
+    # so the cluster egress NetworkPolicy doesn't block it.
+    gethomepage.dev/icon: https://raw.githubusercontent.com/coroot/coroot/main/front/public/icon.svg
 spec:
   parentRefs:
     - name: platform


### PR DESCRIPTION
## Problem

Coroot shows **no icon** on the Homepage dashboard — "whatever is configured is not found".

## Root cause

The Coroot route and the `Observability` layout group both reference the icon name `coroot` / `coroot.png`. Homepage resolves bare icon names against the **dashboard-icons** CDN (with `mdi-`/`si-`/`sh-` prefixes for Material Design / Simple Icons / selfh.st). **Coroot is not present in any of those sets** (verified against dashboard-icons, selfh.st and simple-icons), so the request 404s and the card renders blank.

## Fix

- **Coroot service** (`coroot` HTTPRoute): point `gethomepage.dev/icon` at Coroot's upstream brand SVG `https://raw.githubusercontent.com/coroot/coroot/main/front/public/icon.svg`. This matches the **existing convention in this repo** — the Cilium and OpenBao routes already use upstream `raw.githubusercontent.com` logo URLs for the same "not in dashboard-icons" reason. Homepage fetches icons **client-side** (the user's browser), so the cluster egress NetworkPolicy does not block it.
- **Observability group header**: use the always-available `mdi-chart-line` Material Design icon (group headers are a category, not the app).

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/` → renders `gethomepage.dev/icon: https://raw.githubusercontent.com/coroot/coroot/main/front/public/icon.svg`
- `kubectl kustomize k8s/providers/hetzner/apps/` → renders `icon: mdi-chart-line` for the Observability group
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` both build
- No stale `coroot.png` / `icon: coroot` references remain
- Upstream SVG URL verified reachable (120×120, Coroot brand green `#4BB649`)
