### PR TITLE
fix(coroot): serve Coroot on observability.${domain}

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -26,7 +26,7 @@ data:
           entryPoints: ["web"]
           service: hubble-ui
         coroot:
-          rule: "Host(`coroot.${domain}`)"
+          rule: "Host(`observability.${domain}`)"
           entryPoints: ["web"]
           service: coroot
         opencost:

--- a/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
@@ -22,14 +22,14 @@ spec:
       namespace: kube-system
       sectionName: https
   hostnames:
-    - coroot.${domain}
+    - observability.${domain}
   rules:
     - filters:
         - type: RequestHeaderModifier
           requestHeaderModifier:
             set:
               - name: X-Auth-Request-Redirect
-                value: https://coroot.${domain}/
+                value: https://observability.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:

--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -61,7 +61,7 @@ spec:
         # deep-link back to the affected app in this instance. Same host the
         # HTTPRoute + auth-proxy serve the UI on; `${domain}` is substituted by
         # Flux from the per-cluster variables-cluster ConfigMap.
-        baseURL: https://coroot.${domain}
+        baseURL: https://observability.${domain}
         webhook:
           url: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}
           incidents: true


### PR DESCRIPTION
## Goal

Serve the Coroot UI on **`observability.platform.devantler.tech`** instead of `coroot.platform.devantler.tech`.

## Change

Updates the hostname in all four places that reference it, so the route, the SSO redirect, the forward-auth fan-out, and Slack deep-links stay in lockstep:

| File | What |
|------|------|
| `coroot/httproute.yaml` | HTTPRoute `hostnames` |
| `coroot/httproute.yaml` | `X-Auth-Request-Redirect` header (oauth2-proxy post-login redirect) |
| `auth-proxy/config-map.yaml` | Traefik `Host()` match rule (oauth2-proxy → auth-proxy fan-out to the Coroot Service) |
| `hetzner/.../coroot-patch.yaml` | Coroot CR `notificationIntegrations.baseURL` (prod Slack incident/alert deep-links) |

## Why it's safe (no cert / DNS work needed)

- **TLS**: the central Gateway certificate (`kube-system/gateway-certificate`) is a wildcard — `["platform.devantler.tech", "*.platform.devantler.tech"]` — so `observability.platform.devantler.tech` is already covered.
- **DNS**: `external-dns` is running and publishes records from the Gateway/HTTPRoute, so the new host is created automatically and the old one withdrawn.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/` → renders `Host(\`observability.${domain}\`)`, hostname `observability.${domain}`, and the redirect header on `observability.${domain}`
- `kubectl kustomize k8s/providers/hetzner/infrastructure/` → Coroot CR `baseURL: https://observability.${domain}`
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` both build
- No `coroot.${domain}` references remain anywhere in `k8s/`

## Note

The internal Traefik router/service **keys** in `auth-proxy/config-map.yaml` stay named `coroot` (they're internal identifiers, not DNS) and the Service still lives in the `coroot` namespace on `main` — this PR is hostname-only. The companion namespace-move PR is separate.
