### PR TITLE
refactor(coroot): move Coroot to the observability namespace

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -44,7 +44,7 @@ spec:
                 - kubescape
                 - kubevirt
                 - cdi
-                - coroot
+                - observability
                 - velero
       mutate:
         patchStrategicMerge:
@@ -72,7 +72,7 @@ spec:
                 - kubescape
                 - kubevirt
                 - cdi
-                - coroot
+                - observability
                 - velero
       mutate:
         foreach:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-host-restrictions.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-host-restrictions.yaml
@@ -47,7 +47,7 @@ spec:
                 - kubescape
                 - kubevirt
                 - cdi
-                - coroot
+                - observability
                 - velero
           - resources:
               names:
@@ -78,7 +78,7 @@ spec:
                 - kubescape
                 - kubevirt
                 - cdi
-                - coroot
+                - observability
                 - velero
           - resources:
               names:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-pod-security.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-pod-security.yaml
@@ -51,7 +51,7 @@ spec:
                 - kubescape
                 - kubevirt
                 - cdi
-                - coroot
+                - observability
                 - velero
           - resources:
               names:
@@ -107,7 +107,7 @@ spec:
                 - kubescape
                 - kubevirt
                 - cdi
-                - coroot
+                - observability
                 - velero
           - resources:
               names:
@@ -139,7 +139,7 @@ spec:
                 - kubescape
                 - kubevirt
                 - cdi
-                - coroot
+                - observability
                 - velero
           - resources:
               names:

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -45,7 +45,7 @@ patches:
                   # Flux Kustomization cluster-wide. Exempt it like the other
                   # platform-owned namespaces; its sizing is VPA-owned, not
                   # quota-bounded. The LimitRange (rule 1) still applies.
-                  - coroot
+                  - observability
       - op: add
         path: /spec/rules/0/generate/generateExisting
         value: true

--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -54,7 +54,7 @@ data:
         coroot:
           loadBalancer:
             servers:
-              - url: "http://coroot-coroot.coroot.svc.cluster.local:8080"
+              - url: "http://coroot-coroot.observability.svc.cluster.local:8080"
         opencost:
           loadBalancer:
             servers:

--- a/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
@@ -39,7 +39,7 @@ spec:
     # Coroot UI upstream (metrics/logs/traces/profiles/alerts).
     - toEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: coroot
+            k8s:io.kubernetes.pod.namespace: observability
       toPorts:
         - ports:
             - port: "8080"

--- a/k8s/bases/infrastructure/controllers/coroot/heartbeat-cronjob.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/heartbeat-cronjob.yaml
@@ -16,7 +16,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: coroot-heartbeat
-  namespace: coroot
+  namespace: observability
 spec:
   schedule: "* * * * *"
   concurrencyPolicy: Forbid
@@ -46,7 +46,7 @@ spec:
                 - -c
                 - >-
                   curl -sf --max-time 5
-                  http://coroot-prometheus.coroot.svc.cluster.local:9090/-/healthy
+                  http://coroot-prometheus.observability.svc.cluster.local:9090/-/healthy
                   && curl -sf --max-time 10
                   "${alertmanager_heartbeat_url:=https://example.invalid/no-heartbeat-configured}"
                   || true

--- a/k8s/bases/infrastructure/controllers/coroot/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/helm-release.yaml
@@ -2,7 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: coroot-operator
-  namespace: coroot
+  namespace: observability
   labels:
     # The operator chart ships the `Coroot` CRD; let Flux manage it.
     helm.toolkit.fluxcd.io/crds: enabled

--- a/k8s/bases/infrastructure/controllers/coroot/helm-repository.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/helm-repository.yaml
@@ -2,7 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: coroot
-  namespace: coroot
+  namespace: observability
 spec:
   interval: 24h
   url: https://coroot.github.io/helm-charts

--- a/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
@@ -9,7 +9,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: coroot
-  namespace: coroot
+  namespace: observability
   annotations:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Coroot

--- a/k8s/bases/infrastructure/controllers/coroot/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: coroot
+  name: observability
   labels:
     # Coroot's node-agent DaemonSet uses eBPF + hostPath/hostPID to collect
     # metrics, logs, traces and profiles from every node — it requires

--- a/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: allow-coroot
-  namespace: coroot
+  namespace: observability
 spec:
   endpointSelector: {}
   ingress:
@@ -10,10 +10,10 @@ spec:
     # cluster-agent, plus the heartbeat CronJob probing Prometheus.
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: coroot
+            k8s:io.kubernetes.pod.namespace: observability
     # The eBPF node-agent runs with host networking on every node, so its
     # telemetry push appears as the host / remote-node entity rather than a
-    # coroot-namespace endpoint. It pushes everything (metrics, logs, traces,
+    # observability-namespace endpoint. It pushes everything (metrics, logs, traces,
     # profiles) to the Coroot app's /v1/* endpoints on :8080 only — it does not
     # reach Prometheus or ClickHouse directly (the app fans those out
     # intra-namespace), so this is scoped to :8080 for least privilege.

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
@@ -17,7 +17,7 @@ spec:
       namespace: kube-system
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      namespace: coroot
+      namespace: observability
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: opencost

--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -17,7 +17,7 @@ apiVersion: coroot.com/v1
 kind: Coroot
 metadata:
   name: coroot
-  namespace: coroot
+  namespace: observability
 spec:
   # NB: the Coroot app version is managed by the operator (pin via
   # spec.communityEdition.image if ever needed) — there is no spec.version
@@ -39,7 +39,7 @@ spec:
 
   # Bundled Prometheus = the metrics TSDB. Kept as a real Prometheus (we do
   # NOT set storeMetricsInClickhouse) precisely so OpenCost can still query it
-  # at http://coroot-prometheus.coroot.svc.cluster.local:9090.
+  # at http://coroot-prometheus.observability.svc.cluster.local:9090.
   prometheus:
     retention: 7d
     storage:

--- a/k8s/bases/infrastructure/kustomization.yaml
+++ b/k8s/bases/infrastructure/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
   - http-scaled-objects/
   # OpenCost lives in the `infrastructure` layer (not `controllers`) because it
   # hard-fails at startup unless it can query Coroot's bundled Prometheus
-  # (coroot-prometheus.coroot.svc:9090), which the operator only builds from the
+  # (coroot-prometheus.observability.svc:9090), which the operator only builds from the
   # Coroot CR in *this* layer. In `infrastructure-controllers` it would deadlock:
   # that layer's health check would wait for OpenCost to become Ready, but the CR
   # that produces its Prometheus can't be applied until the layer is Ready.

--- a/k8s/bases/infrastructure/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/opencost/helm-release.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   # LAYER PLACEMENT — this HelmRelease lives in the `infrastructure` Kustomization
   # (not `infrastructure-controllers`). OpenCost FTL-exits on boot if it cannot
-  # reach Coroot's bundled Prometheus at coroot-prometheus.coroot.svc:9090, which
+  # reach Coroot's bundled Prometheus at coroot-prometheus.observability.svc:9090, which
   # the operator only builds from the Coroot CR in the `infrastructure` layer.
   # Keeping OpenCost in `infrastructure-controllers` is a hard deadlock: that
   # layer health-checks OpenCost (never Ready without the Prometheus) while the CR
@@ -18,7 +18,7 @@ spec:
   # built coroot-prometheus, so it is not sufficient on its own; the layer move is.
   dependsOn:
     - name: coroot-operator
-      namespace: coroot
+      namespace: observability
   interval: 2m
   timeout: 10m
   install:
@@ -86,7 +86,7 @@ spec:
           enabled: false
         external:
           enabled: true
-          url: "http://coroot-prometheus.coroot.svc.cluster.local:9090"
+          url: "http://coroot-prometheus.observability.svc.cluster.local:9090"
 
       # Hetzner Cloud custom pricing — CX33 monthly cap decomposed into
       # per-resource-unit USD costs. CX33 spec verified live with

--- a/k8s/bases/infrastructure/opencost/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/opencost/networkpolicy.yaml
@@ -35,7 +35,7 @@ spec:
     # Coroot's bundled Prometheus for cost data
     - toEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: coroot
+            k8s:io.kubernetes.pod.namespace: observability
       toPorts:
         - ports:
             - port: "9090"

--- a/k8s/bases/infrastructure/security-exceptions/controller-rbac.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/controller-rbac.yaml
@@ -53,7 +53,7 @@ spec:
             - cnpg-system
             - velero
             - keda
-            - coroot
+            - observability
             - kubescape
             - vertical-pod-autoscaler
             - kubevirt

--- a/k8s/bases/infrastructure/security-exceptions/health-probes.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/health-probes.yaml
@@ -33,7 +33,7 @@ spec:
             - cnpg-system
             - velero
             - keda
-            - coroot
+            - observability
             - kubescape
             - vertical-pod-autoscaler
             - longhorn-system

--- a/k8s/bases/infrastructure/security-exceptions/infrastructure-privileged.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/infrastructure-privileged.yaml
@@ -3,7 +3,7 @@
 # Cilium (CNI) needs: privileged, hostPath, hostNetwork, hostPID, NET_ADMIN, SYS_ADMIN
 # Longhorn (storage) needs: privileged, hostPath, hostPID
 # Velero node-agent (backup) needs: hostPath, privileged
-# Coroot node-agent (coroot) needs: privileged, hostPath, hostPID for eBPF
+# Coroot node-agent (observability) needs: privileged, hostPath, hostPID for eBPF
 # SPIRE agent (identity) needs: hostPath, hostPID
 # KubeVirt (VM hosting) needs: privileged, hostPath, hostPID, NET_ADMIN
 # CDI (container disk images) needs: privileged for disk operations
@@ -48,7 +48,7 @@ spec:
           values:
             - kube-system
             - longhorn-system
-            - coroot
+            - observability
             - velero
             - kubevirt
             - cdi

--- a/k8s/bases/infrastructure/security-exceptions/service-account-tokens.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/service-account-tokens.yaml
@@ -45,7 +45,7 @@ spec:
             - cnpg-system
             - velero
             - keda
-            - coroot
+            - observability
             - kubescape
             - vertical-pod-autoscaler
             - kubevirt

--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -3,14 +3,14 @@ apiVersion: coroot.com/v1
 kind: Coroot
 metadata:
   name: coroot
-  namespace: coroot
+  namespace: observability
 spec:
   # Persist on Hetzner Cloud block storage. The base uses the default storage
   # class (fine for ephemeral local/CI), but in prod a VPA eviction, node
   # drain, or autoscaler scale-down would otherwise wipe all telemetry. hcloud
   # block storage (not Longhorn) for the same reason OpenBao/Prometheus used
   # it: the ~36 GiB Talos rootfs is too small to host Longhorn replicas this
-  # large. Velero's daily backup of the coroot namespace ships these to R2.
+  # large. Velero's daily backup of the observability namespace ships these to R2.
   storage:
     className: hcloud
     size: 2Gi


### PR DESCRIPTION
## Goal

Move the Coroot stack from the `coroot` namespace to **`observability`**.

## What changed (22 files, every reference in lockstep)

**Coroot's own resources** → `observability`: operator HelmRelease, HelmRepository, the `Coroot` CR, HTTPRoute, NetworkPolicy, heartbeat CronJob, and the Namespace object.

**Consumers that address Coroot by service DNS** (prefix preserved, only the namespace segment changes):
- OpenCost Prometheus connection → `coroot-prometheus.observability.svc:9090`
- heartbeat liveness probe → `coroot-prometheus.observability.svc:9090`
- auth-proxy forward-auth fan-out → `coroot-coroot.observability.svc:8080`
- matching NetworkPolicy pod-namespace selectors (opencost, auth-proxy, coroot)

**Cross-namespace + policy wiring:**
- oauth2-proxy `ReferenceGrant` `from[].namespace`
- Kyverno **security exceptions** (privileged-PSS, host-restrictions, pod-security, add-security-context, SA-tokens, controller-rbac, health-probes) and the **resource-quota exemption** now name `observability` — otherwise the moved privileged node-agent pods would be **denied**.

Directory names stay `coroot/` and resource/Service names stay `coroot-*` (the component is still Coroot); only the Kubernetes namespace changes.

## ⚠️ Destructive at deploy time

Flux `prune` will delete the old `coroot` namespace and its **4 hcloud PVCs (~55 GiB)**; the operator then recreates an **empty** stack in `observability`, so existing metrics/logs/traces history is discarded.

- Coroot is only ~1 day old in prod, so the lost history is negligible.
- The daily Velero backup of the `coroot` namespace is **currently failing** (see the separate BackupStorageLocation fix), so there is no restore safety net — fine here given the negligible history, but worth knowing.

## Validation

- `kubectl kustomize` builds: `providers/hetzner/infrastructure/controllers`, `providers/hetzner/infrastructure`, `providers/hetzner/apps`, `clusters/local`, `clusters/prod` — all pass
- Rendered output verified: Namespace object = `observability`; operator + CR in `observability`; OpenCost/auth-proxy/heartbeat all resolve `*.observability.svc`; Kyverno exceptions list `observability`
- No `namespace: coroot`, `*.coroot.svc`, or `- coroot` allow-list entries remain anywhere in `k8s/`

## Relation to the other Coroot PRs

Independent of the icon (#1769) and DNS (#1770) PRs — they edit different lines of the shared files (`auth-proxy/config-map.yaml`, `coroot-patch.yaml`), so all three merge without conflict in any order.
