### PR TITLE
fix(cilium): disable unused SPIRE mutual authentication

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,8 +29,8 @@ read it, so everything needed for review is restated here.)
   component that drops a required `dependsOn` or creates a cycle.
 - `HelmRelease`: pin chart versions; prefer a `HelmRepository`/`OCIRepository` source over inline values
   sprawl. Flag unpinned or `latest` chart refs.
-- Provider split: SPIRE mutual auth is on in prod and disabled in the Docker overlay — keep changes overlay-scoped,
-  don't leak a local-only setting into a base or the prod path.
+- Provider split: WireGuard encryption is on in prod and disabled in the Docker overlay — keep changes overlay-scoped,
+  don't leak a local-only setting into a base or the prod path. (SPIRE mutual auth is currently disabled cluster-wide.)
 
 ## Validation (static only — never run a cluster for review)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This is a **GitOps-based Kubernetes platform** — not a traditional code reposi
 
 - **Flux CD** — GitOps engine reconciling from OCI artifacts
 - **Kustomize** — manifest templating and overlays
-- **Cilium** — CNI and Gateway API (SPIRE-based mutual authentication is enabled in prod; the Docker provider overlay disables it for local/CI)
+- **Cilium** — CNI and Gateway API (transparent WireGuard encryption is enabled in prod and disabled in the Docker overlay for local/CI; SPIRE-based mutual authentication is currently disabled cluster-wide — no policy requires `authentication.mode: required`, so it only produced spire-agent noise — and is re-enabled in the Cilium HelmRelease when a mutual-auth policy is introduced)
 - **Talos Linux** — immutable Kubernetes OS
 - **KSail** — unified cluster and workload lifecycle management (Talos + Docker for local, Talos + Hetzner for prod)
 - **SOPS + Age** — secret encryption at rest (per-environment Age keys)

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -145,12 +145,12 @@ spec:
       nodeEncryption: true
     # SPIRE mutual authentication is DISABLED. It provides workload *identity*
     # for policies with `authentication.mode: required`, but no
-    # CiliumNetworkPolicy in this platform uses that mode — so SPIRE issued no
-    # identities and produced nothing but a constant per-node spire-agent
+    # CiliumNetworkPolicy currently uses that mode — so SPIRE issues no
+    # identities and produces nothing but a constant per-node spire-agent
     # "no identity issued" error stream (flagged by Coroot), plus an idle
-    # spire-server + 7-pod spire-agent DaemonSet. WireGuard encryption (above)
-    # is orthogonal and already protects all pod/node traffic on the wire;
-    # SPIRE adds no value until a mutual-auth policy actually exists. The
+    # spire-server and a per-node spire-agent DaemonSet. WireGuard encryption
+    # (above) is orthogonal and already protects all pod/node traffic on the
+    # wire; SPIRE adds no value until a mutual-auth policy exists. The
     # `install:` block is kept (inert) so re-enabling is a one-line flip — at
     # which point also restore the docker overlay's explicit opt-out.
     authentication:

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -143,11 +143,21 @@ spec:
       enabled: true
       type: wireguard
       nodeEncryption: true
+    # SPIRE mutual authentication is DISABLED. It provides workload *identity*
+    # for policies with `authentication.mode: required`, but no
+    # CiliumNetworkPolicy in this platform uses that mode — so SPIRE issued no
+    # identities and produced nothing but a constant per-node spire-agent
+    # "no identity issued" error stream (flagged by Coroot), plus an idle
+    # spire-server + 7-pod spire-agent DaemonSet. WireGuard encryption (above)
+    # is orthogonal and already protects all pod/node traffic on the wire;
+    # SPIRE adds no value until a mutual-auth policy actually exists. The
+    # `install:` block is kept (inert) so re-enabling is a one-line flip — at
+    # which point also restore the docker overlay's explicit opt-out.
     authentication:
-      enabled: true
+      enabled: false
       mutual:
         spire:
-          enabled: true
+          enabled: false
           install:
             namespace: kube-system
             existingNamespace: true


### PR DESCRIPTION
## Problem

`spire-agent` shows an elevated error rate in Coroot — ~1/sec across all 7 nodes:

```
level=error msg="no identity issued" method=SubscribeToX509SVIDs   service=DelegatedIdentity
level=error msg="no identity issued" method=SubscribeToX509Bundles service=DelegatedIdentity
```

## Root cause

Cilium SPIRE mutual authentication is enabled in prod, but **no `CiliumNetworkPolicy` / `CiliumClusterwideNetworkPolicy` uses `authentication.mode: required`** (verified: `0` live policies reference `authentication:`). SPIRE therefore has no workload entries to issue, so every cilium-agent delegated-identity subscription returns "no identity issued". The feature is fully enabled but **entirely unused** — it just runs an idle `spire-server` + a 7-pod `spire-agent` DaemonSet and emits a constant error stream.

SPIRE provides workload **identity** (mutual authentication); it is **orthogonal** to the WireGuard encryption that is already enabled and already protects all pod-to-pod / node-to-node traffic on the wire. Until a policy actually requires mutual auth, SPIRE adds nothing over WireGuard.

## Fix

Disable `authentication` in the **base** Cilium HelmRelease (the docker overlay already disabled it for local/CI). WireGuard encryption is untouched. The `install:` block — including the `#40533` start-up workaround — is kept inert so re-enabling is a one-line flip; restore the docker overlay's explicit opt-out at that point.

## Validation

- `kubectl kustomize` builds for `providers/hetzner/infrastructure/controllers`, `providers/docker/infrastructure/controllers`, `clusters/local`, `clusters/prod` — all pass
- Rendered prod Cilium HelmRelease: `authentication.enabled: false`, `mutual.spire.enabled: false`; docker overlay unchanged
- WireGuard `encryption.enabled: true` remains in prod

## Note

After deploy, Cilium uninstalls SPIRE; the (now-unused) Kyverno privileged exceptions for `spire-server`/`spire-agent` become inert — harmless, can be pruned later.
