### PR TITLE
fix(coroot): give ClickHouse enough memory to stop merge-OOM errors

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -21,6 +21,23 @@ spec:
       className: hcloud
       size: 20Gi
   clickhouse:
+    # ClickHouse ships config.xml with max_server_memory_usage=0 (auto), so it
+    # derives its memory ceiling from the cgroup limit. Left at the auto-vpa
+    # floor (≈128Mi req / 512Mi limit) that ceiling lands at ~224 MiB, and
+    # ClickHouse then throws "Code 241: memory limit exceeded" on every
+    # background merge and on Coroot's own trace ingestion — by far the largest
+    # source of Coroot's self-reported error logs/alerts. Pin a generous
+    # limit:request ratio: the auto-vpa generated VPA runs in
+    # controlledValues:RequestsAndLimits, so it preserves this 4:1 ratio when it
+    # sets the request from live usage — keeping the limit (and thus ClickHouse's
+    # memory ceiling) ~4x the request instead of clamping it back to the floor.
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi
     storage:
       className: hcloud
       size: 15Gi


### PR DESCRIPTION
## Problem

~20 of the 42 Coroot alerts (the single biggest group) come from `coroot-clickhouse` flooding error logs:

```
<Error> MergeTreeBackgroundExecutor: Exception while executing background task ... 
<Error> executeQuery: Code: 241. DB::Exception: (total) memory limit exceeded: would use 223.99 MiB
```

…which in turn cascades into `coroot-coroot` errors (`MEMORY_LIMIT_EXCEEDED` on trace ingestion).

## Root cause

ClickHouse's `config.xml` ships `max_server_memory_usage=0` (**auto**), so it derives its memory ceiling from the **cgroup limit**. ClickHouse is a StatefulSet, so auto-vpa manages it in `updateMode: Initial` at the floor (`~128Mi request / 512Mi limit`) — which puts the auto ceiling at **~224 MiB**. Every background merge and Coroot's own trace ingestion then exceed it. It's a feedback trap: ClickHouse self-caps low → its observed usage stays low → the VPA recommendation stays low → it never gets more.

## Fix

Pin `clickhouse.resources` with a generous **4:1 limit:request ratio** (`512Mi request / 2Gi limit`). The auto-vpa VPA runs `controlledValues: RequestsAndLimits`, which **preserves the authored limit:request ratio** when it sizes the request from live usage — so the limit (ClickHouse's effective memory ceiling) tracks at ~4× the request instead of being clamped back to the 512Mi floor. ClickHouse's auto ceiling rises to ~1.8 GiB and the merge/ingestion OOMs stop.

This is the documented escape from the VPA `RequestsAndLimits` floor trap — **no change to the cluster-wide `auto-vpa` policy is required**.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/` renders the Coroot CR with `clickhouse.resources` (req cpu 250m / mem 512Mi, lim cpu 2 / mem 2Gi)
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` both build
- The keeper (`coroot-clickhouse-keeper`, ~109 MiB) is left under VPA — it isn't memory-starved

## Note

Prod-only (hetzner overlay), matching where the other ClickHouse sizing (storage classes) already lives. Tunable — if live VPA recommendations later show ClickHouse wants more, the ratio carries it.
