### PR TITLE
fix(homepage): drain on termination to stop rollout 502 storms on the SSO proxies

### DIFF
--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -92,6 +92,25 @@ spec:
               - op: add
                 path: /spec/template/spec/containers/0/readinessProbe/timeoutSeconds
                 value: 5
+              # Graceful drain on termination. The release rolls often (helm
+              # revisions + reloader restarts) and the Service's ClientIP
+              # affinity (below) pins each auth-proxy pod to one homepage
+              # replica. Without draining, a rolling pod stops serving the
+              # instant it is SIGTERMed while auth-proxy is still routed to it,
+              # so the rollout window returns 502 Bad Gateway — and the
+              # dashboard's ~14 /api/* polls per refresh amplify that into a
+              # latency+error incident on oauth2-proxy and auth-proxy. A short
+              # preStop keeps the old pod answering until it has been removed
+              # from the Service endpoints and the affinity has rebalanced.
+              - op: add
+                path: /spec/template/spec/terminationGracePeriodSeconds
+                value: 30
+              - op: add
+                path: /spec/template/spec/containers/0/lifecycle
+                value:
+                  preStop:
+                    exec:
+                      command: ["/bin/sh", "-c", "sleep 10"]
           # Flicker fix: with replicaCount=2 and the chart's default ClusterIP
           # service, the Kubernetes widget's poll for node/cluster CPU/memory
           # round-robins between two pods that each maintain their own


### PR DESCRIPTION
## Problem

oauth2-proxy and auth-proxy showed a **critical "high latency and errors" incident** in Coroot (both, since they sit in series). Live evidence:

- Coroot incidents: `oauth2-proxy` and `auth-proxy` both opened **critical** incidents (now resolved).
- The errors are **502 Bad Gateway**, and every single one is for `platform.devantler.tech` — i.e. the **homepage** backend — on homepage's own dashboard calls (`/api/kubernetes/status/*`, `/api/widgets`, `/api/bookmarks`, …).
- The 502 burst (~12:32–12:36) ended exactly when a **new homepage ReplicaSet** became ready (12:36:48). Homepage rolls **repeatedly** (helm release is at **v23**; another roll at 14:03).
- CPU throttling on the proxies was negligible (0.004–0.007 s/s) — it is **not** under-resourcing.

## Root cause

The homepage Service has **`sessionAffinity: ClientIP`** (deliberately added so the cluster-CPU/memory widget reads from a consistent replica cache). That pins each **auth-proxy** pod — a stable-IP client — to a single homepage replica. Homepage has **no graceful drain**, so when it rolls, the pinned replica stops serving the instant it's `SIGTERM`ed while auth-proxy is still routed to it → **connection refused → 502** for the rollout window. Because homepage's dashboard fires ~14 `/api/*` polls per refresh through `oauth2-proxy → auth-proxy → homepage`, one briefly-bad backend becomes a **flood** of 502s that trips Coroot's SLO on both proxies.

## Fix

Add a `preStop` drain (`sleep 10`) and an explicit `terminationGracePeriodSeconds: 30` to the homepage pod (in the existing helm-release post-renderer). The terminating pod keeps answering until it has been removed from the Service endpoints and the ClientIP affinity has rebalanced — so a rollout no longer drops requests. The flicker fix (ClientIP affinity) is left untouched.

## Validation

- `kubectl kustomize` builds: `providers/hetzner/apps`, `providers/docker/apps`, `clusters/local`, `clusters/prod` — all pass
- The post-renderer renders the `preStop` + `terminationGracePeriodSeconds` ops
- `kubectl apply --dry-run=client` against the live cluster: clean (only benign last-applied-config warnings)
- Image `ghcr.io/gethomepage/homepage:v1.12.3` is alpine-based → `/bin/sh` + `sleep` are present

## Follow-up (separate)

Homepage rolls unusually often (v23 helm revisions; two rolls within ~1.5h). This PR makes each roll request-lossless, but it's worth understanding *why* it rolls so frequently (chart/Renovate churn vs. drift) — tracked separately, not required for this fix.
