### PR TITLE
feat: upgrade Kubernetes to v1.35.5, track it via Renovate, drop unused SPIRE (WireGuard-only encryption)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ read it, so everything needed for review is restated here.)
   component that drops a required `dependsOn` or creates a cycle.
 - `HelmRelease`: pin chart versions; prefer a `HelmRepository`/`OCIRepository` source over inline values
   sprawl. Flag unpinned or `latest` chart refs.
-- Provider split: SPIRE mutual auth is on in prod and disabled in the Docker overlay — keep changes overlay-scoped,
+- Provider split: WireGuard transparent encryption is on in prod and disabled in the Docker overlay — keep changes overlay-scoped,
   don't leak a local-only setting into a base or the prod path.
 
 ## Validation (static only — never run a cluster for review)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,6 +48,17 @@
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/controlplaneio-fluxcd/charts/flux-operator",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the pinned Kubernetes version in ksail.prod.yaml against kubernetes/kubernetes GitHub releases. Dependabot can't track a bare `kubernetesVersion:` string (no regex/custom managers, no generic version ecosystem), so Renovate owns it via the `# renovate:` annotation above the field. NB: a Kubernetes MINOR must land in lockstep with a Talos version that supports it (Talos v1.12.4's ceiling is k8s 1.35) — the kubernetes/kubernetes packageRule below blocks auto-merge for minor/major so a human pairs it with a Talos bump; only 1.x patch bumps auto-merge.",
+      "managerFilePatterns": [
+        "/^ksail\\.prod\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+kubernetesVersion:\\s*(?<currentValue>\\S+)"
+      ],
+      "versioningTemplate": "semver"
     }
   ],
   "minor": {
@@ -98,9 +109,6 @@
         "/^kubescape-operator$/",
         "/^trivy-operator$/",
         "/^external-secrets$/",
-        "/^spire$/",
-        "/^spire-agent$/",
-        "/^spire-server$/",
         "/^velero$/",
         "/^reloader$/"
       ],
@@ -138,6 +146,17 @@
         "@devantler-tech/**"
       ],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Kubernetes (kubernetes/kubernetes) is pinned in ksail.prod.yaml: a minor/major bump must be paired with a Talos version that supports it (Talos v1.12.4's ceiling is k8s 1.35). Bumping the K8s minor without bumping Talos first breaks prod bring-up, and CI's system-test runs off ksail.yaml (no kubernetesVersion) so it does NOT exercise the prod pin. Track every version, but require manual review for minor + major; 1.x patch bumps still auto-merge via the ksail.prod.yaml file rule above. This rule is intentionally last so it wins on automerge.",
+      "matchPackageNames": [
+        "kubernetes/kubernetes"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "automerge": false
     }
   ],
   "ignorePaths": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This is a **GitOps-based Kubernetes platform** — not a traditional code reposi
 
 - **Flux CD** — GitOps engine reconciling from OCI artifacts
 - **Kustomize** — manifest templating and overlays
-- **Cilium** — CNI and Gateway API (SPIRE-based mutual authentication is enabled in prod; the Docker provider overlay disables it for local/CI)
+- **Cilium** — CNI and Gateway API (WireGuard transparent pod/node encryption is enabled in prod; the Docker provider overlay disables it for local/CI)
 - **Talos Linux** — immutable Kubernetes OS
 - **KSail** — unified cluster and workload lifecycle management (Talos + Docker for local, Talos + Hetzner for prod)
 - **SOPS + Age** — secret encryption at rest (per-environment Age keys)

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -1,7 +1,7 @@
 # TODO: Upstream `auto-vpa.yaml` to Kyverno policies repository.
 #
 # kube-system is intentionally NOT excluded: its controllers (cilium,
-# cilium-envoy, spire-agent, coredns, metrics-server, hubble, hcloud
+# cilium-envoy, coredns, metrics-server, hubble, hcloud
 # ccm/csi, tetragon, cluster-autoscaler) carry ~10Gi of hand-tuned request
 # floors that VPA can right-size to observed usage instead. Static
 # control-plane pods (kube-apiserver/etcd/scheduler/controller-manager) are
@@ -15,11 +15,11 @@
 #
 # On k8s < 1.33 the gate is alpha/off, so InPlaceOrRecreate falls back to
 # Recreate: VPA applies a recommendation by EVICTING the pod. For the
-# kube-system DaemonSets (cilium / spire-agent) that is a brief per-node
-# datapath blip as each pod restarts, one node at a time; spire-server
-# (StatefulSet) uses updateMode Initial and is never evicted. Until prod is
-# upgraded to >= 1.33 (target 1.34; Talos 1.12 supports k8s 1.30-1.35),
-# expect a one-time round of such evictions as VPA applies its initial recs.
+# kube-system DaemonSets (e.g. cilium) that is a brief per-node datapath
+# blip as each pod restarts, one node at a time; singleton StatefulSets use
+# updateMode Initial and are never evicted. Prod now runs k8s >= 1.33
+# (1.35; Talos 1.12 supports k8s 1.30-1.35), so in-place resize is active
+# and this eviction fallback no longer applies.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-host-restrictions.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-host-restrictions.yaml
@@ -4,8 +4,8 @@
 # Addresses kubescape controls: C-0045, C-0048, C-0041, C-0038
 #
 # Infrastructure namespaces are excluded because CNI (Cilium), storage
-# (Longhorn), node telemetry (Coroot), identity (SPIRE), and backup (Velero)
-# require host-level access by design.
+# (Longhorn), node telemetry (Coroot), and backup (Velero) require
+# host-level access by design.
 #
 # Local-path-provisioner helper pods (used in local/CI clusters) are
 # excluded by name pattern because they mount hostPath in app namespaces

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -131,9 +131,17 @@ spec:
     # traffic.  KubeSpan (Talos-layer WireGuard between nodes) is not
     # enabled in this cluster, so without this setting inter-node pod
     # traffic would transit the Hetzner private network in cleartext.
-    # SPIRE mutual authentication below provides workload *identity*; this
-    # block provides on-the-wire *encryption*. They are independent and
-    # complementary.
+    # This is the platform's single, native, transparent encryption layer:
+    # it lives in the CNI and needs zero per-workload configuration.
+    #
+    # Cilium mutual authentication (SPIRE) was deliberately removed: it
+    # provided workload *identity* only (not encryption), no NetworkPolicy
+    # enforced `authentication.mode: required`, and it ran spire-server + a
+    # per-node spire-agent (with a chown init-container workaround for
+    # cilium/cilium#40533) for no actual enforcement. Native K8s Pod
+    # Certificates (KEP-4317, beta/off in 1.35) are likewise identity-only
+    # and require per-app changes, so they do not replace this layer.
+    # Identity-based mTLS can be reintroduced here if a policy ever needs it.
     #
     # Requires the kernel WireGuard module (present in the Talos kernel
     # since 5.6) and kubeProxyReplacement=true (set above).
@@ -143,52 +151,6 @@ spec:
       enabled: true
       type: wireguard
       nodeEncryption: true
-    authentication:
-      enabled: true
-      mutual:
-        spire:
-          enabled: true
-          install:
-            namespace: kube-system
-            existingNamespace: true
-            # Resource requests promote spire-server and spire-agent pods
-            # out of BestEffort QoS. cilium-agent's SPIRE Delegate API
-            # client relies on the per-node spire-agent admin socket — if
-            # the agent is evicted/OOMKilled the cilium-agent on that
-            # node stays stuck retrying "SPIRE admin socket does not
-            # exist" and ClusterIP routing degrades alongside it.
-            agent:
-              resources:
-                requests:
-                  cpu: 50m
-                  memory: 128Mi
-            # TODO: Remove workaround when SPIRE no longer fails to start (https://github.com/cilium/cilium/issues/40533)
-            server:
-              resources:
-                requests:
-                  cpu: 50m
-                  memory: 128Mi
-              initContainers:
-              - command:
-                - /bin/sh
-                - -c
-                - |
-                  chown -R 1000:1000 /run/spire/data
-                  chown -R 1000:1000 /tmp/spire-server
-                image: docker.io/library/busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
-                imagePullPolicy: IfNotPresent
-                name: chown
-                securityContext:
-                  runAsGroup: 0
-                  runAsUser: 0
-                volumeMounts:
-                - mountPath: /run/spire/data
-                  name: spire-data
-                - mountPath: /tmp/spire-server/private
-                  name: spire-server-socket
-              securityContext:
-                runAsGroup: 1000
-                runAsUser: 1000
     gatewayAPI:
       enabled: true
       enableAlpn: true

--- a/k8s/bases/infrastructure/security-exceptions/infrastructure-privileged.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/infrastructure-privileged.yaml
@@ -4,7 +4,6 @@
 # Longhorn (storage) needs: privileged, hostPath, hostPID
 # Velero node-agent (backup) needs: hostPath, privileged
 # Coroot node-agent (coroot) needs: privileged, hostPath, hostPID for eBPF
-# SPIRE agent (identity) needs: hostPath, hostPID
 # KubeVirt (VM hosting) needs: privileged, hostPath, hostPID, NET_ADMIN
 # CDI (container disk images) needs: privileged for disk operations
 apiVersion: kubescape.io/v1beta1
@@ -14,9 +13,8 @@ metadata:
 spec:
   reason: >-
     CNI (Cilium), distributed storage (Longhorn), node telemetry
-    (Coroot node-agent), identity (SPIRE agent), backup
-    (Velero node-agent), and virtualisation (KubeVirt, CDI) require
-    host-level access by design.
+    (Coroot node-agent), backup (Velero node-agent), and
+    virtualisation (KubeVirt, CDI) require host-level access by design.
   posture:
     - controlID: C-0057
       action: ignore

--- a/k8s/providers/docker/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -8,15 +8,10 @@ spec:
   values:
     # Local Docker provider has a single Talos container — there is no
     # node-to-node wire, and pod-to-pod traffic stays inside one Linux
-    # network namespace. Disabling encryption and SPIRE mTLS keeps the
-    # local cluster lean and avoids the WireGuard kernel module setup.
+    # network namespace. Disabling encryption keeps the local cluster lean
+    # and avoids the WireGuard kernel module setup.
     encryption:
       enabled: false
-    authentication:
-      enabled: false
-      mutual:
-        spire:
-          enabled: false
     gatewayAPI:
       hostNetwork:
         enabled: true

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -99,9 +99,13 @@ spec:
     # from k8s 1.33) lets VPA -- already 1.6 with updateMode InPlaceOrRecreate
     # -- resize pods, including the kube-system datapath now under auto-vpa, in
     # place instead of evicting them. Upgraded one minor at a time
-    # (1.32 -> 1.33 -> 1.34); landed on 1.34 because 1.33 reaches EOL
-    # 2026-06-28. Talos v1.12.4's ceiling is Kubernetes 1.35.
-    kubernetesVersion: v1.34.8
+    # (1.32 -> 1.33 -> 1.34 -> 1.35). 1.35 is Talos v1.12.4's ceiling, so the
+    # next minor (1.36) requires bumping Talos to >= 1.13 FIRST -- Renovate
+    # auto-merges only 1.35.x patches here and opens (but does not auto-merge)
+    # a PR for the next minor (see the kubernetes/kubernetes packageRule in
+    # .github/renovate.json).
+    # renovate: datasource=github-releases depName=kubernetes/kubernetes
+    kubernetesVersion: v1.35.5
     talos:
       # Pin Talos to match the ISO so 'ksail cluster update' doesn't attempt
       # an unwanted in-place upgrade to ksail's default version.


### PR DESCRIPTION
## Summary

Three related changes to the prod cluster config, requested together:

1. **Upgrade prod Kubernetes `v1.34.8` → `v1.35.5`** (latest 1.35 patch).
2. **Track the Kubernetes version declaratively** via Renovate (Dependabot can't).
3. **Simplify pod-to-pod encryption to WireGuard only** by removing the unused SPIRE mutual-auth stack.

| Change | File(s) | Effect |
| --- | --- | --- |
| K8s `v1.34.8`→`v1.35.5` | `ksail.prod.yaml` | Latest 1.35 patch; 1.35 is Talos v1.12.4's ceiling, so no Talos bump needed |
| Renovate tracking + safety gate | `.github/renovate.json` | New `customManager` + a `packageRule` gating minor/major to manual review |
| Remove unused SPIRE, keep WireGuard | `cilium/helm-release.yaml`, docker patch | WireGuard unchanged; spire-server + per-node spire-agent removed |
| Doc/comment hygiene | `AGENTS.md`, `copilot-instructions.md`, 3 policy files | No policy logic changed |

## 1 · Kubernetes v1.35.5

`v1.35.5` (2026-05-12) is the latest 1.35 patch, and **1.35 is Talos v1.12.4's ceiling** (Talos 1.12.7 ships 1.35.4), so this is exactly the "one minor at a time, within Talos's ceiling" step the file already documents — no Talos bump. Takes effect on the next prod deploy (`ksail --config ksail.prod.yaml cluster update`), which rolls kubelets to 1.35.5 node-by-node.

## 2 · Declarative version tracking (Renovate, not Dependabot)

**Dependabot cannot track a bare `kubernetesVersion:` string** — it has no regex/custom managers and no generic "version" ecosystem (this repo's `renovate.json` already notes "Dependabot can't track curl-downloaded release assets"). Renovate already owns the repo's non-standard pins, so:

- A 3rd **`customManager`** reads a `# renovate: datasource=github-releases depName=kubernetes/kubernetes` annotation above the field (verified to capture `v1.35.5`).
- A **`packageRule`** (placed last, so it wins on automerge) gates **minor/major** K8s bumps to **manual review**, because:
  - a minor (1.36) **exceeds Talos v1.12.4's ceiling** and would break prod bring-up, and
  - CI's system-test runs off `ksail.yaml` (no `kubernetesVersion`), so it **never exercises the prod pin** — only the post-merge prod deploy does.
- **1.35.x patches still auto-merge** (within Talos's ceiling, low risk), so the cluster stays current automatically without the footgun.

> A K8s minor PR (e.g. 1.36) must be paired with a Talos bump to ≥1.13 (version + ISO) before merging.

## 3 · Pod encryption: WireGuard only (native mTLS analysis)

You asked for the most native, simple, no-per-deployment encryption between pods. **Cilium WireGuard already is exactly that** — transparent, CNI-level, zero per-workload config — so it stays unchanged (`encryption: {enabled, type: wireguard, nodeEncryption}`).

- **Native K8s 1.35 "mTLS" (Pod Certificates / KEP-4317)** is *beta, off by default* and **identity material only**: pods must consume the mounted cert/key per-deployment, and Cilium 1.19 doesn't consume them. It is **not** a transparent-encryption layer and does **not** replace WireGuard. Noted as a future watch-item.
- **SPIRE mutual auth was enabled but enforced by zero NetworkPolicies** (no `authentication.mode: required` anywhere), so spire-server + a per-node spire-agent — plus a chown init-container workaround for [cilium/cilium#40533](https://github.com/cilium/cilium/issues/40533) and QoS workarounds — ran for **no actual enforcement**. Removed. Identity-based mTLS can be reintroduced if a policy ever needs it.

The Kyverno security-exceptions / host-restriction policies match by **namespace** (kube-system), not by `spire-agent`, so removing SPIRE changes **no policy logic** — only comments/`reason:` text were touched.

## Validation

- `kubectl kustomize` builds clean for **both providers'** `infrastructure-controllers` and `infrastructure` layers (and `clusters/{local,prod}`).
- Rendered Cilium release confirmed **WireGuard-on / SPIRE-absent** in both docker and hetzner.
- `renovate.json` is valid JSON; the new `customManager` regex verified to capture `v1.35.5`.
  - ⚠️ `npx renovate-config-validator` flags `managerFilePatterns` — but it resolved **Renovate 37.x** (pre-v40, when the field was `fileMatch`); the **current** schema defines `managerFilePatterns` (used by all 5 pre-existing managers here). Stale-validator false positive, not a config error.

## Operational note

The K8s bump rolls kubelets to 1.35.5 node-by-node on the next prod deploy; removing SPIRE tears down spire-server/agent on the next reconcile (WireGuard encryption is unaffected).
