### PR TITLE
feat(renovate): track Talos Linux version via custom manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,6 +48,20 @@
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/controlplaneio-fluxcd/charts/flux-operator",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the Talos Linux distribution version pinned in the prod node install image (talos/cluster/install-image.yaml). The image is served by the Talos Image Factory (factory.talos.dev), whose OCI registry does NOT implement tag listing (`/v2/<schematic>/tags/list` returns 404), so the image's own registry cannot be a version datasource — which is also why Dependabot cannot track it (its docker manager can only query the image registry, and has no regex/custom manager to point the lookup elsewhere). Resolve the version from the authoritative siderolabs/talos GitHub releases instead. The second matchString keeps the documented schematic-URL version in the file comment in sync with the image tag. This only edits this file; the source-of-truth talos.version and the Hetzner iso snapshot id in the protected ksail.prod.yaml must be bumped in lockstep by a maintainer (see the matching packageRule below, which holds it on the Dependency Dashboard for manual approval and disables automerge).",
+      "managerFilePatterns": [
+        "/^talos/cluster/install-image\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "image:\\s*factory\\.talos\\.dev/installer/[a-f0-9]+:(?<currentValue>v[0-9.]+)",
+        "target=hcloud&version=(?<currentValue>[0-9.]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "siderolabs/talos",
+      "versioningTemplate": "semver"
     }
   ],
   "minor": {
@@ -138,6 +152,17 @@
         "@devantler-tech/**"
       ],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Talos Linux distribution upgrades (tracked by the custom manager above; depName siderolabs/talos) are surfaced for manual, coordinated promotion — never automerged like the other deps here. A Talos bump spans files no bot may fully edit: this manager only touches talos/cluster/install-image.yaml, but the source-of-truth talos.version and the Hetzner iso snapshot id live in the protected ksail.prod.yaml, and a lockstep kubernetesVersion bump may be needed when Talos's supported Kubernetes range moves. dependencyDashboardApproval holds the update on the Dependency Dashboard until a maintainer approves it; automerge:false (placed last so it overrides the broad talos/** and major-update automerge rules above) then keeps the resulting PR open for the maintainer to complete the lockstep ksail.prod.yaml edits before merging.",
+      "matchPackageNames": [
+        "siderolabs/talos"
+      ],
+      "automerge": false,
+      "dependencyDashboardApproval": true,
+      "addLabels": [
+        "talos"
+      ]
     }
   ],
   "ignorePaths": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,17 +51,18 @@
     },
     {
       "customType": "regex",
-      "description": "Track the Talos Linux distribution version pinned in the prod node install image (talos/cluster/install-image.yaml). The image is served by the Talos Image Factory (factory.talos.dev), whose OCI registry does NOT implement tag listing (`/v2/<schematic>/tags/list` returns 404), so the image's own registry cannot be a version datasource — which is also why Dependabot cannot track it (its docker manager can only query the image registry, and has no regex/custom manager to point the lookup elsewhere). Resolve the version from the authoritative siderolabs/talos GitHub releases instead. The second matchString keeps the documented schematic-URL version in the file comment in sync with the image tag. This only edits this file; the source-of-truth talos.version and the Hetzner iso snapshot id in the protected ksail.prod.yaml must be bumped in lockstep by a maintainer (see the matching packageRule below, which holds it on the Dependency Dashboard for manual approval and disables automerge).",
+      "description": "Track the Talos Linux distribution version pinned in the prod node install image (talos/cluster/install-image.yaml). The image is served by the Talos Image Factory (factory.talos.dev), whose OCI registry does NOT implement tag listing (`/v2/<schematic>/tags/list` returns 404), so the image's own registry cannot be a version datasource — which is also why Dependabot cannot track it (its docker manager can only query the image registry, and has no regex/custom manager to point the lookup elsewhere). Resolve the version from the authoritative siderolabs/talos GitHub releases instead. Both matchStrings capture the numeric version only and extractVersionTemplate strips the leading `v` from the `vX.Y.Z` release tags, so the resolved version matches both captures; the image tag keeps its `v` via a regex literal outside the group. This keeps the image tag (`:vX.Y.Z`) and the schematic-URL comment (`version=X.Y.Z`) updated in sync. This only edits this file; the source-of-truth talos.version and the Hetzner iso snapshot id in the protected ksail.prod.yaml must be bumped in lockstep by a maintainer (see the matching packageRule below, which holds it on the Dependency Dashboard for manual approval and disables automerge).",
       "managerFilePatterns": [
         "/^talos/cluster/install-image\\.ya?ml$/"
       ],
       "matchStrings": [
-        "image:\\s*factory\\.talos\\.dev/installer/[a-f0-9]+:(?<currentValue>v[0-9.]+)",
+        "image:\\s*factory\\.talos\\.dev/installer/[a-f0-9]+:v(?<currentValue>[0-9.]+)",
         "target=hcloud&version=(?<currentValue>[0-9.]+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "siderolabs/talos",
-      "versioningTemplate": "semver"
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
   "minor": {

--- a/talos/cluster/install-image.yaml
+++ b/talos/cluster/install-image.yaml
@@ -6,6 +6,16 @@
 #     - siderolabs/qemu-guest-agent (Hetzner Cloud VM integration)
 #
 # Schematic: https://factory.talos.dev/?arch=amd64&extensions=siderolabs%2Fiscsi-tools&extensions=siderolabs%2Fqemu-guest-agent&extensions=siderolabs%2Futil-linux-tools&target=hcloud&version=1.12.4
+#
+# Renovate (.github/renovate.json custom manager) tracks the Talos version in the
+# image tag below, resolved from siderolabs/talos GitHub releases — the Image Factory
+# registry doesn't support OCI tag listing, so the image's own registry can't be the
+# datasource (and Dependabot, which can only query that registry, can't track it).
+# New releases are surfaced on Renovate's Dependency Dashboard for manual approval —
+# this is never auto-opened or auto-merged. After approving, complete the upgrade in
+# lockstep: bump `talos.version` AND the Hetzner `iso` snapshot id in the protected
+# ksail.prod.yaml (plus `kubernetesVersion` if Talos's supported Kubernetes range
+# moves). Re-generate the schematic id below only when the extension list changes.
 machine:
   install:
     image: factory.talos.dev/installer/e187c9b90f773cd8c84e5a3265c5554ee787b2fe67b508d9f955e90e7ae8c96c:v1.12.4


### PR DESCRIPTION
## What

Track **Talos Linux distribution version upgrades** declaratively with Renovate.

- **[.github/renovate.json](https://github.com/devantler-tech/platform/blob/claude/sweet-rosalind-a8d23c/.github/renovate.json)** — adds a custom regex manager + a packageRule:
  - Custom manager on `talos/cluster/install-image.yaml`: `datasource: github-releases`, `depName: siderolabs/talos`. Two match strings keep the installer **image tag** and the documented **schematic-URL version** comment in sync.
  - packageRule (placed last so it wins): `dependencyDashboardApproval: true` + `automerge: false` + a `talos` label.
- **[talos/cluster/install-image.yaml](https://github.com/devantler-tech/platform/blob/claude/sweet-rosalind-a8d23c/talos/cluster/install-image.yaml)** — a maintainer-facing comment explaining the tracking and the lockstep bump.

## Why Renovate and not Dependabot

The request preferred Dependabot, but it's a hard technical blocker, not a config gap:

- The only bot-editable Talos version string is the installer image tag in `talos/cluster/install-image.yaml` — `factory.talos.dev/installer/<schematic>:v1.12.4`. (The source-of-truth `talos.version` + `iso` live in the protected `ksail.prod.yaml`, and the ISO is a numeric Hetzner snapshot id, not a version.)
- Dependabot can read `image:` in Kubernetes YAML, **but its docker manager can only query the image's own registry for tags** — and the Talos Image Factory registry **doesn't implement tag listing**: `GET https://factory.talos.dev/v2/installer/<schematic>/tags/list` → **404** (verified). Dependabot also has **no regex/custom manager** ([dependabot/feedback#154](https://github.com/dependabot/feedback/issues/154)) to point the lookup elsewhere.
- Renovate fixes exactly this by **decoupling the lookup**: the regex manager reads the tag from the file but resolves versions from the authoritative `siderolabs/talos` GitHub releases. This mirrors the two existing custom managers already in `renovate.json` (pinned CLI versions, flux-operator chart).

## Why it's gated, not auto-merged

A real Talos bump spans files no bot may fully edit: `talos.version` **and** the Hetzner `iso` snapshot id are in the **protected** `ksail.prod.yaml` (plus a possible `kubernetesVersion` bump). So Renovate only **surfaces** the release on the Dependency Dashboard; a maintainer approves, completes the `ksail.prod.yaml` edits in the PR, then merges. The `dependencyDashboardApproval` gate makes this safe regardless of automerge precedence — nothing happens unattended.

This is **immediately useful**: the repo is pinned at `v1.12.4` while upstream stable is `v1.12.8` / `v1.13.3`, so a dashboard entry appears on the next Renovate run. Pre-releases (`-alpha`/`-rc`) are filtered by Renovate's default `ignoreUnstable`.

## Validation

- `renovate.json` is valid JSON; the official Renovate config validator passes (`Config validated successfully`) once the only complaint from the locally-available **v37** validator — `managerFilePatterns`, a key it predates and flags for the *existing* managers too — is isolated. That key is the current name and matches the 5 existing uses in the file.
- Both regexes match the real file content (`v1.12.4` / `1.12.4`); `siderolabs/talos` releases confirmed to use `vX.Y.Z` tags.
- Both kustomize overlays still build (`kubectl kustomize k8s/clusters/{local,prod}`) — orthogonal, since `talos/**` and `renovate.json` aren't in the kustomize tree.

## Reviewer notes

- No change to the actual pinned Talos version — this only sets up tracking.
- `ksail.prod.yaml`, `*.enc.yaml`, and `.sops.yaml` are untouched (protected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
