### PR TITLE
feat(cilium): enforce pod-to-pod mTLS via SPIRE mutual authentication (#1777)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,8 +29,10 @@ read it, so everything needed for review is restated here.)
   component that drops a required `dependsOn` or creates a cycle.
 - `HelmRelease`: pin chart versions; prefer a `HelmRepository`/`OCIRepository` source over inline values
   sprawl. Flag unpinned or `latest` chart refs.
-- Provider split: SPIRE mutual auth is on in prod and disabled in the Docker overlay — keep changes overlay-scoped,
-  don't leak a local-only setting into a base or the prod path.
+- Provider split: SPIRE mutual auth is enabled **and enforced** in prod (a cluster-wide `CiliumClusterwideNetworkPolicy`,
+  `require-mutual-auth`, in the hetzner overlay requires `authentication.mode: required` on pod-to-pod ingress; WireGuard
+  wire encryption is orthogonal and also on) and disabled in the Docker overlay, so the policy is prod-only — keep changes
+  overlay-scoped, don't leak a local-only setting into a base or the prod path.
 
 ## Validation (static only — never run a cluster for review)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This is a **GitOps-based Kubernetes platform** — not a traditional code reposi
 
 - **Flux CD** — GitOps engine reconciling from OCI artifacts
 - **Kustomize** — manifest templating and overlays
-- **Cilium** — CNI and Gateway API (SPIRE-based mutual authentication is enabled in prod; the Docker provider overlay disables it for local/CI)
+- **Cilium** — CNI and Gateway API. SPIRE-based mutual authentication is enabled **and enforced** in prod: a cluster-wide `CiliumClusterwideNetworkPolicy` (`require-mutual-auth`, hetzner overlay) requires `authentication.mode: required` on all pod-to-pod ingress, complementary to WireGuard wire encryption (WireGuard encrypts the wire; SPIRE authenticates the workload identity — both are wanted). The Docker provider overlay disables SPIRE for local/CI, so the policy is prod-only.
 - **Talos Linux** — immutable Kubernetes OS
 - **KSail** — unified cluster and workload lifecycle management (Talos + Docker for local, Talos + Hetzner for prod)
 - **SOPS + Age** — secret encryption at rest (per-environment Age keys)

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -164,6 +164,26 @@ spec:
                   memory: 128Mi
             # TODO: Remove workaround when SPIRE no longer fails to start (https://github.com/cilium/cilium/issues/40533)
             server:
+              # spire-server is a single-replica StatefulSet backed by an
+              # SQLite datastore on a ReadWriteOnce PVC (Cilium chart default).
+              # Now that the hetzner require-mutual-auth policy enforces
+              # pod-to-pod mTLS, this server sits in the data path: while it is
+              # down, NEW identity pairs cannot authenticate. Established flows
+              # ride through via cilium-agent's auth cache, and the
+              # cilium-operator re-syncs entries from CiliumIdentities, so brief
+              # restarts are tolerable. Datastore durability already comes from
+              # the PVC binding to longhorn (the cluster-default StorageClass,
+              # 3-way replicated). Do NOT make these tempting "HA" changes:
+              #   * replicas > 1 — the SQLite + RWO datastore is single-writer;
+              #     real HA needs an external SQL datastore (a much larger
+              #     change, out of scope here).
+              #   * a minAvailable PodDisruptionBudget — with one replica it
+              #     only blocks node drains / autoscaler scale-down / Talos
+              #     upgrades, without adding any availability.
+              #   * pinning dataStorage.storageClass — a StatefulSet
+              #     volumeClaimTemplate is immutable, so changing it would wedge
+              #     the Helm upgrade on the live cluster (the PVC already lands
+              #     on longhorn via the default StorageClass anyway).
               resources:
                 requests:
                   cpu: 50m

--- a/k8s/providers/docker/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -10,6 +10,10 @@ spec:
     # node-to-node wire, and pod-to-pod traffic stays inside one Linux
     # network namespace. Disabling encryption and SPIRE mTLS keeps the
     # local cluster lean and avoids the WireGuard kernel module setup.
+    # The prod-only require-mutual-auth CiliumClusterwideNetworkPolicy
+    # (hetzner overlay) is therefore not rendered for local/CI — a policy
+    # requiring an auth handshake with SPIRE off would drop pod-to-pod
+    # traffic here.
     encryption:
       enabled: false
     authentication:

--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/clusterwidenetworkpolicy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/clusterwidenetworkpolicy.yaml
@@ -1,0 +1,56 @@
+---
+# Cluster-wide pod-to-pod mutual authentication (mTLS) — prod only.
+#
+# Cilium's SPIRE integration is enabled in the base HelmRelease
+# (authentication.mutual.spire.enabled: true), but Cilium only issues a
+# workload identity for traffic that a policy marks
+# `authentication.mode: required`. With zero such policies, SPIRE has no
+# entries to issue and every cilium-agent delegated-identity subscription
+# logs `no identity issued` ~1/sec on every node
+# (devantler-tech/platform#1777). This policy requires mutual auth on all
+# pod-to-pod ingress, so Cilium registers identities with SPIRE, the SVIDs
+# get issued, and the error stream clears — while actually enforcing
+# pod-to-pod mTLS (the goal), not merely silencing the logs.
+#
+# WireGuard wire encryption (encryption.enabled: true in the base) is
+# orthogonal and stays on: WireGuard encrypts the bytes on the wire between
+# nodes, SPIRE mutual auth verifies *which workload* sits on each end. Both
+# are wanted — defence in depth at the transport layer and the identity
+# layer.
+#
+# enableDefaultDeny is false on purpose. A CiliumClusterwideNetworkPolicy
+# that selects every endpoint (endpointSelector: {}) and carries an ingress
+# section would otherwise flip EVERY pod into ingress default-deny
+# (whitelist) mode and drop all traffic not explicitly allowed — including
+# host, world and kube-apiserver ingress, cluster-wide. Setting
+# enableDefaultDeny.ingress: false keeps the policy purely additive: it
+# attaches the mutual-auth requirement to pod-to-pod ingress without denying
+# anything else. Rule-level enforcement (the auth handshake) still applies
+# to matched traffic — exactly the way an L7 rule keeps enforcing with
+# default-deny disabled.
+#
+# Prod (hetzner) only: SPIRE mutual auth is enabled on Hetzner but disabled
+# in the docker/local overlay (single Talos container, no node-to-node
+# wire), so deploying this policy locally — where the auth handshake could
+# never complete — would drop all pod-to-pod traffic. The split is
+# intentional and documented in AGENTS.md.
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: require-mutual-auth
+spec:
+  # Every pod is a potential destination ...
+  endpointSelector: {}
+  # ... but only ADD the mutual-auth requirement; never deny unmatched
+  # traffic (see header comment).
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingress:
+    # ... for ingress from any other pod. Host / world / kube-apiserver
+    # sources are matched by entity selectors, not fromEndpoints, so they
+    # are unaffected by this rule.
+    - fromEndpoints:
+        - {}
+      authentication:
+        mode: required

--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterwidenetworkpolicy.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -30,6 +30,10 @@ resources:
   - ../../../../bases/infrastructure/controllers/trust-manager/
   - ../../../../bases/infrastructure/controllers/velero/
   - ../../../../bases/infrastructure/controllers/vertical-pod-autoscaler/
+  # Prod-only: layers a cluster-wide mutual-auth (SPIRE mTLS) policy on top of
+  # the base Cilium controller listed above. SPIRE is enabled only on Hetzner,
+  # so the policy lives here, not in the base — see cilium/ for the rationale.
+  - cilium/
   - coredns/
   - external-dns/
   - flux-instance/


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Closes #1777.

## Problem

`spire-agent` shows an elevated error rate in Coroot — ~1/sec on every node:

```
level=error msg="no identity issued" method=SubscribeToX509SVIDs   service=DelegatedIdentity
level=error msg="no identity issued" method=SubscribeToX509Bundles service=DelegatedIdentity
```

## Root cause

Cilium SPIRE mutual authentication is **enabled** in prod (`authentication.mutual.spire.enabled: true` in the base Cilium HelmRelease), but **no `CiliumNetworkPolicy` / `CiliumClusterwideNetworkPolicy` used `authentication.mode: required`**. Cilium only registers a workload identity with SPIRE for traffic a policy marks as requiring auth — so SPIRE had nothing to issue and every cilium-agent delegated-identity subscription returned "no identity issued". The feature was enabled but **unused**.

Per the maintainer's course-correction on #1772, SPIRE is **kept** (complementary to WireGuard) and the goal is to *use* it — enforce pod-to-pod mTLS — not turn it off. This supersedes the disable (#1772) / remove (#1776) drafts.

## Change

A prod-only cluster-wide policy that requires mutual auth on all pod-to-pod ingress:

```yaml
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: require-mutual-auth
spec:
  endpointSelector: {}
  enableDefaultDeny:
    ingress: false
    egress: false
  ingress:
    - fromEndpoints:
        - {}
      authentication:
        mode: required
```

Cilium now registers identities with SPIRE, the SVIDs get issued, the "no identity issued" stream clears, and pod-to-pod mTLS is actually enforced.

### Why `enableDefaultDeny: false` (the safety lever)

A `CiliumClusterwideNetworkPolicy` that selects every endpoint (`endpointSelector: {}`) and carries an ingress section would normally flip **every** pod into ingress default-deny (whitelist) mode and drop all traffic not explicitly allowed — including host, world and kube-apiserver ingress, cluster-wide. Setting `enableDefaultDeny.ingress: false` keeps the policy **purely additive**: it attaches the mutual-auth requirement to pod-to-pod ingress without denying anything else. Per Cilium's docs, rule-level enforcement (the auth handshake, like an L7 redirect) still applies to matched traffic even with default-deny disabled. `fromEndpoints: {}` matches only Cilium-managed endpoints (pods); host/world/kube-apiserver are matched by entity selectors, so they are unaffected.

### Provider split (issue point 4 — local stays opted-out, documented)

SPIRE is enabled only on Hetzner; the docker/local overlay disables it (single Talos container, no node-to-node wire). A policy demanding an auth handshake with SPIRE off would drop all pod-to-pod traffic locally — so the policy lives in the **hetzner overlay only**, never the base. Renders in prod, absent from local (verified below). Documented in `AGENTS.md`, `.github/copilot-instructions.md`, and the docker overlay comment.

### Left untouched (issue points 2, 3, 5)

- **WireGuard** wire encryption (`encryption.enabled: true`, base) — orthogonal, kept on.
- The **#40533** SPIRE start-up workaround (`chown` initContainer) in the Cilium `install:` block — kept.
- The Kyverno **privileged exceptions** for `spire-server`/`spire-agent` — kept (still relevant now that mTLS is enforced).

## Validation

- ✅ `kubectl kustomize` builds: `providers/hetzner/.../controllers`, `providers/docker/.../controllers`, `clusters/local`, `clusters/prod`.
- ✅ Policy renders in **prod only**, absent from local.
- ✅ `ksail workload validate` (both `ksail.yaml` and `ksail.prod.yaml`): the `cilium` groups validate green (`bases/.../cilium` ✔, `providers/hetzner/.../controllers/cilium` ✔).
  - The only failure is the **pre-existing** Coroot stale-catalog schema issue (`coroot.com/v1` rejects `notificationIntegrations`) in `providers/hetzner/infrastructure` — untouched by this PR. `ksail.yaml` already suppresses it via `validation.skipKinds: [Coroot]`, which needs ksail ≥ 7.26.0 (the local toolchain is 7.25.0); on CI/any host with ≥ 7.26.0 it is skipped.

## Acceptance criteria

- [x] At least one `authentication.mode: required` policy added for prod (`require-mutual-auth`). The "no identity issued" stream is expected to clear after deploy — verify in Coroot post-reconcile.
- [x] WireGuard encryption remains enabled in prod (unchanged).
- [x] `kubectl kustomize` builds for hetzner/docker controllers + `clusters/{local,prod}`; `ksail workload validate` green for the cilium groups (only the pre-existing Coroot failure remains).
- [x] `AGENTS.md` / `.github/copilot-instructions.md` state SPIRE mutual auth is **enabled and enforced**.

## Rollout note

On first apply, Cilium establishes auth per identity-pair on demand; brief drops are possible for a pair before its SVID is issued, then it stabilizes. hostNetwork pods use the `host` identity (not `fromEndpoints`), so they are not subject to this rule. Reversible by removing the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
