### PR TITLE
fix(coroot): show Coroot online on the homepage dashboard

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
@@ -17,10 +17,11 @@ metadata:
     gethomepage.dev/group: Observability
     # Status dot: Homepage derives a service's health from the readiness of pods
     # matching `gethomepage.dev/pod-selector`. With no selector it defaults to
-    # `app.kubernetes.io/name=<gethomepage.dev/app|route-name>` = `name=coroot`,
-    # but the coroot-operator labels the app pod `app.kubernetes.io/component=coroot`
-    # (+ `part-of=coroot`) and sets NO `app.kubernetes.io/name` label — so the
-    # default selector matches zero pods and the card renders offline even though
+    # `app.kubernetes.io/name=<gethomepage.dev/app|route-name>`, i.e.
+    # `app.kubernetes.io/name=coroot`. But the coroot-operator labels the app pod
+    # `app.kubernetes.io/component=coroot` (+ `part-of=coroot`) and sets NO
+    # `app.kubernetes.io/name` label — so the default selector matches zero pods
+    # and the card renders offline even though
     # Coroot is healthy. Target the app pod explicitly (same reason the Cilium
     # route pins `k8s-app=hubble-ui` and FleetDM pins `app=fleet`).
     gethomepage.dev/pod-selector: app.kubernetes.io/part-of=coroot,app.kubernetes.io/component=coroot

--- a/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
@@ -15,6 +15,15 @@ metadata:
     gethomepage.dev/name: Coroot
     gethomepage.dev/description: Metrics, logs, traces, profiling and alerts.
     gethomepage.dev/group: Observability
+    # Status dot: Homepage derives a service's health from the readiness of pods
+    # matching `gethomepage.dev/pod-selector`. With no selector it defaults to
+    # `app.kubernetes.io/name=<gethomepage.dev/app|route-name>` = `name=coroot`,
+    # but the coroot-operator labels the app pod `app.kubernetes.io/component=coroot`
+    # (+ `part-of=coroot`) and sets NO `app.kubernetes.io/name` label — so the
+    # default selector matches zero pods and the card renders offline even though
+    # Coroot is healthy. Target the app pod explicitly (same reason the Cilium
+    # route pins `k8s-app=hubble-ui` and FleetDM pins `app=fleet`).
+    gethomepage.dev/pod-selector: app.kubernetes.io/part-of=coroot,app.kubernetes.io/component=coroot
     # Coroot isn't in the dashboard-icons / selfh.st / simple-icons sets Homepage
     # resolves, so `coroot.png` 404s and the card renders blank. Point at Coroot's
     # upstream brand SVG instead — the same upstream-URL pattern this repo already

--- a/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
@@ -21,9 +21,9 @@ metadata:
     # `app.kubernetes.io/name=coroot`. But the coroot-operator labels the app pod
     # `app.kubernetes.io/component=coroot` (+ `part-of=coroot`) and sets NO
     # `app.kubernetes.io/name` label — so the default selector matches zero pods
-    # and the card renders offline even though
-    # Coroot is healthy. Target the app pod explicitly (same reason the Cilium
-    # route pins `k8s-app=hubble-ui` and FleetDM pins `app=fleet`).
+    # and the card renders offline even though Coroot is healthy. Target the app
+    # pod explicitly (same reason the Cilium route pins `k8s-app=hubble-ui` and
+    # FleetDM pins `app=fleet`).
     gethomepage.dev/pod-selector: app.kubernetes.io/part-of=coroot,app.kubernetes.io/component=coroot
     # Coroot isn't in the dashboard-icons / selfh.st / simple-icons sets Homepage
     # resolves, so `coroot.png` 404s and the card renders blank. Point at Coroot's


### PR DESCRIPTION
## Problem

Coroot renders **offline** on the Homepage dashboard despite running 24/7.

## Root cause

Homepage discovers services from the `gethomepage.dev/*` annotations on their HTTPRoutes (`kubernetes: mode: cluster`, `gateway: true`) and derives the status dot from the readiness of the pods that match `gethomepage.dev/pod-selector`. The Coroot route set **no** pod-selector, so Homepage fell back to its documented default — `app.kubernetes.io/name=<gethomepage.dev/app | route-name>`, i.e. `app.kubernetes.io/name=coroot`.

But the coroot-operator labels the running app pod (`coroot-coroot-0`) as:

```
app.kubernetes.io/component=coroot
app.kubernetes.io/part-of=coroot
app.kubernetes.io/managed-by=coroot-operator
```

— there is **no `app.kubernetes.io/name` label at all**. So the default selector matched zero pods and the card was painted offline.

This has been latent since Coroot was introduced (#1742); the namespace move to `observability` (#1771) didn't cause it.

`opencost` shares the identical config (no pod-selector, same Observability group, oauth2-proxy backend) yet shows online — because its Helm chart sets `app.kubernetes.io/name=opencost`, which the default selector happens to match. That contrast pins the cause precisely.

## Fix

Add an explicit `gethomepage.dev/pod-selector` targeting the Coroot app pod:

```
gethomepage.dev/pod-selector: app.kubernetes.io/part-of=coroot,app.kubernetes.io/component=coroot
```

This matches exactly `coroot-coroot-0` (verified live: `1/1 Running`). It's the same pattern the repo already uses for pods that don't follow the `app.kubernetes.io/name=<route-name>` convention — the Cilium route pins `k8s-app=hubble-ui` and FleetDM pins `app=fleet`.

## Validation

- `kubectl kustomize` builds green for both providers; the annotation renders on the Coroot HTTPRoute in `providers/docker/infrastructure/controllers` and `providers/hetzner/infrastructure/controllers`.
- `ksail workload validate`: the `infrastructure/controllers` groups (which contain this route) pass. The one unrelated failure — `providers/hetzner/infrastructure` → `coroot_v1.json` rejecting `notificationIntegrations` — is the pre-existing stale-CRDs-catalog false-positive on the Coroot **CR** (a different layer, untouched here).
- Live cross-check: `kubectl get pods -n observability -l app.kubernetes.io/part-of=coroot,app.kubernetes.io/component=coroot` → `coroot-coroot-0  1/1  Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
