### PR TITLE
fix(homepage): soften logo halo and sharpen the iOS/PWA icon

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -7,7 +7,28 @@ metadata:
 data:
   settings.yaml: |
     title: Platform
-    favicon: https://avatars.githubusercontent.com/u/178524219?v=4&s=32
+    # `favicon` also drives the iOS Add-to-Home-Screen icon: Homepage emits
+    # <link rel="apple-touch-icon" sizes="180x180" href={favicon}> and has no
+    # separate apple-touch-icon setting. At s=32 iOS upscaled a 32px image to
+    # 180px, so the installed PWA tile was badly blurred. Request s=180 to match
+    # the apple-touch-icon size exactly — a crisp, unscaled render (the avatar
+    # tops out at 460x460 upstream) — which the browser also downsamples for the
+    # tab favicon.
+    favicon: https://avatars.githubusercontent.com/u/178524219?v=4&s=180
+    # PWA manifest icons for the installed app. Without this the manifest falls
+    # back to Homepage's own logo; point it at the DevantlerTech avatar so an
+    # installed app stays on-brand. iOS uses the apple-touch-icon above for the
+    # home-screen tile; these cover the web manifest (Android / desktop install /
+    # splash). s=512 is capped to the avatar's native 460x460 — still far sharper
+    # than the old 32px asset.
+    pwa:
+      icons:
+        - src: https://avatars.githubusercontent.com/u/178524219?v=4&s=192
+          type: image/jpeg
+          sizes: 192x192
+        - src: https://avatars.githubusercontent.com/u/178524219?v=4&s=512
+          type: image/jpeg
+          sizes: 512x512
     theme: dark
     # zinc, not slate: homepage's gray chrome (text, card fills, borders, and
     # the #__next page background) follows this `color` ramp. slate is a
@@ -269,8 +290,13 @@ data:
       background-repeat: no-repeat;
     }
 
-    /* Top widgets bar: a hairline separator + soft green halo on the logo,
-       echoing devantler's glass header and glowing hero avatar. */
+    /* Top widgets bar: a hairline separator under the widgets. The logo sat on a
+       hard 16px green halo that read as a glowing ring; drop it and instead
+       feather the logo's own edges into the dark backdrop with a soft radial
+       mask, so the near-black badge dissolves into hsl(224,10%,10%) and reads as
+       a subtle, understated mark rather than a green-rimmed sticker. The mask
+       stays fully opaque across the emblem (inner ~65%) and only fades the flat
+       black margin and corners, so no logo detail is dimmed. */
     #information-widgets {
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
       padding-bottom: 0.85rem;
@@ -278,7 +304,8 @@ data:
     }
     #information-widgets img {
       border-radius: 12px;
-      box-shadow: 0 0 16px rgba(57, 255, 20, 0.22);
+      -webkit-mask-image: radial-gradient(circle, #000 65%, transparent 100%);
+              mask-image: radial-gradient(circle, #000 65%, transparent 100%);
     }
 
     /* Thin, dark scrollbar with a green thumb. */


### PR DESCRIPTION
## What & why

Two cosmetic issues with the **homepage** app, both in `k8s/bases/apps/homepage/config-map.yaml`.

### 1. Green logo halo -> blends into the background
The top-bar logo had a hard green glow (`box-shadow: 0 0 16px rgba(57,255,20,.22)`) that read as a glowing ring. Replaced with a radial `mask-image` that feathers the near-black DevantlerTech badge's edges into the dark backdrop, so it dissolves into `hsl(224,10%,10%)` and reads as a subtle, understated mark. The mask stays fully opaque across the inner ~65% (emblem, antlers, and the "DEVANTLER TECH" text all sit inside that), fading only the flat black margin/corners -- no detail is dimmed. The green accent stays everywhere else (card hovers, underlines, selection, scrollbar).

### 2. Blurry iOS / PWA home-screen icon -> root cause fixed
Homepage emits `<link rel="apple-touch-icon" sizes="180x180" href={favicon}>` and has **no separate apple-touch-icon setting** -- so the iOS home-screen tile *is* the favicon. Ours was pulled at `?s=32` (32x32) and iOS upscaled it 5.6x to 180px -> heavy blur.

- **`favicon` -> `?s=180`**: a verified, native 180x180 render (no scaling) -- exact apple-touch-icon size; the browser downsamples the same asset for the tab favicon.
- **Added `pwa.icons` (192/512)**: so an *installed* PWA's web manifest is branded with the DevantlerTech logo instead of Homepage's default flame. The avatar caps at 460x460 upstream, so the 512 slot is a capped-but-sharp 460.

## Verification
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` build green.
- The homepage base builds; the embedded `settings.yaml` re-parses with the new `pwa` block.
- Confirmed `?s=180` -> real 180x180 and `?s=192` -> 192x192 (not upscaled).
- Confirmed chart `4.11.1` ships homepage `v1.12.3`, which honors the `pwa` setting (added upstream in `v1.10.0`); apple-touch-icon is still tied to `favicon`.

## Reviewer notes
- Visual calls (the mask's `#000 65%` stop, and the actual icon sharpness) can only be confirmed on a rendered page. **iOS caches home-screen icons aggressively** -- after this deploys, remove and re-add the home-screen shortcut to pick up the new icon. The avatar is an opaque JPEG, so it avoids the iOS-18 transparent-icon-on-white behavior.
- Minor open call: the second `pwa` icon declares `sizes: 512x512` while the asset caps at the avatar's native 460x460. Functionally fine (an ~11% upscale, imperceptible), but a strict Lighthouse PWA audit would warn on the mismatch. Happy to switch it to `460x460` for an exact match if preferred -- left at the conventional 512 splash size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
