### PR TITLE
fix(cd): use actions/attest for SBOM and grant artifact-metadata:write

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,6 +23,7 @@ jobs:
       packages: write # push OCI artifacts to GHCR
       id-token: write # mint OIDC token for cosign keyless signing (Fulcio + Rekor)
       attestations: write # write SBOM + SLSA provenance attestations
+      artifact-metadata: write # create the attestation storage record (GHCR linked-artifacts index)
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -216,7 +217,7 @@ jobs:
         # it manages syft's binary integrity itself, so no per-version
         # SHA256 to track here either. Bump syft by editing SYFT_VERSION
         # below; Renovate proposes the bump via the custom regex manager.
-        # Output is CycloneDX JSON, which is the format attest-sbom expects.
+        # Output is CycloneDX JSON, a format actions/attest accepts via sbom-path.
         # `upload-artifact: false` matches today's behaviour (no workflow
         # artifact); the SBOM is attested to the registry in the next step.
         env:
@@ -233,8 +234,10 @@ jobs:
       - name: 🪪 Attest SBOM (Sigstore via cosign keyless)
         # Records the SBOM as a Sigstore in-toto attestation against the
         # OCI manifest's digest. The attestation is uploaded to GHCR and
-        # its index recorded in Rekor.
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        # its index recorded in Rekor. actions/attest-sbom v4 is now just a
+        # deprecated wrapper around actions/attest, so call attest directly
+        # and let its sbom-path input auto-select the SBOM predicate type.
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-digest: ${{ steps.cosign-sign.outputs.digest }}
           subject-name: ghcr.io/devantler-tech/platform/manifests


### PR DESCRIPTION
## What

Clears the two warnings the prod deploy workflow (`cd.yaml`) emits from its attestation steps:

1. `actions/attest-sbom has been deprecated, please use actions/attest instead`
2. `Failed to persist storage record: no artifacts found` + `Please check that the "artifact-metadata:write" permission has been included` — on **both** the SBOM and SLSA-provenance steps

## Changes (`cd.yaml`, +6/−3)

- **SBOM step → `actions/attest`.** `actions/attest-sbom@v4.1.0` is now just a deprecated wrapper that invokes `actions/attest` and prints the deprecation warning. The new pin `actions/attest@59d8942 # v4.1.0` is the **exact SHA `attest-sbom@v4.1.0` already called internally** (visible in the run log), so the attestation output is identical — `sbom-path` auto-selects the SBOM predicate type. The provenance step stays on `actions/attest-build-provenance` (not deprecated; it auto-builds the SLSA predicate).
- **`artifact-metadata: write`** added to the job `permissions:` block. GitHub's storage-record feature (`create-storage-record`, default `true`) needs this scope to record the attestation in the org's artifact-metadata index. The job-level grant covers both attest steps.

## Why "no artifacts found" is misleading

Per the [REST endpoint](https://docs.github.com/rest/orgs/artifact-metadata) the record is created _"on behalf of any artifact matching the digest and associated with a repository owned by the **organization**."_ The maintainer in [actions/attest-build-provenance#781](https://github.com/actions/attest-build-provenance/issues/781) confirms storage records **only work for org-owned repos** — that reporter got a 404 even _with_ the permission because their repo was user-owned. Ours is the inverse: `devantler-tech` is an org and the `platform/manifests` GHCR package is repo-linked (`internal` visibility), so every precondition was already met except the permission.

## Reviewer notes

- **Non-breaking by construction.** The attestations already succeed today (cosign signature + SBOM + SLSA provenance + Rekor + registry upload); the storage record is a non-essential GitHub-UI index. Worst case the warning persists, with no impact on the supply-chain bundle.
- **Live verification.** `cd.yaml` runs only on `v*` tags into prod, so this confirms on the next release tag. If the storage-record warning ever survives, the one-line fallback is `create-storage-record: false` on both steps.
- **No collateral.** `ci.yaml`'s merge-queue deploy intentionally does not attest yet (cosign-only), so it is correctly untouched. Dependabot owns the `github-actions` ecosystem and will keep the renamed `actions/attest` pin current (Renovate's Actions manager is disabled here).
- **Validation.** `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
