### PR TITLE
fix(cilium): bootstrap SPIRE so mutual auth issues identities; exempt CoreDNS

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/clusterwidenetworkpolicy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/clusterwidenetworkpolicy.yaml
@@ -8,7 +8,8 @@
 # entries to issue and every cilium-agent delegated-identity subscription
 # logs `no identity issued` ~1/sec on every node
 # (devantler-tech/platform#1777). This policy requires mutual auth on all
-# pod-to-pod ingress, so Cilium registers identities with SPIRE, the SVIDs
+# pod-to-pod ingress (except DNS to CoreDNS — see the endpointSelector
+# carve-out below), so Cilium registers identities with SPIRE, the SVIDs
 # get issued, and the error stream clears — while actually enforcing
 # pod-to-pod mTLS (the goal), not merely silencing the logs.
 #
@@ -39,8 +40,31 @@ kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: require-mutual-auth
 spec:
-  # Every pod is a potential destination ...
-  endpointSelector: {}
+  # Every pod is a potential destination EXCEPT CoreDNS. DNS must never
+  # sit behind the mutual-auth handshake. CoreDNS is a regular (non
+  # host-network) pod, so without this carve-out the blanket ingress rule
+  # below makes every pod -> CoreDNS query require mutual auth. A TCP flow
+  # survives that (the first packet is dropped, the auth handshake fires,
+  # and the kernel's retransmit rides the now-established auth), but DNS
+  # over UDP has no transport-layer retransmit: Cilium drops every datagram
+  # until auth is established, and the resolver just times out. Applying
+  # this policy with endpointSelector: {} took prod-wide DNS down within
+  # seconds (every pod logging `lookup <name> ... i/o timeout` against
+  # kube-dns; devantler-tech/platform#1783-followup, 2026-06-05).
+  #
+  # Only CoreDNS needs exempting: a scan of the live cluster found DNS the
+  # *sole* failing traffic class (no post-resolution connection errors),
+  # and the SPIRE control plane is unaffected because cilium-operator and
+  # spire-agent are host-network — their traffic to spire-server is matched
+  # as a `host` entity, not by the fromEndpoints rule below — so there is no
+  # auth-bootstrap dependency to break. k8s-app=kube-dns is the only pod
+  # carrying that label, so the NotIn selector excludes exactly CoreDNS.
+  endpointSelector:
+    matchExpressions:
+      - key: k8s-app
+        operator: NotIn
+        values:
+          - kube-dns
   # ... but only ADD the mutual-auth requirement; never deny unmatched
   # traffic (see header comment).
   enableDefaultDeny:


### PR DESCRIPTION
## Summary

`require-mutual-auth` (#1781) enforced `authentication.mode: required` on all pod-to-pod ingress, which took **prod down** (cluster-wide DNS first, then all cross-node pod-to-pod). Investigation showed the real problem is deeper than the policy: **SPIRE issues no workload SVIDs at all**, so enforcing mutual auth drops every flow. This PR fixes the SPIRE bootstrap so mutual auth actually works, and keeps DNS out of the auth path.

## Root cause (full chain)

```
spire-server's `cilium-init` bootstrap container is wedged ("Waiting for spire-server to start…", 4d)
  └─ it reaches the admin socket via /proc/<spire-server-pid>/root/tmp/spire-server/private/api.sock
       — ptrace-gated: caller uid AND gid must match target, or need CAP_SYS_PTRACE
  └─ cilium#40533 workaround runs spire-server as 1000:1000, but cilium-init has NO securityContext → root (0:0)
       └─ 0:0 ≠ 1000:1000, no CAP_SYS_PTRACE → /proc access EPERM
            └─ cilium-init never runs `spire-server entry create` → ZERO registration entries
                 └─ cilium-operator can't get its own SVID ("no identity issued", attempt=5140)
                      └─ operator can't register workload identities → SPIRE issues nothing
                           └─ every cilium-agent: "no SPIFFE ID for identity/N"
                                └─ #1781's `mode: required` drops all matching pod-to-pod → OUTAGE
```

`pgrep spire-server` (in cilium-init) works only because `/proc/<pid>/comm` is world-readable; traversing `/proc/<pid>/root` is the ptrace-gated step that fails. Node attestation (`k8s_psat`) works fine, which is why SPIRE *looked* healthy. **This predates #1781** — SPIRE was enabled-but-non-functional (logging `no identity issued`); #1781 turned that latent breakage into an outage.

## The fix

1. **`k8s/bases/.../cilium/helm-release.yaml`** — add `authentication.mutual.spire.install.server.podSecurityContext: {runAsUser: 1000, runAsGroup: 1000}`. cilium-init (no SC of its own) then inherits `1000:1000` and matches spire-server, so the `/proc` access succeeds and it seeds the `cilium-agent` + `cilium-operator` entries. The `chown` initContainer keeps its explicit `runAsUser: 0` and the spire-server container its explicit `1000`, so **only cilium-init changes**. Inert on docker (SPIRE disabled). Verified against Cilium v1.19.4: cilium-init ships with no securityContext and `server.podSecurityContext` is a real values key.
2. **`k8s/providers/hetzner/.../cilium/clusterwidenetworkpolicy.yaml`** — exempt CoreDNS (`k8s-app NotIn [kube-dns]`) from the policy. Even with SPIRE working, DNS-over-UDP can't ride the first-packet-drop auth handshake (no transport retransmit). Defense-in-depth: DNS stays up regardless of SPIRE health.

## Validation

- `kubectl kustomize` of base cilium renders the `podSecurityContext`; hetzner + docker controller overlays and both cluster overlays build clean.
- Cilium v1.19.4 chart template confirmed (`templates/spire/server/statefulset.yaml`): cilium-init has no securityContext; pod SC comes from `server.podSecurityContext`.

## ⚠️ Deploy — GitOps can't self-heal while the outage persists

source-controller/helm-controller can't reach each other (the very outage), so Flux can't pull/deploy this fix. Break the deadlock by applying the bootstrap fix to the live spire-server directly (this *strengthens* SPIRE — it does not touch the policy):

```bash
# Recreates spire-server-0 with cilium-init at 1000:1000 → it seeds the SPIRE
# entries → cilium-operator bootstraps → SPIRE issues SVIDs → mutual-auth
# handshakes succeed → cross-node pod-to-pod (and Flux) recover.
kubectl -n kube-system patch statefulset spire-server --type=strategic \
  -p '{"spec":{"template":{"spec":{"securityContext":{"runAsUser":1000,"runAsGroup":1000}}}}}'

# watch it bootstrap:
kubectl -n kube-system logs spire-server-0 -c cilium-init -f
#   expect: "Spire Server is up, initializing cilium spire entries..."
#           "Cilium Spire entries are initialized successfully or already in-sync"
```

The seeded entries persist in the spire-server PVC datastore, so SPIRE keeps issuing even if Flux later reverts the live StatefulSet (until this PR is merged+deployed). Then for durability merge this PR and deploy; afterwards drop the temporary hold on the policy:

```bash
kubectl annotate ciliumclusterwidenetworkpolicy require-mutual-auth kustomize.toolkit.fluxcd.io/reconcile-
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)