### PR TITLE
fix(cd): opt out of attestation storage record to clear "no artifacts found" warning

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,11 @@ jobs:
       packages: write # push OCI artifacts to GHCR
       id-token: write # mint OIDC token for cosign keyless signing (Fulcio + Rekor)
       attestations: write # write SBOM + SLSA provenance attestations
-      artifact-metadata: write # create the attestation storage record (GHCR linked-artifacts index)
+      # No artifact-metadata:write — the attest steps below set
+      # create-storage-record: false, so the storage-record API is never called.
+      # #1787 granted it to clear a "no artifacts found" warning, but the grant
+      # was necessary-but-not-sufficient (actions/attest-build-provenance#781);
+      # see the Attest SBOM step for the full rationale.
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -237,12 +241,24 @@ jobs:
         # its index recorded in Rekor. actions/attest-sbom v4 is now just a
         # deprecated wrapper around actions/attest, so call attest directly
         # and let its sbom-path input auto-select the SBOM predicate type.
+        #
+        # create-storage-record: false opts out of GitHub's artifact-metadata
+        # storage record — a GHCR "linked artifacts" discoverability index, not a
+        # supply-chain control. It cannot succeed here: the manifest is pushed by
+        # oras/ksail + cosign, not a GitHub-native artifact flow, so the
+        # artifact-metadata service has no registered artifact to attach to and
+        # warns "no artifacts found" on every deploy. #1787 mis-read this as a
+        # missing artifact-metadata:write grant; the grant shipped (v1.34.5) and
+        # the warning persisted, because per actions/attest-build-provenance#781
+        # the permission is necessary-but-not-sufficient. The cosign signature,
+        # SBOM attestation, SLSA provenance, and Rekor entry are all unaffected.
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-digest: ${{ steps.cosign-sign.outputs.digest }}
           subject-name: ghcr.io/devantler-tech/platform/manifests
           sbom-path: sbom.cdx.json
           push-to-registry: true
+          create-storage-record: false
 
       - name: 🪪 Attest build provenance (SLSA L3)
         # Generates a SLSA provenance v1.0 statement and attests it against
@@ -251,11 +267,13 @@ jobs:
         # Combined with the cosign signature above and the SBOM
         # attestation, this completes the supply-chain transparency
         # bundle for the platform OCI artifact.
+        # create-storage-record: false for the same reason as the SBOM step above.
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-digest: ${{ steps.cosign-sign.outputs.digest }}
           subject-name: ghcr.io/devantler-tech/platform/manifests
           push-to-registry: true
+          create-storage-record: false
 
       - name: 🔁 Trigger Flux reconciliation
         id: reconcile


### PR DESCRIPTION
The prod deploy's **Attest SBOM** and **Attest build provenance** steps warn on every run:

```
Warning: Failed to create storage record: Error: Failed to persist storage record: no artifacts found
Warning: Please check that the "artifact-metadata:write" permission has been included
```

### Why #1787's fix did not clear it

[#1787](https://github.com/devantler-tech/platform/pull/1787) read the second line literally and granted `artifact-metadata: write`. That grant shipped in **v1.34.5** and the warning **persisted** — re-observed in the **v1.35.1** deploy (run `27032085243`, both attest steps `success`-with-warning). Per [actions/attest-build-provenance#781](https://github.com/actions/attest-build-provenance/issues/781) the permission is **necessary-but-not-sufficient**; the second warning is a generic catch-all the action prints whenever the storage record fails, regardless of the real cause.

### Root cause

The `manifests` artifact reaches GHCR via **oras/ksail + cosign**, not a GitHub-native artifact flow. GitHub's artifact-metadata service therefore has **no registered artifact** to attach a storage record to → `no artifacts found`. This is structural to our delivery model, not a config gap, so it cannot be fixed from the workflow side.

The storage record is a GHCR **"linked artifacts" discoverability index, not a supply-chain control**. The cosign signature, SBOM attestation, SLSA provenance, and Rekor transparency-log entry all succeed and verify **without** it (visible in the same step log: *Attestation created / signed / uploaded to Rekor / repository / registry*).

### Change

- `create-storage-record: false` on **both** attest steps — the deterministic opt-out, so the storage-record API is never called and the warning can no longer fire.
- Drop the now-unused `artifact-metadata: write` job permission (#1787's premise superseded; least privilege restored).

No change to what is deployed, signed, or attested — only the failing, inapplicable discoverability call is removed.

### Validation

- `actionlint .github/workflows/cd.yaml` → clean.
- Behaviour confirmed against the live v1.35.1 CD run; `create-storage-record` verified present (default `true`) on both pinned action SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)