### PR TITLE
fix(umami): create websites when GET returns 200+null on fresh Umami

### DIFF
--- a/k8s/bases/apps/umami/provision-cronjob.yaml
+++ b/k8s/bases/apps/umami/provision-cronjob.yaml
@@ -189,8 +189,13 @@ spec:
                   }
                   async function ensureWebsite(token, s, teamId) {
                     const g = await fetch(base + '/api/websites/' + s.id, { headers: H(token) });
-                    if (g.ok) {
-                      const w = await g.json();
+                    // Umami returns 200 with a `null` body (NOT a 404) for a website id
+                    // that doesn't exist yet, so a 2xx alone doesn't mean it's present —
+                    // only treat it as existing when the body is a real website object,
+                    // otherwise fall through to create. (Dereferencing the null body here
+                    // is what crashed every run, leaving Umami with no websites.)
+                    const w = g.ok ? await g.json() : null;
+                    if (w && w.id) {
                       if (w.teamId === teamId) { console.log('website ok:', s.domain); return; }
                       const t = await fetch(base + '/api/websites/' + s.id + '/transfer', { method: 'POST', headers: H(token), body: JSON.stringify({ teamId }) });
                       if (!t.ok) throw new Error('transfer website ' + s.domain + ' failed: ' + t.status + ' ' + (await t.text()));


### PR DESCRIPTION
## Problem

The `umami-provision-tenants` CronJob fails on **every** run:

```
TypeError: Cannot read properties of null (reading 'teamId')
    at ensureWebsite ([eval]:38:11)
    at async [eval]:98:41
```

Because the job is the only thing that creates Umami teams/websites and rotates the admin password, this left Umami **empty** (no teams, no sites) and the admin password at its default.

## Root cause

`ensureWebsite` does a `GET /api/websites/{id}` and assumes any `2xx` means the website exists:

```js
if (g.ok) {
  const w = await g.json();
  if (w.teamId === teamId) { ... }   // <-- w is null here
```

In Umami 3.1.0 the handler is `return json(await getWebsite(websiteId))`, and `getWebsite()` is a Prisma `findUnique` that returns `null` when the id doesn't exist — so a **missing** website id yields **HTTP 200 with a literal `null` body**, not a 404. The hard-pinned website UUIDs never exist on a fresh install, so the very first website check dereferenced `null.teamId` and aborted the run before the create path ever executed.

## Fix

Only treat the GET result as an existing website when the body is a real object; otherwise fall through to create:

```js
const w = g.ok ? await g.json() : null;
if (w && w.id) {
  // exists → check team / transfer
}
// else create via POST /api/websites
```

`POST /api/websites` accepts the client-supplied `id` (`id ?? uuid()`) and `teamId` (verified against the v3.1.0 schema), so the pinned UUIDs are created correctly. The change is idempotent: once a site exists, subsequent runs see a real object with the right `teamId` and log `website ok`.

## Validation

- `node --check` on the embedded provisioning script — syntax OK
- `kubectl kustomize k8s/clusters/local/` and `.../prod/` — both build
- `ksail workload validate` — `providers/hetzner/apps` (where this CronJob lives) passes. The one unrelated failure is the pre-existing Coroot `notificationIntegrations` stale-CRD-catalog schema issue in `providers/hetzner/infrastructure`.

After merge, the next `*/15` tick (or `kubectl create job -n umami --from=cronjob/umami-provision-tenants umami-provision-now`) should create the teams/websites and rotate the admin password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)