### PR TITLE
docs(auto-vpa): refresh in-place-resize comment for k8s 1.35 GA

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -7,19 +7,18 @@
 # control-plane pods (kube-apiserver/etcd/scheduler/controller-manager) are
 # bare Pods, not Deployment/StatefulSet/DaemonSet, so they never match.
 #
-# IN-PLACE RESIZE (no eviction) requires k8s >= 1.33, where the
-# InPlacePodVerticalScaling feature gate is beta and ON by default. VPA here
-# is already 1.6 (its own InPlaceOrRecreate gate defaults on since 1.5) and
-# the rules below already set updateMode InPlaceOrRecreate, so nothing else
-# needs to change -- the cluster just has to run >= 1.33.
+# IN-PLACE RESIZE (no eviction) is active. InPlacePodVerticalScaling went GA
+# in k8s 1.35 (KEP-1287) and prod runs v1.35.5; VPA is 1.6 (its own
+# InPlaceOrRecreate gate has defaulted on since 1.5) and the rules below set
+# updateMode InPlaceOrRecreate, so VPA right-sizes pods in place instead of
+# evicting them. spire-server (StatefulSet) uses updateMode Initial and is
+# never evicted regardless.
 #
-# On k8s < 1.33 the gate is alpha/off, so InPlaceOrRecreate falls back to
-# Recreate: VPA applies a recommendation by EVICTING the pod. For the
-# kube-system DaemonSets (cilium / spire-agent) that is a brief per-node
-# datapath blip as each pod restarts, one node at a time; spire-server
-# (StatefulSet) uses updateMode Initial and is never evicted. Until prod is
-# upgraded to >= 1.33 (target 1.34; Talos 1.12 supports k8s 1.30-1.35),
-# expect a one-time round of such evictions as VPA applies its initial recs.
+# (Historical: on k8s < 1.33 the gate was alpha/off and InPlaceOrRecreate
+# fell back to Recreate -- VPA applied a recommendation by EVICTING the pod,
+# a one-time per-node datapath blip for the kube-system DaemonSets
+# (cilium / spire-agent). That round is in the past now prod is well past
+# 1.33.)
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:


### PR DESCRIPTION
## What

Refresh the stale header comment on `auto-vpa.yaml`.

`InPlacePodVerticalScaling` went **GA in k8s 1.35** (KEP-1287) and prod runs **v1.35.5**, so the comment's "beta", "k8s < 1.33 fallback", and "Until prod is upgraded to >= 1.33 (target 1.34)" wording was stale. Reworded to state in-place resize is active, with the old eviction behaviour demoted to a historical aside.

**Comment-only — no manifest or behaviour change.** Both overlays (`clusters/local`, `clusters/prod`) build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)