### PR TITLE
fix(cilium): set spire-server podSecurityContext so cilium-init seeds SPIRE entries

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -206,6 +206,24 @@ spec:
                   name: spire-data
                 - mountPath: /tmp/spire-server/private
                   name: spire-server-socket
+              # Pod-level security context. The chart injects a `cilium-init`
+              # bootstrap container (with no securityContext of its own) into this
+              # pod; it seeds the SPIRE registration entries for Cilium and must run
+              # as 1000 to MATCH spire-server. cilium-init reaches spire-server's
+              # admin socket via /proc/<pid>/root, which is ptrace-gated — the
+              # caller's uid+gid must equal the target's. If cilium-init runs as root
+              # (0) while spire-server runs as 1000 it is denied, hangs forever on
+              # "Waiting for spire-server to start...", and never creates the entries.
+              # SPIRE then issues no SVIDs, so the require-mutual-auth policy
+              # black-holes pod-to-pod traffic cluster-wide (kustomize/helm-controller
+              # can no longer reach source-controller — wedging every Flux
+              # reconciliation). `server.securityContext` below sets only the
+              # spire-server *container* and leaves cilium-init as root, so this
+              # pod-level block is what actually fixes the bootstrap.
+              # (cilium/cilium#40533)
+              podSecurityContext:
+                runAsGroup: 1000
+                runAsUser: 1000
               securityContext:
                 runAsGroup: 1000
                 runAsUser: 1000


### PR DESCRIPTION
## Incident

Prod Flux reconciliation was fully wedged: every Kustomization (`bootstrap` → `infrastructure-controllers` → `infrastructure` → `apps`) and **all ~30 HelmReleases** reported artifact-fetch failures against `source-controller`:

```
dial tcp 10.101.135.205:80: i/o timeout
```

`source-controller` itself was healthy (endpoint `10.244.2.9` ready on `prod-worker-1`); the appliers `kustomize-controller` and `helm-controller` (both on `prod-worker-3`) simply could not reach it.

## Root cause

Cluster pod-to-pod traffic is governed by the enforced `require-mutual-auth` `CiliumClusterwideNetworkPolicy` (`authentication.mode: required`), satisfied via SPIRE-issued SVIDs. **SPIRE had stopped issuing identities**, so Cilium dropped every mutual-auth-required connection (`worker-3 → worker-1` here), black-holing the GitOps data path.

Why SPIRE stopped issuing:

- The cilium chart injects a `cilium-init` bootstrap container into the `spire-server` pod that creates the Cilium SPIRE registration entries.
- `cilium-init` has **no securityContext of its own**, so it ran as **root (0)** while `spire-server` runs as **1000**.
- `cilium-init` reaches `spire-server`'s admin socket through `/proc/<pid>/root`, which is **ptrace-gated — the caller's uid+gid must equal the target's**. Root ≠ 1000, so it was denied and hung forever on `Waiting for spire-server to start...`, never creating the entries.
- With no entries, every `spire-agent` returns `no identity issued`, `cilium-agent` logs `no SPIFFE ID for spiffe://spiffe.cilium/identity/<N>`, and mutual auth fails closed.

This is a recurrence of the #1777/#1781 SPIRE bootstrap fragility (cilium/cilium#40533). The earlier remediation set `server.securityContext` — but that key maps **only to the spire-server container**, leaving `cilium-init` as root. Confirmed against the live pod and the chart template `templates/spire/server/statefulset.yaml`:

| chart values key | renders to |
|---|---|
| `server.securityContext` | spire-server **container** SC (line 110) |
| `server.podSecurityContext` | **pod-level** SC — inherited by `cilium-init` (line 46) |

## Fix

Add `server.podSecurityContext: { runAsGroup: 1000, runAsUser: 1000 }` so the chart-injected `cilium-init` inherits 1000 and matches `spire-server`. The existing container-level `securityContext` is kept (harmless, explicit). The `chown` initContainer keeps its own `runAsUser: 0` override, so volume permissions are unaffected.

**Validated** — both provider controller overlays build:

```
kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/   # prod  ✓
kubectl kustomize k8s/providers/docker/infrastructure/controllers/    # local ✓
```

## ⚠️ This PR alone does NOT un-wedge prod (deadlock)

Flux cannot self-deploy this fix while reconciliation is wedged (the cilium HelmRelease can't fetch its chart from the unreachable `source-controller`). A **one-time out-of-band bootstrap** is required to break the deadlock; SPIRE entries persist in the PVC afterward:

```bash
# Patch the StatefulSet template so cilium-init inherits uid/gid 1000, then recreate the pod
kubectl -n kube-system patch statefulset spire-server --type=merge \
  -p '{"spec":{"template":{"spec":{"securityContext":{"runAsUser":1000,"runAsGroup":1000}}}}}'
kubectl -n kube-system rollout restart statefulset spire-server

# Verify cilium-init stops "Waiting..." and seeds entries; SPIRE then issues SVIDs,
# mutual auth recovers, and Flux self-heals within a few minutes.
kubectl -n kube-system logs spire-server-0 -c cilium-init -f
flux reconcile kustomization bootstrap --with-source -n flux-system
```

The live patch is on the StatefulSet template (so it survives pod recreation) and is not auto-reverted by routine reconciliation (no Helm drift detection); merging this PR makes it durable on the next cilium upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
