### PR TITLE
docs(runbook): correct Talos upgrade procedure — ksail can't safely roll it

### DIFF
--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -67,24 +67,72 @@ kubectl -n <ns> rollout restart deployment/<name>
 
 ## Scenario 2 — Planned rolling Talos / Kubernetes upgrade
 
-Bump the Talos ISO ID in `ksail.prod.yaml` (or the Kubernetes version
-in the ksail config) and re-run `ksail cluster update`. ksail cordons and
-replaces nodes one at a time; PDBs hold the line.
+> ⚠️ **The Talos OS upgrade on this cluster is NOT driven by `ksail cluster
+> update`.** A plain `ksail cluster update` ignores a changed
+> `spec.cluster.talos.version` (it prints the diff but does not roll the OS),
+> and `ksail cluster update --update-distribution` upgrades nodes with the
+> *bare* `ghcr.io/siderolabs/installer:<ver>`, which **drops the
+> `iscsi-tools` / `util-linux-tools` / `qemu-guest-agent` extensions** and
+> would break Longhorn storage and the Hetzner guest agent. Upgrade the OS
+> manually with the **Factory** image instead (below).
+> Upstream: [devantler-tech/ksail#5077](https://github.com/devantler-tech/ksail/issues/5077).
+
+**Pre-flight (either upgrade)** — confirm HA so a rolling node reboot holds the line:
 
 ```bash
-# Pre-flight: confirm every multi-replica workload has a PDB
+# Every multi-replica workload has a PodDisruptionBudget
 kubectl get pdb -A
 
-# Pre-flight: confirm RollingUpdate strategy uses maxUnavailable: 0
+# RollingUpdate strategy uses maxUnavailable: 0
 kubectl get deploy -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}\t{.spec.strategy.rollingUpdate.maxUnavailable}{"\n"}{end}'
-
-# Apply the upgrade
-ksail --config ksail.prod.yaml cluster update
 ```
 
 If anything reports `maxUnavailable` other than `0`, that workload was
 either added without an HA configuration or has a chart limitation — fix
 before upgrading.
+
+### Talos OS version
+
+1. Land the version bump in git first: `spec.cluster.talos.version` +
+   `machine.install.image` in `talos/cluster/install-image.yaml` (Renovate
+   opens this PR automatically) and the matching Hetzner `iso` snapshot id in
+   `ksail.prod.yaml` (maintainer step — not auto-derivable). New nodes boot
+   from a schematic snapshot ksail builds from `talos.version` + `extensions`,
+   so the `iso` field is currently informational for boot — but keep it
+   consistent with the pinned version.
+2. Roll the upgrade **manually**, one node at a time (workers first, then
+   control-planes), using the **Factory installer image pinned in
+   `talos/cluster/install-image.yaml`** — it carries the extensions, so they
+   survive the upgrade (the ksail flag does not — see the warning above):
+
+```bash
+# Exact image (incl. schematic id) is in talos/cluster/install-image.yaml:
+IMAGE="factory.talos.dev/installer/e187c9b90f773cd8c84e5a3265c5554ee787b2fe67b508d9f955e90e7ae8c96c:v1.13.3"
+
+kubectl get nodes -o wide   # node IPs; do workers first, control-planes last
+
+for node in <worker-ips...> <control-plane-ips...>; do
+  talosctl --talosconfig ~/.talos/config --nodes "$node" \
+    upgrade --image "$IMAGE" --preserve --wait
+  kubectl get nodes          # wait until this node is Ready again before the next
+  talosctl --nodes "$node" get extensions   # confirm extensions survived
+done
+```
+
+`--preserve` keeps the data partitions and lets Talos manage the etcd
+member leave/rejoin on control-planes; upgrading sequentially keeps etcd
+quorum. Never upgrade more than one node at a time.
+
+### Kubernetes version
+
+Bump `spec.cluster.kubernetesVersion` in `ksail.prod.yaml` (keep it within the
+pinned Talos release's supported range) and apply with a plain update — ksail
+re-renders the machine config with the pinned kube-\* / kubelet versions and
+rolls them onto the nodes (no `--update-distribution`, which would touch the OS):
+
+```bash
+ksail --config ksail.prod.yaml cluster update
+```
 
 ---
 

--- a/talos/cluster/install-image.yaml
+++ b/talos/cluster/install-image.yaml
@@ -18,6 +18,14 @@
 # string, so it can't be auto-derived), bumping `kubernetesVersion` if Talos's supported
 # Kubernetes range moves, and re-generating the schematic id below only when the extension
 # list changes.
+#
+# Upgrading EXISTING nodes: this Factory image is the one to roll out — it
+# carries the extensions above. Do NOT use `ksail cluster update
+# --update-distribution`: it upgrades nodes to the bare
+# `ghcr.io/siderolabs/installer:<ver>` and strips these extensions, breaking
+# Longhorn and the Hetzner guest agent (upstream: devantler-tech/ksail#5077).
+# Roll it by hand instead — `talosctl upgrade --image <this image> --preserve`,
+# one node at a time. See docs/dr/runbook.md → Scenario 2.
 machine:
   install:
     image: factory.talos.dev/installer/e187c9b90f773cd8c84e5a3265c5554ee787b2fe67b508d9f955e90e7ae8c96c:v1.13.3


### PR DESCRIPTION
## Problem

`ksail --config ksail.prod.yaml cluster update` does not upgrade Talos to the pinned `spec.cluster.talos.version` (currently `v1.13.3`, bumped by Renovate in #1801). The nodes stay on the old version.

## Root cause (upstream — ksail)

Investigated against the exact installed ksail (`v7.26.0` / `fede6e18`). Two upstream behaviors combine:

1. **A plain `cluster update` does not roll the Talos OS.** OS upgrades are opt-in via `--update-distribution` (intended since [ksail#4260](https://github.com/devantler-tech/ksail/issues/4260)). With a `talos.version` pin, the pin only *caps* an explicit upgrade and feeds the snapshot/image for *new* nodes; the diff reports `cluster.talos.version` as an in-place change but applies nothing to existing nodes — and gives no hint to use the flag. (Contrast: `kubernetesVersion` *is* applied by a plain update — see [ksail#4936](https://github.com/devantler-tech/ksail/issues/4936). That asymmetry is the trap.)

2. **`--update-distribution` is unsafe on this cluster.** `UpgradeDistribution` rolls nodes onto the **bare** `ghcr.io/siderolabs/installer:<ver>` (`installerImageFromTag`), ignoring the configured schematic / `spec.cluster.talos.extensions`. Our nodes run the **Factory** image with `iscsi-tools` + `util-linux-tools` + `qemu-guest-agent`; a bare-installer upgrade **strips those extensions**, which would break Longhorn storage and the Hetzner guest agent. (Create / snapshot / autoscaler all build the Factory image from the schematic — only the upgrade path drops it. No `--installer-image` override flag exists.)

Filed upstream: **[devantler-tech/ksail#5077](https://github.com/devantler-tech/ksail/issues/5077)** (covers both, primary = the extension-stripping bug).

So there is no safe one-flag fix via ksail today, and wiring `--update-distribution` into CD would be **actively harmful** (it'd strip extensions on the next deploy). This PR therefore does **not** touch the CD/CI invocation.

## What this PR changes (docs only — no manifest/CD change)

- **`docs/dr/runbook.md` Scenario 2** previously said "bump the version and re-run `ksail cluster update`", which is a no-op for the Talos OS. Rewritten to:
  - warn that ksail can't safely roll the OS here (links #5077),
  - give the **safe manual procedure**: `talosctl upgrade --image <pinned Factory image> --preserve` one node at a time (workers first), verifying extensions survive,
  - split the Kubernetes-version upgrade (which *does* work via a plain `cluster update`) into its own subsection.
- **`talos/cluster/install-image.yaml`**: a guard comment at the image line so the caveat is visible where Renovate/maintainers bump the version.

## Not in scope / follow-ups for the maintainer

- **Actually upgrading prod to v1.13.3** is a live, node-rebooting operation — run the runbook Scenario 2 commands manually (I don't run prod mutations). Existing nodes will pick up v1.13.3 from the Factory installer.
- **`ksail.prod.yaml` `iso: 125127`** is stale (comment says v1.12.4) vs `version: v1.13.3`. Since this cluster boots new nodes from a schematic snapshot built from `talos.version` + `extensions`, the `iso` field is effectively unused for boot, so this is **not** the cause of the symptom — but the value/comment are inconsistent and worth correcting. `ksail.prod.yaml` is protected, so left for the maintainer.
- Optional: an automated `workflow_dispatch` that runs the safe `talosctl upgrade` per node — happy to build it if wanted.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅ and `k8s/clusters/prod/` ✅ both build (unaffected — no `k8s/` change).
- `talos/cluster/install-image.yaml` parses (`yq` → image resolves); change is comments-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
