### PR TITLE
fix(cilium): pin SPIRE datastore to hcloud-csi to break Longhorn mTLS deadlock

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -171,19 +171,29 @@ spec:
               # down, NEW identity pairs cannot authenticate. Established flows
               # ride through via cilium-agent's auth cache, and the
               # cilium-operator re-syncs entries from CiliumIdentities, so brief
-              # restarts are tolerable. Datastore durability already comes from
-              # the PVC binding to longhorn (the cluster-default StorageClass,
-              # 3-way replicated). Do NOT make these tempting "HA" changes:
+              # restarts are tolerable.
+              #
+              # The datastore StorageClass is intentionally NOT set here. On
+              # hetzner it is pinned to hcloud-csi by the prod overlay
+              # (providers/hetzner/.../cilium/patches/spire-datastorage-patch.yaml)
+              # — NOT the cluster-default longhorn. The reason is a circular
+              # dependency: Longhorn's own control plane is pod-to-pod traffic
+              # behind this very mTLS gate, so binding spire-server's PVC to
+              # longhorn means that when SPIRE is down Longhorn cannot attach the
+              # PVC, so SPIRE cannot start, so it stays down — a deadlock that
+              # wedged all of prod during the 2026-06-06 Talos node roll. An
+              # hcloud Cloud Volume attaches via the Hetzner API (not pod-to-pod)
+              # and survives node death, breaking the cycle. See the overlay
+              # patch for the full rationale and the one-time StatefulSet-recreate
+              # step (volumeClaimTemplate is immutable).
+              #
+              # Do NOT make these tempting "HA" changes:
               #   * replicas > 1 — the SQLite + RWO datastore is single-writer;
               #     real HA needs an external SQL datastore (a much larger
               #     change, out of scope here).
               #   * a minAvailable PodDisruptionBudget — with one replica it
               #     only blocks node drains / autoscaler scale-down / Talos
               #     upgrades, without adding any availability.
-              #   * pinning dataStorage.storageClass — a StatefulSet
-              #     volumeClaimTemplate is immutable, so changing it would wedge
-              #     the Helm upgrade on the live cluster (the PVC already lands
-              #     on longhorn via the default StorageClass anyway).
               resources:
                 requests:
                   cpu: 50m

--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/patches/spire-datastorage-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/patches/spire-datastorage-patch.yaml
@@ -1,0 +1,62 @@
+---
+# Prod-only: put the SPIRE server datastore on Hetzner Cloud block storage
+# (hcloud-csi) instead of Longhorn, to break a circular dependency that wedges
+# the whole cluster.
+#
+# spire-server issues the SVIDs that satisfy the require-mutual-auth policy, so
+# it sits IN the pod-to-pod mTLS data path. By default its single-replica
+# StatefulSet binds a ReadWriteOnce PVC to the cluster-default StorageClass
+# (longhorn). Longhorn's OWN control plane is pod-to-pod traffic
+# (longhorn-csi-plugin -> longhorn-backend:9500 -> instance-managers), so it is
+# itself behind the mTLS gate. That creates a deadlock:
+#
+#   SPIRE down -> Longhorn control plane black-holed (no SVIDs) -> cannot
+#   attach spire-server's PVC -> spire-server cannot start -> no SVIDs -> loop.
+#
+# GitOps cannot self-heal out of it either, because helm-controller ->
+# source-controller is on the same black-holed path. This took prod fully down
+# during the Talos 1.12.4 -> 1.13.3 node roll on 2026-06-06 (every Flux
+# Kustomization + ~30 HelmReleases stuck on "context deadline exceeded" reaching
+# source-controller; devantler-tech/platform).
+#
+# hcloud-csi removes the dependency: a Hetzner Cloud Volume is attached/detached
+# via the Hetzner API by the hcloud CSI controller (talks to its sidecars over a
+# unix socket and to the Hetzner API over the internet — never pod-to-pod), so
+# it attaches even while SPIRE is down. A single cloud block device also
+# survives node death and re-attaches to the replacement node, so unlike a
+# Longhorn volume whose replicas all sat on the workers that rolled together, it
+# is not faulted by a node roll. mTLS stays fully enforced everywhere and
+# WireGuard still encrypts every byte on the wire — this changes only WHERE
+# spire-server keeps its SQLite datastore.
+#
+# size: 10Gi is the Hetzner Cloud Volume minimum (the SPIRE datastore needs
+# ~1Gi; the chart default 1Gi is rejected by csi.hetzner.cloud). The `hcloud`
+# StorageClass is WaitForFirstConsumer, so the volume is created in the same
+# location as the node spire-server schedules onto (no topology mismatch).
+#
+# PROD/HETZNER ONLY: SPIRE is disabled in the docker overlay (no spire-server
+# StatefulSet is rendered) and the `hcloud` StorageClass does not exist locally,
+# so this override lives in the hetzner patch, not the base.
+#
+# OPERATIONAL NOTE (StatefulSet volumeClaimTemplate is immutable): changing the
+# datastore StorageClass/size cannot be applied in place — the first cilium
+# reconcile after this lands will fail the Helm upgrade until the live
+# spire-server StatefulSet is recreated. Delete it once so Flux recreates it on
+# hcloud-csi: `kubectl -n kube-system delete statefulset spire-server` (the
+# SQLite datastore re-bootstraps — cilium-operator re-syncs entries from
+# CiliumIdentities and the cilium-agent auth cache rides the brief restart).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  values:
+    authentication:
+      mutual:
+        spire:
+          install:
+            server:
+              dataStorage:
+                storageClass: hcloud
+                size: 10Gi

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -53,6 +53,9 @@ patches:
   - path: openbao/patches/helm-release-patch.yaml
   # Prod-only fail-closed WireGuard encryption (egress strict mode) — see file.
   - path: cilium/patches/helm-release-patch.yaml
+  # Prod-only: move the SPIRE server datastore off Longhorn onto hcloud-csi to
+  # break the SPIRE <-> Longhorn <-> mTLS circular deadlock — see file.
+  - path: cilium/patches/spire-datastorage-patch.yaml
   # Prod-only: switch Velero to a MIXED backup model — CSI volume snapshots +
   # data movement for Longhorn-backed PVCs (→ R2), file-system (Kopia) backup
   # for openbao + any non-Longhorn PVC. The base tier stays all-FSB because the


### PR DESCRIPTION
## Problem — prod reconciliation fully wedged (SEV-1)

On 2026-06-06, during the Talos `1.12.4 → 1.13.3` node roll, the entire Flux chain wedged: every Kustomization (`bootstrap → infrastructure-controllers → infrastructure → apps`) and ~30 HelmReleases stuck on `Could not load chart … source-controller … i/o timeout`.

Root cause is a **circular dependency** (not the `cilium-init` securityContext bug fixed in #1809 — that fix is correctly deployed):

1. `spire-server` issues the SVIDs that satisfy the prod `require-mutual-auth` policy, so it sits **in the pod-to-pod mTLS data path**.
2. Its single-replica StatefulSet binds a RWO PVC to the cluster-default StorageClass, **longhorn**.
3. Longhorn's own control plane is pod-to-pod traffic (`longhorn-csi-plugin → longhorn-backend:9500 → instance-managers`), so it is **itself behind the mTLS gate**.

```
SPIRE down → Longhorn control plane black-holed (no SVIDs)
          → cannot attach spire-server's PVC
          → spire-server cannot start
          → no SVIDs  ──┘  (deadlock)
```

GitOps can't self-heal because `helm-controller → source-controller` rides the same black-holed path. Live evidence: `spire-server-0` Pending with `FailedAttachVolume … node … not found`; csi-attacher logging `Get "http://longhorn-backend:9500/…": context deadline exceeded` (Longhorn can't reach its **own** backend); every cilium-agent logging `SPIRE admin socket does not exist` / `no SPIFFE ID`.

The node roll was the trigger (all three Longhorn replicas of every volume sat on the workers that rolled together), but the deadlock is the reason the cluster **can't recover on its own**.

## Fix

Pin the SPIRE datastore to **hcloud-csi** in the prod overlay instead of Longhorn:

```yaml
# providers/hetzner/.../cilium/patches/spire-datastorage-patch.yaml
authentication: { mutual: { spire: { install: { server:
  dataStorage:
    storageClass: hcloud
    size: 10Gi          # Hetzner Cloud Volume minimum
}}}}
```

A Hetzner Cloud Volume is attached/detached **via the Hetzner API** by the hcloud CSI controller (sidecars over a unix socket, Hetzner API over the internet — never pod-to-pod), so it attaches even while SPIRE/mTLS is down, breaking the cycle. A single cloud block device also survives node death and re-attaches to the replacement node, so it isn't faulted by a node roll the way a Longhorn volume with all replicas on the rolled pool is.

**Security posture is unchanged:** mTLS stays fully enforced everywhere and WireGuard still encrypts every byte on the wire. Only *where* spire-server keeps its SQLite datastore changes. This deliberately reverses the “don't pin storageClass / longhorn is fine” note in the base HelmRelease (that note assumed longhorn was a safe dependency — it is the trap); the base comment is updated to point here.

## ⚠️ Deploy note — one-time StatefulSet recreate

A StatefulSet `volumeClaimTemplate` is **immutable**, so the first cilium reconcile after this merges will fail the Helm upgrade until the live StatefulSet is recreated:

```bash
kubectl -n kube-system delete statefulset spire-server
```

Flux then recreates it on hcloud-csi. The SQLite datastore re-bootstraps (cilium-operator re-syncs entries from `CiliumIdentity` resources; the cilium-agent auth cache rides the brief restart). On a cluster that is currently wedged this folds into the live recovery — the StatefulSet has to come back regardless.

## Validation

- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` — both build.
- `ksail --config ksail.prod.yaml workload validate` — `providers/hetzner/infrastructure/controllers/cilium validated ✓`. (The one unrelated failure is the pre-existing stale Coroot `coroot.com/v1` CRDs-catalog schema issue in `providers/hetzner/infrastructure`, a path this PR does not touch.)
- Rendered hetzner cilium HelmRelease confirmed to carry the `dataStorage` override **and** retain the base SPIRE config (chown initContainer, `podSecurityContext: runAsUser 1000` from #1809) **and** the WireGuard `strictMode` patch.
- Docker overlay confirmed unaffected: SPIRE disabled, no `hcloud`/`dataStorage` leak.

## Follow-ups

- **~~Exempt `longhorn-system` from `require-mutual-auth`~~ — REJECTED (keep full mTLS).** This was floated as defense-in-depth against the *other* edge of the cycle (Longhorn's control plane being black-holed by a SPIRE blip), but it is unnecessary once this PR lands, and it would needlessly drop mTLS enforcement on an infra namespace. With the datastore on hcloud, the **entire** SPIRE control plane is off the pod-to-pod mesh data path — `spire-server`'s only clients are `cilium-operator` and the per-node `spire-agent`, both `hostNetwork: true` (matched as the `host` entity, never `fromEndpoints`), and its storage now attaches via the Hetzner API. So SPIRE always bootstraps independently of Longhorn → SVIDs always flow → `longhorn-system` keeps working under full mTLS. A `spire-server` restart becomes a brief, self-healing blip rather than a deadlock. **No exemption; longhorn-system stays under SPIRE mTLS.**
- **Upstream:** filed [cilium/cilium#46392](https://github.com/cilium/cilium/issues/46392) — the bundled SPIRE server datastore defaulting to the cluster-default StorageClass creates this circular dependency with any storage backend whose control plane is mesh-gated (Longhorn). Asks for a docs warning + a way to keep the datastore robustly independent of the mesh (`extraVolumes`, or a working ephemeral `emptyDir` datastore). This PR is the in-repo fix regardless of the upstream outcome.
- **RC-2 / operational:** all Longhorn replicas of every volume landed on the three workers that rolled simultaneously, faulting every volume at once. Pace the Talos roll one replica-bearing node at a time (let Longhorn rebuild between nodes), and/or revisit replica anti-affinity. Operational + protected `ksail.prod.yaml`, not a manifest fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
