### PR TITLE
feat(talos): verify first-party image signatures at the node pull layer

### DIFF
--- a/k8s/bases/infrastructure/security-exceptions/image-verification.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/image-verification.yaml
@@ -1,17 +1,23 @@
 ---
-# Exempt image signature verification cluster-wide.
-# This platform does not yet have image signing infrastructure (cosign /
-# sigstore). All images are pulled from trusted registries (GHCR, Docker Hub)
-# but are not cryptographically verified.
+# Exempt image signature verification cluster-wide (kubescape C-0237).
+# First-party images (ghcr.io/devantler-tech/*) ARE cosign-signed and verified
+# — by Flux on the OCI manifest artifacts (apps' sync.yaml verify.provider:
+# cosign) and, at the node pull layer, by Talos ImageVerificationConfig
+# (talos/cluster/image-verification.yaml). But third-party chart images
+# (Cilium, Longhorn, Coroot, registry.k8s.io, …) are not all signed, and there
+# is no admission-layer signature enforcement, so this cluster-wide control —
+# which scans every workload image ref — remains exempted.
 apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: image-verification
 spec:
   reason: >-
-    Image signing infrastructure (cosign/sigstore) is not yet implemented.
-    Images are pulled from trusted registries but are not cryptographically
-    signed or verified.
+    First-party images (ghcr.io/devantler-tech/*) are cosign-signed and
+    verified at both the Flux OCI source layer and the Talos containerd pull
+    layer (ImageVerificationConfig). Third-party chart images are not all
+    signed and there is no admission-layer signature enforcement, so this
+    cluster-wide control still fails on unsigned workload images.
   posture:
     - controlID: C-0237
       action: ignore

--- a/talos/cluster/image-verification.yaml
+++ b/talos/cluster/image-verification.yaml
@@ -1,0 +1,44 @@
+# Container image signature verification (Talos 1.13+, ImageVerificationConfig).
+#
+# Verifies cosign signatures at the containerd PULL layer on every node — a
+# defense-in-depth complement to the GitOps-source verification Flux already
+# performs on OCI *manifest* artifacts (apps' sync.yaml verify.provider:
+# cosign). This gates the actual container-image bytes containerd pulls, which
+# Flux and the Kyverno admission layer never see (e.g. kubelet-managed static
+# pods, a compromised registry serving a tampered image).
+#
+# Scope: FIRST-PARTY images only (ghcr.io/devantler-tech/*). These are built,
+# pushed, and keyless-cosign-signed by the shared reusable workflow
+# devantler-tech/reusable-workflows/.github/workflows/publish-app.yaml (it runs
+# `cosign sign` on BOTH the manifests artifact and the container image). That
+# is the SAME signing identity the apps' Flux OCIRepository verify blocks
+# already pin, so this adds no new trust root. Currently covers the wedding-app
+# and ascoachingogvaner container images running in prod.
+#
+# FAIL-OPEN by design: an image is verified only when it MATCHES a rule; an
+# image matching NO rule is pulled WITHOUT verification. So third-party chart
+# images (Cilium, Longhorn, Coroot, registry.k8s.io control-plane images, …)
+# are unaffected — this is intentionally NOT a deny-all-unsigned control, and
+# there is deliberately no broad `deny:` catch-all. Note the converse: an image
+# that DOES match this rule but fails verification is blocked (ImagePullBackOff),
+# so the glob is kept to first-party images whose signing pipeline is known.
+#
+# A rule over a system registry (e.g. registry.k8s.io/*, the canonical Talos
+# example) would gate control-plane/etcd image pulls — high blast radius on
+# this cluster given the manual-talosctl recovery path — so it is deliberately
+# omitted for now and can be added later once the first-party rule is proven.
+#
+# This does NOT satisfy kubescape C-0237 (see
+# k8s/bases/infrastructure/security-exceptions/image-verification.yaml): that
+# control scans workload image refs at the cluster layer, cannot observe Talos
+# node-level verification, and still fails while unsigned third-party images run.
+#
+# Reference:
+#   https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/imageverificationconfig/
+apiVersion: v1alpha1
+kind: ImageVerificationConfig
+rules:
+  - image: ghcr.io/devantler-tech/*
+    keyless:
+      issuer: https://token.actions.githubusercontent.com
+      subjectRegex: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$


### PR DESCRIPTION
## Summary

Adopts one Talos 1.13 feature now that prod runs **v1.13.3**: a node-level **`ImageVerificationConfig`** that cosign-verifies **first-party container images** (`ghcr.io/devantler-tech/*`) at the **containerd pull layer** on every node.

This is defense-in-depth at a layer nothing else covers today:
- Flux's `verify: provider: cosign` only checks the **OCI *manifest* artifacts** (`.../<app>/manifests`) at the GitOps source layer — pulled by source-controller, not containerd.
- There is **no Kyverno `verifyImages` policy** in `cluster-policies/`.
- `ImageVerificationConfig` gates the actual **container-image bytes** containerd pulls — covering paths Flux/Kyverno never see (kubelet-managed static pods, a compromised registry serving a tampered image).

## Why this is safe

- **Same trust root, no new identity.** First-party images are built + keyless-cosign-signed by `devantler-tech/reusable-workflows/.github/workflows/publish-app.yaml`, which runs `cosign sign` on **both** the manifests artifact **and** the container image. The rule pins the **exact issuer/subject the apps' Flux verify blocks already pin** (`issuer: https://token.actions.githubusercontent.com`, `subjectRegex: .../publish-app.yaml@.+`).
- **Fail-open by design.** An image is verified only if it **matches a rule**; images matching no rule pull **unverified**. So third-party charts (Cilium, Longhorn, Coroot, `registry.k8s.io` control-plane images, …) are untouched. There is **no broad `deny:` catch-all** and **no system-registry rule** — those carry high blast radius on this cluster (manual-talosctl recovery), and can be added later once the first-party rule is proven.
- **Contained blast radius.** The only images this rule gates are first-party (`wedding-app`, `ascoachingogvaner` today), all signed by the standard pipeline → verification passes. A mismatch would block only those, never the control plane.
- **Non-retroactive rollout.** Verification runs on **pull**, so already-cached images on running nodes are unaffected; first-party images are re-verified on their next pull (deploy/restart/new node) and are signed.
- **Prod-only.** Lives in `talos/` (Hetzner), like `disk-encryption.yaml` / `audit-logging.yaml` / `oidc.yaml`. The local/CI Docker provider uses `talos-local/` and is unaffected.

## kubescape C-0237 — kept exempted (intentionally not flipped)

The earlier plan floated flipping the `C-0237` exception. Investigation shows that's **wrong**: C-0237 scans *workload image refs at the cluster layer* and **cannot observe Talos node-level verification**, and it keeps failing while unsigned third-party chart images run. So the exception **stays** — but its reason is refreshed from the now-inaccurate *"image signing infrastructure … is not yet implemented"* to state that first-party images **are** signed and verified (Flux OCI + Talos), while the cluster-wide control remains exempted pending admission-layer enforcement + fully-signed third-party images.

## Changes

- **`talos/cluster/image-verification.yaml`** (new) — the `ImageVerificationConfig` doc (heavily commented with scope/fail-open/why-no-system-registry).
- **`k8s/bases/infrastructure/security-exceptions/image-verification.yaml`** — refreshed C-0237 reason only (no posture change).

## Validation

- `talosctl 1.13.3 validate` — **valid** for a merged controlplane config (`controlplane.yaml` + the new doc) and standalone, in `cloud` mode. Confirms the `keyless.subjectRegex` schema.
- `kubectl kustomize k8s/clusters/prod/` and `.../local/` — build OK.
- `kubectl kustomize k8s/bases/infrastructure/security-exceptions/` — builds OK with the refreshed reason rendered.
- Full Talos+Docker system test runs in CI (does not exercise the prod-only `talos/` doc, but covers the security-exceptions change).

## Possible follow-up (separate PR, opt-in)

Add a `registry.k8s.io/*` keyless rule (the canonical Talos example, `krel-trust@k8s-releng-prod.iam.gserviceaccount.com` / `https://accounts.google.com`) to verify control-plane/etcd images. Deliberately **not** in this PR — higher blast radius; the v1.13.2 boot-lockout bug ([talos#13342](https://github.com/siderolabs/talos/issues/13342)) is fixed in v1.13.3 (PR #13349 / commit `9de3c12d9`), but it's worth earning confidence on the first-party rule first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)