### PR TITLE
fix(talos): pin HostnameConfig auto:off so v1.13 keeps platform node names

### DIFF
--- a/talos/cluster/hostname.yaml
+++ b/talos/cluster/hostname.yaml
@@ -1,0 +1,21 @@
+# Use the platform-provided hostname (the Hetzner server name) instead of
+# Talos's auto-generated stable hostname.
+#
+# Talos v1.13 changed the HostnameConfig default to `auto: stable`, which
+# derives the node hostname from the machine's identity (e.g. `talos-6jk-4yw`)
+# rather than the cloud platform's server name (`prod-worker-2`, etc.). On the
+# 1.12.4 -> 1.13.3 upgrade this renamed every existing node, which broke the
+# hcloud cloud-controller-manager: it matches Kubernetes node names to Hetzner
+# server names, so it logged `no matching server found for node 'talos-...':
+# server not found` and never assigned a providerID. The renamed nodes kept the
+# `node.cloudprovider.kubernetes.io/uninitialized` taint, became unschedulable,
+# and the resulting capacity crunch wedged reconciliation cluster-wide
+# (2026-06-06/07 incident).
+#
+# `auto: off` disables Talos's auto-generated hostname so the node uses the
+# hostname supplied by the Hetzner platform metadata (the server name), which is
+# what the CCM expects. Autoscaler-provisioned nodes already use platform
+# hostnames, so this only restores the prior behaviour for upgraded nodes.
+apiVersion: v1alpha1
+kind: HostnameConfig
+auto: "off"


### PR DESCRIPTION
## Problem — prod reconciliation wedged by the Talos 1.12.4 → 1.13.3 node roll

Talos **v1.13 changed the `HostnameConfig` default to `auto: stable`**, which derives a node's hostname from its machine identity (e.g. `talos-6jk-4yw`) instead of the cloud platform's server name. The repo's `talos/cluster/` set no `HostnameConfig`, so the upgrade **renamed every existing node** `prod-control-plane-*`/`prod-worker-*` → `talos-xxx`.

That broke the **hcloud cloud-controller-manager**, which matches Kubernetes node names to Hetzner **server** names:

```
node_controller: error syncing 'talos-jo8-ff0': failed to get instance metadata:
  no matching server found for node 'talos-jo8-ff0': server not found, requeuing
```

So the renamed nodes never got a `providerID`, kept the `node.cloudprovider.kubernetes.io/uninitialized=NoSchedule` taint, and became **unschedulable**. With the original node pool effectively halved, the cluster hit a capacity crunch (e.g. `velero-upgrade-crds` `Pending` / `Insufficient memory`) → infra-controllers health-check stuck → whole Flux chain wedged. It also produced duplicate ghost node objects and stranded the CCM + kubelet-serving-cert-approver on dead nodes (`tls: internal error`, unapproved kubelet CSRs).

This is the root cause behind the [[talos-113-hostnameconfig-renames-nodes]] class of incidents.

## Fix

Add a cluster-wide `HostnameConfig` with **`auto: off`**, so Talos uses the hostname supplied by the **Hetzner platform metadata (the server name)** — exactly what the CCM expects and how the cluster behaved before v1.13.

```yaml
# talos/cluster/hostname.yaml
apiVersion: v1alpha1
kind: HostnameConfig
auto: "off"
```

- `talos/cluster/*.yaml` is auto-applied to **all** nodes by ksail's native Talos patches (same mechanism as the existing `image-verification.yaml` / `disable-cdi.yaml` auxiliary-document patches).
- Autoscaler-provisioned nodes already use platform hostnames, so this only **restores the prior behaviour for upgraded nodes** — no change for them.
- `"off"` is quoted to avoid the YAML 1.1 `off`→boolean coercion.

## Why this is the right layer

The hostname must match the Hetzner server name for the CCM (and kubelet serving-cert SANs) to work. `auto: off` defers to platform metadata, which supplies the server name. A per-node `static:` hostname can't be expressed in a cluster-wide patch, and `auto: stable` is precisely what caused the rename.

## Live recovery (separate, operational)

This PR prevents recurrence. The currently-wedged cluster is recovered live by making the already-renamed nodes re-adopt their platform names (apply this same `HostnameConfig auto: off` to the running machines via `talosctl`, no reboot) and deleting the stale `talos-*` node objects — handed to the operator since prod mutation is out of scope for the assistant.

## Validation

- `HostnameConfig` format per the [Talos v1.13 reference](https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/hostnameconfig) (`auto: off` = use external/platform hostname).
- Single additive file; no wiring change (ksail auto-discovers `talos/cluster/`). CI `ksail` validation will render it.

> ⚠️ Authored via the GitHub API from a non-isolated local checkout (this session's worktree was deleted and the shared checkout is on an unrelated branch), to avoid colliding with parallel sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)