### PR TITLE
fix(velero): disable redundant velero-upgrade-crds hook (Flux already manages CRDs)

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -27,6 +27,15 @@ spec:
   timeout: 15m
   # https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml
   values:
+    # Disable the bundled `velero install --crds-only` upgrade hook. The chart
+    # ships its CRDs under crds/, and this HelmRelease already sets
+    # install.crds/upgrade.crds: CreateReplace, so Flux manages the velero CRDs
+    # directly. The redundant hook Job (velero-upgrade-crds) repeatedly hung
+    # during cluster recovery and wedged the whole infrastructure-controllers
+    # reconcile (2026-06-07 incident: upgrade/rollback thrash, then a stuck
+    # pre-upgrade hook). Removing it lets velero reconcile cleanly via Flux while
+    # CRDs stay managed by CreateReplace.
+    upgradeCRDs: false
     image:
       repository: velero/velero
     initContainers:


### PR DESCRIPTION
## Problem

During the 2026-06-07 cluster recovery, the **velero** HelmRelease was the last thing blocking `infrastructure-controllers` (and therefore `infrastructure` → `apps`). Its Helm release thrashed through failed upgrades/rollbacks and a stuck `pending-upgrade`, all rooted in the **`velero-upgrade-crds` Helm hook** (`velero install --crds-only --apply`):

- During the node-rename capacity crunch it sat `Pending` / failed with `client rate limiter Wait ... context deadline`.
- Rollbacks then hit SSA field-ownership conflicts on the `node-agent` DaemonSet (`conflicts with helm-controller`).
- Even a clean reinstall (after wiping the corrupted release history) hung on the same hook with the API healthy — so the hook itself is the persistent fault, not the chaos.

## Fix

Set **`upgradeCRDs: false`** on the velero HelmRelease.

This is safe because **Flux already manages the velero CRDs**:
- the velero chart ships its CRDs under `crds/` (verified: `backups.yaml`, `restores.yaml`, `schedules.yaml`, … — 13 CRDs), and
- this HelmRelease sets `spec.install.crds: CreateReplace` and `spec.upgrade.crds: CreateReplace`.

So the bundled `velero-upgrade-crds` hook is **redundant** — it only re-applies the same CRDs via `velero install --crds-only`. Disabling it removes the hang while CRDs stay managed by Flux's `CreateReplace` (which applies the chart's `crds/` on every reconcile). All 13 velero CRDs are currently `Established=True`.

## Deploy / live note

The running velero release is currently corrupted from the thrash. To recover the live cluster alongside this change, the operator does a clean reinstall with the hook disabled (suspend HR → delete the `owner=helm,name=velero` release secrets → reconcile), so helm-controller installs fresh **without** the hook and adopts the existing healthy `velero` Deployment. Once this PR is deployed, git matches that state so it won't revert.

## Validation

- velero chart 12.0.1 ships `crds/` (Flux `CreateReplace` covers them) — confirmed.
- `upgradeCRDs` is the documented chart toggle for the hook (default `true`).
- Single-key additive change under `spec.values`; CI `ksail` validation renders it.

> ⚠️ Authored via the GitHub API (non-isolated local checkout; see prior incident PRs #1818/#1822).

🤖 Generated with [Claude Code](https://claude.com/claude-code)