### PR TITLE
docs(autoscaling): document automatic recycling of autoscaler nodes on version bump

### DIFF
--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -176,10 +176,29 @@ After a full cluster rebuild (`ksail cluster delete` + `create`):
 
 ### Talos version upgrades
 
-When bumping the Talos version in `ksail.prod.yaml`:
+When bumping the Talos (or Kubernetes) version in `ksail.prod.yaml`, the
+deploy's `ksail cluster update` brings **both** node classes onto the new
+baseline:
+
 1. KSail's snapshot lifecycle manager creates or updates the Talos
-   snapshot automatically during `cluster update`.
-2. The worker machine config is regenerated to match.
+   snapshot automatically during `cluster update`, and the worker machine
+   config is regenerated to match — so **new** autoscaler nodes boot the new
+   version.
+2. The static control planes and workers are upgraded in place (rolling).
+3. **Existing autoscaler nodes are recycled automatically** so they follow the
+   new baseline instead of drifting on the old version: after the refreshed
+   cluster-autoscaler is ready, KSail cordons and drains each autoscaler node
+   one at a time (via the Kubernetes eviction API, honoring
+   PodDisruptionBudgets) and deletes its Hetzner server; the autoscaler then
+   re-provisions any still-needed capacity from the new snapshot on demand.
+   This runs only when the version actually changes — a no-op `cluster update`
+   leaves autoscaler nodes untouched. See the KSail
+   [Autoscaler Node Upgrades](https://ksail.devantler.tech/providers/hetzner/#autoscaler-node-upgrades)
+   docs.
+
+> A strict PodDisruptionBudget on a workload running on autoscaler nodes can
+> slow or block the drain (the update fails rather than force-evicting), so keep
+> PDBs realistic for compute-only/burstable workloads.
 
 ### Hetzner server type changes
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Documents the new KSail behavior that keeps the prod cluster's **autoscaler-managed nodes** on the Talos/Kubernetes baseline.

## Context

Autoscaler nodes on `admin@prod` were running **stale Talos/Kubernetes versions** after `ksail cluster update`: the update upgraded only the static control planes + workers, never the autoscaler-managed nodes (they're created by the cluster-autoscaler from the snapshot, not KSail-owned, so the in-place rolling upgrade skipped them). They drifted until organic scale-down.

The fix lives in KSail — devantler-tech/ksail#5106 (Fixes devantler-tech/ksail#5105): on a version change, `cluster update` now recycles existing autoscaler nodes (cordon + drain via the eviction API honoring PDBs, then delete the Hetzner server; the autoscaler re-provisions from the refreshed snapshot). No `ksail.prod.yaml` change is needed — it's automatic on version change.

## This PR

Docs-only. Updates `docs/node-autoscaling.md` "Talos version upgrades" runbook to describe the end-to-end upgrade flow (refresh snapshot → roll static nodes → **recycle autoscaler nodes**), the eviction/PodDisruptionBudget semantics, and the PDB caveat, and links the KSail provider docs.

`ksail.prod.yaml` (a protected file) is intentionally **not** modified.

## Validation

Docs-only change — no manifest/Kustomize impact. Markdown style matches the existing document.

## Sequencing

Depends on devantler-tech/ksail#5106 shipping in the KSail release the prod deploy uses. Safe to merge independently (documents intended behavior); promote once the KSail change is released.
