### PR TITLE
fix(ci): pin ksail-cluster action to v7.27.0 (broken pull-registry-image ref)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,11 @@ updates:
       # devantler-tech actions/workflows are our own code — bump now, no cooldown.
       exclude:
         - "devantler-tech/*"
+    ignore:
+      # Hold the ksail-cluster composite action at v7.27.0. v7.27.1+ (incl. latest
+      # v7.29.0) reference a local ./.github/actions/pull-registry-image that only
+      # resolves inside ksail's own repo, breaking the System Test job here (upstream
+      # ksail PR #5102 regression). Remove this ignore once upstream repo-qualifies
+      # that path. The ksail-cluster action pin lives in .github/workflows/ci.yaml.
+      - dependency-name: "devantler-tech/ksail"
+        versions: [">=7.27.1"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,13 @@ jobs:
           remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli /usr/share/gradle"
 
       - name: 🧪 System Test
-        uses: devantler-tech/ksail/.github/actions/ksail-cluster@002029a874fbbc27db8033d743ca75a7b570267b # v7.27.2
+        # Pinned to v7.27.0 (last good). v7.27.1+ — including the latest v7.29.0 —
+        # make the ksail-cluster composite action call `uses: ./.github/actions/pull-registry-image`,
+        # a local path that only resolves inside ksail's own repo, so it breaks System Test
+        # for external consumers ("Can't find action.yml ... under .../pull-registry-image").
+        # Upstream regression from ksail PR #5102. Do NOT bump past v7.27.0 until upstream
+        # repo-qualifies that path; Dependabot is told to ignore >=7.27.1 (see .github/dependabot.yaml).
+        uses: devantler-tech/ksail/.github/actions/ksail-cluster@bea170d2a6cf059f96d7fbe3352b7780b89dc8b8 # v7.27.0
         with:
           distribution: Talos
           provider: Docker


### PR DESCRIPTION
## Problem

The **System Test** job ([ci.yaml](.github/workflows/ci.yaml)) consumes the upstream `devantler-tech/ksail/.github/actions/ksail-cluster` composite action. From ksail tag **v7.27.1** onward (regression introduced by [ksail PR #5102](https://github.com/devantler-tech/ksail/pull/5102) / commit `f8879090`), that action calls:

```yaml
uses: ./.github/actions/pull-registry-image
```

A `./` local-action path in a composite action resolves against the **consumer's** `$GITHUB_WORKSPACE` (`/home/runner/work/platform/platform/...`), **not** the action's own repo. The platform repo has no `.github/actions/` directory, so the *📥 Pre-pull registry image* step fails:

```
Can't find 'action.yml','action.yaml' or 'Dockerfile' under
'/home/runner/work/platform/platform/.github/actions/pull-registry-image'.
Did you forget to run actions/checkout before running your local action?
```

This is **deterministic, not flaky**: PRs branched before the pin bump pass; PRs at/after fail. Dependabot PR #1827 bumped the pin `v7.26.0 → v7.27.2` (commit `b83b6a13`) and merged via the **merge queue, which skips System Test**, so `main` now breaks System Test on every k8s-touching PR. The step is **not** cache-gated — cache hits/misses are unrelated.

Verified `v7.27.1`, `v7.27.2`, `v7.28.0`, and `v7.29.0` (latest) **all** carry the broken ref, so bumping *forward* does not fix it.

## Fix

- Pin the action back to **v7.27.0** (`bea170d2`), the last tag where the pre-pull step is an inline `docker pull registry:3` (no local-action ref).
- The `ksail-version: "7.26.0"` input is **unchanged** (independent of the action SHA).
- Add a **Dependabot ignore** for `devantler-tech/ksail >= 7.27.1` ([dependabot.yaml](.github/dependabot.yaml)) so the pin is not auto-reverted (Renovate has `github-actions` disabled; Dependabot owns this pin and excludes `devantler-tech/*` from cooldown).

## Validation

- `yq` parses both `ci.yaml` and `dependabot.yaml` ✅
- No cluster/manifest changes; the `deploy-prod` path is unaffected (it installs ksail via `curl`, not this composite action).

## Follow-up (not in this PR)

- **Upstream:** the `ksail-cluster` action should reference `pull-registry-image` as a repo-qualified action (`devantler-tech/ksail/.github/actions/pull-registry-image@<ref>`) or inline it — the `./` form is unusable by any external consumer. Worth an issue on `devantler-tech/ksail`.
- **CI gap:** the merge queue (`merge_group`) skips System Test, which is how the broken bump reached `main`. Consider running System Test (or a lighter validation) in the queue so this class of break is caught pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)