### PR TITLE
feat(scheduling): prefer baseline workers over autoscaler nodes

### DIFF
--- a/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
@@ -1,0 +1,81 @@
+# Prod / FinOps-only: bias workload scheduling toward the static baseline
+# workers so the cost-optimized autoscaler nodes (the `autoscale-cx*` pools in
+# ksail.prod.yaml) stay idle and scale back to zero whenever the baseline has
+# room. The baseline (3 cx33 workers) is paid for 24/7; every autoscaler node
+# is incremental spend, so keeping them empty until the baseline is full is the
+# cheapest steady state.
+#
+# Mechanism: a SOFT node affinity (preferredDuringSchedulingIgnoredDuringExecution).
+# The scheduler packs pods onto baseline nodes first but may still freely use
+# autoscaler nodes for burst — nothing goes Pending for lack of an explicit
+# toleration, and the autoscaler's scale-down reclaims the burst capacity once
+# load drops. A hard nodeAffinity (or a NoSchedule taint) would defeat burst,
+# which is why the strength is "preferred", not "required".
+#
+# DISCRIMINATOR — KSail contract: autoscaler-provisioned nodes are expected to
+# carry the node label `ksail.io/autoscaled: "true"`; baseline (static) workers
+# and control planes do NOT. There is currently NO Kubernetes node label that
+# distinguishes the two — static workers and autoscaler nodes share an
+# identical Talos worker config (same kubelet --node-labels, same
+# node.longhorn.io/create-default-disk=true, overlapping cx33 instance-type),
+# differing only by node-name prefix (prod-worker-* vs autoscale-*). For this
+# preference to take effect, KSail must stamp this label onto its autoscaler
+# node groups (per-pool kubelet --node-labels in the autoscaler cloud-init).
+# Until that lands this policy is an inert no-op: with the label absent on every
+# node, `DoesNotExist` matches all nodes equally and scheduling is unchanged —
+# so it is safe to ship ahead of the KSail change.
+#
+# Coverage: mutates Pods directly for the broadest reach (Deployments,
+# StatefulSets, DaemonSets, Jobs, CronJobs, bare and operator-created pods).
+# DaemonSet placement ignores soft node affinity, so node-local agents still
+# land on autoscaler nodes. Only the four core control-plane namespaces are
+# excluded; everything else is biased toward baseline to maximize the FinOps
+# benefit.
+#
+# Non-clobbering: `affinity` is left unanchored so strategic merge preserves an
+# existing podAntiAffinity (e.g. the one insert-pod-antiaffinity injects), while
+# the `+(nodeAffinity)` add-anchor leaves any pod that already declares its own
+# nodeAffinity (required or preferred) completely untouched.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: prefer-baseline-nodes
+  annotations:
+    policies.kyverno.io/title: Prefer Baseline Nodes
+    policies.kyverno.io/category: Best Practices, FinOps
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Adds a soft (preferred) node affinity biasing pods toward the static
+      baseline workers and away from the cost-optimized autoscaler nodes
+      (labelled ksail.io/autoscaled=true), so autoscaler capacity stays minimal
+      for better FinOps. Inert until KSail labels its autoscaler nodes.
+spec:
+  rules:
+    - name: prefer-baseline-nodes
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - flux-system
+      mutate:
+        patchStrategicMerge:
+          spec:
+            affinity:
+              # Add a nodeAffinity block only when the pod declares none of its
+              # own — never overwrite a chart/operator's node affinity.
+              +(nodeAffinity):
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    preference:
+                      matchExpressions:
+                        - key: ksail.io/autoscaled
+                          operator: DoesNotExist

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
   - ../../../bases/infrastructure/
   - cluster-issuers/
   - vault-seed/
+  # Prod-only FinOps: a Kyverno ClusterPolicy that biases pod scheduling toward
+  # the static baseline workers and away from the autoscaler nodes, so the
+  # cost-optimized `autoscale-cx*` pools stay idle and scale to zero. Lives in
+  # the hetzner overlay because autoscaling is Hetzner/prod-only; see the file
+  # header for the `ksail.io/autoscaled` node-label contract it depends on.
+  - cluster-policies/prefer-baseline-nodes.yaml
   # Prod-only: reconcile Coroot's node Custom Cloud Pricing to Hetzner rates
   # (Coroot otherwise prices non-AWS/GCP/Azure nodes at the GCP-C4 fallback,
   # ~16x the real bill). Lives in this `infrastructure` layer because it targets


### PR DESCRIPTION
## What

Adds a Kyverno mutate `ClusterPolicy` (`prefer-baseline-nodes`) that injects a **soft** (`preferredDuringSchedulingIgnoredDuringExecution`) node affinity into pods, biasing scheduling toward the **static baseline workers** and away from the cost-optimized **autoscaler nodes** (the `autoscale-cx*` pools in `ksail.prod.yaml`).

## Why (FinOps)

The 3 baseline `cx33` workers are paid for 24/7; every autoscaler node is incremental spend. Today the default scheduler spreads pods across **all** nodes — including autoscaler nodes — which keeps them occupied so they never empty out and never scale down. Biasing the scheduler to **pack baseline first** means autoscaler nodes only fill for genuine burst, and the autoscaler reclaims them once load drops. Net: autoscaler capacity stays minimal.

`preferred` (soft), not `required`/taint — so nothing ever goes `Pending` for lack of an explicit toleration and burst capacity still works. Scale-up and scale-down both behave normally (a soft preference is non-binding for the autoscaler's fit simulation).

## ⚠️ Requires a companion KSail change to take effect

There is **no Kubernetes node label** distinguishing baseline from autoscaler nodes today. I verified this against the live prod cluster — static workers (`prod-worker-*`) and autoscaler nodes (`autoscale-cx*-<hash>`) share an identical Talos worker config: same kubelet `--node-labels`, the **same `node.longhorn.io/create-default-disk=true`** (so that is *not* a discriminator, contrary to first appearances), overlapping `cx33` instance-type, identical topology/hcloud labels. They differ only by **node-name prefix**, which `nodeAffinity` can't match.

So this policy keys on a **contract label** — `ksail.io/autoscaled: "true"` — that **KSail must stamp onto its autoscaler node groups** (per-pool kubelet `--node-labels` in the autoscaler cloud-init). Until that lands:

- **This policy is an inert no-op** — with the label absent on every node, `DoesNotExist` matches all nodes equally and scheduling is unchanged. Safe to merge ahead of the KSail change; it activates automatically once autoscaler nodes carry the label.

This direction (native node label, soft preference) was chosen deliberately over the alternative of having Kyverno label `Node` objects by name-prefix (which would require enabling Kyverno admission on `Node` — filtered out by default — plus node-update RBAC).

**Follow-up:** add the `ksail.io/autoscaled=true` label to autoscaler pools in KSail (`devantler-tech/ksail`). The exact key is a contract — trivial to adjust here if KSail uses a different one.

## Design notes

- **Prod-only:** lives in the hetzner overlay (`k8s/providers/hetzner/infrastructure/`), like the other Hetzner-only infra (Coroot pricing CronJob, Longhorn VolumeSnapshotClass). Absent on local/docker, which has no autoscaler.
- **Coverage:** mutates `Pod` directly (broadest reach — Deployments, StatefulSets, DaemonSets, Jobs, CronJobs, bare/operator pods). DaemonSet placement ignores soft node affinity, so node-local agents still land everywhere. Only the four core control-plane namespaces (`kube-system`, `kube-public`, `kube-node-lease`, `flux-system`) are excluded.
- **Non-clobbering:** `affinity` is left unanchored so strategic merge preserves an existing `podAntiAffinity` (e.g. the one `insert-pod-antiaffinity` injects into most workloads), while the `+(nodeAffinity)` add-anchor leaves any pod that already declares its own node affinity completely untouched. This sidesteps the ambiguous nested-`+()`-on-a-list behavior.
- **Composes** cleanly with the existing `spread-pods` (hard hostname topology spread) and `insert-pod-antiaffinity` policies.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/` → builds, policy present.
- `kubectl kustomize k8s/providers/docker/infrastructure/` → builds, policy **absent** (prod scoping correct).
- `ksail workload validate` → `✔ prefer-baseline-nodes.yaml validated`; all 295 files pass.
- `ksail --config ksail.prod.yaml workload validate` → the only failure is the **pre-existing** Coroot stale-CRD-catalog false positive (`coroot.com … additional properties 'notificationIntegrations' not allowed`, from `coroot-patch.yaml`, last touched by #1773) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
