### PR TITLE
fix(flagger): pin opencost canary port name to stop duplicate-http collision

### DIFF
--- a/k8s/bases/infrastructure/flagger/canary-opencost.yaml
+++ b/k8s/bases/infrastructure/flagger/canary-opencost.yaml
@@ -30,6 +30,15 @@ spec:
   service:
     port: 9090
     targetPort: 9090
+    # Name the primary 9090 port `http-ui` to match the real opencost Service
+    # (http-ui=9090). Without this, Flagger names the primary port `http` by
+    # default, which collides with the `http`=9003 port that portDiscovery copies
+    # below — the generated opencost-canary Service is then rejected with
+    # "spec.ports[1].name: Duplicate value: http", leaving the Canary stuck
+    # Initializing forever (never builds the primary/canary Services). Pinning the
+    # name also preserves the `http-ui` named port the Headlamp OpenCost plugin
+    # depends on (see the NAMED-PORT RISK note above).
+    portName: http-ui
     # Discover the other container ports (notably :9003, the cost API Headlamp
     # queries) so the generated Services expose them too.
     portDiscovery: true


### PR DESCRIPTION
## Problem

The opencost `Canary` ([canary-opencost.yaml](k8s/bases/infrastructure/flagger/canary-opencost.yaml)) has been stuck `Initializing` since **2026-06-05** (~1900 `reconcileService` errors over 36h on the live cluster), so blue/green for opencost never works:

```
reconcileService failed: service opencost-canary create error:
Service "opencost-canary" is invalid: spec.ports[1].name: Duplicate value: "http"
```

**Cause:** the Canary sets `service.port: 9090` + `portDiscovery: true` with no `portName`. Flagger names the primary port `http` by default, and `portDiscovery` copies opencost's existing `http`=9003 port — so the generated `opencost-canary` Service ends up with **two ports named `http`** and the API server rejects it. The live opencost Service is `http=9003, mcp-server=8081, http-ui=9090`.

## Fix

Set `service.portName: http-ui` so the primary 9090 port is named to match the real opencost Service (`http-ui`=9090). The discovered `http`=9003 / `mcp-server`=8081 ports keep their names → no collision. This also **pins the `http-ui` named port** that the Headlamp OpenCost plugin reaches via the apiserver proxy — the exact "NAMED-PORT RISK" the file's own comment flagged.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/flagger/` builds ✅
- `kubectl kustomize k8s/providers/hetzner/infrastructure/` builds (153 resources), `portName: http-ui` rendered ✅
- `kubectl kustomize k8s/clusters/{local,prod}/` build ✅

Low-risk: only adds a port name to the Canary's service spec. If the Headlamp cost panel were to regress, the file documents the revert path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)