### PR TITLE
fix(flux): ignore pod template in HelmRelease drift detection

### DIFF
--- a/k8s/bases/components/helmrelease-drift-detection/kustomization.yaml
+++ b/k8s/bases/components/helmrelease-drift-detection/kustomization.yaml
@@ -14,16 +14,26 @@
 # helm-controller continuously reconciles the cluster back to the rendered
 # release — recreating deleted resources and reverting out-of-band edits.
 #
-# IGNORES: a few fields are legitimately owned by OTHER controllers at runtime;
-# enforcing the chart's value would make Flux fight them in a hot loop:
+# IGNORES: some fields/subtrees are legitimately owned by OTHER controllers at
+# runtime; enforcing the chart's value would make Flux fight them or spam
+# DriftDetected every reconcile:
 #   * /spec/replicas (Deployment/StatefulSet) — HPA / KEDA / Flagger / autoscaler
+#   * /spec/template (Deployment/StatefulSet/DaemonSet) — the pod template is
+#     rewritten on admission by the cluster's Kyverno mutate policies
+#     (add-resource-defaults, add-security-context, insert-pod-antiaffinity,
+#     prefer-baseline-nodes, spread-pods, disable-default-sa-automount), so the
+#     rendered chart spec NEVER matches the live (mutated) spec. Without this,
+#     all 21 workload HelmReleases logged a harmless-but-perpetual DriftDetected
+#     every reconcile, drowning out real drift. Trade-off: a hand-edit to a
+#     running pod template is no longer auto-reverted by drift detection — it is
+#     still re-applied on the next chart/values reconcile, and a DELETE of the
+#     whole workload is still drift and is restored (deletion-recovery — the
+#     reason this component exists — is unaffected; ignores are field-level only).
 #   * Validating/Mutating webhook `.webhooks[].clientConfig.caBundle` — injected
 #     by cert-manager and patched at runtime by operators (cloudnative-pg,
 #     external-secrets, keda, kubescape, vertical-pod-autoscaler)
 #   * APIService `.spec.caBundle` — aggregated-apiserver cert injection
 #   * CRD conversion `.caBundle` — cert-manager CA injection
-# These are field-level ignores only: a wholesale DELETE of any such resource is
-# still drift and is restored.
 #
 # This is a Kustomize Component so the policy is defined once and applied to
 # every layer/provider build that renders HelmReleases (see the `components:`
@@ -45,10 +55,16 @@ patches:
                 kind: Deployment
               paths:
                 - /spec/replicas
+                - /spec/template
             - target:
                 kind: StatefulSet
               paths:
                 - /spec/replicas
+                - /spec/template
+            - target:
+                kind: DaemonSet
+              paths:
+                - /spec/template
             - target:
                 kind: ValidatingWebhookConfiguration
               paths:


### PR DESCRIPTION
## Follow-up to platform-wide drift detection

Enabling `driftDetection.mode: enabled` on every HelmRelease (previous change) had a side effect once live: the helm-controller logged a **harmless but perpetual `DriftDetected` on all 21 workload HelmReleases every reconcile**.

**Cause:** this cluster's Kyverno **mutate** policies rewrite every pod template on admission — `add-resource-defaults`, `add-security-context`, `insert-pod-antiaffinity`, `prefer-baseline-nodes`, `spread-pods`, `disable-default-sa-automount`. So the chart's rendered `spec.template` never matches the live (mutated) `spec.template`, and helm-controller flags drift forever.

**Verified harmless** (before this change): deployment `generation` stayed flat (e.g. dex=6 over 15 days), no pod rollouts, helm revisions unchanged, helm-controller healthy. The corrections were no-ops (SSA field ownership) — but the events drowned out *real* drift.

## Fix

Add `/spec/template` to the drift `ignore` for `Deployment` / `StatefulSet` / `DaemonSet`, so drift detection no longer diffs the Kyverno-owned pod template.

- **Deletion recovery is unaffected** — the whole reason this component exists (the keda `external-scaler` and `homepage` Deployments were drift-deleted and never restored). A DELETE of an entire workload is still drift and is restored; `ignore` is field-level only.
- **Trade-off:** a hand-edit to a *running* pod template (e.g. `kubectl set image`) is no longer auto-reverted by drift detection. It's still re-applied on the next chart/values reconcile, and GitOps discourages hand-edits anyway.

## Validation

- `kubectl kustomize` builds clean for every provider path; the rendered `ignore` includes `/spec/template` for all three workload kinds (27/27 hetzner controllers carry the drift block).
- `ksail --config ksail.prod.yaml workload validate`: 86/86 groups pass; the one unrelated failure is the pre-existing Coroot `notificationIntegrations` CRDs-catalog false-positive (present on `main`).
- System Test CI remains red due to the pre-existing `pull-registry-image` action infra break (affects all PRs), not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)