### PR TITLE
fix(ci): bump ksail-cluster action pin to v7.33.0 (unbreak all platform PRs)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli /usr/share/gradle"
 
       - name: 🧪 System Test
-        uses: devantler-tech/ksail/.github/actions/ksail-cluster@002029a874fbbc27db8033d743ca75a7b570267b # v7.27.2
+        uses: devantler-tech/ksail/.github/actions/ksail-cluster@40889aa1191e8798ee4d1682faf92091fe698678 # v7.33.0
         with:
           distribution: Talos
           provider: Docker


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Every platform CI run (all open PRs) fails at the **🧪 System Test** job with:

```
Run devantler-tech/ksail/.github/actions/ksail-cluster@002029a...
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/platform/platform/.github/actions/pull-registry-image'.
Did you forget to run actions/checkout before running your local action?
```

## Root cause

`.github/workflows/ci.yaml` pinned `devantler-tech/ksail/.github/actions/ksail-cluster` at `002029a` (Jun 6). At that SHA the action's *Pre-pull registry image* step used `uses: ./.github/actions/pull-registry-image`. A `./` path inside a **composite** action resolves against the **consumer's** `$GITHUB_WORKSPACE` (here `work/platform/platform`), not the ksail repo ([actions/runner#1348](https://github.com/actions/runner/issues/1348)) — so the sibling action is never found and every external caller breaks.

ksail's own CI is unaffected because it references the action locally (`./.github/actions/ksail-cluster`), where `./` resolves correctly.

## Fix

ksail fixed this upstream in [devantler-tech/ksail#5119](https://github.com/devantler-tech/ksail/pull/5119) (merged) by making `ksail-cluster` self-contained — it now runs the sibling script via `$GITHUB_ACTION_PATH/../pull-registry-image/pull-registry-image.sh`, which resolves inside the fully-checked-out action repo for any consumer.

That fix ships in **v7.33.0** (`40889aa`). This PR bumps the pin to it:

```diff
- uses: devantler-tech/ksail/.github/actions/ksail-cluster@002029a... # v7.27.2
+ uses: devantler-tech/ksail/.github/actions/ksail-cluster@40889aa... # v7.33.0
```

Verified the action at `40889aa` contains the fixed step and the `pull-registry-image.sh` script. This also aligns the action version with the `KSAIL_VERSION` CLI binary (`7.33.0`) downloaded later in the same workflow.

## Note — why the pin went stale

Renovate's `devantler-tech/ksail` updates (e.g. #1847) only bump the **binary** `KSAIL_VERSION` (`datasource=github-releases`), not this **action digest** — so the action pin drifted (SHA `002029a` with a stale `# v7.27.2` comment). Worth a follow-up to bring this action ref under Renovate's `github-actions` manager so it tracks releases automatically; flagging rather than scope-creeping this fix.