### PR TITLE
fix(ci): give Talos image-verification ghcr.io auth for private packages

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -122,7 +122,21 @@ jobs:
           exit 1
 
       - name: 🔄 Update cluster
-        run: ksail --config ksail.prod.yaml cluster update
+        # --mirror-registry wires ghcr.io credentials into the Talos machine
+        # config (machine.registries.config["ghcr.io"].auth). WITHOUT it, Talos's
+        # ImageVerificationConfig (talos/cluster/image-verification.yaml) fetches
+        # the cosign signature of ghcr.io/devantler-tech/* images ANONYMOUSLY and
+        # gets HTTP 401 on our PRIVATE packages, so any FRESH pull of a first-party
+        # image (e.g. a new tenant release, or after a node roll evicts the cache)
+        # fails verification → ImagePullBackOff. Image *layers* still pull via the
+        # k8s ghcr-auth imagePullSecret; only the node-level signature fetch needs
+        # this. The "=https://ghcr.io" remote is a mirror-to-self: it carries no
+        # redirect, it only attaches the auth. ${GHCR_TOKEN} is expanded by the
+        # shell from the step env (masked in logs); it is NOT committed.
+        # NOTE: ksail has no persistent config field for this, so a `cluster update`
+        # run WITHOUT this flag drops the auth again — any manual update must
+        # include it too. ci.yaml's prod deploy carries the identical flag.
+        run: ksail --config ksail.prod.yaml cluster update --mirror-registry "devantler:${GHCR_TOKEN}@ghcr.io=https://ghcr.io"
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -136,6 +136,9 @@ jobs:
         # NOTE: ksail has no persistent config field for this, so a `cluster update`
         # run WITHOUT this flag drops the auth again — any manual update must
         # include it too. ci.yaml's prod deploy carries the identical flag.
+        # Workaround tracked upstream: devantler-tech/ksail#5132 — once ksail
+        # expands env vars in distribution config files, replace this flag with a
+        # committed talos/cluster/registries.yaml patch using ${GHCR_TOKEN}.
         run: ksail --config ksail.prod.yaml cluster update --mirror-registry "devantler:${GHCR_TOKEN}@ghcr.io=https://ghcr.io"
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,7 +272,14 @@ jobs:
           exit 1
 
       - name: 🔄 Update cluster
-        run: ksail --config ksail.prod.yaml cluster update
+        # --mirror-registry wires ghcr.io credentials into the Talos machine
+        # config so the node-level cosign verification (ImageVerificationConfig)
+        # can fetch signatures for our PRIVATE ghcr.io/devantler-tech/* packages.
+        # Without it, a fresh pull of a first-party image fails verification with
+        # an anonymous 401 → ImagePullBackOff. Must stay in lockstep with the
+        # identical flag in cd.yaml's prod deploy (a `cluster update` without it
+        # drops the auth). See cd.yaml for the full rationale.
+        run: ksail --config ksail.prod.yaml cluster update --mirror-registry "devantler:${GHCR_TOKEN}@ghcr.io=https://ghcr.io"
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,6 +275,7 @@ jobs:
         # an anonymous 401 → ImagePullBackOff. Must stay in lockstep with the
         # identical flag in cd.yaml's prod deploy (a `cluster update` without it
         # drops the auth). See cd.yaml for the full rationale.
+        # Workaround tracked upstream: devantler-tech/ksail#5132.
         run: ksail --config ksail.prod.yaml cluster update --mirror-registry "devantler:${GHCR_TOKEN}@ghcr.io=https://ghcr.io"
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
## Problem

Talos's `ImageVerificationConfig` (`talos/cluster/image-verification.yaml`) verifies cosign signatures on `ghcr.io/devantler-tech/*` at the containerd pull layer. It fetches the signature using the node's `machine.registries` config — but **there is no ghcr.io credential there** (the only registry config is `localRegistry`, scoped to the Flux `/platform/manifests` artifact). So the signature fetch goes out **anonymous → HTTP 401** on our **private** packages.

Image *layers* still pull (kubelet hands containerd the k8s `ghcr-auth` imagePullSecret); only the **node-level signature fetch** is unauthenticated — a separate credential path.

**Effect:** any *fresh* pull of a first-party image fails verification → `ImagePullBackOff`. It's latent until a node lacks the image cached.

### How it surfaced
`ascoachingogvaner` v1.2.0 (`sha256:faaba08…`) stuck `ImagePullBackOff` on `prod-worker-1` after the k8s-1.36 node roll evicted its cache. `wedding-app` looked fine only because its new RS reuses the **same cached digest** (`8fe98196…`, "already present on machine" — never re-verified). The next genuinely-new tenant image would hit the same wall.

The image is **correctly signed-by-digest** and verifies against the Talos keyless identity (confirmed independently) — `401 = auth`, not `404 = missing sig`. Package settings are identical between the two tenants (`private`, same org, repo-linked), so it's not a per-package grant.

## Fix

Pass `--mirror-registry "devantler:${GHCR_TOKEN}@ghcr.io=https://ghcr.io"` to `ksail cluster update` in **both** prod-deploy paths (`cd.yaml` on tags, `ci.yaml` on the merge queue). ksail writes `machine.registries.config["ghcr.io"].auth` from this spec (confirmed in ksail source: `applyMirrorsToConfig` → `addRegistryAuth`; the `splitMirrorSpec` examples include this exact `user:pass@host=remote` shape). The `=https://ghcr.io` remote is a **mirror-to-self** — no redirect, it only attaches the auth.

- `${GHCR_TOKEN}` is the org-owner PAT (already in the step env, masked in logs), expanded by the shell — **never committed**. A `talos/` patch couldn't be used: ksail does not env-expand machine-config patches (`ExpandEnvVars` only covers the ksail config object), so a `${GHCR_TOKEN}` there would be written literally.
- ksail exposes **no persistent config field** for node registry auth (no field-selector; the `--mirror-registry` flag is explicitly not Viper-bound), so the flag must stay in lockstep across both workflows. ⚠️ **A manual `ksail cluster update` without this flag drops the auth** — include it there too.

## Validation

- Both workflow files parse (`yq`).
- ksail-source-confirmed: `--mirror-registry` is accepted by `cluster update` (its help text lists "registry mirrors"); `MirrorRegistry{Username,Password}` → `addRegistryAuth` → `machine.registries.config[host].auth`.
- No live cluster change in this PR; it applies on the next prod deploy. To fix the currently-stuck pod immediately, run `ksail --config ksail.prod.yaml cluster update --mirror-registry "devantler:$GHCR_TOKEN@ghcr.io=https://ghcr.io"` then `kubectl rollout restart deploy/ascoachingogvaner -n ascoachingogvaner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)