### PR TITLE
fix(autoscaling): raise VPA minAllowed CPU floor to 50m for cold-start

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -72,12 +72,19 @@ spec:
                   # below; CPU limits only loosen (less throttling, no OOM).
                   controlledValues: RequestsAndLimits
                   minAllowed:
-                    # CPU floor lowered 50m->15m: live data showed 87 containers
-                    # pinned at the 50m floor using avg 4.4m — VPA was floored,
-                    # not the workloads. CPU is compressible; 15m covers observed
-                    # usage with margin and frees ~3 cores of reserved-unused
-                    # requests. Memory floor kept at 64Mi (memory runs ~89% hot).
-                    cpu: "15m"
+                    # CPU floor raised 15m->50m for cold-start headroom. 15m was
+                    # right-sized to STEADY-STATE usage (avg 4.4m), but with
+                    # RequestsAndLimits it also pinned the LIMIT low (e.g. wedding-app
+                    # at 15m req -> 60m limit, authored 4:1 ratio), which throttled
+                    # COLD START: Node/Next.js apps couldn't boot fast enough to pass
+                    # their liveness probe and crashlooped. Only FRESH starts were hit
+                    # — already-running pods, resized in place, kept serving — so it
+                    # surfaced only on a new ReplicaSet. 50m req -> ~200m limit restores
+                    # the headroom the old pods originally cold-started under. Costs
+                    # ~3 cores of (compressible) CPU requests vs 15m; VPA still
+                    # right-sizes above the floor for steady-state. Memory floor kept
+                    # at 64Mi (memory runs ~89% hot).
+                    cpu: "50m"
                     memory: "64Mi"
                   # Upper bound: stops a leaking/runaway workload from having
                   # its request pushed to an unschedulable size or silently
@@ -127,12 +134,19 @@ spec:
                   # below; CPU limits only loosen (less throttling, no OOM).
                   controlledValues: RequestsAndLimits
                   minAllowed:
-                    # CPU floor lowered 50m->15m: live data showed 87 containers
-                    # pinned at the 50m floor using avg 4.4m — VPA was floored,
-                    # not the workloads. CPU is compressible; 15m covers observed
-                    # usage with margin and frees ~3 cores of reserved-unused
-                    # requests. Memory floor kept at 64Mi (memory runs ~89% hot).
-                    cpu: "15m"
+                    # CPU floor raised 15m->50m for cold-start headroom. 15m was
+                    # right-sized to STEADY-STATE usage (avg 4.4m), but with
+                    # RequestsAndLimits it also pinned the LIMIT low (e.g. wedding-app
+                    # at 15m req -> 60m limit, authored 4:1 ratio), which throttled
+                    # COLD START: Node/Next.js apps couldn't boot fast enough to pass
+                    # their liveness probe and crashlooped. Only FRESH starts were hit
+                    # — already-running pods, resized in place, kept serving — so it
+                    # surfaced only on a new ReplicaSet. 50m req -> ~200m limit restores
+                    # the headroom the old pods originally cold-started under. Costs
+                    # ~3 cores of (compressible) CPU requests vs 15m; VPA still
+                    # right-sizes above the floor for steady-state. Memory floor kept
+                    # at 64Mi (memory runs ~89% hot).
+                    cpu: "50m"
                     memory: "64Mi"
                   # Upper bound: stops a leaking/runaway workload from having
                   # its request pushed to an unschedulable size or silently
@@ -176,12 +190,19 @@ spec:
                   # below; CPU limits only loosen (less throttling, no OOM).
                   controlledValues: RequestsAndLimits
                   minAllowed:
-                    # CPU floor lowered 50m->15m: live data showed 87 containers
-                    # pinned at the 50m floor using avg 4.4m — VPA was floored,
-                    # not the workloads. CPU is compressible; 15m covers observed
-                    # usage with margin and frees ~3 cores of reserved-unused
-                    # requests. Memory floor kept at 64Mi (memory runs ~89% hot).
-                    cpu: "15m"
+                    # CPU floor raised 15m->50m for cold-start headroom. 15m was
+                    # right-sized to STEADY-STATE usage (avg 4.4m), but with
+                    # RequestsAndLimits it also pinned the LIMIT low (e.g. wedding-app
+                    # at 15m req -> 60m limit, authored 4:1 ratio), which throttled
+                    # COLD START: Node/Next.js apps couldn't boot fast enough to pass
+                    # their liveness probe and crashlooped. Only FRESH starts were hit
+                    # — already-running pods, resized in place, kept serving — so it
+                    # surfaced only on a new ReplicaSet. 50m req -> ~200m limit restores
+                    # the headroom the old pods originally cold-started under. Costs
+                    # ~3 cores of (compressible) CPU requests vs 15m; VPA still
+                    # right-sizes above the floor for steady-state. Memory floor kept
+                    # at 64Mi (memory runs ~89% hot).
+                    cpu: "50m"
                     memory: "64Mi"
                   # Lower upper bound than Deployments/StatefulSets: a DaemonSet
                   # pod must schedule on EVERY node, including autoscale-cx23


### PR DESCRIPTION
## Problem

The `auto-vpa` policy floors `minAllowed.cpu` at **15m**, right-sized to *steady-state* usage (avg ~4.4m). But with `controlledValues: RequestsAndLimits`, VPA scales each container's **limit** in proportion to its request — so a floored app also gets a floored limit:

- wedding-app: `15m` request → **`60m` limit** (its authored 4:1 ratio).

60m CPU is too little to **cold-start** a Node/Next.js app. Under throttle it can't answer its liveness probe (`/login:3000`, `initialDelaySeconds: 5`, `periodSeconds: 10`, `failureThreshold: 3`) before being SIGKILL'd (exit 137, reason `Error` — not OOM) → crashloop / stuck rollout.

**Why only now:** only *fresh* starts are affected. Already-running pods are resized **in place** and keep serving, so it surfaced only when a new ReplicaSet appeared (Kyverno `prefer-baseline-nodes` added a soft `nodeAffinity`, spawning one). The old wedding-app pods originally cold-started under the **previous 50m floor** (~200m limit), then VPA resized them down in place — so they survive at 60m while a fresh pod can't reach it.

## Fix

Raise `minAllowed.cpu` **15m → 50m** in all three rules (Deployment / StatefulSet / DaemonSet). New pods are then admitted with ~200m CPU limit (50m × authored ratio) and can boot. The 50m floor is the value the old pods provably cold-started under.

- **Trade-off:** re-reserves ~3 cores of (compressible) CPU requests vs 15m — the inverse of the recent efficiency tuning. VPA still right-sizes *above* the floor for steady-state; memory floor (64Mi) is untouched.
- Platform-wide, as requested — applies to every auto-VPA'd workload, so any CPU-hungry-at-startup app gets the same cold-start headroom.

## Validation

- `kubectl kustomize` builds clean (prod + local); rendered `auto-vpa` shows `cpu: 50m` in all three rules.
- `ksail --config ksail.prod.yaml workload validate`: 86/86 pass (the one unrelated failure is the pre-existing Coroot `notificationIntegrations` CRDs-catalog false-positive on `main`).
- VPA in-place-resizes (updateMode `InPlaceOrRecreate`), so the new floor lands on existing pods without eviction; the stuck wedding-app rollout completes once the new pod is admitted at the higher limit.

> Note: a `startupProbe` on individual apps would be the most surgical long-term complement (decouples boot time from liveness), but this floor fixes the class platform-wide now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)