### PR TITLE
fix(umami): exclude rotated DB secret from Flagger config-tracking

### DIFF
--- a/k8s/bases/apps/umami/db-rotated-external-secret.yaml
+++ b/k8s/bases/apps/umami/db-rotated-external-secret.yaml
@@ -37,6 +37,23 @@ spec:
     creationPolicy: Owner
     template:
       engineVersion: v2
+      # Opt this Secret out of Flagger's config-tracking. Umami runs under a
+      # Flagger Gateway API canary (canary.yaml); by default Flagger snapshots
+      # every Secret/ConfigMap the workload references into a `<name>-primary`
+      # copy that the PRIMARY (prod-serving) Deployment uses, refreshed ONLY on a
+      # successful canary promotion. That breaks for an EXTERNALLY-ROTATED secret:
+      # when OpenBao rotates the `umami` password (7-day static-role schedule),
+      # the live Secret updates but the `umami-db-rotated-primary` snapshot stays
+      # frozen, so the primary authenticates with the stale password and
+      # CrashLoopBackOffs on `28P01 password authentication failed` — and if the
+      # canary cannot promote (e.g. Coroot SLOs unavailable during a node roll)
+      # the snapshot never refreshes and the primary stays wedged. Disabling
+      # tracking makes the primary reference the live `umami-db-rotated` Secret
+      # directly, so it always sees the current rotated password (picked up on the
+      # next pod start — the same rotation pattern every non-Flagger app uses).
+      metadata:
+        annotations:
+          flagger.app/config-tracking: "disabled"
       data:
         password: "{{ .password }}"
   dataFrom:


### PR DESCRIPTION
## Problem

On the **prod** cluster, `umami-umami-primary` is in **CrashLoopBackOff** (exit code 1, 12+ restarts), which also keeps the `apps` Flux Kustomization stuck `Progressing` (it waits on umami health) and leaves the `umami-umami` Flagger **canary `Failed`**.

## Root cause

Umami is onboarded to **Flagger** progressive delivery (`canary.yaml`). Flagger's **config-tracking** snapshots every Secret/ConfigMap the workload references into a `<name>-primary` copy, repoints the **prod-serving primary** Deployment at that copy, and refreshes it **only on a successful canary promotion**.

The umami DB password is **externally rotated by OpenBao** (Database secrets engine, 7-day static role → `umami-db-rotated` ExternalSecret). So when OpenBao rotates:

- the live `umami-db-rotated` Secret updates within ~1m (the canary uses this), but
- the `umami-db-rotated-primary` snapshot stays **frozen at the last promotion** (2026-06-05), so the primary authenticates with a **stale password** → `28P01 password authentication failed` → crashloop.

If the canary can't promote (here it `Failed` — Coroot SLOs were unavailable during a memory-pressure node roll, and the primary was already down so success-rate was 0%), the snapshot **never refreshes** and the primary stays wedged indefinitely. This recurs on **every 7-day rotation**.

**Evidence (read-only, no secret values disclosed):**
- `kubectl get canary -n umami umami-umami` → `STATUS: Failed`
- SHA-256 of `umami-db-rotated.password` vs `umami-db-rotated-primary.password` → **DIFFER** (snapshot is stale vs the live rotated secret)
- primary pod env: `DATABASE_PASSWORD` ← secret `umami-db-rotated-primary` (the snapshot, not the live secret)

## Fix

Annotate the generated `umami-db-rotated` Secret with `flagger.app/config-tracking: "disabled"` (via the ExternalSecret `target.template.metadata.annotations`). Flagger then stops snapshotting it and the **primary references the live `umami-db-rotated` Secret directly** — always the current rotated password, picked up on the next pod start. This is the standard externally-rotated-secret pattern every non-Flagger app already uses; only umami was affected (homepage/opencost canaries `Succeeded`, no rotated `-primary` secrets).

## Validation

- `kubectl kustomize k8s/clusters/prod/` and `.../local/` build ✓
- `kubectl kustomize k8s/providers/hetzner/apps/` build ✓; annotation renders under `spec.target.template.metadata.annotations` ✓
- `kubectl kustomize k8s/providers/docker/apps/` build ✓ (umami is prod-only, excluded — System Test unaffected)
- `ksail --config ksail.prod.yaml workload validate` → **`✔ providers/hetzner/apps validated`** (the single unrelated `providers/hetzner/infrastructure` failure is a pre-existing false positive: the datreeio CRDs-catalog schema for `coroot.com/v1` omits `notificationIntegrations`; the live Coroot HelmRelease is `Ready`)

## One-time live recovery (maintainer)

This stops the *recurrence*. To clear the *currently wedged* primary after this deploys, Flagger should repoint the primary on its next reconcile; if it doesn't immediately, nudge it once:

```
kubectl -n umami delete secret umami-db-rotated-primary   # Flagger won't recreate it
kubectl -n umami rollout restart deployment/umami-umami-primary
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)