### PR TITLE
feat(ksail-operator): add operator with web UI + native Dex OIDC

### DIFF
--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -76,6 +76,7 @@ spec:
             - "https://headlamp.${domain}/oidc-callback"
             - "https://budget.${domain}/oidc/callback"
             - "https://vault.${domain}/ui/vault/auth/oidc/oidc/callback"
+            - "https://ksail.${domain}/api/v1/auth/callback"
           trustedPeers:
             - kubectl
         - name: kubectl

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -57,20 +57,15 @@ spec:
       # the API) so the Git repository stays the single source of truth. OIDC,
       # UI and API remain fully enabled -- only write actions are locked.
       readOnly: true
-    auth:
-      # Native, app-driven OIDC against Dex (Headlamp-style): the operator API
-      # owns the login/callback as a confidential client and establishes a
-      # session cookie. Reuses the shared `public-client` confidential client
-      # (same as oauth2-proxy / Vault / Headlamp) so no new SOPS secret is
-      # needed -- the redirect URI is registered on that client in the dex
-      # HelmRelease.
-      oidc:
-        enabled: true
-        issuerURL: https://dex.${domain}
-        clientID: public-client
-        clientSecret: ${dex_client_secret}
-        redirectURL: https://ksail.${domain}/api/v1/auth/callback
-        scopes: "openid email profile groups"
+    # Native OIDC is intentionally NOT enabled in the base -- it is layered on
+    # in the hetzner (prod) overlay (see ksail-operator/patches/). The operator
+    # performs *eager, fatal* OIDC discovery at startup: the issuer
+    # (https://dex.${domain}) must be resolvable AND TLS-trusted from inside the
+    # cluster, or the manager fails to start and the pod crash-loops. On
+    # local/CI the *.platform.lan names resolve only via the host's /etc/hosts
+    # (not in-cluster CoreDNS), so discovery would fail there. On prod,
+    # dex.platform.devantler.tech resolves via public DNS (netpol allows egress
+    # 443), so OIDC runs there. (auth.oidc.enabled defaults to false.)
     rbac:
       # Use the chart's least-privilege ClusterRole; clusterAdmin (a full
       # cluster-admin wildcard) stays off -- it is a privilege-escalation

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -37,13 +37,11 @@ spec:
     # default "<release>-ksail-operator").
     fullnameOverride: ksail-operator
     operator:
-      # The chart defaults the image tag to appVersion (7.36.0, no "v"), but the
-      # released ksail image is tagged "v7.36.0" -- the no-"v" tag does not
-      # exist, so the chart default would ImagePullBackOff. Pin the "v"-prefixed
-      # tag explicitly. Renovate tracks chart.spec.version (flux manager) but
-      # NOT this values image tag, so bump it in lockstep when the chart bumps.
-      image:
-        tag: v7.36.0
+      # Image tag is left to the chart default (v<appVersion>, per ksail #5168);
+      # chart.spec.version above selects the operator image version. Requires a
+      # chart release carrying #5168 AND a cosign-signed image (ksail #5165, for
+      # prod Talos image verification / platform #1889) -- bump chart.spec.version
+      # to that release.
       # dockerSocket stays disabled: it mounts the host /var/run/docker.sock,
       # which is privileged and does not exist on Talos nodes (containerd, no
       # Docker) -- enabling it would crash-loop the pod.

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -39,8 +39,9 @@ spec:
     operator:
       # The chart defaults the image tag to appVersion (7.36.0, no "v"), but the
       # released ksail image is tagged "v7.36.0" -- the no-"v" tag does not
-      # exist, so the default would ImagePullBackOff. Pin the "v"-prefixed tag
-      # explicitly (Renovate-trackable). Keep in sync with chart.spec.version.
+      # exist, so the chart default would ImagePullBackOff. Pin the "v"-prefixed
+      # tag explicitly. Renovate tracks chart.spec.version (flux manager) but
+      # NOT this values image tag, so bump it in lockstep when the chart bumps.
       image:
         tag: v7.36.0
       # dockerSocket stays disabled: it mounts the host /var/run/docker.sock,
@@ -71,6 +72,7 @@ spec:
         redirectURL: https://ksail.${domain}/api/v1/auth/callback
         scopes: "openid email profile groups"
     rbac:
-      # Least-privilege ClusterRole the operator ships with; clusterAdmin stays
-      # off (it is a privilege-escalation opt-in, not a product feature).
-      create: true
+      # Use the chart's least-privilege ClusterRole; clusterAdmin (a full
+      # cluster-admin wildcard) stays off -- it is a privilege-escalation
+      # opt-in, not a product feature.
+      clusterAdmin: false

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -23,7 +23,7 @@ spec:
   chart:
     spec:
       chart: ksail-operator
-      version: 7.36.0
+      version: 7.41.2
       sourceRef:
         kind: HelmRepository
         name: ksail-operator
@@ -37,11 +37,10 @@ spec:
     # default "<release>-ksail-operator").
     fullnameOverride: ksail-operator
     operator:
-      # Image tag is left to the chart default (v<appVersion>, per ksail #5168);
-      # chart.spec.version above selects the operator image version. Requires a
-      # chart release carrying #5168 AND a cosign-signed image (ksail #5165, for
-      # prod Talos image verification / platform #1889) -- bump chart.spec.version
-      # to that release.
+      # Image tag comes from the chart default (v<appVersion>, per ksail #5168,
+      # first shipped in chart 7.41.2) -> ghcr.io/devantler-tech/ksail:v7.41.2,
+      # which is cosign-signed (ksail #5165) so prod Talos image verification
+      # (platform #1889) accepts it. chart.spec.version above drives the version.
       # dockerSocket stays disabled: it mounts the host /var/run/docker.sock,
       # which is privileged and does not exist on Talos nodes (containerd, no
       # Docker) -- enabling it would crash-loop the pod.

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -23,7 +23,7 @@ spec:
   chart:
     spec:
       chart: ksail-operator
-      version: 0.1.0
+      version: 7.36.0
       sourceRef:
         kind: HelmRepository
         name: ksail-operator
@@ -37,12 +37,12 @@ spec:
     # default "<release>-ksail-operator").
     fullnameOverride: ksail-operator
     operator:
-      # The chart defaults the image tag to appVersion (0.1.0), which is not a
-      # real image tag -- the operator ships in the main ksail image. Pin to a
-      # released tag (Renovate-trackable). Drop this once the chart appVersion
-      # tracks released ksail images.
+      # The chart defaults the image tag to appVersion (7.36.0, no "v"), but the
+      # released ksail image is tagged "v7.36.0" -- the no-"v" tag does not
+      # exist, so the default would ImagePullBackOff. Pin the "v"-prefixed tag
+      # explicitly (Renovate-trackable). Keep in sync with chart.spec.version.
       image:
-        tag: v7.35.0
+        tag: v7.36.0
       # dockerSocket stays disabled: it mounts the host /var/run/docker.sock,
       # which is privileged and does not exist on Talos nodes (containerd, no
       # Docker) -- enabling it would crash-loop the pod.

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ksail-operator
+  namespace: ksail-operator
+  labels:
+    # The chart ships the `Cluster` CRD (clusters.ksail.io); let Flux manage it.
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  interval: 10m0s
+  timeout: 10m
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: ksail-operator
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: ksail-operator
+  # https://github.com/devantler-tech/ksail/tree/main/charts/ksail-operator
+  #
+  # The operator reconciles `Cluster` resources (ksail.io/v1alpha1) and serves
+  # the embedded web UI + REST API on the same port (api.bindPort). All product
+  # features are enabled: operator, REST API, web UI and native OIDC auth.
+  values:
+    # Clean resource names (Service/Deployment "ksail-operator" instead of the
+    # default "<release>-ksail-operator").
+    fullnameOverride: ksail-operator
+    operator:
+      # The chart defaults the image tag to appVersion (0.1.0), which is not a
+      # real image tag -- the operator ships in the main ksail image. Pin to a
+      # released tag (Renovate-trackable). Drop this once the chart appVersion
+      # tracks released ksail images.
+      image:
+        tag: v7.35.0
+      # dockerSocket stays disabled: it mounts the host /var/run/docker.sock,
+      # which is privileged and does not exist on Talos nodes (containerd, no
+      # Docker) -- enabling it would crash-loop the pod.
+      dockerSocket:
+        enabled: false
+    api:
+      # REST API + embedded web UI (consumed same-origin by the SPA).
+      bindPort: 8080
+    ui:
+      # GitOps-enforced platform: the UI is read-only (enforced server-side via
+      # the API) so the Git repository stays the single source of truth. OIDC,
+      # UI and API remain fully enabled -- only write actions are locked.
+      readOnly: true
+    auth:
+      # Native, app-driven OIDC against Dex (Headlamp-style): the operator API
+      # owns the login/callback as a confidential client and establishes a
+      # session cookie. Reuses the shared `public-client` confidential client
+      # (same as oauth2-proxy / Vault / Headlamp) so no new SOPS secret is
+      # needed -- the redirect URI is registered on that client in the dex
+      # HelmRelease.
+      oidc:
+        enabled: true
+        issuerURL: https://dex.${domain}
+        clientID: public-client
+        clientSecret: ${dex_client_secret}
+        redirectURL: https://ksail.${domain}/api/v1/auth/callback
+        scopes: "openid email profile groups"
+    rbac:
+      # Least-privilege ClusterRole the operator ships with; clusterAdmin stays
+      # off (it is a privilege-escalation opt-in, not a product feature).
+      create: true

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-repository.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-repository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ksail-operator
+  namespace: ksail-operator
+spec:
+  type: oci
+  # The ksail-operator chart lives in the KSail repo (charts/ksail-operator) and
+  # is published as an OCI artifact to GHCR. URL mirrors the flux-operator
+  # pattern (oci://ghcr.io/<org>/charts + chart name). Confirm this matches the
+  # actual publish target once the chart-release pipeline lands.
+  url: oci://ghcr.io/devantler-tech/charts

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-repository.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-repository.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   type: oci
   # The ksail-operator chart lives in the KSail repo (charts/ksail-operator) and
-  # is published as an OCI artifact to GHCR. URL mirrors the flux-operator
-  # pattern (oci://ghcr.io/<org>/charts + chart name). Confirm this matches the
-  # actual publish target once the chart-release pipeline lands.
+  # is published as an OCI artifact to GHCR, mirroring the flux-operator pattern
+  # (oci://ghcr.io/<org>/charts + chart name).
   url: oci://ghcr.io/devantler-tech/charts

--- a/k8s/bases/infrastructure/controllers/ksail-operator/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/httproute.yaml
@@ -15,7 +15,7 @@ metadata:
     # would 404. Point at the upstream brand SVG (pinned), the same upstream-URL
     # pattern the Coroot / Cilium / OpenBao routes use. Homepage fetches icons
     # client-side, so the cluster egress NetworkPolicy doesn't block it.
-    gethomepage.dev/icon: https://raw.githubusercontent.com/devantler-tech/ksail/v7.35.0/docs/public/favicon.svg
+    gethomepage.dev/icon: https://raw.githubusercontent.com/devantler-tech/ksail/v7.36.0/docs/public/favicon.svg
     # Status dot: target the operator pod explicitly (the chart labels it
     # name=ksail-operator + component=operator).
     gethomepage.dev/pod-selector: app.kubernetes.io/name=ksail-operator,app.kubernetes.io/component=operator

--- a/k8s/bases/infrastructure/controllers/ksail-operator/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/httproute.yaml
@@ -1,0 +1,38 @@
+# The operator serves the SPA and the REST API (including the OIDC login and
+# /api/v1/auth/callback) on one origin, so the route backends directly to the
+# operator Service -- no oauth2-proxy in front (the operator owns its own OIDC).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ksail-operator
+  namespace: ksail-operator
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: KSail
+    gethomepage.dev/description: Declarative Kubernetes cluster management.
+    gethomepage.dev/group: Kubernetes
+    # KSail isn't in the dashboard-icons set Homepage resolves, so `ksail.png`
+    # would 404. Point at the upstream brand SVG (pinned), the same upstream-URL
+    # pattern the Coroot / Cilium / OpenBao routes use. Homepage fetches icons
+    # client-side, so the cluster egress NetworkPolicy doesn't block it.
+    gethomepage.dev/icon: https://raw.githubusercontent.com/devantler-tech/ksail/v7.35.0/docs/public/favicon.svg
+    # Status dot: target the operator pod explicitly (the chart labels it
+    # name=ksail-operator + component=operator).
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=ksail-operator,app.kubernetes.io/component=operator
+spec:
+  parentRefs:
+    - name: platform
+      namespace: kube-system
+      sectionName: https
+  hostnames:
+    - ksail.${domain}
+  rules:
+    - backendRefs:
+        - name: ksail-operator
+          port: 8080
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload

--- a/k8s/bases/infrastructure/controllers/ksail-operator/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - helm-release.yaml
+  - httproute.yaml
+  - networkpolicy.yaml

--- a/k8s/bases/infrastructure/controllers/ksail-operator/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/namespace.yaml
@@ -1,0 +1,15 @@
+# PSA enforce label intentionally NOT set on the ksail-operator namespace.
+#
+# The ksail-operator chart ships its Deployment with no pod/container
+# securityContext at all. With an explicit pod-security.kubernetes.io/enforce
+# label, kube-apiserver's PSA validator would reject the pod before Kyverno's
+# add-security-context mutating webhook can fill in the restricted defaults
+# (same reason the dex namespace omits the label).
+#
+# The Kyverno validate-pod-security ClusterPolicy (Enforce mode) is already a
+# backstop -- it sees the mutated pod and enforces restricted at the webhook
+# layer.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ksail-operator

--- a/k8s/bases/infrastructure/controllers/ksail-operator/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/networkpolicy.yaml
@@ -1,0 +1,45 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-ksail-operator
+  namespace: ksail-operator
+spec:
+  endpointSelector: {}
+  ingress:
+    # Gateway ingress for the operator UI + REST API.
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Intra-namespace (e.g. leader-election peers).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: ksail-operator
+  egress:
+    # Intra-namespace.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: ksail-operator
+    # Kube API (reconcile Cluster resources, leader election, serve the API).
+    - toEntities:
+        - kube-apiserver
+    # Dex OIDC discovery / token exchange (dex.${domain} via Cloudflare proxy).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # DNS resolution.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - flux-operator/
   - keda/
   - keda-http-add-on/
+  - ksail-operator/
   - kubevirt/
   - kubescape/
   - kyverno/

--- a/k8s/providers/hetzner/infrastructure/controllers/ksail-operator/patches/helm-release-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/ksail-operator/patches/helm-release-patch.yaml
@@ -1,0 +1,27 @@
+# Prod-only: enable the operator's native, app-driven OIDC against Dex.
+#
+# Kept out of the base because the operator does eager, fatal OIDC discovery at
+# startup and the issuer must be resolvable + TLS-trusted from inside the
+# cluster (see the base HelmRelease). On Hetzner, dex.${domain} resolves via
+# public DNS (Cloudflare) and serves a trusted cert, so discovery succeeds; on
+# local/CI the *.platform.lan host-file names are not in-cluster resolvable.
+#
+# Reuses the shared `public-client` confidential client (same as oauth2-proxy /
+# Vault / Headlamp) so no new SOPS secret is needed -- the redirect URI is
+# registered on that client in the dex HelmRelease. This merges into spec.values
+# (it does not replace the base values).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ksail-operator
+  namespace: ksail-operator
+spec:
+  values:
+    auth:
+      oidc:
+        enabled: true
+        issuerURL: https://dex.${domain}
+        clientID: public-client
+        clientSecret: ${dex_client_secret}
+        redirectURL: https://ksail.${domain}/api/v1/auth/callback
+        scopes: "openid email profile groups"

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ../../../../bases/infrastructure/controllers/flux-operator/
   - ../../../../bases/infrastructure/controllers/keda/
   - ../../../../bases/infrastructure/controllers/keda-http-add-on/
+  - ../../../../bases/infrastructure/controllers/ksail-operator/
   - ../../../../bases/infrastructure/controllers/kubescape/
   - ../../../../bases/infrastructure/controllers/kyverno/
   - ../../../../bases/infrastructure/controllers/metrics-server/

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -67,6 +67,10 @@ patches:
   # for openbao + any non-Longhorn PVC. The base tier stays all-FSB because the
   # docker/local-path provider cannot snapshot.
   - path: velero/patches/helm-release-patch.yaml
+  # Prod-only: enable the ksail-operator's native Dex OIDC. The operator does
+  # eager startup OIDC discovery that needs a cluster-resolvable + TLS-trusted
+  # issuer, which the local *.platform.lan host-file domain isn't — see file.
+  - path: ksail-operator/patches/helm-release-patch.yaml
   # NB: the Coroot CR moved to the `infrastructure` layer (so the operator's
   # CRD is installed first), so its hetzner patch now lives in
   # ../coroot/patches/ and is applied by ../kustomization.yaml, not here.


### PR DESCRIPTION
## What

Adds the **KSail operator** (`charts/ksail-operator`) as an infrastructure controller with the operator, REST API + embedded web UI, and **native (app-driven) OIDC against Dex**.

New component: `k8s/bases/infrastructure/controllers/ksail-operator/` (namespace, HelmRepository, HelmRelease, HTTPRoute, CiliumNetworkPolicy), wired into both the base controller list (local/CI) and the explicit hetzner list (prod). Consumes the published OCI chart `oci://ghcr.io/devantler-tech/charts/ksail-operator` **v7.36.0**.

## Feature config

| Feature | Setting | Notes |
|---|---|---|
| Operator + REST API + Web UI | on (`api.bindPort: 8080`) | UI embedded, same origin as API |
| `ui.readOnly` | **`true`** | GitOps-safe: Git/Flux stays source of truth; only writes locked |
| Native OIDC (Dex) | **prod-only** (`enabled: true` on hetzner) | see below |
| `operator.dockerSocket.enabled` | `false` | privileged; no `/var/run/docker.sock` on Talos → would crash-loop |
| `rbac.clusterAdmin` | `false` | least-privilege ClusterRole; no cluster-admin wildcard |

## Native OIDC is prod-only — and why

The operator does **eager, fatal OIDC discovery at manager startup**: the issuer must be resolvable + TLS-trusted *from inside the cluster*, or the manager fails to start and the pod crash-loops. The first full System Test run (which got past a transient kubescape flake and actually built the cluster) surfaced this on local:

```
run operator: start manager: set up OIDC authentication: discover OIDC provider:
Get "https://dex.platform.lan/.well-known/openid-configuration":
lookup dex.platform.lan on 10.96.0.10:53: no such host
```

On **local/CI**, `*.platform.lan` resolves only via the host's `/etc/hosts` (not in-cluster CoreDNS), so discovery fails → crash-loop → HelmRelease never Ready → System Test red. oauth2-proxy / Headlamp / Vault avoid this by discovering OIDC lazily or tolerating an unreachable Dex; the ksail operator is uniquely strict.

**Fix:** OIDC config lives in a **hetzner (prod) overlay patch**, not the base — matching the repo's "base = CI-safe minimal, hetzner patch adds prod-only config" pattern (same as Coroot's prod-only `notificationIntegrations`). On prod, `dex.platform.devantler.tech` resolves via public DNS and serves a trusted cert (the NetworkPolicy already allows egress `:443`), so OIDC works; local/CI runs the operator without OIDC (UI/API still served, read-only, host-only). Verified the kustomize merge: docker renders no `auth.oidc`; hetzner retains all base values and adds `auth.oidc.enabled: true`.

OIDC reuses the shared `public-client` confidential client + `${dex_client_secret}` (no new SOPS secret); callback `https://ksail.${domain}/api/v1/auth/callback` registered on it in the dex HelmRelease.

> **Upstream idea:** if the operator made OIDC discovery non-fatal / retrying at startup (like oauth2-proxy), OIDC could run on local too and the operator would be more robust to Dex bootstrap ordering on prod.

## Image-tag pin (intentional)

`operator.image.tag: v7.36.0` is pinned because the chart's `appVersion` is `7.36.0` (no `v`) while the released image is tagged **`v7.36.0`** — the no-`v` tag doesn't exist, so the chart default would `ImagePullBackOff`. Renovate tracks `chart.spec.version` (flux manager) but **not** this values image tag, so bump it in lockstep on chart bumps.

## Validation

- Rendered the published 7.36.0 chart with the PR values → image `…/ksail:v7.36.0`, `--read-only` + `--oidc-*` flags, Service `:8080`, OIDC Secret + scoped RBAC.
- `ksail workload validate` (local): ✔ **300 files**, exit 0.
- Prod validate: ksail-operator (base + hetzner OIDC patch) ✔; only failing group is the **pre-existing** Coroot stale-catalog false-positive (`coroot_v1.json … 'notificationIntegrations' not allowed`), unrelated.
- `readOnlyRootFilesystem` (Kyverno-enforced) did **not** break the operator — it started cleanly under the restricted PSS (the earlier-flagged risk did not materialize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)