### PR TITLE
fix(umami): list users via /api/admin/users to unblock member provisioning

### DIFF
--- a/k8s/bases/apps/umami/provision-cronjob.yaml
+++ b/k8s/bases/apps/umami/provision-cronjob.yaml
@@ -207,7 +207,11 @@ spec:
                     console.log('website created:', s.domain);
                   }
                   async function findUserId(token, username) {
-                    const r = await fetch(base + '/api/users?pageSize=200&search=' + encodeURIComponent(username), { headers: H(token) });
+                    // List users via the admin endpoint: in Umami 3.x `/api/users`
+                    // only handles POST (create); GET lives at `/api/admin/users`
+                    // (paged + `search`, admin-gated). Hitting `/api/users` here
+                    // returned 405 and aborted every member-provisioning run.
+                    const r = await fetch(base + '/api/admin/users?pageSize=200&search=' + encodeURIComponent(username), { headers: H(token) });
                     if (!r.ok) throw new Error('list users failed: ' + r.status + ' ' + (await r.text()));
                     const u = asArray(await r.json()).find((u) => u.username === username);
                     return u ? u.id : null;


### PR DESCRIPTION
## Problem

The `umami-provision-tenants` CronJob is failing every run. Logs:

```
website created: devantler.tech
website created: ksail.devantler.tech
website created: wedding.platform.devantler.tech
website created: ascoachingogvaner.platform.devantler.tech
Error: list users failed: 405
    at findUserId ([eval]:55:20)
    at async ensureMember ([eval]:65:16)
```

Websites provision fine, but the run aborts at the first team **member** (the
`ascoachingogvaner` read-only customer login), so that login is never created.

## Root cause

`findUserId` lists users with `GET /api/users?...`. In **Umami 3.x** that route
only handles **POST** (create user — which the create path in `ensureMember`
uses successfully); listing moved to `GET /api/admin/users`. A `GET` to
`/api/users` therefore hits a route with no GET handler and returns
**405 Method Not Allowed**, crashing the run.

Verified against [`umami-software/umami@v3.1.0`](https://github.com/umami-software/umami/tree/v3.1.0):
- `src/app/api/users/route.ts` — exports `POST` only, no `GET`.
- `src/app/api/admin/users/route.ts` — exports `GET`, accepts `page`/`pageSize`/`search`, gated by `canViewUsers(auth)` (admin).

## Fix

Point `findUserId` at `/api/admin/users`. The response is the standard paged
`{ data: [...] }` shape already handled by `asArray`, and each user object still
carries `id`/`username`, so the surrounding logic is unchanged. One-line path
change + an explanatory comment.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` both build.
- The hetzner apps overlay renders the new `/api/admin/users` route and no longer references the old `/api/users` one.
- `ksail workload validate` (local) passes all 295 files, including the edited CronJob.
- The prod `ksail validate` `coroot` `notificationIntegrations not allowed` failure is the **known, pre-existing** stale datree CRDs-catalog schema issue — unrelated to this change.

The CronJob is idempotent and runs on a `*/15` schedule, so once merged and
reconciled it self-heals on the next tick (or run it immediately with
`kubectl create job -n umami --from=cronjob/umami-provision-tenants umami-provision-now`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)