### PR TITLE
fix(talos): give nodes ghcr.io auth for first-party image-signature verification

### DIFF
--- a/talos/cluster/registry-auth.yaml
+++ b/talos/cluster/registry-auth.yaml
@@ -1,0 +1,52 @@
+# Node-level ghcr.io registry auth for first-party image-signature verification.
+#
+# talos/cluster/image-verification.yaml (ImageVerificationConfig) verifies the
+# cosign signature of every ghcr.io/devantler-tech/* image at the containerd
+# PULL layer. That signature is a separate artifact stored in the SAME package
+# as the image, and Talos fetches it using THIS machine.registries config —
+# NOT the per-pod `ghcr-auth` imagePullSecret (which kubelet only hands to
+# containerd for the image-layer pull). Our first-party packages are PRIVATE,
+# so without a node-level ghcr.io credential the signature fetch goes out
+# anonymous → HTTP 401 → verification fails → ImagePullBackOff.
+#
+# It's latent: an image already cached on a node is "already present" and never
+# re-verified, so it only bites a FRESH pull — a new tenant release, or an
+# existing image after a node roll evicts its cache (how ascoachingogvaner
+# v1.2.0 wedged on prod-worker-1 after the k8s-1.36 roll).
+#
+# This is pure host AUTH (machine.registries.config), NOT a mirror
+# (machine.registries.mirrors): it attaches a credential to ghcr.io pulls with
+# no endpoint redirect. (ksail's --mirror-registry flag is the wrong tool here —
+# it rewrites the endpoint to a local pull-through container that doesn't exist
+# on Hetzner, and it's only ever processed at `cluster create`, never on
+# `cluster update`.) It is the same credential the cluster already holds for the
+# Flux manifests artifact (spec.cluster.localRegistry), so it adds no new trust.
+#
+# ${GHCR_TOKEN} is expanded by ksail when it loads this patch (envvar.ExpandBytes
+# in LoadPatches) from the deploy step's env — the SAME env var localRegistry
+# already requires — so nothing secret is committed. This is ksail's documented,
+# supported config-as-code pattern for node registry auth (declarative-config
+# docs, "Environment Variable Expansion"; ksail#5135) — explicitly NOT the
+# --mirror-registry CLI flag. Prod-only by construction: this dir pairs with
+# ksail.prod.yaml; local/CI uses talos-local/, which carries no
+# ImageVerificationConfig.
+#
+# CAVEAT — applying to EXISTING nodes: ksail's `cluster update` diff only tracks
+# node count / Talos version / ISO, so a machine-config-only change like this is
+# NOT pushed to already-running nodes (it reports "No changes detected"). This
+# patch makes every node correct-by-construction on create/recreate (and the
+# autoscaler's rendered worker config); to apply it to nodes that are already up,
+# patch them once out-of-band, e.g.:
+#   talosctl --nodes <node-ips> patch mc --patch @<this file, ${GHCR_TOKEN} filled>
+# (registries is a no-reboot field), then restart any pod stuck in
+# ImagePullBackOff. See docs/dr/runbook.md.
+#
+# Reference:
+#   https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/registriesconfig/
+machine:
+  registries:
+    config:
+      ghcr.io:
+        auth:
+          username: devantler
+          password: ${GHCR_TOKEN}


### PR DESCRIPTION
## Problem

`talos/cluster/image-verification.yaml` (`ImageVerificationConfig`) verifies cosign signatures on `ghcr.io/devantler-tech/*` at the containerd **pull** layer. Talos fetches each signature using the node's `machine.registries` config — **not** the per-pod `ghcr-auth` imagePullSecret (kubelet only hands that to containerd for the image-layer pull). Our first-party packages are **private**, and the nodes have **no `ghcr.io` host credential**, so the signature fetch goes out anonymous → **HTTP 401** → verification fails → `ImagePullBackOff`.

It's latent: a digest already cached on a node is "already present" and never re-verified, so it only bites a **fresh** pull — a new tenant release, or an existing image after a node roll evicts its cache. That's how `ascoachingogvaner` v1.2.0 wedged on `prod-worker-1` after the k8s-1.36 roll (`wedding-app` survived only because its digest was still cached).

## Why #1849 didn't work

[#1849](https://github.com/devantler-tech/platform/pull/1849) added `--mirror-registry "…@ghcr.io=https://ghcr.io"` to `ksail … cluster update`. Verified against ksail source, that approach can't work:

- **`--mirror-registry` is create-only.** `cluster update`'s diff (`pkg/svc/provisioner/cluster/talos/update.go`) compares **only** control-plane count, worker count, Talos version, and ISO. With those unchanged it prints `No changes detected` (exactly the deploy log) and never reads the flag.
- **It's the wrong primitive for Hetzner.** `PrepareTalosConfigWithMirrors` hard-codes the mirror endpoint to a **local pull-through container** (`http://prod-ghcr.io:5000`) that doesn't exist on Hetzner — it would break ghcr.io pulls if it ever applied.
- The PR's premise that *"ksail does not env-expand machine-config patches"* is **false** — ksail expands `${VAR}` in every `talos/` patch at load (`LoadPatches → forEachYAMLFile → envvar.ExpandBytes`, tested by `TestLoadPatches_ExpandsEnvVars`). Upstream **[devantler-tech/ksail#5135](https://github.com/devantler-tech/ksail/pull/5135)** (merged) confirms this and documents the committed-patch-with-`${TOKEN}` approach as the **supported** way to give nodes registry auth for private-package cosign verification — and explicitly names #1849's premise as wrong.

## Fix

Add a committed Talos patch `talos/cluster/registry-auth.yaml` setting pure host auth (no mirror redirect):

```yaml
machine:
  registries:
    config:
      ghcr.io:
        auth:
          username: devantler
          password: ${GHCR_TOKEN}
```

- `${GHCR_TOKEN}` is expanded by ksail at load from the deploy step's env — the **same env var `localRegistry` already requires** — so the placeholder is committed and the secret never is. No workflow change needed.
- Prod-only by construction (`talos/` pairs with `ksail.prod.yaml`; local/CI uses `talos-local/`, which carries no `ImageVerificationConfig`).
- Matches the ksail-documented filename/pattern (ksail#5135) for cross-reference.

## Reviewer note — existing nodes need a one-time manual apply

ksail's `cluster update` diff ignores machine-config, so this patch makes **future** nodes correct on create/recreate but is **not** pushed to already-running nodes. To unstick the currently-broken pods, apply it once out-of-band (registries is a no-reboot field):

```bash
sed "s/\${GHCR_TOKEN}/$GHCR_TOKEN/" talos/cluster/registry-auth.yaml > /tmp/registry-auth.patch.yaml
talosctl --nodes <control-plane + worker IPs> patch mc --patch @/tmp/registry-auth.patch.yaml
kubectl rollout restart deploy/ascoachingogvaner -n ascoachingogvaner
```

## Validation

- `talos/cluster/registry-auth.yaml` parses as valid YAML and matches the sibling machine-config patch shape (e.g. `sysctls.yaml`, `kubelet.yaml`).
- `kubectl kustomize k8s/clusters/prod/` and `…/local/` both build (this change is outside `k8s/`).

Supersedes #1849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)