### PR TITLE
fix(umami): restore Analytics homepage tile via Flagger apex annotations

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -128,8 +128,9 @@ data:
             icon: unifi
             href: https://unifi.ui.com
             description: Central hub for managing on-prem UniFi network infrastructure.
-    # Analytics is populated dynamically from the Umami HTTPRoute's
-    # gethomepage.dev annotations (k8s/bases/apps/umami/httproute.yaml).
+    # Analytics is populated dynamically from the gethomepage.dev annotations on
+    # Umami's Flagger-generated HTTPRoute (k8s/bases/apps/umami/canary.yaml,
+    # spec.service.apex.annotations).
   bookmarks.yaml: |
     - Personal:
         - Personal Site:

--- a/k8s/bases/apps/umami/canary.yaml
+++ b/k8s/bases/apps/umami/canary.yaml
@@ -30,11 +30,26 @@ spec:
     gatewayRefs:
       - name: platform
         namespace: kube-system
+    # Tile metadata for the Homepage dashboard. Flagger copies spec.service.apex
+    # annotations/labels onto the HTTPRoute it generates (pkg/router/gateway_api.go),
+    # so the gethomepage.dev/* annotations the hand-written route used to carry are
+    # reproduced here — Umami reappears under the Analytics group, discovered the
+    # same way as every other app. pod-selector keys on app.kubernetes.io/instance
+    # (NOT /name): Flagger's default --selector-labels (app,name,
+    # app.kubernetes.io/name) rewrites app.kubernetes.io/name to
+    # "umami-umami-primary" on the primary Deployment, while leaving
+    # app.kubernetes.io/instance=umami intact on the running pods.
+    apex:
+      annotations:
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/name: Umami
+        gethomepage.dev/description: Privacy-first web analytics.
+        gethomepage.dev/group: Analytics
+        gethomepage.dev/icon: si-umami
+        gethomepage.dev/href: https://analytics.${domain}
+        gethomepage.dev/pod-selector: app.kubernetes.io/instance=umami
     # Re-add the HSTS header the hand-written route used to set. (Edge HSTS is
-    # also applied by Cloudflare in prod, so this is defence-in-depth.) The old
-    # route's gethomepage.dev/* tile annotations are NOT reproducible on a
-    # Flagger-generated route — re-add Umami to the homepage dashboard via static
-    # config if the tile is wanted.
+    # also applied by Cloudflare in prod, so this is defence-in-depth.)
     headers:
       response:
         set:

--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -77,7 +77,8 @@ spec:
       # Service port 80 -> container port 3000 (named `http`).
       port: 80
     # Routing, ingress and NetworkPolicy are handled by the platform's own
-    # resources (httproute.yaml + networkpolicy.yaml), not the chart.
+    # resources (canary.yaml's Flagger-generated HTTPRoute + networkpolicy.yaml),
+    # not the chart.
     gatewayAPI:
       enabled: false
     ingress:


### PR DESCRIPTION
## Problem

Umami no longer appears under **Analytics** on the homepage dashboard.

**Root cause:** [#1768](https://github.com/devantler-tech/platform/pull/1768) (commit `005f891a`, platform-wide Flagger progressive delivery) **deleted umami's hand-written `httproute.yaml`** when Flagger took over route generation. Homepage's Kubernetes integration (`kubernetes.yaml: gateway: true`) discovers tiles from `gethomepage.dev/*` annotations on HTTPRoutes. The old route carried those annotations (`group: Analytics`, `icon: si-umami`, …); the **Flagger-generated** route carried none, so the tile silently disappeared. The `canary.yaml` comment even claimed the annotations were *"NOT reproducible on a Flagger-generated route"* — which is incorrect.

## Fix

Flagger **does** copy `spec.service.apex.{annotations,labels}` onto the HTTPRoute it generates (verified in [`pkg/router/gateway_api.go`](https://github.com/fluxcd/flagger/blob/main/pkg/router/gateway_api.go) — set on create, merge-preserved on update). So the `gethomepage.dev/*` tile annotations are re-added under `spec.service.apex.annotations` in the Canary — keeping umami's discovery identical to every other app, prod-only (umami isn't in the docker overlay), and the config-map comment accurate.

- `k8s/bases/apps/umami/canary.yaml` — add `spec.service.apex.annotations` with the tile metadata; correct the misleading "NOT reproducible" comment.
- `k8s/bases/apps/homepage/config-map.yaml` — fix stale `httproute.yaml` reference.
- `k8s/bases/apps/umami/helm-release.yaml` — fix stale `httproute.yaml` reference.

### Status-dot subtlety

`gethomepage.dev/pod-selector` keys on `app.kubernetes.io/instance=umami`, **not** `…/name` like the old route. Flagger's default `--selector-labels` (`app,name,app.kubernetes.io/name`) **rewrites `app.kubernetes.io/name` → `umami-umami-primary`** on the primary Deployment, so both the old `name=umami` selector and Homepage's default (`name=<route>` = `name=umami-umami`) would match zero pods and show a false "offline" dot. `…/instance=umami` is left intact by Flagger and matches the running primary pods.

## Validation

- `kubectl kustomize k8s/clusters/{local,prod}/` — both build. ✓
- `ksail workload validate` (local) — 295 files green. ✓
- `ksail --config ksail.prod.yaml workload validate` — **`providers/hetzner/apps validated ✓`** (where umami + homepage live). The single failure is the **pre-existing Coroot stale-catalog false-positive** (`coroot_v1.json … 'notificationIntegrations' not allowed`), unrelated to this change — no coroot files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)