### PR TITLE
fix(talos): open ingress firewall for Cilium mutual-auth port 4250

### DIFF
--- a/talos/control-planes/ingress-firewall.yaml
+++ b/talos/control-planes/ingress-firewall.yaml
@@ -5,7 +5,7 @@
 #   - apid (50000) and Kubernetes API (6443): open to all (external management)
 #   - kubelet (10250), trustd (50001): cluster-internal only
 #   - etcd (2379-2380): cluster-internal only (Hetzner assigns IPs dynamically)
-#   - Cilium VXLAN (8472), WireGuard (51871), health (4240), Hubble peer (4244): cluster-internal only
+#   - Cilium VXLAN (8472), WireGuard (51871), health (4240), Hubble peer (4244), mutual-auth (4250): cluster-internal only
 #   - NodePort range (30000-32767): cluster-internal (Hetzner Cloud LB)
 #   - Node exporter (9100): cluster-internal (Prometheus scraping)
 #
@@ -115,6 +115,27 @@ portSelector:
 ingress:
   - subnet: 10.0.0.0/16
   - subnet: 10.244.0.0/16
+---
+# Cilium SPIRE mutual authentication (authentication.mutual.spire.enabled in
+# the cilium HelmRelease). cilium-agents perform the agent-to-agent mTLS
+# handshake on TCP 4250 (the mesh-auth listener) for every pod-to-pod flow
+# the hetzner require-mutual-auth CiliumClusterwideNetworkPolicy marks
+# `authentication.mode: required`. The source is the peer node's
+# host-network cilium-agent, so the traffic arrives from the node CIDR.
+# NetworkDefaultActionConfig: block drops inbound 4250 unless allowed here;
+# without this rule the cross-node handshake times out
+# (`dial tcp 10.0.1.x:4250: i/o timeout`) and Cilium black-holes the
+# authenticated flow cluster-wide (control-plane endpoints such as
+# cilium-operator and any pod scheduled here are equally affected).
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cilium-mutual-auth-ingress
+portSelector:
+  ports:
+    - 4250
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
 ---
 apiVersion: v1alpha1
 kind: NetworkRuleConfig

--- a/talos/workers/ingress-firewall.yaml
+++ b/talos/workers/ingress-firewall.yaml
@@ -4,7 +4,7 @@
 # Policy summary (workers are more restrictive than control planes):
 #   - apid (50000): open to all (KSail manages workers via public IPs)
 #   - kubelet (10250): cluster-internal only
-#   - Cilium VXLAN (8472), WireGuard (51871), health (4240), Hubble peer (4244): cluster-internal only
+#   - Cilium VXLAN (8472), WireGuard (51871), health (4240), Hubble peer (4244), mutual-auth (4250): cluster-internal only
 #   - NodePort range (30000-32767): cluster-internal (Hetzner Cloud LB)
 #   - Node exporter (9100): cluster-internal (Prometheus scraping)
 #
@@ -83,6 +83,29 @@ portSelector:
 ingress:
   - subnet: 10.0.0.0/16
   - subnet: 10.244.0.0/16
+---
+# Cilium SPIRE mutual authentication (authentication.mutual.spire.enabled in
+# the cilium HelmRelease). cilium-agents perform the agent-to-agent mTLS
+# handshake on TCP 4250 (the mesh-auth listener) for every pod-to-pod flow
+# the hetzner require-mutual-auth CiliumClusterwideNetworkPolicy marks
+# `authentication.mode: required`. The source is the peer node's
+# host-network cilium-agent, so the traffic arrives from the node CIDR.
+# NetworkDefaultActionConfig: block drops inbound 4250 unless allowed here;
+# without this rule the cross-node handshake times out
+# (`dial tcp 10.0.1.x:4250: i/o timeout`) and Cilium black-holes the
+# authenticated flow. That silently broke the coroot-heartbeat dead-man's
+# switch: its coroot-prometheus health-gate only succeeded when the CronJob
+# happened to land on Prometheus's node, so the external healthchecks.io
+# ping was suppressed almost every minute.
+apiVersion: v1alpha1
+kind: NetworkRuleConfig
+name: cilium-mutual-auth-ingress
+portSelector:
+  ports:
+    - 4250
+  protocol: tcp
+ingress:
+  - subnet: 10.0.0.0/16
 ---
 apiVersion: v1alpha1
 kind: NetworkRuleConfig


### PR DESCRIPTION
## Symptom

The `coroot-heartbeat` dead-man's-switch was not pinging healthchecks.io, so the external monitor showed the check inactive — i.e. it would fire even though the platform is up.

## Root cause

The Talos host firewall (`NetworkDefaultActionConfig: ingress: block`, `talos/cluster/ingress-firewall-default.yaml`) allowlists every Cilium node-to-node port **except TCP 4250**, the Cilium SPIRE mutual-authentication ("mesh-auth") handshake port:

| port | purpose | rule present |
|------|---------|--------------|
| 8472/udp | VXLAN | ✅ |
| 51871/udp | WireGuard | ✅ |
| 4240/tcp | health | ✅ |
| 4244/tcp | Hubble peer | ✅ |
| **4250/tcp** | **SPIRE mutual auth** | ❌ **missing** |

Once the hetzner `require-mutual-auth` `CiliumClusterwideNetworkPolicy` enforces `authentication.mode: required` on pod-to-pod ingress, cilium-agents dial peers on TCP 4250 to complete the mTLS handshake. The firewall silently dropped those packets — confirmed on the live cluster:

```
Failed to authenticate request ... failed to dial 10.0.1.x:4250: i/o timeout  authType=spire
Failed to authenticate request ... failed to dial <worker public IP>:4250: connect: no route to host
```

So cross-node mutual auth never completes and Cilium black-holes the authenticated flow.

### Why this surfaced as the heartbeat

`coroot-heartbeat` gates its external ping on first reaching `coroot-prometheus:9090/-/healthy`:

```
curl -sf prometheus/-/healthy && curl -sf "$alertmanager_heartbeat_url" || true
```

That intra-cluster call requires mutual auth. Prometheus is pinned to one node, the CronJob is scheduled anywhere, so the gate only succeeded on the rare minute the pod co-located with Prometheus; otherwise the cross-node handshake timed out, the `&&` short-circuited, and `|| true` masked it. The check URL, Flux substitution, egress policy, and the CronJob itself were all correct — the firewall was the only gap.

This degraded mutual auth **cluster-wide** (many identity pairs in the agent logs), not just the heartbeat; the platform survived on same-node flows, established-flow auth caching, and the policy's `enableDefaultDeny: false`.

## Fix

Add a `cilium-mutual-auth-ingress` `NetworkRuleConfig` (TCP 4250, source `10.0.0.0/16` node CIDR) to both `talos/workers/ingress-firewall.yaml` and `talos/control-planes/ingress-firewall.yaml`, mirroring the existing Cilium node-to-node rules.

## ⚠️ Required manual step (live nodes)

`ksail cluster update` does **not** push machine-config changes to existing nodes — it only reconciles count/version/ISO. This PR fixes new/rebuilt nodes; the **current** nodes need a one-time out-of-band apply, e.g. per node:

```bash
talosctl --nodes <node-ip> patch machineconfig --patch @talos/workers/ingress-firewall.yaml         # workers
talosctl --nodes <cp-ip>   patch machineconfig --patch @talos/control-planes/ingress-firewall.yaml  # control planes
```

(no reboot — ingress firewall rules apply live). After applying, confirm the `:4250 i/o timeout` lines clear from the cilium-agent logs and that healthchecks.io starts receiving pings.

## Validation

- Both files parse as multi-doc YAML; the new rule renders with `ports: [4250]`, `protocol: tcp`, `ingress: 10.0.0.0/16`, all other rules intact.
- `kubectl kustomize k8s/clusters/{local,prod}/` both build (talos/ is outside the kustomize tree; unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)