### PR TITLE
fix(infra): make the whole PDB fleet uniformly maxUnavailable: 1 (keep nodes drainable)

### DIFF
--- a/k8s/bases/apps/fleetdm/pod-disruption-budget.yaml
+++ b/k8s/bases/apps/fleetdm/pod-disruption-budget.yaml
@@ -4,9 +4,11 @@ metadata:
   name: fleetdm
   namespace: fleetdm
 spec:
-  # minAvailable: 0 allows KEDA to scale the deployment to zero replicas
-  # without creating a permanently-violated PDB.
-  minAvailable: 0
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880).
+  # fleetdm is KEDA scale-to-zero (0 or 1 replica), so maxUnavailable: 1 keeps the
+  # node drainable at every replica count — same guarantee the previous
+  # minAvailable: 0 gave, now consistent with the rest of the fleet.
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: fleet

--- a/k8s/bases/apps/homepage/pod-disruption-budget.yaml
+++ b/k8s/bases/apps/homepage/pod-disruption-budget.yaml
@@ -4,7 +4,15 @@ metadata:
   name: homepage
   namespace: homepage
 spec:
-  minAvailable: 1
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880).
+  # Homepage is a Flagger target: replicas are stripped from the HelmRelease so
+  # the primary actually runs the chart default of 1 (not homepage_replicas: 2),
+  # which minAvailable: 1 would render undrainable. The disruption controller
+  # sums the scales of every managed controller this selector matches
+  # (homepage-primary + the scaled-to-0 canary Deployment), so maxUnavailable: 1
+  # permits exactly one eviction at the steady state and stays 1-at-a-time
+  # during a rollout.
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: homepage

--- a/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
@@ -4,7 +4,12 @@ metadata:
   name: auth-proxy
   namespace: oauth2-proxy
 spec:
-  minAvailable: 1
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880):
+  # it never deadlocks a node drain regardless of replica count and still bounds
+  # disruption to one pod at a time. auth_proxy_replicas is "2" today, but
+  # minAvailable would silently re-introduce an undrainable node the moment the
+  # floor dropped to 1.
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: auth-proxy

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/pod-disruption-budget.yaml
@@ -4,7 +4,12 @@ metadata:
   name: cloudnative-pg
   namespace: cnpg-system
 spec:
-  minAvailable: 1
+  # maxUnavailable: 1 (not minAvailable: 1) keeps the node drainable at the prod
+  # single-replica floor (cloudnative_pg_replicas: "1"). minAvailable: 1 over a
+  # single ready replica permits zero voluntary evictions and makes the hosting
+  # node undrainable; at 2+ replicas maxUnavailable: 1 still bounds disruption to
+  # one pod at a time.
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: cloudnative-pg

--- a/k8s/providers/docker/infrastructure/controllers/coredns/pod-disruption-budget.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/pod-disruption-budget.yaml
@@ -4,7 +4,11 @@ metadata:
   name: coredns
   namespace: kube-system
 spec:
-  minAvailable: 1
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880):
+  # it never deadlocks a node drain regardless of replica count and still bounds
+  # disruption to one pod at a time. This CoreDNS Deployment runs 2 replicas, so
+  # maxUnavailable: 1 is behaviourally identical to the old minAvailable: 1.
+  maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: kube-dns

--- a/k8s/providers/hetzner/infrastructure/controllers/hcloud-ccm/pod-disruption-budget.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/hcloud-ccm/pod-disruption-budget.yaml
@@ -4,7 +4,12 @@ metadata:
   name: hcloud-cloud-controller-manager
   namespace: kube-system
 spec:
-  minAvailable: 1
+  # maxUnavailable: 1 (not minAvailable: 1) keeps the node drainable at the prod
+  # single-replica floor (hcloud_ccm_replicas: "1"). minAvailable: 1 over a
+  # single ready replica permits zero voluntary evictions and makes the hosting
+  # node undrainable; at 2+ replicas maxUnavailable: 1 still bounds disruption to
+  # one pod at a time.
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: hcloud-cloud-controller-manager

--- a/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/pod-disruption-budget.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/pod-disruption-budget.yaml
@@ -4,7 +4,12 @@ metadata:
   name: origin-ca-issuer
   namespace: cert-manager
 spec:
-  minAvailable: 1
+  # maxUnavailable: 1 (not minAvailable: 1) keeps the node drainable when the
+  # workload runs 0/1 replicas — origin_ca_issuer_replicas is "0" in prod (the
+  # service is disabled). minAvailable: 1 over <2 ready replicas permits zero
+  # voluntary evictions and makes every hosting node undrainable; at 2+ replicas
+  # maxUnavailable: 1 still bounds disruption to one pod at a time.
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: origin-ca-issuer


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Closes #1880

## Root cause

A `PodDisruptionBudget` with `minAvailable: 1` over a workload running **fewer than 2 ready replicas** permits **zero** voluntary disruptions. Any node hosting such a pod can never be drained — the eviction API loops until the drain timeout aborts, deadlocking ksail autoscaler-node recycles and rolling reboots (the prod `ksail cluster update` failure on `cert-manager/origin-ca-issuer`).

Because the platform's replica floors are config-variable (`${..._replicas:=N}`, scale-to-zero via KEDA, Flagger stripping `replicas`), *any* hand-authored `minAvailable: 1` is one config change away from silently deadlocking a drain.

## Fix

Convert **every** hand-authored PDB to **`maxUnavailable: 1`** — one drain-safe convention that holds at every replica count:

| replicas | `minAvailable: 1` | `maxUnavailable: 1` |
|---|---|---|
| 0 | n/a (PDB inert) | drainable (no pods) |
| 1 | **0 evictions → undrainable** | drainable (the 1 pod can go) |
| 2+ | 1-at-a-time | 1-at-a-time (identical) |

`maxUnavailable: 1` was preferred over the old `fleetdm` `minAvailable: 0` precedent because at 2+ replicas it still gives rolling, one-pod-at-a-time protection (which `minAvailable: 0` would not), while never deadlocking at the 0/1 floor.

### Broken in prod (replica floor < 2) — the actual bug

- `origin-ca-issuer` (hetzner) — `origin_ca_issuer_replicas: "0"` (disabled in prod) — *the incident*
- `cloudnative-pg` (base) — `cloudnative_pg_replicas: "1"`
- `hcloud-cloud-controller-manager` (hetzner) — `hcloud_ccm_replicas: "1"`
- `homepage` (base) — **latent instance the issue missed**: `homepage_replicas: "2"` is vestigial (zero references — Flagger strips `replicas`, so the primary runs the chart default of **1**). `minAvailable: 1` already made the homepage node undrainable. Safe under Flagger: the disruption controller **sums the scales of every managed controller** the selector matches (`homepage-primary` + the scaled-to-0 canary Deployment) — it only fails on *unmanaged* pods — so `maxUnavailable: 1` resolves `expectedCount = 1` and permits one eviction at steady state, staying 1-at-a-time during a rollout.

### Converted for uniformity / future-proofing (were correct, now consistent)

- `auth-proxy` (base) — floor `2` today; future-proofs a drop to 1
- `coredns` (docker provider, local/CI-only) — 2 replicas; behaviourally identical
- `fleetdm` (base) — was `minAvailable: 0` (KEDA scale-to-zero); `maxUnavailable: 1` gives the same guarantee, now consistent with the fleet

After this PR, **all 7 hand-authored PDBs use `maxUnavailable: 1`** — no `minAvailable` remains, so the deadlock class can't recur regardless of how replica floors move.

## Note / follow-up

`homepage_replicas: "2"` in `k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml` is dead (Flagger owns homepage replicas). Left in place here to keep this PR scoped to PDBs; worth removing in a separate cleanup.

## Validation (static, no cluster)

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — both build.
- All 7 PDBs confirmed rendering `maxUnavailable: 1`; no `minAvailable` left.
- `ksail workload validate` — **295/295 files pass**.
- `ksail --config ksail.prod.yaml workload validate` — changed kustomizations pass; the single failure is the **pre-existing Coroot CRDs-catalog schema lag** (`coroot.com/coroot_v1.json` rejects `notificationIntegrations`), unrelated to this change.

## Context

Pairs with the ksail-side change that stops recycling autoscaler nodes for in-place-applicable config changes. A drain is still mandatory for genuine Talos OS bumps / reboots, so the platform must guarantee its workloads stay drainable — which this restores.