### PR TITLE
docs(auth-proxy): point removal TODO at GEP-1494 ExternalAuth plan

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
@@ -1,4 +1,13 @@
-# TODO: Remove this auth-proxy component when Cilium supports native forward auth (https://github.com/cilium/cilium/issues/23797)
+# TODO: Delete this whole component once on Cilium >= 1.20 (stable) and replace the
+# oauth2-proxy reverse-proxy + Traefik host fan-out with the native Gateway API
+# ExternalAuth HTTPRoute filter (GEP-1494). This Traefik instance exists ONLY because
+# oauth2-proxy reverse-proxy mode has a single static upstream and can't host-fan-out;
+# the ExternalAuth filter moves auth onto each HTTPRoute and routes straight to the
+# backend, so this proxy becomes redundant. Filter shipped in Cilium 1.20
+# (cilium/cilium#45739); repo is on 1.19.4, which lacks it. Needs experimental-channel
+# Gateway API CRDs + a netpol/SPIRE ripple + an /oauth2/* bypass route.
+# Execute-ready plan: https://github.com/devantler-tech/platform/issues/1881
+# (supersedes the old cilium/cilium#23797 pointer)
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Sharpens the stale removal TODO on the Traefik `auth-proxy` component.

**Before:** TODO pointed at the broad CFP [cilium/cilium#23797](https://github.com/cilium/cilium/issues/23797) ("when Cilium supports native forward auth").

**After:** points at the concrete mechanism — the native Gateway API **`ExternalAuth` HTTPRoute filter** ([GEP-1494](https://gateway-api.sigs.k8s.io/geps/gep-1494/)), which shipped in **Cilium 1.20** via [cilium/cilium#45739](https://github.com/cilium/cilium/pull/45739) — and links the execute-ready tracking issue #1881.

The `auth-proxy` exists only because oauth2-proxy reverse-proxy mode has a single static upstream and can't host-fan-out; the `ExternalAuth` filter moves auth onto each HTTPRoute and routes straight to the backend, making this Traefik proxy redundant. We're on Cilium 1.19.4 (no filter yet), so this is a comment-only change documenting the path — **no manifest behavior change**.

### Validation
- `kubectl kustomize k8s/clusters/local/` — builds
- `kubectl kustomize k8s/clusters/prod/` — builds

Tracking issue with the full migration plan: #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)