### PR TITLE
fix(secrets): seed R2 credentials from variables-cluster, not the stale base placeholder

### DIFF
--- a/k8s/bases/apps/umami/db-backup-external-secret.yaml
+++ b/k8s/bases/apps/umami/db-backup-external-secret.yaml
@@ -18,6 +18,15 @@ spec:
   target:
     name: umami-db-backup-r2
     creationPolicy: Owner
+    template:
+      # REGION is a constant ("auto") rather than a fetched secret — CNPG's
+      # s3Credentials.region must point at a Secret key, and barman-cloud/boto3
+      # need a region for SigV4 signing. "auto" is R2's environment-independent
+      # convention (the same value Velero's BackupStorageLocation uses).
+      data:
+        ACCESS_KEY_ID: "{{ .ACCESS_KEY_ID }}"
+        SECRET_ACCESS_KEY: "{{ .SECRET_ACCESS_KEY }}"
+        REGION: "auto"
   data:
     - secretKey: ACCESS_KEY_ID
       remoteRef:

--- a/k8s/bases/apps/umami/db-backup-external-secret.yaml
+++ b/k8s/bases/apps/umami/db-backup-external-secret.yaml
@@ -1,0 +1,29 @@
+# R2 credentials for umami-db's CNPG barmanObjectStore backup (postgres-cluster.yaml).
+# Projects the shared backup R2 key/secret from OpenBao (infrastructure/backup/r2 —
+# the same path Velero's velero-r2-credentials reads) into a Secret in the umami
+# namespace, where CNPG's backup s3Credentials must live (it can only reference a
+# Secret in the Cluster's own namespace). Replaces the previously-orphaned
+# `cnpg-r2-credentials` ExternalSecret that was created in cnpg-system and never
+# referenced by any Cluster.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: umami-db-backup-r2
+  namespace: umami
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: umami-db-backup-r2
+    creationPolicy: Owner
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: infrastructure/backup/r2
+        property: access_key_id
+    - secretKey: SECRET_ACCESS_KEY
+      remoteRef:
+        key: infrastructure/backup/r2
+        property: secret_access_key

--- a/k8s/bases/apps/umami/db-scheduled-backup.yaml
+++ b/k8s/bases/apps/umami/db-scheduled-backup.yaml
@@ -1,0 +1,18 @@
+# Daily base backup of umami-db to R2 via the cluster's barmanObjectStore
+# (postgres-cluster.yaml). Combined with continuous WAL archiving (auto-enabled
+# by barmanObjectStore), this gives point-in-time recovery within the 30d
+# retention window. `immediate: true` seeds the first backup as soon as this is
+# applied so the cluster is not left backup-less waiting for the first 03:00 tick.
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: umami-db-daily
+  namespace: umami
+spec:
+  # CNPG cron is 6-field (seconds first): 03:00 UTC daily.
+  schedule: "0 0 3 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: umami-db

--- a/k8s/bases/apps/umami/kustomization.yaml
+++ b/k8s/bases/apps/umami/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - postgres-cluster.yaml
   - db-superuser-pushsecret.yaml
   - db-rotated-external-secret.yaml
+  - db-backup-external-secret.yaml
+  - db-scheduled-backup.yaml
   - helm-repository.yaml
   - helm-release.yaml
   # httproute.yaml removed — Flagger generates and owns Umami's HTTPRoute from

--- a/k8s/bases/apps/umami/networkpolicy.yaml
+++ b/k8s/bases/apps/umami/networkpolicy.yaml
@@ -53,6 +53,14 @@ spec:
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: umami
+    # CNPG -> Cloudflare R2 (S3) for barmanObjectStore WAL archiving + base
+    # backups (postgres-cluster.yaml). Mirrors the velero allow-velero policy.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # Kube API (CNPG operator manages the cluster)
     - toEntities:
         - kube-apiserver

--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -78,6 +78,9 @@ spec:
         secretAccessKey:
           name: umami-db-backup-r2
           key: SECRET_ACCESS_KEY
+        region:
+          name: umami-db-backup-r2
+          key: REGION
       wal:
         compression: gzip
       data:

--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -57,3 +57,28 @@ spec:
       memory: 256Mi
     limits:
       memory: 512Mi
+  # Off-cluster DB backup to Cloudflare R2 (continuous WAL archiving + base
+  # backups, so PITR is possible). This is the in-tree barmanObjectStore — still
+  # supported on CNPG 1.29.x but deprecated in favour of the Barman Cloud Plugin;
+  # a future operator major (Renovate-gated to manual review) is the trigger to
+  # migrate. Credentials come from `umami-db-backup-r2` (db-backup-external-secret.yaml,
+  # OpenBao infrastructure/backup/r2 — the SAME R2 creds Velero uses); the daily
+  # base backup is driven by db-scheduled-backup.yaml. r2_* are Flux-substituted
+  # from variables-base (prod values; umami is prod-only). Egress to R2 is opened
+  # in networkpolicy.yaml.
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      destinationPath: s3://${r2_bucket}/cnpg/umami-db
+      endpointURL: ${r2_endpoint}
+      s3Credentials:
+        accessKeyId:
+          name: umami-db-backup-r2
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: umami-db-backup-r2
+          key: SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip

--- a/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
+++ b/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
@@ -30,26 +30,3 @@ spec:
       remoteRef:
         key: infrastructure/backup/r2
         property: secret_access_key
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: cnpg-r2-credentials
-  namespace: cnpg-system
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: openbao
-    kind: ClusterSecretStore
-  target:
-    name: cnpg-r2-credentials
-    creationPolicy: Owner
-  data:
-    - secretKey: ACCESS_KEY_ID
-      remoteRef:
-        key: infrastructure/backup/r2
-        property: access_key_id
-    - secretKey: SECRET_ACCESS_KEY
-      remoteRef:
-        key: infrastructure/backup/r2
-        property: secret_access_key

--- a/k8s/bases/infrastructure/vault-seed/push-secrets.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secrets.yaml
@@ -14,7 +14,11 @@ spec:
       kind: ClusterSecretStore
   selector:
     secret:
-      name: variables-base
+      # R2 backup credentials are per-environment and maintained in the
+      # cluster-scoped secret (variables-cluster), not the shared base. The
+      # base copy is a stale placeholder (a truncated 27-char access_key_id)
+      # that the BSL rejects with "access key has length 27, should be 32".
+      name: variables-cluster
   data:
     - match:
         secretKey: r2_access_key_id


### PR DESCRIPTION
## Context — verifying the R2 fix on `main`

Following up on the R2 backup outage. The fix on `main` (`fcbf7db9`) rotated `r2_secret_access_key` in **`variables-cluster`**, but the live `BackupStorageLocation` is still `Unavailable` with the unchanged error:

```
api error InvalidArgument: Credential access key has length 27, should be 32
```

## Root cause — the PushSecret reads the wrong secret

There are two SOPS secrets in `flux-system`, both carrying R2 keys:

| Secret | `r2_access_key_id` length | Maintained? |
|--------|---------------------------|-------------|
| `variables-base` (`k8s/bases/bootstrap`) | **27 chars** (truncated placeholder) | stale — last touched by the `variables/→bootstrap/` rename (#1684) |
| `variables-cluster` (`k8s/clusters/<env>/bootstrap`) | **32 chars** (correct) | yes — holds the real per-env creds + the freshly-rotated secret |

`seed-r2-credentials` seeds OpenBao (`infrastructure/backup/r2`) from **`variables-base`** — so the truncated 27-char `access_key_id` is what flows to Velero (and CNPG), and that's the `length 27` the BSL rejects. The error is about the **access key ID**, which the `main` fix didn't touch; the correct one has been sitting in `variables-cluster` all along.

## Fix

Point the `seed-r2-credentials` PushSecret selector at **`variables-cluster`**, where the real per-environment R2 credentials live. `seed-cloudflare` still reads `variables-base` (`cloudflare_api_token` is a genuinely shared infra credential — unaffected).

Once deployed, ESO re-pushes the correct creds to OpenBao → `velero-r2-credentials` / `cnpg-r2-credentials` refresh → the BSL re-validates. This also **unblocks CNPG-native R2 backups** (separate PR), which read the same OpenBao path.

## Validation

- `kubectl kustomize k8s/clusters/{local,prod}/` — both build.
- `ksail --config ksail.prod.yaml workload validate` — `providers/hetzner/infrastructure/vault-seed validated ✔` (the one failure, `providers/hetzner/infrastructure`, is the pre-existing Coroot CRD catalog-schema issue, unrelated).
- Rendered selector confirmed: `seed-r2-credentials → variables-cluster`; `seed-cloudflare → variables-base` (unchanged).
- Both `clusters/local` and `clusters/prod` `variables-cluster` carry `r2_access_key_id` + `r2_secret_access_key`, so the repoint is safe for CI and prod.

## Follow-up

The now-unused R2 keys in `variables-base-secret.enc.yaml` are a harmless redundant copy; they can be dropped in a future re-encrypt (requires the Age key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)