### PR TITLE
feat(umami): wire CNPG-native R2 backups for umami-db

### DIFF
--- a/k8s/bases/apps/umami/db-backup-external-secret.yaml
+++ b/k8s/bases/apps/umami/db-backup-external-secret.yaml
@@ -1,0 +1,29 @@
+# R2 credentials for umami-db's CNPG barmanObjectStore backup (postgres-cluster.yaml).
+# Projects the shared backup R2 key/secret from OpenBao (infrastructure/backup/r2 —
+# the same path Velero's velero-r2-credentials reads) into a Secret in the umami
+# namespace, where CNPG's backup s3Credentials must live (it can only reference a
+# Secret in the Cluster's own namespace). Replaces the previously-orphaned
+# `cnpg-r2-credentials` ExternalSecret that was created in cnpg-system and never
+# referenced by any Cluster.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: umami-db-backup-r2
+  namespace: umami
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: umami-db-backup-r2
+    creationPolicy: Owner
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: infrastructure/backup/r2
+        property: access_key_id
+    - secretKey: SECRET_ACCESS_KEY
+      remoteRef:
+        key: infrastructure/backup/r2
+        property: secret_access_key

--- a/k8s/bases/apps/umami/db-scheduled-backup.yaml
+++ b/k8s/bases/apps/umami/db-scheduled-backup.yaml
@@ -1,0 +1,18 @@
+# Daily base backup of umami-db to R2 via the cluster's barmanObjectStore
+# (postgres-cluster.yaml). Combined with continuous WAL archiving (auto-enabled
+# by barmanObjectStore), this gives point-in-time recovery within the 30d
+# retention window. `immediate: true` seeds the first backup as soon as this is
+# applied so the cluster is not left backup-less waiting for the first 03:00 tick.
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: umami-db-daily
+  namespace: umami
+spec:
+  # CNPG cron is 6-field (seconds first): 03:00 UTC daily.
+  schedule: "0 0 3 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: barmanObjectStore
+  cluster:
+    name: umami-db

--- a/k8s/bases/apps/umami/kustomization.yaml
+++ b/k8s/bases/apps/umami/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - postgres-cluster.yaml
   - db-superuser-pushsecret.yaml
   - db-rotated-external-secret.yaml
+  - db-backup-external-secret.yaml
+  - db-scheduled-backup.yaml
   - helm-repository.yaml
   - helm-release.yaml
   # httproute.yaml removed — Flagger generates and owns Umami's HTTPRoute from

--- a/k8s/bases/apps/umami/networkpolicy.yaml
+++ b/k8s/bases/apps/umami/networkpolicy.yaml
@@ -53,6 +53,14 @@ spec:
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: umami
+    # CNPG -> Cloudflare R2 (S3) for barmanObjectStore WAL archiving + base
+    # backups (postgres-cluster.yaml). Mirrors the velero allow-velero policy.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # Kube API (CNPG operator manages the cluster)
     - toEntities:
         - kube-apiserver

--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -57,3 +57,28 @@ spec:
       memory: 256Mi
     limits:
       memory: 512Mi
+  # Off-cluster DB backup to Cloudflare R2 (continuous WAL archiving + base
+  # backups, so PITR is possible). This is the in-tree barmanObjectStore — still
+  # supported on CNPG 1.29.x but deprecated in favour of the Barman Cloud Plugin;
+  # a future operator major (Renovate-gated to manual review) is the trigger to
+  # migrate. Credentials come from `umami-db-backup-r2` (db-backup-external-secret.yaml,
+  # OpenBao infrastructure/backup/r2 — the SAME R2 creds Velero uses); the daily
+  # base backup is driven by db-scheduled-backup.yaml. r2_* are Flux-substituted
+  # from variables-base (prod values; umami is prod-only). Egress to R2 is opened
+  # in networkpolicy.yaml.
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      destinationPath: s3://${r2_bucket}/cnpg/umami-db
+      endpointURL: ${r2_endpoint}
+      s3Credentials:
+        accessKeyId:
+          name: umami-db-backup-r2
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: umami-db-backup-r2
+          key: SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip

--- a/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
+++ b/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
@@ -30,26 +30,3 @@ spec:
       remoteRef:
         key: infrastructure/backup/r2
         property: secret_access_key
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: cnpg-r2-credentials
-  namespace: cnpg-system
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: openbao
-    kind: ClusterSecretStore
-  target:
-    name: cnpg-r2-credentials
-    creationPolicy: Owner
-  data:
-    - secretKey: ACCESS_KEY_ID
-      remoteRef:
-        key: infrastructure/backup/r2
-        property: access_key_id
-    - secretKey: SECRET_ACCESS_KEY
-      remoteRef:
-        key: infrastructure/backup/r2
-        property: secret_access_key


### PR DESCRIPTION
## Why

`umami-db` (the only **platform-owned** CNPG cluster — `wedding-db` / `ascoachingogvaner` are tenant-owned in their own repos) had **no `spec.backup`** at all. The prod database relied solely on Velero PVC backups (themselves broken until #1884), and the `cnpg-r2-credentials` ExternalSecret created for CNPG sat **unused in `cnpg-system`** — the wrong namespace, since CNPG `backup.s3Credentials` can only reference a Secret in the Cluster's own namespace. Net: the prod Umami DB had **zero working backups**.

## What

- **`spec.backup.barmanObjectStore`** on `umami-db` → `s3://${r2_bucket}/cnpg/umami-db` on Cloudflare R2: continuous WAL archiving + base backups (gzip), `retentionPolicy: 30d`. This gives PITR within the window.
- **`umami-db-backup-r2`** ExternalSecret in the `umami` namespace, sourced from OpenBao `infrastructure/backup/r2` (the same R2 creds Velero uses). Replaces the orphaned `cnpg-system/cnpg-r2-credentials` (removed in this PR).
- **`umami-db-daily`** ScheduledBackup — 03:00 UTC, `immediate: true` to seed the first backup on apply.
- **NetworkPolicy egress** to R2 (`world:443`), mirroring `allow-velero`. The umami namespace has a default-deny egress; without this rule WAL archiving is silently dropped.

`${r2_bucket}` / `${r2_endpoint}` are Flux-substituted from `variables-base` (prod values; umami is prod-only).

### In-tree vs plugin
In-tree `barmanObjectStore` is **deprecated on CNPG 1.29.x but still functional**, and it reuses the existing R2 credential path with zero new infrastructure. The Barman Cloud Plugin is the long-term replacement; the trigger to migrate is a CNPG operator **major** bump (Renovate-gated to manual review).

## ⚠️ Depends on #1884 — stacked

This reads the same OpenBao R2 path, so it needs the **corrected 32-char `access_key_id`** from #1884 to upload. It is **stacked on `claude/fix-r2-pushsecret-variables-cluster`** so the creds land first. Merging the backup config against the broken 27-char key would fail WAL archiving and pile up unarchived WAL on umami-db's 5 Gi volume. GitHub will retarget the base to `main` once #1884 merges.

## Validation

- `kubectl kustomize k8s/clusters/{local,prod}/` — both build.
- `ksail --config ksail.prod.yaml workload validate` → `bases/apps/umami ✔`, `providers/hetzner/apps ✔` (so `${r2_*}` substitute and the rendered CNPG backup schema is valid), `bases/infrastructure/external-secrets ✔` (dead-secret removal clean). The lone failure, `providers/hetzner/infrastructure`, is the pre-existing Coroot CRD catalog-schema issue, unrelated.

## Verify after merge (both PRs deployed)

```
kubectl -n umami get scheduledbackup,backup
kubectl -n umami get cluster umami-db -o jsonpath='{.status.conditions}'   # ContinuousArchiving = True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
