### PR TITLE
fix(backups): point R2 at the real bucket platform-backups

### DIFF
--- a/k8s/bases/bootstrap/variables-base-config-map.yaml
+++ b/k8s/bases/bootstrap/variables-base-config-map.yaml
@@ -11,7 +11,7 @@ data:
   # Shared bucket for Velero and CNPG backups across all clusters.
   # Velero / CNPG namespace themselves with per-env prefixes — set in
   # each clusters/<env>/bootstrap/variables-cluster-config-map.yaml.
-  r2_bucket: devantler-platform-backups
+  r2_bucket: platform-backups
   cloudflare_zone: devantler.tech
   r2_prefix_velero: velero
   r2_prefix_cnpg: cnpg


### PR DESCRIPTION
## Problem

Prod has **no working backups**, found during a live cluster investigation:

- Velero `BackupStorageLocation/default` is **`Unavailable`** with `rpc error: ... NoSuchBucket: The specified bucket does not exist`.
- `velero-daily-full` has been **FailedValidation every day** (Jun 2–8).
- The umami CNPG cluster `umami-db` has **`lastSuccessfulBackup: null`** — it has never successfully backed up.

## Root cause

The shared `r2_bucket` variable (in the non-encrypted [`k8s/bases/bootstrap/variables-base-config-map.yaml`](../blob/main/k8s/bases/bootstrap/variables-base-config-map.yaml), consumed by Velero's `${r2_bucket}` and umami's CNPG `s3://${r2_bucket}/cnpg/umami-db`) was set to **`devantler-platform-backups`**, which does not exist in the R2 account. The real bucket is **`platform-backups`** — the name already used by the `clusters/local` overlay and documented in [`docs/dr/velero-cnpg.md`](../blob/main/docs/dr/velero-cnpg.md).

The wrong value was latent because the R2 **credentials** were failing first; #1884 fixed the credentials, which finally let the request reach R2 and surface the missing bucket.

## Fix

Correct the value in the shared base ConfigMap so prod (Velero + CNPG) inherits the right bucket. `clusters/local` already overrides `r2_bucket` to `platform-backups`, so this is a no-op there.

```diff
-  r2_bucket: devantler-platform-backups
+  r2_bucket: platform-backups
```

## Validation

- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.
- `kubectl kustomize k8s/bases/bootstrap/` renders `r2_bucket: platform-backups`.
- `grep -rn devantler-platform-backups k8s docs` → no remaining references.

Once merged and reconciled, the `default` BSL should validate (Available) and the next `velero-daily-full` / CNPG backup should succeed. Worth confirming `firstRecoverabilityPoint` becomes non-null on `umami-db` after the next backup window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)