### PR TITLE
fix(talos): verify ksail-operator image against its own cosign identity

### DIFF
--- a/talos/cluster/image-verification.yaml
+++ b/talos/cluster/image-verification.yaml
@@ -7,13 +7,25 @@
 # Flux and the Kyverno admission layer never see (e.g. kubelet-managed static
 # pods, a compromised registry serving a tampered image).
 #
-# Scope: FIRST-PARTY images only (ghcr.io/devantler-tech/*). These are built,
-# pushed, and keyless-cosign-signed by the shared reusable workflow
+# Scope: FIRST-PARTY APP images, enumerated PER-REPO (deliberately NOT a
+# ghcr.io/devantler-tech/* wildcard — see below). These are built, pushed, and
+# keyless-cosign-signed by the shared reusable workflow
 # devantler-tech/reusable-workflows/.github/workflows/publish-app.yaml (it runs
 # `cosign sign` on BOTH the manifests artifact and the container image). That
 # is the SAME signing identity the apps' Flux OCIRepository verify blocks
-# already pin, so this adds no new trust root. Currently covers the wedding-app
-# and ascoachingogvaner container images running in prod.
+# already pin, so this adds no new trust root. Currently the wedding-app and
+# ascoachingogvaner container images running in prod.
+#
+# Why per-repo and NOT a ghcr.io/devantler-tech/* wildcard: that wildcard also
+# matches ghcr.io/devantler-tech/ksail — the ksail-operator image — which
+# ksail's own release pipeline does NOT cosign-sign. Since a rule fails CLOSED
+# for a matching-but-unverifiable image (the converse note below), the wildcard
+# pinned the operator in ImagePullBackOff ("no valid signature found: bundle
+# tag not found"). Enumerating per app keeps the operator (and any other
+# unsigned first-party tooling image) on the fail-open path. New signed app
+# images must be added here explicitly; an unlisted first-party container image
+# falls through to fail-open at the node layer, but is still cosign-verified at
+# the Flux OCIRepository + Kyverno layers.
 #
 # FAIL-OPEN by design: an image is verified only when it MATCHES a rule; an
 # image matching NO rule is pulled WITHOUT verification. So third-party chart
@@ -38,7 +50,11 @@
 apiVersion: v1alpha1
 kind: ImageVerificationConfig
 rules:
-  - image: ghcr.io/devantler-tech/*
+  - image: ghcr.io/devantler-tech/wedding-app*
+    keyless:
+      issuer: https://token.actions.githubusercontent.com
+      subjectRegex: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
+  - image: ghcr.io/devantler-tech/ascoachingogvaner*
     keyless:
       issuer: https://token.actions.githubusercontent.com
       subjectRegex: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$

--- a/talos/cluster/image-verification.yaml
+++ b/talos/cluster/image-verification.yaml
@@ -7,38 +7,28 @@
 # Flux and the Kyverno admission layer never see (e.g. kubelet-managed static
 # pods, a compromised registry serving a tampered image).
 #
-# Scope: FIRST-PARTY APP images, enumerated PER-REPO (deliberately NOT a
-# ghcr.io/devantler-tech/* wildcard — see below). These are built, pushed, and
-# keyless-cosign-signed by the shared reusable workflow
-# devantler-tech/reusable-workflows/.github/workflows/publish-app.yaml (it runs
-# `cosign sign` on BOTH the manifests artifact and the container image). That
-# is the SAME signing identity the apps' Flux OCIRepository verify blocks
-# already pin, so this adds no new trust root. Currently the wedding-app and
-# ascoachingogvaner container images running in prod.
+# Scope: FIRST-PARTY images (ghcr.io/devantler-tech/*). All are keyless-cosign
+# signed, but by TWO different signing identities, so they need two rules:
+#   1. ghcr.io/devantler-tech/ksail — the ksail-operator image — is signed by
+#      ksail's OWN release pipeline (devantler-tech/ksail .github/workflows/
+#      cd.yaml; see that repo's GoReleaser `docker_signs` step).
+#   2. the app images (wedding-app, ascoachingogvaner, …) are signed by the
+#      shared reusable workflow reusable-workflows/.github/workflows/
+#      publish-app.yaml — the SAME identity their Flux OCIRepository verify
+#      blocks already pin.
+# Talos evaluates rules in order, first match wins, so the specific ksail rule
+# MUST precede the ghcr.io/devantler-tech/* catch-all.
 #
-# Why per-repo and NOT a ghcr.io/devantler-tech/* wildcard: that wildcard also
-# matches ghcr.io/devantler-tech/ksail — the ksail-operator image — which
-# ksail's own release pipeline does NOT cosign-sign. Since a rule fails CLOSED
-# for a matching-but-unverifiable image (the converse note below), the wildcard
-# pinned the operator in ImagePullBackOff ("no valid signature found: bundle
-# tag not found"). Enumerating per app keeps the operator (and any other
-# unsigned first-party tooling image) on the fail-open path. New signed app
-# images must be added here explicitly; an unlisted first-party container image
-# falls through to fail-open at the node layer, but is still cosign-verified at
-# the Flux OCIRepository + Kyverno layers.
-#
-# FAIL-OPEN by design: an image is verified only when it MATCHES a rule; an
-# image matching NO rule is pulled WITHOUT verification. So third-party chart
-# images (Cilium, Longhorn, Coroot, registry.k8s.io control-plane images, …)
-# are unaffected — this is intentionally NOT a deny-all-unsigned control, and
-# there is deliberately no broad `deny:` catch-all. Note the converse: an image
-# that DOES match this rule but fails verification is blocked (ImagePullBackOff),
-# so the glob is kept to first-party images whose signing pipeline is known.
+# FAIL-OPEN by design for everything else: an image matching NO rule is pulled
+# WITHOUT verification, so third-party chart images (Cilium, Longhorn, Coroot,
+# registry.k8s.io control-plane images, …) are unaffected — this is
+# intentionally NOT a deny-all-unsigned control. The converse: an image that
+# DOES match a rule but fails verification is blocked (ImagePullBackOff).
 #
 # A rule over a system registry (e.g. registry.k8s.io/*, the canonical Talos
 # example) would gate control-plane/etcd image pulls — high blast radius on
 # this cluster given the manual-talosctl recovery path — so it is deliberately
-# omitted for now and can be added later once the first-party rule is proven.
+# omitted for now and can be added later once the first-party rules are proven.
 #
 # This does NOT satisfy kubescape C-0237 (see
 # k8s/bases/infrastructure/security-exceptions/image-verification.yaml): that
@@ -50,11 +40,17 @@
 apiVersion: v1alpha1
 kind: ImageVerificationConfig
 rules:
-  - image: ghcr.io/devantler-tech/wedding-app*
+  # ksail-operator image — signed by ksail's OWN release pipeline (cd.yaml),
+  # a different keyless identity than publish-app.yaml. MUST precede the
+  # catch-all below (first-match-wins). Requires ksail >= the first release
+  # that ships the GoReleaser docker_signs cosign step (devantler-tech/ksail
+  # #5165) AND the ksail-operator HelmRelease pinned to that signed image tag.
+  - image: ghcr.io/devantler-tech/ksail*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
-  - image: ghcr.io/devantler-tech/ascoachingogvaner*
+      subjectRegex: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
+  # First-party APP images signed by reusable-workflows/publish-app.yaml.
+  - image: ghcr.io/devantler-tech/*
     keyless:
       issuer: https://token.actions.githubusercontent.com
       subjectRegex: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$


### PR DESCRIPTION
## Problem (found via Coroot: `ksail-operator` reporting `instances 0/1`)

`ksail-operator` is **down** — `ImagePullBackOff`:

```
Failed to verify image "ghcr.io/devantler-tech/ksail:v7.36.0" with talos:
image verification failed: no valid signature found: bundle tag not found
```

The Talos `ImageVerificationConfig` rule `ghcr.io/devantler-tech/*` (added in #1819, intended for the `publish-app.yaml`-signed app images) also matches `ghcr.io/devantler-tech/ksail` — the operator image — which **wasn't being signed**. Since the rule fails *closed*, the operator was blocked.

## Fix — verify, don't fail-open

> ⏪ This PR was reworked. The first commit narrowed the wildcard so the unsigned image fell through to **fail-open** — a workaround. The second commit replaces that with the **proper fix**: keep verifying every first-party image, and verify the ksail image against its *own* signing identity.

The companion change **[devantler-tech/ksail#5165](https://github.com/devantler-tech/ksail/pull/5165)** makes ksail's release pipeline keyless-cosign-sign the operator image. This PR then:
- **restores** the `ghcr.io/devantler-tech/*` catch-all (publish-app.yaml identity) for the app images, and
- **adds a more-specific `ghcr.io/devantler-tech/ksail*` rule, ordered first** (Talos is first-match-wins), trusting ksail's `cd.yaml` keyless identity:

```yaml
rules:
  - image: ghcr.io/devantler-tech/ksail*          # ksail-operator, signed by ksail/cd.yaml
    keyless:
      issuer: https://token.actions.githubusercontent.com
      subjectRegex: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
  - image: ghcr.io/devantler-tech/*                # app images, signed by publish-app.yaml
    keyless:
      issuer: https://token.actions.githubusercontent.com
      subjectRegex: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
```

No fail-open; the operator image is genuinely verified.

## ⚠️ Depends on — do NOT merge/apply before both
1. **[devantler-tech/ksail#5165](https://github.com/devantler-tech/ksail/pull/5165)** merged **and a ksail release cut that signs the image** — current tags (incl. v7.36.0) are unsigned and will still fail closed.
2. The `ksail-operator` HelmRelease **pinned to that signed image tag**.

Applying before then leaves the operator in `ImagePullBackOff` (unchanged from today). And like all Talos machine-config, a maintainer must `talosctl patch mc` for live nodes — `ksail cluster update` doesn't push it.

## Validation
- YAML parses; `kind: ImageVerificationConfig`, 2 rules (ksail-specific first).
- Not a Kustomize manifest, so `ksail workload validate` / `kubectl kustomize` don't cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)