### PR TITLE
feat(longhorn): scale longhorn-ui to zero when idle via KEDA HTTP

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -59,7 +59,12 @@ data:
           loadBalancer:
             servers:
               - url: "http://opencost.opencost.svc.cluster.local:9090"
+        # Longhorn UI is KEDA HTTP scale-to-zero (like hubble-ui above), so this
+        # forwards to the KEDA interceptor rather than longhorn-frontend
+        # directly. The interceptor matches the Host (longhorn.${domain}, see
+        # the longhorn-ui HTTPScaledObject), scales longhorn-ui 0->1, then
+        # proxies to longhorn-frontend. Hetzner-only and inert on local.
         longhorn:
           loadBalancer:
             servers:
-              - url: "http://longhorn-frontend.longhorn-system.svc.cluster.local:80"
+              - url: "http://keda-add-ons-http-interceptor-proxy.keda.svc.cluster.local:8080"

--- a/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
@@ -88,6 +88,15 @@ spec:
         - ports:
             - port: "8081"
               protocol: TCP
+    # longhorn-ui (Hetzner-only; Service longhorn-frontend :80 -> pod :8000).
+    # Inert on local where longhorn-system has no pods.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: longhorn-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
     # DNS resolution
     - toEndpoints:
         - matchLabels:

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -95,6 +95,14 @@ data:
   longhorn_csi_attacher_replicas: "2"
   longhorn_csi_provisioner_replicas: "2"
   longhorn_csi_resizer_replicas: "2"
+  # The longhorn-ui (longhorn-frontend) is the read/write web dashboard only —
+  # it is NOT in the storage data path. Volume provisioning, attach/detach,
+  # replica rebuilds, CSI snapshots, and Velero backups are all driven by
+  # longhorn-manager, the CSI sidecars, and the instance-managers, none of
+  # which depend on the UI. Scale it to 0 to reclaim its pod; Longhorn stays
+  # fully manageable via CRDs/kubectl and GitOps. Re-enable the dashboard at
+  # longhorn.${domain} by setting this back to "1".
+  longhorn_ui_replicas: "0"
   # --- Non-essential services scaled to 0 ---
   # Origin CA issuer requests 1 CPU (50% of worker allocatable) for a simple
   # cert controller. Disabled until we actually need Cloudflare Origin certs.

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -95,13 +95,16 @@ data:
   longhorn_csi_attacher_replicas: "2"
   longhorn_csi_provisioner_replicas: "2"
   longhorn_csi_resizer_replicas: "2"
-  # The longhorn-ui (longhorn-frontend) is the read/write web dashboard only —
-  # it is NOT in the storage data path. Volume provisioning, attach/detach,
-  # replica rebuilds, CSI snapshots, and Velero backups are all driven by
-  # longhorn-manager, the CSI sidecars, and the instance-managers, none of
-  # which depend on the UI. Scale it to 0 to reclaim its pod; Longhorn stays
-  # fully manageable via CRDs/kubectl and GitOps. Re-enable the dashboard at
-  # longhorn.${domain} by setting this back to "1".
+  # The longhorn-ui (longhorn-frontend) is the web dashboard only — it is NOT in
+  # the storage data path (longhorn-manager, the CSI sidecars, and the
+  # instance-managers run the data plane and never touch the UI). It is wired for
+  # KEDA HTTP scale-to-zero like hubble-ui, so this is the INITIAL replica count
+  # only: the longhorn-ui HTTPScaledObject (providers/hetzner/infrastructure/
+  # http-scaled-objects/longhorn.yaml) owns /spec/replicas at runtime — held at 0
+  # while idle, scaled 0->1 on the first request to longhorn.${domain} (Gateway ->
+  # oauth2-proxy -> auth-proxy -> KEDA interceptor -> longhorn-ui), then back to 0
+  # after the scaledownPeriod. Start at 0 to avoid running the pod until first use.
+  # (Flux drift detection ignores Deployment /spec/replicas, so it won't fight KEDA.)
   longhorn_ui_replicas: "0"
   # --- Non-essential services scaled to 0 ---
   # Origin CA issuer requests 1 CPU (50% of worker allocatable) for a simple

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/networkpolicy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/networkpolicy.yaml
@@ -19,12 +19,16 @@ spec:
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: longhorn-system
-    # Longhorn UI reached via auth-proxy (oauth2-proxy SSO) after
-    # authentication. longhorn-frontend forwards to the longhorn-ui pod, which
-    # serves on container port 8000 (Service longhorn-frontend: 80 -> 8000).
+    # Longhorn UI is KEDA HTTP scale-to-zero, so the direct client is the KEDA
+    # interceptor, not auth-proxy: Gateway -> oauth2-proxy -> auth-proxy ->
+    # interceptor -> longhorn-frontend. longhorn-frontend forwards to the
+    # longhorn-ui pod on container port 8000 (Service longhorn-frontend: 80 ->
+    # 8000). Mirrors allow-hubble-ui; mutual auth (require-mutual-auth) is
+    # applied cluster-wide, so only the L3/L4 allow is needed here.
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+            k8s:io.kubernetes.pod.namespace: keda
+            app.kubernetes.io/component: interceptor
       toPorts:
         - ports:
             - port: "8000"

--- a/k8s/providers/hetzner/infrastructure/http-scaled-objects/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/http-scaled-objects/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - longhorn.yaml

--- a/k8s/providers/hetzner/infrastructure/http-scaled-objects/longhorn.yaml
+++ b/k8s/providers/hetzner/infrastructure/http-scaled-objects/longhorn.yaml
@@ -1,0 +1,39 @@
+# Scale the Longhorn UI to zero when idle via the KEDA HTTP add-on — the same
+# pattern hubble-ui uses (k8s/bases/infrastructure/http-scaled-objects/
+# hubble-ui.yaml). The longhorn-ui is the web dashboard only and is not in the
+# storage data path, so parking it at 0 between visits costs nothing while the
+# data plane (longhorn-manager, CSI sidecars, instance-managers) keeps running.
+#
+# Traffic path on a cold start: Gateway -> oauth2-proxy (SSO) -> auth-proxy
+# (Host fan-out, repointed to the interceptor in the auth-proxy config-map) ->
+# KEDA interceptor (holds the request, scales longhorn-ui 0->1) ->
+# longhorn-frontend Service (:80 -> pod :8000). The interceptor matches on the
+# Host header, so `hosts` must equal the public hostname.
+#
+# Hetzner-only: Longhorn is deployed solely on prod, so this lives in the
+# hetzner overlay rather than bases/ (longhorn-system does not exist on local).
+# It sits in the `infrastructure` layer (not `infrastructure/controllers/`) so
+# the http.keda.sh CRD shipped by the keda-http-add-on HelmRelease is
+# established first.
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: longhorn-ui
+  namespace: longhorn-system
+spec:
+  hosts:
+    - longhorn.${domain}
+  scaleTargetRef:
+    name: longhorn-ui
+    service: longhorn-frontend
+    port: 80
+  replicas:
+    min: 0
+    max: 1 # Single-pod admin UI; one replica is plenty and keeps it cheap.
+  scaledownPeriod: 300
+  scalingMetric:
+    requestRate:
+      granularity: 1s
+      targetValue: 100
+      window: 1m

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -22,6 +22,11 @@ resources:
   # are established first — see volume-snapshot-classes/longhorn.yaml. (hcloud
   # block storage has no snapshot support, so openbao stays on FSB.)
   - volume-snapshot-classes/
+  # Prod-only KEDA HTTP scale-to-zero for the Longhorn UI. Kept in this
+  # `infrastructure` layer (not `infrastructure/controllers/`) so the
+  # http.keda.sh CRD shipped by the keda-http-add-on HelmRelease is established
+  # first. longhorn-system is Hetzner-only, so this can't live in bases/.
+  - http-scaled-objects/
 components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — covers the
   # opencost HelmRelease in this layer. See


### PR DESCRIPTION
## What

Wire the Longhorn UI (`longhorn-ui` / `longhorn-frontend`) for **KEDA HTTP scale-to-zero** — idle → 0 replicas, scale 0→1 on the first request to `longhorn.${domain}`, back to 0 after the `scaledownPeriod`. This is the same pattern `hubble-ui` already uses behind the identical SSO chain.

## Why it's safe

The Longhorn UI is the web dashboard **only** — it is **not** in the storage data path. The data plane (`longhorn-manager`, the CSI sidecars, the instance-managers) runs independently and never touches the UI, so parking it at zero between visits costs nothing operationally. Volume provisioning, attach/detach, replica rebuilds, CSI snapshots, and Velero backups all continue regardless of UI replica count.

## How it works

Cold-start request path:

```
Gateway → oauth2-proxy (SSO) → auth-proxy (Host fan-out) → KEDA interceptor → longhorn-frontend (:80 → pod :8000)
```

The interceptor holds the request, scales `longhorn-ui` 0→1, then proxies to the backend.

## Changes

- **`http-scaled-objects/longhorn.yaml`** (new, hetzner-only) — `HTTPScaledObject` (min 0 / max 1) targeting the `longhorn-ui` Deployment via the `longhorn-frontend` Service. Placed in the hetzner `infrastructure` layer so the `http.keda.sh` CRD (shipped by `keda-http-add-on` in the controllers layer) exists first; `longhorn-system` is Hetzner-only so it can't live in `bases/`.
- **auth-proxy config-map** — repoint the `longhorn` router to `keda-add-ons-http-interceptor-proxy.keda:8080` (was `longhorn-frontend` directly). Inert on local (no HTTPRoute sends `longhorn.${domain}` there).
- **NetworkPolicy** — `allow-longhorn` ingress now allows the KEDA interceptor → `longhorn-ui:8000` (replacing the direct oauth2-proxy rule); `allow-keda` egress now allows → `longhorn-system:8000`. Mutual auth (`require-mutual-auth`) is applied cluster-wide, so only the L3/L4 allow is needed — same as `allow-hubble-ui`.
- **`longhorn_ui_replicas: "0"`** — kept as the *initial* value; KEDA owns `/spec/replicas` at runtime. Flux drift detection already ignores Deployment `/spec/replicas`, so it won't fight KEDA.

## Consequences

- First visit after idle incurs a brief cold-start while `longhorn-ui` (a small nginx static-server + proxy) starts; `longhorn-manager` is always up, so the dashboard loads once the pod is ready.
- The Homepage "Storage → Longhorn" card will show offline while idle (cosmetic), same as the other KEDA scale-to-zero UIs.

## Validation

- `kubectl kustomize k8s/clusters/{prod,local}/` ✅ build
- `kubectl kustomize k8s/providers/hetzner/infrastructure/` ✅ renders the `longhorn-ui` HTTPScaledObject in `longhorn-system`
- `ksail --config ksail.prod.yaml workload validate` → `✔ providers/hetzner/infrastructure/http-scaled-objects validated`, plus `✔ ...auth-proxy`, `✔ ...keda`, `✔ ...longhorn`. The one unrelated `✗` is the pre-existing `coroot.com/v1 notificationIntegrations` stale-catalog schema failure, untouched here.
- `ksail workload validate` (local) → all 298 files validated ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)