### PR TITLE
fix(opencost): pin Homepage pod-selector to survive Flagger rename

### DIFF
--- a/k8s/bases/infrastructure/opencost/httproute.yaml
+++ b/k8s/bases/infrastructure/opencost/httproute.yaml
@@ -12,6 +12,19 @@ metadata:
     gethomepage.dev/description: Kubernetes cost allocation and FinOps.
     gethomepage.dev/group: Observability
     gethomepage.dev/icon: opencost.png
+    # Status dot: Homepage derives health from the readiness of pods matching
+    # `gethomepage.dev/pod-selector`. With no selector it defaults to
+    # `app.kubernetes.io/name=<route-name>`, i.e. `app.kubernetes.io/name=opencost`,
+    # which the OpenCost chart used to satisfy directly. But OpenCost is now a
+    # Flagger Canary (infrastructure/flagger/canary-opencost.yaml): the running
+    # pods belong to the generated `opencost-primary` Deployment, and Flagger's
+    # default --selector-labels (app,name,app.kubernetes.io/name) rewrites
+    # `app.kubernetes.io/name` to `opencost-primary` on it — so the default
+    # selector matches zero pods and the card renders offline even though OpenCost
+    # is healthy (it never scales to zero). Key on the stable
+    # `app.kubernetes.io/instance` label instead, which Flagger leaves intact on
+    # both the primary and canary pods (same fix as the Umami canary).
+    gethomepage.dev/pod-selector: app.kubernetes.io/instance=opencost
 spec:
   parentRefs:
     - name: platform


### PR DESCRIPTION
## Problem

The **OpenCost** tile on the Homepage dashboard renders **offline** 24/7, even though OpenCost is healthy and never scales to zero.

## Root cause

Homepage derives a tile's status dot from the readiness of pods matching `gethomepage.dev/pod-selector`. With no selector it defaults to `app.kubernetes.io/name=<route-name>`, i.e. `app.kubernetes.io/name=opencost`. The OpenCost chart sets exactly that label on its pods, which is why OpenCost was historically the one route that worked *without* an explicit selector (it was the "control").

OpenCost is now managed by a **Flagger Canary** ([`canary-opencost.yaml`](k8s/bases/infrastructure/flagger/canary-opencost.yaml)), which is wired into **both** the docker and hetzner overlays via `bases/infrastructure/flagger/`. In a Flagger blue/green rollout the running pods belong to the generated `opencost-primary` Deployment, and Flagger's default `--selector-labels` (`app,name,app.kubernetes.io/name`) **rewrites `app.kubernetes.io/name` to `opencost-primary`** on it. So Homepage's default selector now matches zero pods → permanent offline dot.

This is the same failure mode the **Umami** canary already documents and works around.

## Fix

Pin an explicit selector on the OpenCost HTTPRoute keyed on the stable label Flagger leaves **intact** on both primary and canary pods:

\`\`\`yaml
gethomepage.dev/pod-selector: app.kubernetes.io/instance=opencost
\`\`\`

This works in every environment regardless of whether Flagger is mid-rollout (the OpenCost chart sets `app.kubernetes.io/instance=opencost` on the base Deployment too, so it also matches if the canary is ever absent).

## Validation

- `kubectl kustomize k8s/providers/docker/infrastructure/` — builds, annotation renders
- `kubectl kustomize k8s/providers/hetzner/infrastructure/` — builds, annotation renders
- `ksail workload validate` — **297 files validated** ✔