### PR TITLE
feat(flux-operator): scale the Flux UI to zero via a standalone web release

### DIFF
--- a/k8s/bases/infrastructure/controllers/flux-operator/helm-release-web.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/helm-release-web.yaml
@@ -1,0 +1,81 @@
+---
+# The Flux Status web UI, split out of the flux-operator release as a
+# standalone web-server-only deployment (web.serverOnly). This is the half of
+# the chart that carries no controller responsibilities, so — unlike the
+# always-on operator/reconciler — it is safe to scale to zero. It is fronted by
+# the KEDA HTTP add-on (see ../../http-scaled-objects/flux-operator-web.yaml),
+# so it idles down to 0 replicas and cold-starts on the next request to
+# flux.${domain}.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flux-operator-web
+  namespace: flux-system
+  labels:
+    helm.toolkit.fluxcd.io/helm-test: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  dependsOn:
+    # CRDs and the cluster-admin/aggregation RBAC are owned by the operator
+    # release (installCRDs is off here). Ordering the install AFTER the operator
+    # has turned its own web off also hands the flux-web-user/flux-web-admin
+    # ClusterRoles over to this release without a Helm ownership conflict.
+    - name: flux-operator
+  chart:
+    spec:
+      chart: flux-operator
+      version: 0.50.0
+      sourceRef:
+        kind: HelmRepository
+        name: flux-operator
+  interval: 10m0s
+  timeout: 10m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+      remediateLastFailure: true
+  values:
+    # Distinct name so all label selectors (and the homepage pod-selector)
+    # separate the web pods from the operator pods.
+    nameOverride: flux-operator-web
+    fullnameOverride: flux-operator-web
+    # CRDs are installed and owned by the flux-operator release.
+    installCRDs: false
+    web:
+      enabled: true
+      # Run as a UI-only deployment with no reconciler (--web-server-only). This
+      # drops the operator's cluster-admin binding and the FluxInstance
+      # reconcile loop, leaving a stateless front end that is safe to scale to
+      # zero.
+      serverOnly: true
+      # The web UI is reached via the KEDA interceptor and guarded by the repo's
+      # CiliumNetworkPolicy (allow-flux), so skip the chart's permissive
+      # "allow 9080 from all namespaces" plain NetworkPolicy.
+      networkPolicy:
+        create: false
+      # Create the flux-web-user / flux-web-admin standard roles here (the
+      # operator release no longer does, since its web is disabled). The
+      # flux-web-admins ClusterRoleBinding binds devantler-tech:admins to these.
+      rbac:
+        createRoles: true
+      config:
+        baseURL: https://flux.${domain}
+        authentication:
+          type: OAuth2
+          oauth2:
+            provider: OIDC
+            clientID: flux-web
+            clientSecret: ${flux_web_client_secret}
+            issuerURL: https://dex.${domain}
+            scopes:
+              - openid
+              - profile
+              - email
+              - groups
+              - offline_access
+            impersonation:
+              username: "claims.email"
+              groups: "has(claims.groups) ? claims.groups : []"

--- a/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
@@ -27,23 +27,9 @@ spec:
       remediateLastFailure: true
   values:
     web:
-      config:
-        baseURL: https://flux.${domain}
-        authentication:
-          type: OAuth2
-          oauth2:
-            provider: OIDC
-            clientID: flux-web
-            clientSecret: ${flux_web_client_secret}
-            issuerURL: https://dex.${domain}
-            scopes:
-              - openid
-              - profile
-              - email
-              - groups
-              - offline_access
-            impersonation:
-              username: "claims.email"
-              groups: "has(claims.groups) ? claims.groups : []"
-      rbac:
-        createRoles: true
+      # The Flux Status web UI now runs as the standalone `flux-operator-web`
+      # release (web.serverOnly) so it can scale to zero via the KEDA HTTP
+      # add-on without taking the reconciler down with it. This release is the
+      # operator/reconciler only — it must stay running at all times, so it is
+      # deliberately NOT a scale-to-zero target. See helm-release-web.yaml.
+      enabled: false

--- a/k8s/bases/infrastructure/controllers/flux-operator/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/httproute.yaml
@@ -10,7 +10,9 @@ metadata:
     gethomepage.dev/group: Kubernetes
     gethomepage.dev/icon: flux-cd
     gethomepage.dev/href: https://flux.${domain}
-    gethomepage.dev/pod-selector: app.kubernetes.io/name=flux-operator
+    # Targets the standalone web UI pods, not the always-on operator, so the
+    # status dot reflects the UI's real (scale-to-zero) availability.
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=flux-operator-web
 spec:
   parentRefs:
     - name: platform
@@ -19,9 +21,13 @@ spec:
   hostnames:
     - flux.${domain}
   rules:
+    # Route through the KEDA HTTP interceptor so the flux-operator-web
+    # deployment can scale to zero and cold-start on demand
+    # (see ../../http-scaled-objects/flux-operator-web.yaml).
     - backendRefs:
-        - name: flux-operator
-          port: 9080
+        - name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
+          port: 8080
       filters:
         - type: ResponseHeaderModifier
           responseHeaderModifier:

--- a/k8s/bases/infrastructure/controllers/flux-operator/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - helm-release-web.yaml
   - helm-repository.yaml
   - httproute.yaml
   - networkpolicy.yaml

--- a/k8s/bases/infrastructure/controllers/flux-operator/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/networkpolicy.yaml
@@ -6,9 +6,12 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    # Gateway ingress for flux-web UI
-    - fromEntities:
-        - ingress
+    # flux-operator-web UI: the cold-start path is Gateway -> KEDA interceptor
+    # -> flux-operator-web:9080, so the client reaching :9080 is the interceptor
+    # pod in the keda namespace, not the reserved "ingress" identity.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: keda
       toPorts:
         - ports:
             - port: "9080"

--- a/k8s/bases/infrastructure/controllers/keda-http-add-on/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/keda-http-add-on/reference-grant.yaml
@@ -14,6 +14,9 @@ spec:
       namespace: fleetdm
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
+      namespace: flux-system
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
       namespace: headlamp
     - group: gateway.networking.k8s.io
       kind: HTTPRoute

--- a/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
@@ -88,6 +88,13 @@ spec:
         - ports:
             - port: "8081"
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: flux-system
+      toPorts:
+        - ports:
+            - port: "9080"
+              protocol: TCP
     # DNS resolution
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/http-scaled-objects/flux-operator-web.yaml
+++ b/k8s/bases/infrastructure/http-scaled-objects/flux-operator-web.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: flux-operator-web
+  namespace: flux-system
+spec:
+  hosts:
+    - flux.${domain}
+  scaleTargetRef:
+    name: flux-operator-web
+    service: flux-operator-web
+    port: 9080
+  replicas:
+    min: 0
+    max: 1 # Low-traffic admin UI with server-side OIDC sessions; pin to 1 so live status streams don't bounce across replicas.
+  scaledownPeriod: 300
+  scalingMetric:
+    requestRate:
+      granularity: 1s
+      targetValue: 100
+      window: 1m

--- a/k8s/bases/infrastructure/http-scaled-objects/kustomization.yaml
+++ b/k8s/bases/infrastructure/http-scaled-objects/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - flux-operator-web.yaml
   - hubble-ui.yaml

--- a/k8s/providers/docker/infrastructure/controllers/flux-operator/patches/helm-release-web-patch.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/flux-operator/patches/helm-release-web-patch.yaml
@@ -2,13 +2,15 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: flux-operator
+  name: flux-operator-web
   namespace: flux-system
 spec:
   values:
-    # The platform CA bundle is mounted so the operator trusts the local
-    # registry / sources over the self-signed platform CA. (The web UI's
-    # insecure-OIDC override moved to flux-operator-web's patch.)
+    web:
+      config:
+        # Local Dex is fronted by the self-signed platform CA; skip OIDC issuer
+        # TLS verification for the Docker/CI provider only.
+        insecure: true
     extraVolumes:
       - name: platform-ca
         configMap:

--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -30,6 +30,11 @@ patches:
     path: flux-operator/patches/helm-release-patch.yaml
   - target:
       kind: HelmRelease
+      name: flux-operator-web
+      namespace: flux-system
+    path: flux-operator/patches/helm-release-web-patch.yaml
+  - target:
+      kind: HelmRelease
       name: kubescape
       namespace: kubescape
     path: kubescape/patches/helm-release-patch.yaml


### PR DESCRIPTION
## Why

The "Flux Operator UI" is **not** a separate workload — in the `flux-operator` chart it's served in-process by the operator's `manager` container (port 9080), gated by `web.enabled`. So "scaling the UI to zero" could only mean scaling the always-on, `system-cluster-critical` reconciler Deployment to zero, which is not safe (the operator only running when someone has the web page open).

This implements the safe path: split the UI into its own **web-server-only** deployment that carries no controller duties, then put *that* behind the KEDA HTTP add-on so it idles to zero like the other rarely-used UIs (whoami, hubble-ui, …).

## What

- **Operator release** (`flux-operator`): `web.enabled: false` — operator/reconciler only, always on. Keeps `cluster-admin` + the FluxInstance reconcile loop; its Service drops port 9080.
- **New `flux-operator-web` release**: `web.serverOnly: true` (`--web-server-only`), `installCRDs: false`, `dependsOn` the operator. Reuses the operator's CRDs and cleanly takes over the `flux-web-user`/`flux-web-admin` ClusterRoles. No `cluster-admin`; impersonation runs off the chart's `-view` role. Carries the OIDC (`flux-web` → Dex) config.
- **Routing**: `flux-web` HTTPRoute repointed from `flux-operator:9080` → the KEDA interceptor (`keda-add-ons-http-interceptor-proxy:8080`). Homepage `pod-selector` now targets `app.kubernetes.io/name=flux-operator-web`, so the status dot reflects the UI's real availability rather than the always-up operator.
- **Scale-to-zero**: `HTTPScaledObject` (`min: 0`, `max: 1`, `scaledownPeriod: 300`) in the `infrastructure` layer. `max: 1` because the UI holds server-side OIDC sessions / live status streams. Drift detection already ignores `/spec/replicas`, and the rendered Deployment has no `replicas` field, so Flux and KEDA don't fight.
- **NetworkPolicy / refs**: `allow-flux` accepts `:9080` from the keda namespace (the interceptor, not the `ingress` entity); `allow-keda` egresses to `flux-system:9080`; the interceptor `ReferenceGrant` is extended to `flux-system`.
- **Docker provider**: the local-TLS override (insecure OIDC issuer verification + platform-CA bundle) moves onto the web release, since it is now the OIDC client. The operator keeps the platform-CA bundle for registry/source TLS.

## Validation

- `kubectl kustomize` builds green for both clusters and all four provider overlays (docker/hetzner × controllers/infrastructure).
- `ksail workload validate` (local): **299 files validated**, 0 errors.
- `ksail --config ksail.prod.yaml workload validate`: only failure is the **pre-existing** Coroot stale-catalog schema issue (`notificationIntegrations not allowed` on `coroot.com/v1`), unrelated to this change.
- `helm template` of both releases confirms: web release → `--web-server-only`, 9080 Service, distinct `flux-operator-web` labels, no `replicas` field, no `cluster-admin`, OIDC config secret + standard roles present; operator release → metrics-only on 8080, keeps `cluster-admin`, no web roles/secret.

## Behavioural note

On the existing prod cluster this is a cutover: the operator upgrade drops the in-pod web first, then the web release installs and the route repoints — expect a brief Flux UI blip during reconciliation. First hit after idle pays a cold-start (interceptor buffers the request while scaling 0→1); the OIDC redirect to Dex completes once the pod is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)