### PR TITLE
fix(hetzner): bump baseline workers cx33→cx43 for memory headroom

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -125,7 +125,17 @@ spec:
       # maxNodesTotal <= serverLimit (10 <= 10). See the autoscaler block.
       serverLimit: 10
       controlPlaneServerType: cx33
-      workerServerType: cx33
+      # Baseline workers on cx43 (8c/16G) rather than cx33 (4c/8G). These 3
+      # static workers carry the platform's full memory footprint plus the
+      # ~2 GB/node fixed per-node agent tax (Cilium, Longhorn, coroot/kubescape
+      # node-agents). On 8 GB nodes that tax + VPA's peak-sized (correct,
+      # OOM-safe) memory requests saturated node *requests* to ~99% while real
+      # usage sat ~50%, leaving no reschedule headroom and forcing ~2-3m
+      # autoscaler cold-boots on every reschedule (the page-timeout flap). 16 GB
+      # workers amortize the fixed tax over more capacity and let VPA apply its
+      # requests without eviction churn. Control planes stay cx33 (their load
+      # is steady and well within 8 GB).
+      workerServerType: cx43
       location: fsn1
       networkCidr: 10.0.0.0/16
       placementGroupStrategy: Spread


### PR DESCRIPTION
## What

Bump the Hetzner **baseline worker** server type `cx33 → cx43` (8 vCPU / 16 GB) in `ksail.prod.yaml`. Control planes stay `cx33`; node counts and `maxNodesTotal`/`serverLimit` are unchanged.

## Why

Investigated a report of homepage/coroot pages loading slowly and intermittently timing out. Root cause (confirmed on the live cluster, read-only):

- The 3 static workers run the platform's full memory footprint **plus a fixed ~2 GB/node per-node agent tax** (Cilium, Longhorn, coroot/kubescape node-agents). On 8 GB cx33 nodes that tax is ~27% of the node.
- VPA sizes memory requests to each workload's **peak + margin** (correct and OOM-safe — memory is non-compressible). Summed, that saturated node **requests to ~99%** while real **usage sat ~50%**.
- With zero reschedule headroom, any pod that moved went `Unschedulable` → the autoscaler had to **cold-boot a fresh Hetzner node (~2-3 min)**. During that window the single-replica UIs (`homepage`, `coroot-coroot`) went fully down and the shared SSO proxies (`auth-proxy`/`oauth2-proxy`) ran degraded → multiple pages slow/timeout at once.

This is a **capacity** issue, not a right-sizing bug — VPA was actually trying to grow memory and being blocked by full nodes (`ResizeDeferred: OutOfmemory`). The mature fix for "use the node fully before autoscaling" is **fewer/bigger nodes** (amortize the fixed per-node tax, reduce fragmentation, statistical multiplexing), not under-requesting memory.

cx43 doubles baseline capacity **24 GB → 48 GB**, dropping worker requests from ~99% to ~45% and cutting the per-node agent tax from ~27% to ~13% of a node.

It was **not** CPU throttling (measured ~0% across the path) and **not** cold-start (these apps don't scale to zero).

## Reviewer notes / apply caveats

⚠️ **Merging this triggers a prod `cluster update` via the merge queue** (`ci.yaml` on `merge_group`). Treat the merge as the go-signal for the node change — keep this a draft until ready.

1. **Longhorn storage nodes — replace ONE at a time.** These workers are the only Longhorn storage nodes (3 nodes / 3 replicas). Recreating a worker destroys its replicas; drain/replace worker-1, wait for Longhorn to rebuild to 3 healthy replicas, then worker-2, then worker-3. Never drop below 2 healthy replicas.
2. **Verify `ksail cluster update` actually rolls a server-*type* change.** KSail's update diff has historically covered only count/version/ISO — a `workerServerType` change on existing static workers may be a no-op, requiring manual node replacement.
3. **Capacity/location:** primary stays `fsn1`; `hel1` is already in `fallbackLocations` (+`placementGroupFallbackToNone`), covering current cx43 availability in Helsinki. Same `eu-central` zone, so a cross-DC fallback works with a small latency cost.
4. **Cost:** ~+€21/mo (3× cx33 ≈ €8.11 → 3× cx43 ≈ €14.99).
5. No `k8s/` changes — auto-vpa ceilings (6Gi/3CPU Deployment, 1Gi DaemonSet) still fit cx43.

## Validation

`ksail.prod.yaml` re-parsed clean; only `spec.provider.hetzner.workerServerType` changed (single scalar + explanatory comment). No manifest/Kustomize changes, so overlay builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)