### PR TITLE
fix(cnpg): run umami-db HA so its PDB stops blocking eviction

### DIFF
--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -14,7 +14,18 @@ metadata:
   name: umami-db
   namespace: umami
 spec:
-  instances: 1
+  # Run 3 instances (1 primary + 2 streaming replicas) for high availability.
+  # A single-instance Cluster makes CNPG create a `<cluster>-primary`
+  # PodDisruptionBudget with minAvailable=1 on the only pod, which BLOCKS every
+  # voluntary eviction — a node drain (Talos roll, autoscaler scale-down) hangs
+  # forever, and an involuntary node loss takes the database offline until the
+  # pod reschedules. With >=2 instances CNPG drains a node by promoting a replica
+  # (switchover) and sets the replica PDB to minAvailable=instances-1, so drains
+  # proceed one pod at a time and the database survives any single node going
+  # away. Three lands one instance on each of the 3 static Longhorn storage
+  # workers via CNPG's default (preferred) pod anti-affinity, keeping a
+  # primary+replica quorum even while one node is under maintenance.
+  instances: 3
   # Expose the postgres superuser so OpenBao's Database secrets engine has a
   # stable admin to rotate the `umami` application role's password (the engine
   # cannot rotate a role using that same role's credentials, so it needs a

--- a/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
@@ -5,6 +5,16 @@ metadata:
   namespace: wedding-app
 spec:
   patches:
+    # The wedding-db CNPG Cluster ships from the tenant's OCI artifact as a
+    # single instance. Patch it to longhorn storage AND to 3 instances (1
+    # primary + 2 replicas) for high availability: a single-instance Cluster
+    # gets a `<cluster>-primary` PodDisruptionBudget with minAvailable=1 on the
+    # sole pod, which blocks every voluntary eviction (a node drain during a
+    # Talos roll or autoscaler scale-down hangs) and drops the database on any
+    # node loss. With 3 instances CNPG promotes a replica to drain a node and
+    # sets the replica PDB to minAvailable=instances-1, so drains proceed and
+    # the database survives a node shutdown. The 3 instances spread one per
+    # static Longhorn storage worker via CNPG's default pod anti-affinity.
     - target:
         group: postgresql.cnpg.io
         kind: Cluster
@@ -15,6 +25,7 @@ spec:
         metadata:
           name: wedding-db
         spec:
+          instances: 3
           storage:
             storageClass: longhorn
     - target:

--- a/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
@@ -5,16 +5,11 @@ metadata:
   namespace: wedding-app
 spec:
   patches:
-    # The wedding-db CNPG Cluster ships from the tenant's OCI artifact as a
-    # single instance. Patch it to longhorn storage AND to 3 instances (1
-    # primary + 2 replicas) for high availability: a single-instance Cluster
-    # gets a `<cluster>-primary` PodDisruptionBudget with minAvailable=1 on the
-    # sole pod, which blocks every voluntary eviction (a node drain during a
-    # Talos roll or autoscaler scale-down hangs) and drops the database on any
-    # node loss. With 3 instances CNPG promotes a replica to drain a node and
-    # sets the replica PDB to minAvailable=instances-1, so drains proceed and
-    # the database survives a node shutdown. The 3 instances spread one per
-    # static Longhorn storage worker via CNPG's default pod anti-affinity.
+    # storageClass is a platform-specific override: the wedding-app OCI artifact
+    # is environment-agnostic and must not hardcode Hetzner's longhorn class.
+    # HA (spec.instances: 3, for the PDB / node-drain reasons documented on the
+    # umami-db Cluster) is owned by the wedding-app source repo, so it is
+    # deliberately NOT patched here.
     - target:
         group: postgresql.cnpg.io
         kind: Cluster
@@ -25,7 +20,6 @@ spec:
         metadata:
           name: wedding-db
         spec:
-          instances: 3
           storage:
             storageClass: longhorn
     - target:


### PR DESCRIPTION
## Problem

`wedding-db-1` and `umami-db-1` were single-instance CloudNativePG Clusters. For a single instance, CNPG creates a `<cluster>-primary` PodDisruptionBudget with `minAvailable: 1` on the sole pod, which **blocks every voluntary eviction**:

- a node drain (Talos roll, autoscaler scale-down) hangs forever, and
- an involuntary node loss takes the database offline until the pod reschedules.

## Fix (durable: HA)

Run the databases with **3 instances** (1 primary + 2 streaming replicas). With ≥2 instances CNPG drains a node by promoting a replica (switchover) and sets the replica PDB to `minAvailable: instances-1`, so drains proceed one pod at a time and the database survives any single node going away. Three instances land one per static Longhorn storage worker via CNPG's default (preferred) pod anti-affinity, keeping a primary+replica quorum even while one node is under maintenance.

- **umami-db** — `spec.instances` 1 → 3 in the base Cluster (`k8s/bases/apps/umami/postgres-cluster.yaml`; prod-only app, excluded from the docker overlay).
- **wedding-db** — its Cluster ships from the wedding-app OCI artifact, and **that repo now sets `spec.instances: 3` directly**, so the platform no longer patches it. The hetzner-overlay patch keeps only the `storageClass: longhorn` override (a Hetzner-specific concern the environment-agnostic tenant artifact must not hardcode).

The OpenBao-managed `umami` role password is unaffected: the Cluster already declares `managed.roles` with no `passwordSecret`, so a switchover never re-applies/clobbers the rotated password.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` build clean.
- `kubectl kustomize k8s/providers/hetzner/apps/` renders `instances: 3` on the umami-db Cluster; the wedding-app Flux Kustomization patch carries only `storageClass: longhorn`.
- `ksail --config ksail.prod.yaml workload validate` → `providers/hetzner/apps validated ✔`. The only `✗` is the pre-existing Coroot CRD-catalog schema issue (`notificationIntegrations not allowed` on the stale `coroot.com/v1` datree schema) in `providers/hetzner/infrastructure`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)