### PR TITLE
fix(apps): run whoami and fleetdm always-on HA (KEDA min 2)

### DIFF
--- a/k8s/bases/apps/fleetdm/http-scaled-object.yaml
+++ b/k8s/bases/apps/fleetdm/http-scaled-object.yaml
@@ -12,10 +12,13 @@ spec:
     service: fleetdm-service
     port: 8080
   replicas:
-    min: 0
+    # Always-on HA: min 2 keeps the Fleet server replicated at all times
+    # (survives a pod/node failure) rather than scaling to zero. The app tier is
+    # stateless — state lives in MySQL/Redis.
+    min: 2
     max: 2
-  # Longer cooldown for FleetDM — enrolled devices check in periodically.
-  # 15 minutes of silence before scale-to-zero.
+  # Cooldown retained for any future scale-down; enrolled devices check in
+  # periodically.
   scaledownPeriod: 900
   scalingMetric:
     requestRate:

--- a/k8s/bases/apps/whoami/http-scaled-object.yaml
+++ b/k8s/bases/apps/whoami/http-scaled-object.yaml
@@ -12,7 +12,9 @@ spec:
     service: whoami
     port: 80
   replicas:
-    min: 0
+    # Always-on HA: min 2 keeps two replicas serving at all times (survives a
+    # pod/node failure) rather than scaling to zero. whoami is stateless.
+    min: 2
     max: 2
   scaledownPeriod: 300
   scalingMetric:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -17,7 +17,10 @@
 #     for any new singleton / scale-to-zero / operator-managed workload;
 #   * Flagger primaries (*-primary) and the scaled-to-0 canary sources -- Flagger
 #     owns their replica count;
-#   * KEDA scale-to-zero targets -- a floor defeats scale-to-zero;
+#   * KEDA-managed (autoscaled) targets -- the floor governs statically-declared
+#     replicas, not KEDA-owned counts. whoami/fleetdm run always-on HA (min 2);
+#     hubble-ui/headlamp/actual-budget/longhorn-ui are single-pod by hard
+#     constraint (per-pod connection or OIDC state, SQLite-on-RWO, admin UI);
 #   * namespaces whose workloads genuinely can't run 3: velero (chart hardcodes
 #     replicas: 1, no leader election), flux controllers, coroot (observability)
 #     and testkube (operator-managed singletons), and openbao (HA needs a Raft
@@ -73,10 +76,11 @@ spec:
                 - observability
                 - openbao
                 - testkube
-          # KEDA scale-to-zero targets, Flagger canary primaries (*-primary) and
-          # the scaled-to-0 canary sources -- their replica count is owned by a
-          # controller, not declared statically (the Flagger primary runs the HA
-          # replicas).
+          # KEDA-managed (autoscaled) targets and Flagger canary primaries
+          # (*-primary) + scaled-to-0 sources -- their replica count is owned by
+          # a controller, not declared statically. whoami/fleetdm now run
+          # always-on HA (min 2); hubble-ui/headlamp/actual-budget/longhorn-ui
+          # stay single-pod (per-pod state / SQLite-on-RWO / admin UI).
           - resources:
               names:
                 - "?*-primary"

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -40,8 +40,9 @@ data:
   # whoami/fleetdm: min 0, max 2
   # actual-budget: parked at 0/0 (unused; SQLite on RWO PVC keeps max≤1 when re-enabled)
   headlamp_replicas: "1"
-  whoami_replicas: "1"
-  fleetdm_replicas: "1"
+  # whoami/fleetdm run always-on HA (HTTPScaledObject min 2), not scale-to-zero.
+  whoami_replicas: "2"
+  fleetdm_replicas: "2"
   # Standalone MySQL (no replication). The bitnami replication topology causes
   # VPA `InPlaceOrRecreate` evictions to drop DDL connections mid-migration on
   # initial install (3 mysql pods churning simultaneously). Standalone is


### PR DESCRIPTION
Stacked on #1901. The KEDA scale-to-zero apps — made HA where the app actually supports multiple replicas.

## Always-on HA (min 2)
| App | Why it's safe |
|---|---|
| **whoami** | stateless echo |
| **fleetdm** | app tier is stateless (state in MySQL/Redis) |

`HTTPScaledObject` `replicas.min: 0 → 2`, initial replicas `1 → 2`. KEDA still owns the count; these stay exempt from the floor (the floor governs *statically-declared* replicas, not autoscaled ones).

## Genuinely single-pod (stay as-is, documented)
| App | Hard constraint |
|---|---|
| **hubble-ui** | per-pod connection state — streaming sessions bounce across pods |
| **headlamp** | OIDC login state is in-memory per pod |
| **actual-budget** | SQLite on an RWO PVC (single writer) |
| **longhorn-ui** | max-1 admin dashboard |

## ⚠️ Trade-off
This **abandons scale-to-zero** for whoami/fleetdm (always 2 pods, ~idle cost). The maintainer deliberately built scale-to-zero for these; revert per-app by setting the `HTTPScaledObject` `min` back to `0` if the idle cost outweighs the availability.

**Validation:** `ksail workload validate` passes for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
