### PR TITLE
fix(apps): run homepage and umami Flagger primaries at 3 replicas for HA

### DIFF
--- a/k8s/bases/apps/homepage/canary.yaml
+++ b/k8s/bases/apps/homepage/canary.yaml
@@ -6,10 +6,10 @@
 # new version. The public path (httproute.yaml -> oauth2-proxy -> auth-proxy ->
 # homepage apex Service) is untouched and always resolves to the primary.
 #
-# ⚠️ High blast radius (platform front page) — watch the first rollout. Flagger
-# owns replicas (stripped in the HelmRelease), so the primary runs the chart
-# default (1) instead of 2: a minor HA reduction. Latency threshold is generous
-# because Homepage is a single-threaded Next.js SSR app that bursts under load.
+# ⚠️ High blast radius (platform front page) — watch the first rollout. The
+# HelmRelease postRenderer pins the source replicas to 3, so Flagger runs the
+# primary at 3 for HA. Latency threshold is generous because Homepage is a
+# single-threaded Next.js SSR app that bursts under load.
 apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:

--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -32,11 +32,15 @@ spec:
               kind: Deployment
               name: homepage
             patch: |
-              # Flagger owns the canary deployment's replicas (it scales to zero
-              # between rollouts) — strip the chart's replicas so Flux does not
-              # fight it. See canary.yaml.
-              - op: remove
+              # Flagger copies the source Deployment's replicas onto the primary.
+              # Pin it to 3 for an HA primary (require-three-replicas) instead of
+              # removing it (which left the primary at the chart default of 1).
+              # Flux drift detection ignores /spec/replicas, so Flagger's
+              # between-rollout scale-to-zero of this source is not fought. See
+              # canary.yaml.
+              - op: replace
                 path: /spec/replicas
+                value: 3
               - op: add
                 path: /metadata/annotations/configmap.reloader.stakater.com~1reload
                 value: homepage
@@ -137,9 +141,9 @@ spec:
   # ---
   # https://github.com/M0NsTeRRR/helm-charts/blob/main/charts/homepage/values.yaml
   values:
-    # replicaCount intentionally omitted — Flagger manages canary replicas (the
-    # chart's replicas field is stripped by the postRenderer above). The primary
-    # therefore runs the chart default of 1 instead of 2.
+    # replicaCount intentionally omitted — the postRenderer above pins the
+    # source Deployment's replicas to 3, which Flagger copies onto the primary
+    # (so the primary runs 3 for HA).
     # Homepage is a single-threaded Next.js server: it idles near ~3m CPU but
     # bursts hard on every load — server-rendering the page, polling ~14
     # service statuses against kube-apiserver, and aggregating the cluster /

--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -23,18 +23,20 @@ spec:
         kind: HelmRepository
         name: umami
   postRenderers:
-    # Flagger owns the canary (umami-umami) Deployment's replicas — it scales the
-    # deployment to zero between rollouts. Strip the chart's replicas field so
-    # Flux's reconcile does not fight Flagger's scaling (otherwise the pod flaps
-    # every interval). See k8s/bases/apps/umami/canary.yaml.
+    # Flagger copies the source (umami-umami) Deployment's replicas onto the
+    # primary. Pin it to 3 for an HA primary (require-three-replicas) instead of
+    # removing it (which left the primary at the chart default of 1). Flux drift
+    # detection ignores /spec/replicas, so Flagger's between-rollout
+    # scale-to-zero of this source is not fought. See k8s/bases/apps/umami/canary.yaml.
     - kustomize:
         patches:
           - target:
               kind: Deployment
               name: umami-umami
             patch: |
-              - op: remove
+              - op: replace
                 path: /spec/replicas
+                value: 3
   # https://github.com/helmforgedev/charts/blob/main/charts/umami/values.yaml
   values:
     # replicaCount intentionally omitted — Flagger manages canary replicas


### PR DESCRIPTION
Stacked on #1902. The Flagger-managed apps — make their **primaries** run HA.

## Mechanism
Flagger copies the source Deployment's `spec.replicas` onto the `-primary`. The postRenderers previously **removed** `/spec/replicas` (so Flux wouldn't fight Flagger's between-rollout scale-to-zero of the source), which left each primary at the chart default of **1** — the maintainer documented this as "a minor HA reduction".

This **pins the source replicas to 3** (`op: replace` instead of `op: remove`), so Flagger runs the primary at 3. Safe because the platform's **Flux drift detection already ignores `/spec/replicas`** — Flagger's scale-to-zero of the source isn't corrected, which was the whole reason for the original strip.

| App | Change |
|---|---|
| **homepage** (apex) | primary 1 → 3 |
| **umami** (analytics) | primary 1 → 3 |
| **opencost** | left at 1 — cost *exporter*, singleton by nature (3 = duplicate compute/metrics), already observability-exempt |

## ⚠️ Watch
homepage is the platform front page (high blast radius). The change is to the replica-pinning only (probes/affinity/topology-spread untouched), but **watch the first Flagger rollout** after this lands.

**Validation:** `ksail workload validate` passes for the changed files. (Flagger's runtime replica copy is exercised in-cluster, not by `kubectl kustomize`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
