### PR TITLE
fix(flagger): keep RollingUpdate strategy to unblock HelmRelease upgrades

### DIFF
--- a/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
@@ -78,3 +78,35 @@ spec:
         memory: 64Mi
       limits:
         memory: 256Mi
+
+  # Keep the Deployment on a RollingUpdate strategy. The chart hardcodes
+  # `strategy.type: Recreate` on the flagger Deployment
+  # (charts/flagger/templates/deployment.yaml) with no values override. An
+  # earlier chart revision rendered RollingUpdate, so the live Deployment carries
+  # an API-defaulted `rollingUpdate{maxSurge,maxUnavailable}` block. Server-side
+  # apply does NOT prune that block when `type` flips to Recreate, so the merged
+  # object is rejected as invalid — `spec.strategy.rollingUpdate may not be
+  # specified when strategy type is 'Recreate'` — and every Helm upgrade fails
+  # and rolls back, stalling the flagger HelmRelease and wedging
+  # infrastructure-controllers (→ infrastructure → apps). Flagger runs leader
+  # election, so the brief pod overlap a rolling update allows is safe. The chart
+  # exposes no value for this, so patch the rendered Deployment back to
+  # RollingUpdate via a post-renderer; set the rollingUpdate params explicitly
+  # (the Kubernetes defaults) so helm-controller fully owns the field, the
+  # applied object matches the live object exactly, and drift detection (which
+  # does not ignore /spec/strategy) sees no diff.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: flagger
+            patch: |
+              - op: replace
+                path: /spec/strategy/type
+                value: RollingUpdate
+              - op: add
+                path: /spec/strategy/rollingUpdate
+                value:
+                  maxSurge: 25%
+                  maxUnavailable: 25%


### PR DESCRIPTION
## Problem

On prod, the `flagger` HelmRelease is stuck failing every upgrade and rolling back (observed at `flagger.v48`), which fails the `infrastructure-controllers` health check and **wedges the whole `infrastructure-controllers → infrastructure → apps` Flux chain**:

```
Helm upgrade failed for release flagger-system/flagger: server-side apply failed:
Deployment.apps "flagger" is invalid: spec.strategy.rollingUpdate: Forbidden:
may not be specified when strategy `type` is 'Recreate'
```

## Root cause

The flagger chart **hardcodes** `strategy.type: Recreate` on its Deployment ([`charts/flagger/templates/deployment.yaml`](https://github.com/fluxcd/flagger/blob/v1.43.0/charts/flagger/templates/deployment.yaml)) with no values override. An earlier chart revision rendered `RollingUpdate`, so the **live** Deployment carries an API-defaulted `rollingUpdate{maxSurge: 25%, maxUnavailable: 25%}` block. Server-side apply does **not** prune that block when `type` flips to `Recreate`, so the merged object is invalid and the API server rejects it — the upgrade fails and Flux rolls back, looping forever.

## Fix

Keep flagger on **RollingUpdate** (the live state, and what we want — flagger runs leader election so the brief pod overlap is safe). The chart has no value for the strategy, so this uses a Flux `postRenderers` kustomize patch to set the rendered Deployment's strategy back to `RollingUpdate`, with the `rollingUpdate` params set explicitly so:

- helm-controller fully owns `/spec/strategy`,
- the applied object matches the live object exactly (apply is valid, conflict gone),
- drift detection (which does **not** ignore `/spec/strategy`) sees no diff.

## Validation

- `kubectl kustomize k8s/clusters/{local,prod}/` build clean
- `kubectl kustomize k8s/bases/infrastructure/controllers/flagger/` renders the post-renderer patch
- `kubectl apply --dry-run=client` on the HelmRelease: schema-valid
- `ksail workload validate`: ✔ 308 files validated (flagger included)

Once merged and reconciled, the flagger upgrade applies cleanly and `infrastructure-controllers` clears its flagger blocker. (Note: ksail-operator is a separate, operational blocker — stale image-verification config on the autoscale nodes — tracked outside this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)