### PR TITLE
fix(policy): scope prefer-baseline-nodes mutate to CREATE so it can't break pod updates

### DIFF
--- a/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
@@ -58,6 +58,22 @@ spec:
           - resources:
               kinds:
                 - Pod
+              # CREATE only. A node affinity is consulted solely by the scheduler
+              # at pod-creation time and is immutable thereafter, so there is
+              # nothing to mutate on UPDATE. Worse, mutating on UPDATE breaks
+              # in-place pod updates: the Kubernetes pod-update validation forbids
+              # changing `spec.affinity`, so adding it during any UPDATE of a pod
+              # that has no affinity yet (e.g. a controller patching a finalizer
+              # or annotation) gets the whole request rejected with "pod updates
+              # may not change fields other than ...". Without this restriction
+              # Kyverno registers the mutating webhook for CREATE *and* UPDATE; a
+              # stuck-terminating Job pod on a deleted node (orphaned
+              # batch.kubernetes.io/job-tracking finalizer) could not be cleaned
+              # up because every finalizer-removal patch tripped this. Scoping to
+              # CREATE keeps the scheduling bias intact and stops the webhook from
+              # touching updates.
+              operations:
+                - CREATE
       exclude:
         any:
           - resources:


### PR DESCRIPTION
## Problem

`vault-config-6q6st` (openbao) is stuck **Terminating** for ~46h. Root cause is two-fold:

1. Its node (`prod-worker-1`) was removed during the Talos node churn, so the already-requested deletion can never be confirmed by a kubelet.
2. It still carries the `batch.kubernetes.io/job-tracking` finalizer, but its owning `Job/vault-config` is gone (Helm hook, deleted post-success) — so nothing strips the finalizer.

Removing the finalizer is the fix, **but every finalizer-removal patch is rejected**:

```
The Pod "vault-config-6q6st" is invalid: spec: Forbidden: pod updates may not
change fields other than spec.containers[*].image, ... (affinity added)
```

## Root cause (the actual bug)

The `prefer-baseline-nodes` mutate `ClusterPolicy` matches `Pod` with **no `operations` restriction**, so Kyverno registers its mutating webhook for **CREATE _and_ UPDATE**. A node affinity is only consulted by the scheduler at creation and is immutable afterwards — so there is nothing to mutate on UPDATE. Worse, injecting `spec.affinity` during an in-place UPDATE of a pod that has none yet violates the Kubernetes pod-update immutability rules, so the **entire request is rejected**.

This silently breaks in-place pod patches (finalizer/annotation updates by controllers, cleanup tooling, etc.) in every non-excluded namespace for any affinity-less pod. The stuck pod is just where it surfaced.

## Fix

Scope the rule to `operations: [CREATE]`. The scheduling bias is fully preserved (affinity is applied at the only time it matters — pod creation), and the webhook stops touching updates, so finalizer removal and other in-place patches work again. The policy stays inert until KSail labels its autoscaler nodes (unchanged).

## Validation

- `kubectl kustomize k8s/clusters/{local,prod}/` build clean
- `kubectl apply --dry-run=client` against the live API: accepted (`configured (dry run)`)
- `ksail workload validate`: ✔ 308 files validated

Once this is live, the orphaned `vault-config-*` finalizer can be removed and the pod will delete (and any future in-place pod update stops being blocked cluster-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)