### PR TITLE
fix(ksail-operator): pin runAsUser 65532 so the non-root container can start

### DIFF
--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -68,3 +68,37 @@ spec:
       # cluster-admin wildcard) stays off -- it is a privilege-escalation
       # opt-in, not a product feature.
       clusterAdmin: false
+
+  # Pin a numeric runAsUser so the kubelet can verify the container is non-root.
+  # The ksail image declares a NAMED user (`USER nonroot:nonroot`; that account
+  # is UID/GID 65532 in the image's /etc/passwd). The platform's
+  # add-security-context Kyverno policy injects `runAsNonRoot: true` on the pod
+  # and container, but no numeric runAsUser, and the chart ships no
+  # securityContext of its own. With runAsNonRoot set and only a *named* image
+  # user, the kubelet cannot prove the user is non-root -- "container has
+  # runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is
+  # non-root" -- so the container never starts (CreateContainerConfigError). The
+  # chart exposes no securityContext value, so set the UID via a post-renderer.
+  # add-security-context uses +(...) add-anchors, so it layers
+  # runAsNonRoot/seccomp/drop-caps on top without clobbering this runAsUser.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: ksail-operator
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: ksail-operator
+              spec:
+                template:
+                  spec:
+                    securityContext:
+                      runAsUser: 65532
+                      runAsGroup: 65532
+                    containers:
+                      - name: operator
+                        securityContext:
+                          runAsUser: 65532


### PR DESCRIPTION
## Problem

With the autoscale-node image-verification fixed, `ksail-operator` finally pulls its image — but the pod now fails to start with `CreateContainerConfigError`:

```
Error: container has runAsNonRoot and image has non-numeric user (nonroot),
cannot verify user is non-root
```

So ksail-operator still blocks `infrastructure-controllers → infrastructure → apps`.

## Root cause

- The ksail image declares a **named** user: `USER nonroot:nonroot` (that account is UID/GID **65532** in the image's `/etc/passwd`).
- The platform's `add-security-context` Kyverno policy injects `runAsNonRoot: true` on the pod and container, but **no numeric `runAsUser`**, and the chart ships no securityContext of its own.
- With `runAsNonRoot` set and only a *named* image user, the kubelet can't prove the user is non-root → refuses to start the container.

This was masked until now by the earlier image-verification `ImagePullBackOff`.

## Fix

The chart exposes no securityContext value, so pin the numeric UID via a Flux `postRenderers` kustomize patch (pod + container `runAsUser: 65532`, matching the image's `nonroot`). `add-security-context` uses `+(...)` add-anchors, so it still layers `runAsNonRoot`/seccomp/drop-caps on top without clobbering this `runAsUser`.

## Validation

- `kubectl kustomize k8s/clusters/{local,prod}/` build clean
- `kubectl apply --dry-run=client`: schema-valid
- `ksail workload validate`: ✔ 308 files validated
- UID confirmed from the image: `crane export … | tar -xO etc/passwd` → `nonroot:x:65532:65532`

🤖 Generated with [Claude Code](https://claude.com/claude-code)