### PR TITLE
refactor(infrastructure): hetzner tracks controller aggregate, not a hand list

### DIFF
--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -1,9 +1,15 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# This aggregate is the controller set EVERY provider gets — adding a subdir
+# here ships it to all providers, with no per-provider allowlist to keep in sync.
+# Provider-/cluster-local controllers are intentionally NOT listed here; the
+# provider overlay that needs them references them directly:
+#   - cdi/ + kubevirt/ : VM stack, local/CI only (docker provider). No
+#       VirtualMachines/DataVolumes run on Hetzner and virt-handler crash-loops
+#       with zero VMs, so prod opts out by simply not referencing them.
 resources:
   - auth-proxy/
-  - cdi/
   - cert-manager/
   - cilium/
   - cloudnative-pg/
@@ -15,7 +21,6 @@ resources:
   - keda/
   - keda-http-add-on/
   - ksail-operator/
-  - kubevirt/
   - kubescape/
   - kyverno/
   - metrics-server/

--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -3,6 +3,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../../bases/infrastructure/controllers/
+  # Local/CI-only VM stack — kept out of the base aggregate (prod has no VMs).
+  # The KubeVirt CR is patched below.
+  - ../../../../bases/infrastructure/controllers/cdi/
+  - ../../../../bases/infrastructure/controllers/kubevirt/
   - coredns/
   - flux-instance/
   - minio/

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -2,36 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Base controllers are listed explicitly (instead of the aggregate
-  # `../../../../bases/infrastructure/controllers/` include) so prod can opt
-  # OUT of controllers that are unused on Hetzner, freeing memory while the
-  # cluster is being right-sized. Disabled for now:
-  #   - kubevirt + cdi : no VirtualMachines / DataVolumes exist; virt-handler
-  #                      was crash-looping (1000+ restarts) with zero VMs.
-  # NOTE: a new base controller must be added to this list to reach prod.
-  # Local/CI (docker provider) still deploys the full base controller set.
-  - ../../../../bases/infrastructure/controllers/auth-proxy/
-  - ../../../../bases/infrastructure/controllers/cert-manager/
-  - ../../../../bases/infrastructure/controllers/cilium/
-  - ../../../../bases/infrastructure/controllers/cloudnative-pg/
-  - ../../../../bases/infrastructure/controllers/coroot/
-  - ../../../../bases/infrastructure/controllers/dex/
-  - ../../../../bases/infrastructure/controllers/external-secrets/
-  - ../../../../bases/infrastructure/controllers/flagger/
-  - ../../../../bases/infrastructure/controllers/flux-operator/
-  - ../../../../bases/infrastructure/controllers/keda/
-  - ../../../../bases/infrastructure/controllers/keda-http-add-on/
-  - ../../../../bases/infrastructure/controllers/ksail-operator/
-  - ../../../../bases/infrastructure/controllers/kubescape/
-  - ../../../../bases/infrastructure/controllers/kyverno/
-  - ../../../../bases/infrastructure/controllers/metrics-server/
-  - ../../../../bases/infrastructure/controllers/oauth2-proxy/
-  - ../../../../bases/infrastructure/controllers/openbao/
-  - ../../../../bases/infrastructure/controllers/reloader/
-  - ../../../../bases/infrastructure/controllers/tetragon/
-  - ../../../../bases/infrastructure/controllers/trust-manager/
-  - ../../../../bases/infrastructure/controllers/velero/
-  - ../../../../bases/infrastructure/controllers/vertical-pod-autoscaler/
+  # Full base controller aggregate — prod tracks every base controller
+  # automatically. The VM stack (cdi + kubevirt) is the only base-level
+  # exclusion and is no longer in the aggregate (it lives in the docker provider,
+  # local/CI only): no VirtualMachines/DataVolumes exist on Hetzner and
+  # virt-handler crash-looped (1000+ restarts) with zero VMs.
+  - ../../../../bases/infrastructure/controllers/
   # Prod-only: layers a cluster-wide mutual-auth (SPIRE mTLS) policy on top of
   # the base Cilium controller listed above. SPIRE is enabled only on Hetzner,
   # so the policy lives here, not in the base — see cilium/ for the rationale.


### PR DESCRIPTION
## What

The hetzner controllers overlay re-listed **22 base controllers by hand** ([`providers/hetzner/infrastructure/controllers/kustomization.yaml`](../blob/main/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml)) solely to exclude the local-only VM stack (`cdi` + `kubevirt`). Its own comment flagged the footgun:

> NOTE: a new base controller must be added to this list to reach prod.

So any controller added to `bases/infrastructure/controllers/` shipped to local/CI but **silently never reached prod** until someone remembered to also edit the hand list.

## Change

Invert the default so prod tracks base automatically, and make the exclusion explicit in one place:

- `cdi/` + `kubevirt/` removed from the **base aggregate** and referenced directly by the **docker** provider — they are local/CI only (no `VirtualMachine`/`DataVolume` runs on Hetzner; virt-handler crash-looped with zero VMs).
- **hetzner** now references `../../../../bases/infrastructure/controllers/` (the aggregate) instead of 22 hand-maintained lines.

Net: a new base controller reaches **both** providers with no allowlist to update; the VM stack is the single, documented exclusion, co-located with the only provider that uses it. Net −16 lines.

Why move rather than `$patch: delete`: cdi/kubevirt aren't single HelmReleases — each is a full operator bundle (CRDs, RBAC, namespace, CR), so deleting them from the aggregate would need ~20 fragile delete stanzas. Moving them to their sole consumer is both smaller and more correct.

## Validation (behavior-preserving)

- `kubectl kustomize` for **both** `providers/{docker,hetzner}/infrastructure/controllers/` is **byte-identical** to the pre-change render (docker 124 resources incl. cdi+kubevirt; hetzner 126 without).
- `ksail workload validate` unchanged vs. baseline: **local 0 failures**; **prod**'s only failure is the pre-existing coroot CRD catalog-schema issue (untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)