### PR TITLE
refactor(infrastructure): centralize HelmRelease Flux remediation defaults

### DIFF
--- a/k8s/bases/apps/actual-budget/helm-release.yaml
+++ b/k8s/bases/apps/actual-budget/helm-release.yaml
@@ -8,13 +8,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: actualbudget

--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -9,14 +9,8 @@ metadata:
 spec:
   interval: 2m
   timeout: 15m
-  install:
-    remediation:
-      retries: -1
   upgrade:
     force: true
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: fleet

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -9,13 +9,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: headlamp

--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -11,13 +11,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: homepage

--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -8,13 +8,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: umami

--- a/k8s/bases/apps/whoami/helm-release.yaml
+++ b/k8s/bases/apps/whoami/helm-release.yaml
@@ -9,13 +9,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: whoami

--- a/k8s/bases/components/helmrelease-flux-defaults/kustomization.yaml
+++ b/k8s/bases/components/helmrelease-flux-defaults/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+# Platform-wide Flux reliability defaults for every HelmRelease.
+#
+# WHY: the enforce-flux-best-practices Kyverno policy requires every HelmRelease
+# to set install/upgrade remediation (retries + remediateLastFailure). That block
+# is 100% identical across all ~37 HelmReleases, so it was copy-pasted into each
+# one. This Component defines it once and merges it into every HelmRelease, the
+# same way bases/components/helmrelease-drift-detection applies drift detection.
+#
+# Strategic-merge (not JSON6902) so it MERGES: it creates spec.install/upgrade
+# when absent and leaves sibling fields (install.crds, upgrade.crds/force) and
+# per-chart values untouched. Per-HR values would win on conflict, but these
+# values are uniform policy, so the merge is a no-op wherever a HR still sets it.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+    patch: |
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: not-used
+      spec:
+        install:
+          remediation:
+            retries: -1
+        upgrade:
+          remediation:
+            retries: -1
+            remediateLastFailure: true

--- a/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
@@ -19,13 +19,8 @@ spec:
         name: cert-manager
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   values:
     # Restricted PSS baseline: add runAsNonRoot to container SCs (chart leaves it unset, which fails validate-container-security).

--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -18,13 +18,6 @@ spec:
         name: cilium
   interval: 10m0s
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/values.yaml
   values:
     securityContext:

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/helm-release.yaml
@@ -10,13 +10,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: cloudnative-pg

--- a/k8s/bases/infrastructure/controllers/coroot/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/helm-release.yaml
@@ -12,13 +12,8 @@ spec:
   timeout: 10m
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://github.com/coroot/helm-charts/tree/main/charts/coroot-operator
   #
   # The operator is the maintained install path (the all-in-one `coroot`

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -10,13 +10,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: dex

--- a/k8s/bases/infrastructure/controllers/external-secrets/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/external-secrets/helm-release.yaml
@@ -11,13 +11,8 @@ spec:
   timeout: 10m
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: external-secrets

--- a/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
@@ -21,13 +21,8 @@ spec:
   timeout: 10m
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: flagger

--- a/k8s/bases/infrastructure/controllers/flagger/loadtester-helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flagger/loadtester-helm-release.yaml
@@ -8,13 +8,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: loadtester

--- a/k8s/bases/infrastructure/controllers/flux-operator/helm-release-web.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/helm-release-web.yaml
@@ -30,13 +30,6 @@ spec:
         name: flux-operator
   interval: 10m0s
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   values:
     # Distinct name so all label selectors (and the homepage pod-selector)
     # separate the web pods from the operator pods.

--- a/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/helm-release.yaml
@@ -18,13 +18,6 @@ spec:
         name: flux-operator
   interval: 10m0s
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   values:
     web:
       # The Flux Status web UI now runs as the standalone `flux-operator-web`

--- a/k8s/bases/infrastructure/controllers/keda-http-add-on/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/keda-http-add-on/helm-release.yaml
@@ -11,13 +11,6 @@ spec:
   timeout: 10m
   dependsOn:
     - name: keda
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: keda-add-ons-http

--- a/k8s/bases/infrastructure/controllers/keda/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/keda/helm-release.yaml
@@ -10,13 +10,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: keda

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -13,13 +13,8 @@ spec:
   timeout: 10m
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: ksail-operator

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -9,13 +9,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 15m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: kubescape-operator

--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -10,13 +10,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 15m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: kyverno

--- a/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/metrics-server/helm-release.yaml
@@ -9,13 +9,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: metrics-server

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -10,13 +10,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: oauth2-proxy

--- a/k8s/bases/infrastructure/controllers/openbao/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/helm-release.yaml
@@ -8,13 +8,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: openbao

--- a/k8s/bases/infrastructure/controllers/reloader/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/reloader/helm-release.yaml
@@ -9,13 +9,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: reloader

--- a/k8s/bases/infrastructure/controllers/testkube/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/testkube/helm-release.yaml
@@ -10,13 +10,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: testkube

--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -17,13 +17,6 @@ spec:
         name: cilium
   interval: 10m0s
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://github.com/cilium/tetragon/blob/main/install/kubernetes/tetragon/values.yaml
   #
   # eBPF-based runtime security observability. Sibling to the Cilium

--- a/k8s/bases/infrastructure/controllers/trust-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/trust-manager/helm-release.yaml
@@ -20,13 +20,8 @@ spec:
         name: cert-manager
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://artifacthub.io/packages/helm/cert-manager/trust-manager
   values:
     crds:

--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -17,13 +17,8 @@ spec:
         name: vmware-tanzu
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   timeout: 15m
   # https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/values.yaml
   values:

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -9,13 +9,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   test:
     enable: false
   chart:

--- a/k8s/bases/infrastructure/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/opencost/helm-release.yaml
@@ -21,13 +21,6 @@ spec:
       namespace: observability
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: opencost

--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -12,6 +12,7 @@ components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — see
   # bases/components/helmrelease-drift-detection.
   - ../../../../bases/components/helmrelease-drift-detection
+  - ../../../../bases/components/helmrelease-flux-defaults
 patches:
   - target:
       kind: HelmRelease

--- a/k8s/providers/docker/infrastructure/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/kustomization.yaml
@@ -9,3 +9,4 @@ components:
   # opencost HelmRelease in this layer. See
   # bases/components/helmrelease-drift-detection.
   - ../../../bases/components/helmrelease-drift-detection
+  - ../../../bases/components/helmrelease-flux-defaults

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — see
   # bases/components/helmrelease-drift-detection.
   - ../../../bases/components/helmrelease-drift-detection
+  - ../../../bases/components/helmrelease-flux-defaults
 patches:
   - target:
       group: kustomize.toolkit.fluxcd.io

--- a/k8s/providers/hetzner/infrastructure/controllers/external-dns/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/external-dns/helm-release.yaml
@@ -8,13 +8,6 @@ metadata:
 spec:
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: external-dns

--- a/k8s/providers/hetzner/infrastructure/controllers/hcloud-ccm/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/hcloud-ccm/helm-release.yaml
@@ -16,13 +16,6 @@ spec:
         name: hcloud
   interval: 10m0s
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/chart/values.yaml
   values:
     networking:

--- a/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
@@ -17,13 +17,6 @@ spec:
         name: hcloud
   interval: 10m0s
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://github.com/hetznercloud/csi-driver/blob/main/chart/values.yaml
   values:
     global:

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -54,6 +54,7 @@ components:
   # Helm-rendered resources deleted/mutated out-of-band — the cause of the
   # silently-broken keda external-scaler and homepage Deployments.
   - ../../../../bases/components/helmrelease-drift-detection
+  - ../../../../bases/components/helmrelease-flux-defaults
 patches:
   - path: flux-operator/patches/helm-release-patch.yaml
   - path: openbao/patches/helm-release-patch.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -25,13 +25,8 @@ spec:
   interval: 10m0s
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   timeout: 10m
   # https://github.com/longhorn/charts/blob/master/charts/longhorn/values.yaml
   values:

--- a/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/helm-release.yaml
@@ -8,13 +8,6 @@ spec:
     - name: cert-manager
   interval: 2m
   timeout: 10m
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   chart:
     spec:
       chart: origin-ca-issuer

--- a/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
@@ -21,13 +21,8 @@ spec:
         name: piraeus
   install:
     crds: CreateReplace
-    remediation:
-      retries: -1
   upgrade:
     crds: CreateReplace
-    remediation:
-      retries: -1
-      remediateLastFailure: true
   # https://artifacthub.io/packages/helm/piraeus-charts/snapshot-controller
   values:
     # The cluster-wide snapshot.storage.k8s.io CRDs (VolumeSnapshot{,Class,

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -32,6 +32,7 @@ components:
   # opencost HelmRelease in this layer. See
   # bases/components/helmrelease-drift-detection.
   - ../../../bases/components/helmrelease-drift-detection
+  - ../../../bases/components/helmrelease-flux-defaults
 patches:
   - path: gateway-patch.yaml
     target:


### PR DESCRIPTION
## What

The `install`/`upgrade` remediation block required by the `enforce-flux-best-practices` Kyverno policy:

```yaml
install:
  remediation:
    retries: -1
upgrade:
  remediation:
    retries: -1
    remediateLastFailure: true
```

was copy-pasted **byte-identical into all 37 HelmReleases** (~190 lines). Centralize it into a Kustomize Component — the same mechanism already used for `helmrelease-drift-detection` — and delete the inline copies.

## How

- New `k8s/bases/components/helmrelease-flux-defaults/` merges the remediation block into every `HelmRelease`.
- **Strategic-merge** (not JSON6902) so it *merges*: creates `spec.install`/`spec.upgrade` when absent and leaves sibling fields untouched — `install.crds`, `upgrade.crds`, and velero's `upgrade.force` are all preserved.
- Wired into the same five overlay layers as drift detection: `providers/{docker,hetzner}/infrastructure`, `.../infrastructure/controllers`, and `hetzner/apps`.

Net: −185 lines across 37 HelmReleases; new HelmReleases no longer need to restate the block.

## Validation (behavior-preserving)

- `kubectl kustomize` for **all five** HR-rendering provider paths is **byte-identical** to before (59 rendered HR instances total).
- `ksail workload validate`: **local 0 failures**; **prod** unchanged (its only failure is the pre-existing coroot catalog-schema issue). The sole delta is `88 → 89 kustomizations validated` — the new Component itself.
- Standalone base HRs no longer carry `remediation`, which is schema-valid (optional in the CRD). On the live cluster Flux always renders HRs **through** an overlay that includes the Component, so the Kyverno `enforce-flux-best-practices` gate still sees the field.

## Note

This intentionally leaves `interval`/`timeout` inline (they have a few deliberate per-chart values, unlike the 100%-uniform remediation block). The one pre-existing label inconsistency (`origin-ca-issuer` missing `helm.toolkit.fluxcd.io/remediation: enabled`) is left for a separate change to keep this PR a pure behavior-preserving refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)