### PR TITLE
refactor(infrastructure): use path-only kustomize patches where self-identifying

### DIFF
--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -12,39 +12,14 @@ components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — see
   # bases/components/helmrelease-drift-detection.
   - ../../../../bases/components/helmrelease-drift-detection
+# Each patch file self-identifies (apiVersion/kind/name/namespace), so a path is
+# enough — no redundant `target:` selector. Matches the path-only style used by
+# the hetzner overlays.
 patches:
-  - target:
-      kind: HelmRelease
-      name: cilium
-      namespace: kube-system
-    path: cilium/patches/helm-release-patch.yaml
-  - target:
-      kind: HelmRelease
-      name: metrics-server
-      namespace: kube-system
-    path: metrics-server/patches/helm-release-patch.yaml
-  - target:
-      kind: HelmRelease
-      name: flux-operator
-      namespace: flux-system
-    path: flux-operator/patches/helm-release-patch.yaml
-  - target:
-      kind: HelmRelease
-      name: flux-operator-web
-      namespace: flux-system
-    path: flux-operator/patches/helm-release-web-patch.yaml
-  - target:
-      kind: HelmRelease
-      name: kubescape
-      namespace: kubescape
-    path: kubescape/patches/helm-release-patch.yaml
-  - target:
-      kind: HelmRelease
-      name: tetragon
-      namespace: kube-system
-    path: tetragon/patches/helm-release-patch.yaml
-  - target:
-      kind: KubeVirt
-      name: kubevirt
-      namespace: kubevirt
-    path: kubevirt/patches/kubevirt-cr-patch.yaml
+  - path: cilium/patches/helm-release-patch.yaml
+  - path: metrics-server/patches/helm-release-patch.yaml
+  - path: flux-operator/patches/helm-release-patch.yaml
+  - path: flux-operator/patches/helm-release-web-patch.yaml
+  - path: kubescape/patches/helm-release-patch.yaml
+  - path: tetragon/patches/helm-release-patch.yaml
+  - path: kubevirt/patches/kubevirt-cr-patch.yaml

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -7,32 +7,22 @@ components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — see
   # bases/components/helmrelease-drift-detection.
   - ../../../bases/components/helmrelease-drift-detection
+# Strategic-merge patch files self-identify (apiVersion/kind/name/namespace), so
+# they need only a path — no redundant `target:` selector. JSON6902 patches have
+# no embedded identity and keep an explicit target (see whoami below).
 patches:
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      kind: Kustomization
-      name: ascoachingogvaner
-      namespace: ascoachingogvaner
-    path: ascoachingogvaner/patches/kustomization-patch.yaml
+  - path: ascoachingogvaner/patches/kustomization-patch.yaml
   # fleetdm disabled 2026-06-03 (see bases/apps/kustomization.yaml). Its
   # prod-only HelmRelease patch (timeout + MySQL primary service address +
   # hcloud storageClass) and the providers/hetzner/apps/fleetdm/ dir were
   # removed with the app: an unreferenced patch fragment is schema-validated
   # standalone by `ksail workload validate`, and a partial HelmRelease (no
   # spec.interval) fails. Restore the patch from git history if re-enabling.
-  - target:
-      kind: HelmRelease
-      name: headlamp
-      namespace: headlamp
-    path: headlamp/patches/helm-release-patch.yaml
-  - target:
-      group: kustomize.toolkit.fluxcd.io
-      kind: Kustomization
-      name: wedding-app
-      namespace: wedding-app
-    path: wedding-app/patches/kustomization-patch.yaml
+  - path: headlamp/patches/helm-release-patch.yaml
+  - path: wedding-app/patches/kustomization-patch.yaml
   # Pilot: user namespaces (hostUsers: false) on whoami — prod-only; see the
-  # patch file for the full rationale.
+  # patch file for the full rationale. JSON6902 patch (a list of ops) has no
+  # embedded identity, so it must keep an explicit target.
   - target:
       kind: HelmRelease
       name: whoami

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -33,10 +33,9 @@ components:
   # bases/components/helmrelease-drift-detection.
   - ../../../bases/components/helmrelease-drift-detection
 patches:
+  # gateway-patch self-identifies (Gateway/platform/kube-system), so a path is
+  # enough — no explicit target, matching the coroot patch below.
   - path: gateway-patch.yaml
-    target:
-      kind: Gateway
-      name: platform
   # Prod-only Coroot tuning: hcloud-backed persistent storage + Slack webhook
   # wiring. The CR it patches comes from ../../../bases/infrastructure/coroot/
   # (the `infrastructure` layer); the strategic-merge patch matches on the


### PR DESCRIPTION
## What

Kustomize patch entries mixed two equivalent styles — an explicit `target:` selector next to `path:`, and `path:` alone — sometimes in the same file. Since every **strategic-merge** patch file already carries full identity (`apiVersion`/`kind`/`name`/`namespace`), the `target:` block merely restated it and was redundant.

## Change

Drop the redundant `target:` selectors, keeping `path:` alone — the path-only style the hetzner overlays already use and that the coroot-patch comment documents. Converted 11 entries across 3 files:

- `providers/docker/infrastructure/controllers` — 7 HelmRelease/KubeVirt patches
- `providers/hetzner/apps` — 3 (ascoachingogvaner, headlamp, wedding-app)
- `providers/hetzner/infrastructure` — 1 (gateway-patch)

**Principled exception:** `whoami`'s patch is **JSON6902** (a list of ops, no embedded identity) so it genuinely requires a `target:` — kept, now with a comment explaining why. The remaining mix is intentional and documented, not accidental.

## Validation (behavior-preserving)

- `kubectl kustomize` for all three affected provider paths is **byte-identical** to before.
- `ksail workload validate`: **local 0 failures**; **prod** unchanged (only the pre-existing coroot catalog-schema failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)