### PR TITLE
chore(deps): group ksail CLI + operator chart into one Renovate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -109,6 +109,15 @@
       "enabled": false
     },
     {
+      "description": "Group the ksail-release dependencies that Renovate manages — the CLI (KSAIL_VERSION custom manager, datasource github-releases, in ci.yaml/cd.yaml) and the ksail-operator OCI Helm chart (flux manager, helm-release.yaml) — into one PR (groupName 'ksail'), so a single ksail release stops opening a separate PR for each. The devantler-tech/ksail GitHub Action is intentionally NOT included: github-actions is owned exclusively by Dependabot (.github/dependabot.yaml), so that bump stays a separate Dependabot PR. Both grouped deps resolve to the same upstream ksail version, and the devantler-tech 0-day minimumReleaseAge rule below still matches these first-party deps, so the grouped PR opens immediately.",
+      "matchPackageNames": [
+        "devantler-tech/ksail",
+        "ghcr.io/devantler-tech/charts/ksail-operator",
+        "ksail-operator"
+      ],
+      "groupName": "ksail"
+    },
+    {
       "description": "Security-critical controllers — labelled so security-driven bumps are visible in the PR feed. Automerge stays ON: CI (system-test on a real Talos+Docker cluster, kubescape NSA scan, gitleaks, zizmor, CodeQL) is the trust gate.",
       "matchManagers": [
         "helmv3",


### PR DESCRIPTION
## What

Adds a single Renovate `packageRule` that groups the two **Renovate-managed** ksail-release dependencies under `groupName: "ksail"`:

- the **CLI** pin — `KSAIL_VERSION` (custom regex manager, datasource `github-releases`) in `.github/workflows/ci.yaml` and `cd.yaml`
- the **`ksail-operator` OCI Helm chart** (`flux` manager) in `k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml`

## Why

Renovate opens one PR per dependency by default, so a single ksail release fanned out into separate PRs for the CLI and the operator chart. Grouping them means **one Renovate PR per release** instead of two.

## What this does NOT change

The `devantler-tech/ksail` GitHub Action (`uses:` in `ci.yaml`) stays owned by **Dependabot** — `github-actions` remains disabled in Renovate. That bump therefore remains its own Dependabot PR. A truly single PR across both deps + the action isn't possible: Renovate and Dependabot can't co-author a PR, and neither the CLI version string nor the Flux `HelmRelease` can be tracked by Dependabot.

Net effect: **2 PRs per ksail release (down from 3).**

## Notes for reviewer

- The existing `devantler-tech/**` 0-day `minimumReleaseAge` rule still matches both grouped deps (first-party), so the grouped PR opens immediately — no behavior change there.
- Automerge is unchanged: both deps already automerge on green via the existing minor/patch/major rules; grouping just shares the branch/PR.
- Validated with `renovate-config-validator` (Renovate 43.x): *Config validated successfully*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)