### PR TITLE
style(kustomize): add yaml document-start markers + normalize list indent

### DIFF
--- a/k8s/bases/apps/actual-budget/kustomization.yaml
+++ b/k8s/bases/apps/actual-budget/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/apps/ascoachingogvaner/kustomization.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/apps/fleetdm/kustomization.yaml
+++ b/k8s/bases/apps/fleetdm/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/apps/headlamp/kustomization.yaml
+++ b/k8s/bases/apps/headlamp/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/apps/homepage/kustomization.yaml
+++ b/k8s/bases/apps/homepage/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/apps/kustomization.yaml
+++ b/k8s/bases/apps/kustomization.yaml
@@ -1,17 +1,18 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- actual-budget/
-- ascoachingogvaner/
-# fleetdm disabled 2026-06-03 — not in use. The manifests under
-# bases/apps/fleetdm/ are retained; re-enable by uncommenting the line below.
-# The prod-only HelmRelease patch (providers/hetzner/apps/fleetdm/) was
-# removed with the app — restore it from git history if re-enabling. The
-# infra-layer plumbing (OpenBao policies/seeds, NetworkPolicies, Kubescape
-# security exceptions, prod config-map vars) is intentionally left idle.
-# - fleetdm/
-- headlamp/
-- homepage/
-- umami/
-- whoami/
-- wedding-app/
+  - actual-budget/
+  - ascoachingogvaner/
+  # fleetdm disabled 2026-06-03 — not in use. The manifests under
+  # bases/apps/fleetdm/ are retained; re-enable by uncommenting the line below.
+  # The prod-only HelmRelease patch (providers/hetzner/apps/fleetdm/) was
+  # removed with the app — restore it from git history if re-enabling. The
+  # infra-layer plumbing (OpenBao policies/seeds, NetworkPolicies, Kubescape
+  # security exceptions, prod config-map vars) is intentionally left idle.
+  # - fleetdm/
+  - headlamp/
+  - homepage/
+  - umami/
+  - whoami/
+  - wedding-app/

--- a/k8s/bases/apps/umami/kustomization.yaml
+++ b/k8s/bases/apps/umami/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/apps/wedding-app/kustomization.yaml
+++ b/k8s/bases/apps/wedding-app/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/apps/whoami/kustomization.yaml
+++ b/k8s/bases/apps/whoami/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/cluster-secret-stores/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-secret-stores/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/cdi/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/cdi/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/cert-manager/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/cert-manager/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/cloudnative-pg/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/cloudnative-pg/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/coredns/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/coredns/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/dex/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/external-secrets/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/external-secrets/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/flagger/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/flagger/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/keda-http-add-on/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/keda-http-add-on/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/keda/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/keda/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/kubescape/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/kubevirt/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kubevirt/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/metrics-server/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/metrics-server/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/openbao/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/reloader/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/reloader/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/testkube/crds/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/testkube/crds/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/testkube/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/testkube/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/trust-manager/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/trust-manager/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/velero/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/external-secrets/kustomization.yaml
+++ b/k8s/bases/infrastructure/external-secrets/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/flagger/kustomization.yaml
+++ b/k8s/bases/infrastructure/flagger/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/opencost/kustomization.yaml
+++ b/k8s/bases/infrastructure/opencost/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/security-exceptions/kustomization.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/vault-backup/kustomization.yaml
+++ b/k8s/bases/infrastructure/vault-backup/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/vault-config/kustomization.yaml
+++ b/k8s/bases/infrastructure/vault-config/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/bases/infrastructure/vault-seed/kustomization.yaml
+++ b/k8s/bases/infrastructure/vault-seed/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/providers/docker/infrastructure/cluster-issuers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/cluster-issuers/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/providers/docker/infrastructure/controllers/coredns/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/providers/docker/infrastructure/controllers/minio/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/minio/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/providers/hetzner/infrastructure/cluster-issuers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-issuers/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/providers/hetzner/infrastructure/controllers/coredns/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/coredns/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/origin-ca-issuer/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
## What

Add the leading `---` document-start marker to the **44** `kustomization.yaml` files that had none (the other 45 already had one), and normalize the single file using 0-indent list items (`bases/apps/kustomization.yaml`) to the repo's 2-space style. yamllint `document-start` + consistent indentation.

## Important caveat (why not all 45 "missing" files)

A naive "first line ≠ `---`" sweep is **wrong**: files that carry `---` *after* a leading comment block (e.g. `auth-proxy`, which is `<comment>` → `---` → content — itself valid yamllint) would get a **second** `---`, creating an empty leading YAML document that kustomize rejects as `kustomization.yaml is empty`. This PR only prepends to files that have **no `---` line at all**, leaving comment-then-marker files untouched.

That failure mode is caught only by `ksail workload validate` (which builds every kustomization **standalone**), not by `kubectl kustomize` of the cluster overlay (which renders only the Flux Kustomization CRs and never recurses into the bases).

## Validation (behavior-preserving)

- `kubectl kustomize` for both clusters is **byte-identical** to before.
- `ksail workload validate`: **local 0 failures**; **prod** unchanged (only the pre-existing coroot catalog-schema failure).

## Follow-up (not in this PR)

A repo-wide yamllint `document-start` rule would enforce this going forward and extend it to non-kustomization YAML — left out to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)