### PR TITLE
fix(policy): exempt operator namespaces and Flagger source from replica-floor

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -20,10 +20,11 @@
 #   * KEDA scale-to-zero targets -- a floor defeats scale-to-zero;
 #   * single-purpose control-plane / operator namespaces (velero, cnpg-system,
 #     reloader, flagger-system, flux-system, observability, openbao, testkube,
-#     vertical-pod-autoscaler) and the leader-election singletons that share a
-#     namespace with HA workloads (hcloud CCM/CSI controller, snapshot-controller,
-#     external-dns, trust-manager, origin-ca-issuer, the kyverno background/
-#     reports/cleanup controllers) -- 1 active replica is correct by design.
+#     vertical-pod-autoscaler, external-secrets, keda, kubescape) and the
+#     leader-election singletons that share a namespace with HA workloads (hcloud
+#     CCM/CSI controller, snapshot-controller, external-dns, trust-manager,
+#     origin-ca-issuer, the kyverno background/reports/cleanup controllers) --
+#     1 active replica is correct by design.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -60,7 +61,13 @@ spec:
           # Single-purpose control-plane / operator namespaces: every workload
           # here is a leader-election singleton or operator-managed (1 active by
           # design). vertical-pod-autoscaler is included -- its admission webhook
-          # runs 2 and that is acceptable HA for an internal controller.
+          # runs 2 and that is acceptable HA for an internal controller. The same
+          # holds for external-secrets (controller + webhook + cert-controller),
+          # keda (operator, metrics-apiserver, admission-webhook and the HTTP
+          # add-on controller/interceptor/scaler) and kubescape (operator, storage,
+          # kubevuln, kubescape) -- dedicated operator namespaces whose every
+          # Deployment is a leader-election controller or webhook, none of which a
+          # 3-replica floor would make more available.
           - resources:
               namespaces:
                 - velero
@@ -72,9 +79,15 @@ spec:
                 - openbao
                 - testkube
                 - vertical-pod-autoscaler
+                - external-secrets
+                - keda
+                - kubescape
           # KEDA scale-to-zero targets, Flagger canary primaries (*-primary) and
           # the scaled-to-0 canary sources -- their replica count is owned by a
-          # controller, not declared statically.
+          # controller, not declared statically. The canary sources are matched by
+          # name here (the "?*-primary" glob only covers the primaries); Flagger
+          # scales each source Deployment to 0, so opencost belongs alongside the
+          # other onboarded apps (homepage, umami-umami).
           - resources:
               names:
                 - "?*-primary"
@@ -86,6 +99,7 @@ spec:
                 - longhorn-ui
                 - homepage
                 - umami-umami
+                - opencost
           # Leader-election singletons that share a namespace with HA workloads
           # we DO want flagged (kube-system, cert-manager, kyverno), so they are
           # excluded by name rather than namespace.


### PR DESCRIPTION
## What

`validate-replica-floor` (Audit) is currently the **only** source of Warning events on the prod cluster — it fires 60+ `PolicyViolation` events every reconcile. A subset of those are false positives the policy's own header comment already classifies as *"a replica floor is wrong, not missing"*, but the `exclude` block doesn't actually cover them. This aligns the rule with its documented intent.

### Changes
- **`opencost`** → added to the Flagger-canary-source name exclusion. opencost was onboarded to Flagger, so its source `Deployment` is scaled to **0** by the canary (`opencost-primary` runs 2/2). The exclude only matched `?*-primary`, never the source — same situation as `homepage` and `umami-umami`, which were already listed.
- **`external-secrets`, `keda`, `kubescape`** → added to the operator-namespace exclusion. Each is a dedicated, single-purpose operator namespace whose every `Deployment` is a leader-election controller or webhook (ESO controller/webhook/cert-controller; the KEDA operator/metrics-apiserver/admission-webhook + HTTP add-on controller/interceptor/scaler; the Kubescape operator/storage/kubevuln/kubescape). They are structurally identical to the already-excluded `velero` / `observability` / `vertical-pod-autoscaler` namespaces — a 3-replica floor would not make any of them more available.

This silences ~11 of the recurring violations (keda ×6, kubescape ×4, opencost ×1).

### Deliberately left flagged (genuine human HA decision, as the policy intends)
`cert-manager` (controller/webhook/cainjector — the author already by-name-excluded only trust-manager/origin-ca-issuer, signalling these were reviewed and kept), `dex`, `oauth2-proxy`, and the tenant apps `wedding-app` / `ascoachingogvaner`. These are user-facing / SSO-path workloads where raising to 3 vs. exempting is a real cost/availability tradeoff for a maintainer to make.

## Why
Per repo convention a healthy cluster should not emit Warning noise; the policy is Audit specifically to surface under-replicated workloads "for a human to raise (or exempt) deliberately". These four are provably-benign-by-design exemptions, not an enforcement change.

## Validation
- `ksail workload validate` (local): ✅ 308 files validated.
- `kubectl kustomize` of `bases/infrastructure/cluster-policies`, `clusters/prod`, `clusters/local`: ✅ all build.
- Server-side `kubectl apply --dry-run`: ✅ ClusterPolicy accepted by the live Kyverno CRD.
- `ksail --config ksail.prod.yaml workload validate` reports one **pre-existing, unrelated** failure: `coroot.com/v1` `notificationIntegrations` "additional properties not allowed" — a stale datreeio CRDs-catalog schema vs. the live Coroot operator CRD (the field is accepted in-cluster). It is in `providers/hetzner/infrastructure` (the Coroot CR), not this policy, and the skip-kinds fix would live in the protected `ksail.prod.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
