### PR TITLE
fix(infra): run the auth, webhook and critical-controller tier at 3 replicas for HA

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -88,6 +88,7 @@ spec:
                 - longhorn-ui
                 - homepage
                 - umami-umami
+                - opencost
           # Single-replica-only by design: external-dns (chart has no
           # replicaCount; >1 replica = duplicate Cloudflare writes + throttling),
           # origin-ca-issuer (disabled, 0 replicas) and flagger-loadtester

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -13,16 +13,21 @@ data:
   issuer_name: letsencrypt-prod
   # Per-env prefixes inside the shared R2 bucket.
   r2_prefix_velero: velero/prod
-  # --- Critical controllers (2 replicas for HA during VPA evictions) ---
-  # With VPA updateMode=InPlaceOrRecreate, single-replica services get 502s
-  # during eviction. User-facing auth and admission webhooks need 2+ replicas.
-  cert_manager_replicas: "2"
-  metrics_server_replicas: "2"
+  # --- Critical controllers (3 replicas for HA; require-three-replicas floor) ---
+  # With VPA updateMode=InPlaceOrRecreate, single-replica services get 502s during
+  # eviction. The replica-floor (#1898/#1900) wants 3 so a maxUnavailable: 1 PDB +
+  # topology spread survive a node drain AND a concurrent failure with zero
+  # downtime (2 only survives the drain). These run leader election or are
+  # stateless/admission webhooks, so the third replica is a cheap warm standby.
+  # cert_manager_replicas drives the controller, webhook AND cainjector; the keda
+  # vars drive the operator, admission webhooks, HTTP scaler and interceptor floor.
+  cert_manager_replicas: "3"
+  metrics_server_replicas: "3"
   vpa_admission_replicas: "3"
-  keda_operator_replicas: "2"
-  keda_webhooks_replicas: "2"
-  keda_scaler_replicas: "2"
-  keda_interceptor_min_replicas: "2"
+  keda_operator_replicas: "3"
+  keda_webhooks_replicas: "3"
+  keda_scaler_replicas: "3"
+  keda_interceptor_min_replicas: "3"
   # --- Leader-elected operators (3 replicas for HA; require-three-replicas) ---
   # One replica is active; the rest are warm standbys that take over on a node
   # failure/drain. velero stays 1 — its chart hardcodes replicas: 1 and it has
@@ -62,10 +67,12 @@ data:
   actual_budget_replicas_min: "0"
   actual_budget_replicas_max: "1"
   hubble_ui_replicas: "1"
-  # Auth chain: 2 replicas for HA during VPA evictions (prevents 502s).
-  dex_replicas: "2"
-  oauth2_proxy_replicas: "2"
-  auth_proxy_replicas: "2"
+  # Auth chain: 3 replicas for HA (require-three-replicas floor). User-facing auth
+  # must survive a node drain + a concurrent failure; also prevents 502s during VPA
+  # InPlaceOrRecreate evictions.
+  dex_replicas: "3"
+  oauth2_proxy_replicas: "3"
+  auth_proxy_replicas: "3"
   # --- Hetzner Cloud ---
   hetzner_lb_location: "fsn1"
   hetzner_lb_type: "lb11"
@@ -132,6 +139,9 @@ data:
   # --- OpenBao secrets vault ---
   openbao_replicas: "1"
   openbao_storage_size: 10Gi
-  # --- External Secrets Operator ---
-  external_secrets_replicas: "2"
+  # --- External Secrets Operator (3 replicas for HA; require-three-replicas) ---
+  # Drives the controller, webhook and cert-controller. Controller + cert-controller
+  # are leader-elected and the webhook is stateless, so the third replica is a warm
+  # standby that keeps the operator available through a node drain + failure.
+  external_secrets_replicas: "3"
 


### PR DESCRIPTION
## What
Continues the HA replica-floor rollout (#1898 → #1900). #1900 brought the leader-elected operators to 3 replicas; this brings the documented **"2 replicas for HA"** tier up to the `require-three-replicas` floor rather than exempting it. A 2-replica workload only survives a node drain; **3** + the `maxUnavailable: 1` PDB + topology spread also survive a *concurrent* failure during the drain.

Bumped (prod `variables-cluster-config-map.yaml`, 2 → 3):
| var | covers |
|---|---|
| `cert_manager_replicas` | cert-manager controller **+ webhook + cainjector** |
| `external_secrets_replicas` | ESO controller **+ webhook + cert-controller** |
| `dex_replicas`, `oauth2_proxy_replicas`, `auth_proxy_replicas` | the auth chain |
| `keda_operator_replicas`, `keda_webhooks_replicas`, `keda_scaler_replicas`, `keda_interceptor_min_replicas` | KEDA operator, admission webhooks, HTTP scaler, interceptor floor |
| `metrics_server_replicas` | metrics-server |

All run leader election or are stateless/admission webhooks, so the third replica is a warm standby (each chart verified to support it; a single var drives all sub-components for cert-manager and external-secrets). `vpa_admission` stays 2 — the VPA namespace is exempt from the floor and VPA HA is handled separately.

Also **exempts `opencost`** from the floor: it was onboarded to Flagger, so its source Deployment is scaled to 0 (`opencost-primary` runs the HA replicas) — same class as the `homepage`/`umami-umami` canary sources already listed.

## Why
Bring workloads **up to** the HA floor, not exempt them (this supersedes an earlier, now-closed attempt of mine, #1935, that exempted operator namespaces — wrong direction). This closes the largest remaining chunk of `validate-replica-floor` violations the right way.

## Capacity
Adds ~14 controller pods of memory requests. The cluster is capacity-tuned and the autoscaler provisions a worker as needed; a baseline worker bump may be wanted before merge (same caveat #1900 carried).

## Still flagged after this (follow-up — no chart `replicaCount` or needs per-chart HA verification)
`keda-operator-metrics-apiserver`, `keda-add-ons-http` controller-manager, `kubescape` ×4, `cilium-operator`, `coredns`, `hubble-relay`, `spire-server`, `tetragon-operator`, `kubelet-serving-cert-approver`, `kyverno-admission`, the Longhorn CSI sidecars, `cluster-autoscaler`, `ksail-operator`, and the `wedding-app` / `ascoachingogvaner` tenant apps. Several are Cilium/Talos/ksail-bootstrap-managed and want individual verification — best staged across follow-up PRs to keep capacity in check.

## Validation
- `ksail workload validate` (local): ✅ 308 files.
- `ksail --config ksail.prod.yaml workload validate`: passes for every changed file; the one failure is the **pre-existing** `coroot.com/v1` `notificationIntegrations` CRD-catalog schema flake (no coroot files touched; its skip-kinds fix lives in the protected `ksail.prod.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
