### PR TITLE
fix(flagger): make strategy post-renderer robust to the missing chart strategy block

### DIFF
--- a/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
@@ -81,22 +81,23 @@ spec:
       limits:
         memory: 256Mi
 
-  # Keep the Deployment on a RollingUpdate strategy. The chart hardcodes
-  # `strategy.type: Recreate` on the flagger Deployment
-  # (charts/flagger/templates/deployment.yaml) with no values override. An
-  # earlier chart revision rendered RollingUpdate, so the live Deployment carries
-  # an API-defaulted `rollingUpdate{maxSurge,maxUnavailable}` block. Server-side
-  # apply does NOT prune that block when `type` flips to Recreate, so the merged
-  # object is rejected as invalid — `spec.strategy.rollingUpdate may not be
-  # specified when strategy type is 'Recreate'` — and every Helm upgrade fails
-  # and rolls back, stalling the flagger HelmRelease and wedging
-  # infrastructure-controllers (→ infrastructure → apps). Flagger runs leader
-  # election, so the brief pod overlap a rolling update allows is safe. The chart
-  # exposes no value for this, so patch the rendered Deployment back to
-  # RollingUpdate via a post-renderer; set the rollingUpdate params explicitly
-  # (the Kubernetes defaults) so helm-controller fully owns the field, the
-  # applied object matches the live object exactly, and drift detection (which
-  # does not ignore /spec/strategy) sees no diff.
+  # Pin the Deployment's update strategy deterministically. The chart's
+  # `strategy.type: Recreate` only renders when leaderElection is DISABLED; with
+  # leaderElection enabled (above, for HA) the chart omits the strategy block
+  # entirely, so the Deployment falls back to the API default RollingUpdate with
+  # an API-defaulted `rollingUpdate{maxSurge,maxUnavailable}`. The rendered
+  # manifest then has no /spec/strategy while the live object does, which drift
+  # detection (which does not ignore /spec/strategy) would flag every reconcile.
+  # So set the whole block explicitly to the Kubernetes defaults: helm-controller
+  # owns the field, the applied object matches the live object, and drift sees no
+  # diff.
+  #
+  # Use `op: add` on the whole /spec/strategy object (not `op: replace` on
+  # /spec/strategy/type): since the chart now renders no strategy block,
+  # `replace` fails at install with "doc is missing path: /spec/strategy/type".
+  # `add` on /spec (which always exists) creates-or-replaces deterministically,
+  # and remains correct if a future chart/leaderElection change reintroduces a
+  # strategy block.
   postRenderers:
     - kustomize:
         patches:
@@ -104,11 +105,10 @@ spec:
               kind: Deployment
               name: flagger
             patch: |
-              - op: replace
-                path: /spec/strategy/type
-                value: RollingUpdate
               - op: add
-                path: /spec/strategy/rollingUpdate
+                path: /spec/strategy
                 value:
-                  maxSurge: 25%
-                  maxUnavailable: 25%
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 25%
+                    maxUnavailable: 25%


### PR DESCRIPTION
## Problem

The System Test fails on **every** k8s PR (surfaced on #1929, but not caused by it). The flagger HelmRelease install fails at post-render:

```
Helm install failed for release flagger-system/flagger with chart flagger@1.43.0:
error while running post render on manifests: replace operation does not apply:
doc is missing path: /spec/strategy/type: missing value
```

…which wedges `infrastructure-controllers → infrastructure → apps`.

## Root cause (regression from #1900)

[#1900](https://github.com/devantler-tech/platform/pull/1900) enabled flagger `leaderElection` for HA. The flagger chart only renders `strategy.type: Recreate` when leaderElection is **disabled**; with it **enabled** the chart **omits the `strategy` block entirely**. The existing post-renderer used `op: replace /spec/strategy/type`, and `replace` fails when the target path doesn't exist — so the install now dies deterministically.

(#1900's own System Test presumably passed before the leaderElection commit landed, or merged via the merge queue, which skips the docker System Test.)

## Fix

Replace the `replace`+`add` pair with a single **`op: add /spec/strategy`** for the whole strategy object. `/spec` always exists on a Deployment, so `add` creates-or-replaces deterministically whether or not the chart renders a strategy block — and still pins the explicit RollingUpdate defaults so drift detection (which doesn't ignore `/spec/strategy`) sees no diff. The comment is updated to reflect the leaderElection interaction.

## Validation

- `ksail workload validate`: **local 0 failures**; **prod** unchanged (only the pre-existing coroot CRD-catalog schema flake). Both provider controller overlays build.
- The post-render itself is only exercisable in the **System Test** (it runs at Helm install time) — this PR's System Test is the real confirmation. `op: add` on `/spec` cannot raise the "missing path" error by construction.

## Impact

Unblocks the System Test for all open k8s PRs (#1927/#1928 already merged; this restores green for #1929, #1931, and the merge queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)