### PR TITLE
fix(umami): restart the Flagger primary on DB-password rotation via Reloader

### DIFF
--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -28,6 +28,20 @@ spec:
             patch: |
               - op: remove
                 path: /spec/replicas
+              # OpenBao rotates the umami DB password out of band (7-day static
+              # role), refreshed into the umami-db-rotated Secret. The app reads it
+              # into DATABASE_URL at startup, so a running pod keeps a stale
+              # password after a rotation and crashes with Prisma P1000 until
+              # restarted. Stakater Reloader restarts a workload when a Secret it
+              # is annotated for changes. The live workload is the Flagger primary
+              # (umami-umami-primary); Flagger does NOT carry this annotation onto
+              # the primary (it freezes/filters primary metadata at creation —
+              # fluxcd/flagger#1032), so the propagate-reloader-to-flagger-primary
+              # ClusterPolicy copies it across. The annotation here also keeps the
+              # canary source itself reloadable.
+              - op: add
+                path: /metadata/annotations/secret.reloader.stakater.com~1reload
+                value: umami-db-rotated
   # https://github.com/helmforgedev/charts/blob/main/charts/umami/values.yaml
   values:
     # replicaCount intentionally omitted — Flagger manages canary replicas

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/propagate-reloader-to-flagger-primary.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/propagate-reloader-to-flagger-primary.yaml
@@ -1,0 +1,69 @@
+# Makes Stakater Reloader work with Flagger-managed workloads.
+#
+# An app fronted by a Flagger canary serves traffic from a Flagger-created
+# "<name>-primary" Deployment; the chart's own "<name>" Deployment is the canary
+# SOURCE, which Flagger scales to 0 between rollouts. Reloader reads its trigger
+# annotation (secret.reloader.stakater.com/reload) from a workload's TOP-LEVEL
+# metadata and restarts that workload when the named Secret changes.
+#
+# Flagger copies the source Deployment's metadata annotations to the primary only
+# at first creation, never updates them afterwards (fluxcd/flagger#1032), and the
+# copy is filtered -- so a reloader annotation on the source does NOT reliably
+# reach the primary (verified in-cluster: homepage-primary carries none of its
+# source's annotations). The effect: when an out-of-band-rotated Secret changes
+# (e.g. OpenBao rotates umami-db-rotated every 7 days), Reloader restarts the
+# scaled-to-0 SOURCE -- a no-op -- while the live PRIMARY keeps its stale startup
+# credentials and crash-loops (umami: Prisma P1000) until a manual restart.
+#
+# This mutate-existing rule copies a source Deployment's
+# secret.reloader.stakater.com/reload annotation onto its "<name>-primary", so
+# Reloader restarts the primary on rotation. mutateExistingOnPolicyUpdate applies
+# it to primaries that already exist (not just ones created after the policy).
+# Workloads without a "-primary" (non-Flagger apps such as fleetdm/headlamp) have
+# no target, so the rule is a harmless no-op for them. Mirrors the existing
+# mutate-existing pattern in disable-default-sa-automount.yaml.
+#
+# The background controller needs update access on apps/Deployments to run this
+# mutate-existing patch (Kyverno verifies the grant at policy admission). That
+# grant is an aggregated ClusterRole shipped one layer earlier with the Kyverno
+# controller (controllers/kyverno/background-controller-rbac.yaml) so it is live
+# and aggregated before this policy is admitted.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: propagate-reloader-to-flagger-primary
+  annotations:
+    policies.kyverno.io/title: Propagate Reloader Annotation to Flagger Primary
+    policies.kyverno.io/category: Best Practices, Progressive Delivery
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Deployment
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Copies a Flagger canary source Deployment's
+      secret.reloader.stakater.com/reload annotation onto its <name>-primary so
+      Stakater Reloader restarts the live primary when the referenced Secret
+      rotates (Flagger does not carry the annotation across itself).
+spec:
+  rules:
+    - name: copy-secret-reload-to-primary
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+      preconditions:
+        all:
+          - key: "{{ request.object.metadata.annotations.\"secret.reloader.stakater.com/reload\" || '' }}"
+            operator: NotEquals
+            value: ""
+      mutate:
+        mutateExistingOnPolicyUpdate: true
+        targets:
+          - apiVersion: apps/v1
+            kind: Deployment
+            name: "{{ request.object.metadata.name }}-primary"
+            namespace: "{{ request.object.metadata.namespace || request.namespace }}"
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              secret.reloader.stakater.com/reload: "{{ request.object.metadata.annotations.\"secret.reloader.stakater.com/reload\" }}"

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - best-practices/add-security-context.yaml
   - best-practices/auto-vpa.yaml
   - best-practices/disable-default-sa-automount.yaml
+  - best-practices/propagate-reloader-to-flagger-primary.yaml
   - best-practices/restrict-tenant-secret-stores.yaml
   - best-practices/validate-host-restrictions.yaml
   - best-practices/validate-pdb-drain-safe.yaml

--- a/k8s/bases/infrastructure/controllers/kyverno/background-controller-rbac.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/background-controller-rbac.yaml
@@ -1,0 +1,32 @@
+# Extra permissions for Kyverno's background controller.
+#
+# Kyverno aggregates any ClusterRole carrying the
+# rbac.kyverno.io/aggregate-to-background-controller label into the background
+# controller's ClusterRole (kyverno:background-controller). By default that
+# controller can only write the resource kinds the bundled policies touch (e.g.
+# the default ServiceAccount for disable-default-sa-automount) and has NO write
+# access to Deployments.
+#
+# The propagate-reloader-to-flagger-primary ClusterPolicy (cluster-policies, the
+# next Flux layer) uses mutateExisting to patch annotations onto Flagger
+# "<name>-primary" Deployments. Kyverno checks this grant at policy admission and
+# rejects the policy without it, so the grant ships here -- one layer earlier
+# (infrastructure-controllers) than the policy (infrastructure) -- ensuring it is
+# live and aggregated before the policy is admitted.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:background-controller:mutate-deployments
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch

--- a/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - networkpolicy.yaml
+  - background-controller-rbac.yaml


### PR DESCRIPTION
## What
Makes **Stakater Reloader work with Flagger-managed workloads**, fixing umami's recurring `Prisma P1000` crash on DB-password rotation.

### The bug
OpenBao rotates umami's DB password (7-day static role) into the `umami-db-rotated` Secret. umami reads it into `DATABASE_URL` **at startup**, so a running pod keeps stale credentials after a rotation and crash-loops until restarted (and the `umami-provision-tenants` CronJob then fails auth). The repo's dual-owner CNPG role and `flagger.app/config-tracking: disabled` are already correct — the missing piece is a **restart trigger on rotation**.

### Why the obvious fix didn't work (and the correction)
I'd initially concluded Flagger and Reloader can't coexist — **that was wrong**. They can, but not by simply annotating the source:
- Reloader reads its trigger annotation from a workload's **top-level metadata** and restarts that workload.
- The live umami workload is the **Flagger primary** (`umami-umami-primary`). Flagger sets a primary's metadata annotations **only at first creation**, never updates them afterwards ([fluxcd/flagger#1032](https://github.com/fluxcd/flagger/issues/1032)), and filters them on copy — so a reloader annotation on the canary *source* never lands on the primary. Verified in-cluster: `homepage-primary` carries **none** of its source's annotations.

So Reloader was restarting the scaled-to-0 *source* (a no-op) while the live *primary* kept crashing.

### The fix (general — fixes the class)
1. Annotate the umami canary **source** with `secret.reloader.stakater.com/reload: umami-db-rotated` (postRenderer).
2. New Kyverno **mutate-existing** ClusterPolicy `propagate-reloader-to-flagger-primary` copies that annotation onto `<name>-primary`, mirroring the existing `disable-default-sa-automount` pattern. `mutateExistingOnPolicyUpdate` annotates the already-running primary, not just future ones. Non-Flagger workloads have no `-primary` target → harmless no-op.
3. Grant Kyverno's background controller `update` on `apps/Deployments` via an aggregated ClusterRole, shipped **one Flux layer earlier** (with the Kyverno controller) so it's aggregated *before* the policy is admitted — Kyverno checks this grant at policy admission (the server-side dry-run confirmed both the requirement and that the policy is otherwise structurally valid).

Any Flagger canary app needing reloader on its primary now works.

## Validation
- `ksail workload validate` local ✅ 310 files; prod ✅ for every changed file (the one prod failure is the **pre-existing** `coroot.com/v1 notificationIntegrations` CRD-catalog schema flake — unrelated).
- `kubectl kustomize` of cluster-policies, controllers/kyverno, clusters/prod, clusters/local — all build.
- Kyverno accepted the policy structure on server-side dry-run; the only dry-run error is the auth check (RBAC isn't live in a dry-run), satisfied at real apply by the earlier-layer ClusterRole. CI's docker system test exercises the full apply (RBAC + policy ordering) end-to-end.

## Immediate recovery (one-time, for the maintainer)
The currently-broken primary holds an already-rotated password and needs a one-time restart to recover now; the policy prevents recurrence:
```
kubectl -n umami rollout restart deploy/umami-umami-primary
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
