### PR TITLE
fix(cilium): allow remote-node identities under WireGuard egress strict mode

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -16,9 +16,24 @@
 # pod traffic (never leaves the host) and pod->node-IP / pod->internet traffic
 # (destinations outside the pod CIDR) are unaffected and not dropped.
 #
-# allowRemoteNodeIdentities is left at its default (false): the Hetzner node
-# CIDR (10.0.0.0/16 — ksail.prod.yaml networkCidr) does not overlap the pod
-# CIDR (10.244.0.0/16), so no remote-node-identity exemption is required.
+# allowRemoteNodeIdentities is set true because this cluster runs in tunnel
+# (VXLAN) routing mode (routing-mode: tunnel). Cilium REQUIRES it whenever
+# tunneling is used — node-identity (IPCache) propagation is only eventually
+# consistent, so during the convergence window after a node joins/reboots
+# (constant here: the Hetzner autoscaler churns cattle workers) the source node
+# may not yet know a peer's identity. Left false, strict mode fails CLOSED on
+# that node-identity traffic too, dropping the cilium-agent SPIRE mutual-auth
+# handshake (TCP 4250) and cilium-health host probes (TCP 4240) to the
+# not-yet-propagated peer. That black-holes the mTLS the hetzner
+# require-mutual-auth policy demands, so every auth-gated cross-node pod flow
+# to/from a freshly churned node stalls (observed: KEDA http-add-on scaler
+# CrashLoopBackOff, Longhorn replica-rebuild storms, the umami provisioner and
+# coroot-heartbeat failing, cilium-health "2/9 reachable"). true exempts only
+# node-IDENTITY traffic from the strict drop (it may briefly ride unencrypted
+# during that window, then converges to WireGuard); pod-to-pod traffic across
+# the egress CIDR below stays fail-closed. The earlier "CIDRs don't overlap so
+# it isn't required" reasoning was wrong: the Cilium rule is "tunneling is used
+# OR (direct routing AND CIDR overlap)", so tunneling alone makes it mandatory.
 #
 # Uses the non-deprecated encryption.strictMode.egress.* keys (the top-level
 # encryption.strictMode.{enabled,cidr} keys are deprecated as of Cilium 1.19).
@@ -47,3 +62,8 @@ spec:
         egress:
           enabled: true
           cidr: 10.244.0.0/16
+          # Required in tunnel routing mode (see header): exempts node-identity
+          # traffic from the strict drop so the SPIRE mutual-auth handshake and
+          # cilium-health host probes survive the IPCache propagation window
+          # during node churn. Pod-to-pod across the CIDR above stays fail-closed.
+          allowRemoteNodeIdentities: true


### PR DESCRIPTION
## Root cause

Prod's hetzner cilium patch (`k8s/providers/hetzner/infrastructure/controllers/cilium/patches/helm-release-patch.yaml`) enables **WireGuard egress strict mode** (fail‑closed encryption) but left `encryption.strictMode.egress.allowRemoteNodeIdentities` at the default **`false`**.

Cilium **requires** this be `true` whenever **tunnel routing** is used — and this cluster runs `routing-mode: tunnel` (VXLAN). The rule is *"tunneling is used **OR** (direct routing **AND** node/pod CIDR overlap)"*, so tunneling alone makes it mandatory; the patch's original *"CIDRs don't overlap, so it isn't required"* reasoning was incorrect. (Refs: Cilium [Transparent Encryption](https://docs.cilium.io/en/stable/security/network/encryption/) docs — `EncryptionStrictEgressAllowRemoteNodeIdentities` *"is required when tunneling is used …"*.)

Node‑identity (IPCache) propagation is **eventually consistent**. During the convergence window after a node joins/reboots — *constant here* because the Hetzner autoscaler churns cattle workers — the source node doesn't yet know a peer's identity. With the flag `false`, strict mode fails **closed** on that node‑identity traffic and **drops**:

- the cilium‑agent **SPIRE mutual‑auth handshake** (`TCP 4250`), and
- **cilium‑health** host probes (`TCP 4240`)

to the not‑yet‑propagated peer. That black‑holes the mTLS the `require-mutual-auth` CCNP demands, so every auth‑gated **cross‑node** pod flow to/from a freshly churned node stalls.

## Observed on live prod (before this change)

- `cilium-agent` logs spamming `failed to authenticate request … dial tcp 10.0.1.x:4250: i/o timeout` (and `no route to host` to peer public IPs).
- `cilium-health status`: **2/9 reachable** from worker agents — control‑plane→worker fine, **worker→worker dropped** (same dest port, different source ⇒ it's the strict‑mode node‑identity drop, not the firewall, which already allows 4250/4240 from the node CIDR).
- **KEDA** http‑add‑on `external-scaler` **CrashLoopBackOff** (68 restarts) — can't reach interceptor `/queue` on churned nodes.
- **Longhorn** replica‑rebuild storms / `i/o timeout` between instance‑managers on autoscale nodes.
- **umami** provision‑tenants CronJob + **coroot‑heartbeat** failing intermittently.

All are downstream of the same dropped node‑to‑node mTLS.

## Fix

Set `encryption.strictMode.egress.allowRemoteNodeIdentities: true`.

This exempts **only node‑identity** traffic from the strict drop (it may briefly ride unencrypted during the propagation window, then converges to WireGuard). **Pod‑to‑pod** traffic across the egress CIDR (`10.244.0.0/16`) **stays fail‑closed**, so the encryption posture for workload data is unchanged. Also corrects the now‑wrong header comment.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/` → builds; rendered cilium HelmRelease carries `strictMode.egress.allowRemoteNodeIdentities: true`.
- `kubectl kustomize k8s/clusters/prod` and `k8s/clusters/local` → build clean.
- Docker overlay disables encryption entirely, so this is prod/hetzner‑only and not exercised by the CI System Test — **validate on first prod reconcile** (cilium‑agent auth errors should stop; `cilium-health` should return to 9/9).

> ⚠️ Prod security‑adjacent change. Once Flux reconciles, the cilium‑config change rolls the cilium‑agents, which also clears the accumulated stale node/identity state causing the current black‑hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)