### PR TITLE
fix(oauth2-proxy): don't mount an unused ServiceAccount API token

### DIFF
--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -22,6 +22,14 @@ spec:
     deploymentAnnotations:
       configmap.reloader.stakater.com/reload: oauth2-proxy
     replicaCount: ${oauth2_proxy_replicas:=2}
+    serviceAccount:
+      # oauth2-proxy authenticates against Dex and proxies to in-cluster HTTP
+      # upstreams (auth-proxy) — it never calls the Kubernetes API, and its
+      # ServiceAccount has zero Role/ClusterRole bindings. Don't mount an API
+      # token it can't use: a mounted-but-unused token is pure attack surface
+      # (Kubescape C-0261/C-0034/C-0190). The chart applies this to both the SA
+      # and the pod template.
+      automountServiceAccountToken: false
     podDisruptionBudget:
       enabled: true
       # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 never deadlocks


### PR DESCRIPTION
## What

Set `serviceAccount.automountServiceAccountToken: false` on the oauth2-proxy HelmRelease.

## Why

oauth2-proxy's ServiceAccount has **zero Role/ClusterRole bindings** (verified on live prod — no `clusterrolebindings` or namespaced `rolebindings` reference it), yet `automountServiceAccountToken` defaults to `true` on both the SA and the pod. oauth2-proxy only:
- authenticates against **Dex** (OIDC), and
- proxies to the in-cluster **auth-proxy** HTTP upstream.

It never calls the Kubernetes API, so the mounted token is unusable and is **pure attack surface** (Kubescape C-0261 / C-0034 / C-0190). This is defence-in-depth with **no behavioural change** — nothing could use the token anyway.

## Validation

- `kubectl kustomize k8s/clusters/prod` and `k8s/clusters/local` → build clean.
- Rendered HelmRelease carries `serviceAccount.automountServiceAccountToken: false` (the `oauth2-proxy/manifests` chart applies it to both the SA and the pod template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)