### PR TITLE
feat(overprovisioning): keep a warm spare Hetzner node for instant spikes

### DIFF
--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -27,6 +27,13 @@ resources:
   # http.keda.sh CRD shipped by the keda-http-add-on HelmRelease is established
   # first. longhorn-system is Hetzner-only, so this can't live in bases/.
   - http-scaled-objects/
+  # Prod-only over-provisioning ("spare room"): low-priority `pause` pods that
+  # reserve ~one autoscaler node's worth of capacity, so the Cluster Autoscaler
+  # keeps a warm, near-empty Hetzner node ready and a traffic spike preempts
+  # them and schedules instantly instead of waiting for a new server to boot.
+  # Hetzner-only because the autoscaler is Hetzner/prod-only; see the dir's
+  # file headers for the priority/sizing/VPA-avoidance reasoning.
+  - overprovisioning/
 components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — covers the
   # opencost HelmRelease in this layer. See

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - priority-class.yaml
+  - replicaset.yaml

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/namespace.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/namespace.yaml
@@ -1,0 +1,17 @@
+# Dedicated namespace for the over-provisioning ("spare room") pause workload.
+#
+# Kept out of any app/infra namespace so the buffer is trivially observable
+# (`kubectl -n overprovisioning get pods`) and so a single ResourceQuota/cost
+# line attributes the warm-node spend to over-provisioning explicitly.
+#
+# PSA restricted at admission: the pause pods carry a fully specified
+# restricted securityContext (see replicaset.yaml), so they pass Pod Security
+# without leaning on the Kyverno add-security-context webhook — same posture as
+# flagger-system / reloader.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: overprovisioning
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/priority-class.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/priority-class.yaml
@@ -1,0 +1,37 @@
+# Priority tier for the over-provisioning pause pods — deliberately BELOW every
+# real workload so any genuine pod can preempt (evict) a pause pod and take its
+# warm capacity instantly, then let the autoscaler refill the buffer in the
+# background.
+#
+# Value −1 is chosen precisely, between two thresholds:
+#
+#   • BELOW 0 (the implicit priority of any pod with no priorityClassName) so a
+#     normal workload always outranks the buffer and preempts it on a full
+#     cluster — this is what makes a spike absorb instantly instead of waiting
+#     for a new Hetzner server to boot.
+#
+#   • ABOVE the Cluster Autoscaler's `--expendable-pods-priority-cutoff`
+#     (upstream default −10). Pods *below* that cutoff are treated as
+#     "expendable": the autoscaler neither scales UP to place them nor counts
+#     them when deciding a node is empty enough to scale DOWN. A pause pod at
+#     −1 is therefore NOT expendable, so a Pending pause pod DOES trigger a
+#     scale-up (the whole point), and a node holding only pause pods is NOT
+#     reclaimed — which is exactly how the warm spare node is kept alive.
+#     If KSail ever lowers that cutoff at/below −1, the buffer would stop
+#     provisioning nodes; keep this value strictly greater than the cutoff.
+#
+# preemptionPolicy: Never — a pause pod must never itself evict another pod. It
+# only ever waits to be scheduled (triggering the autoscaler) or be preempted;
+# it is filler, never an aggressor.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: overprovisioning
+value: -1
+globalDefault: false
+preemptionPolicy: Never
+description: >-
+  Over-provisioning ("spare room") buffer pods. Ranked below all real
+  workloads (so they are preempted first) but above the cluster-autoscaler
+  expendable cutoff (so Pending buffer pods still trigger a scale-up). Never
+  preempts other pods.

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/replicaset.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/replicaset.yaml
@@ -1,0 +1,118 @@
+# Over-provisioning ("spare room") buffer — keeps one warmed-up Hetzner server
+# sitting empty and ready so a traffic spike schedules INSTANTLY instead of
+# waiting ~2-3 min for the Hetzner API to boot a new node.
+#
+# How it works (the classic cluster-autoscaler over-provisioning pattern):
+#   1. This workload runs do-nothing `pause` pods at the `overprovisioning`
+#      priority (−1, below every real workload — see priority-class.yaml) that
+#      RESERVE a chunk of capacity (~most of one autoscaler node) while using
+#      essentially zero CPU/RAM.
+#   2. Because that reservation does not fit on the busy baseline workers, the
+#      Cluster Autoscaler provisions one cost-optimized `autoscale-cx*` node to
+#      hold it — a warm, near-empty server.
+#   3. When a real (higher-priority) pod can't fit, the scheduler PREEMPTS a
+#      pause pod and takes its warm node immediately. The evicted pause pod goes
+#      Pending, which makes the autoscaler boot a replacement node in the
+#      background — restoring the buffer.
+# Net steady state: baseline workers + one warm spare node, always ready.
+#
+# === Why a bare ReplicaSet and not a Deployment ===
+# `auto-vpa` (k8s/bases/.../best-practices/auto-vpa.yaml) generates a
+# VerticalPodAutoscaler for every Deployment/StatefulSet/DaemonSet with
+# `synchronize: true`. A VPA would observe that these pods use ~0 resources and
+# right-size their REQUESTS down to its minAllowed floor — collapsing the very
+# reservation that creates the spare room, and `synchronize: true` means we
+# can't durably override it with our own updateMode: "Off" VPA (Kyverno reverts
+# it). A bare ReplicaSet is matched by NONE of those three kinds, so no VPA is
+# generated and the reservation stays fixed. It also sidesteps
+# `validate-replica-floor` (Deployment/StatefulSet only) — a 3-replica floor is
+# meaningless for a capacity buffer whose replica count is a tuning knob, not an
+# availability guarantee. The pod-level PSS enforce policy still applies (and we
+# comply below).
+#
+# === Sizing (TUNE ME) ===
+# requests == limits == 2 CPU / 4Gi. The smallest overflow pool is `cx33`
+# (4 vCPU / 8 GB; see ksail.prod.yaml). A fresh cx33 must also run the per-node
+# kube-system DaemonSets (cilium, spire-agent, tetragon, hcloud-csi node, …),
+# which take ~0.3 CPU / ~1.5 GB, so the buffer is deliberately set BELOW raw
+# allocatable to guarantee it still fits a brand-new cx33 (otherwise the
+# autoscaler would jump to a pricier cx43). 2 CPU / 4Gi is also far too large to
+# squeeze onto the already-loaded baseline workers, so it reliably forces a new
+# node. Scale the buffer by raising replicas (one warm node per replica) or the
+# per-pod request — bounded by ksail.prod.yaml's maxNodesTotal: 10.
+#
+# === FinOps trade-off ===
+# This intentionally runs counter to `prefer-baseline-nodes.yaml`, which keeps
+# the autoscaler pools scaled to zero to minimize spend. Over-provisioning buys
+# spike latency back by paying for ~one extra cx33 (~€5/mo) 24/7. The soft
+# nodeAffinity below keeps that spend on the cheapest *autoscaler* capacity once
+# KSail stamps the `ksail.io/autoscaled` label, rather than consuming baseline.
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: overprovisioning
+  namespace: overprovisioning
+  labels:
+    app.kubernetes.io/name: overprovisioning
+    app.kubernetes.io/component: cluster-buffer
+    app.kubernetes.io/part-of: platform
+spec:
+  # One warm spare node. Raise to widen the buffer (N replicas ≈ N warm nodes).
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: overprovisioning
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: overprovisioning
+        app.kubernetes.io/component: cluster-buffer
+        app.kubernetes.io/part-of: platform
+    spec:
+      # Below every real workload, so spikes preempt this first.
+      priorityClassName: overprovisioning
+      # Nothing to talk to and nothing to authenticate as.
+      automountServiceAccountToken: false
+      # Evict fast on preemption — the pod does nothing, so don't wait 30s.
+      terminationGracePeriodSeconds: 0
+      # Declaring our OWN nodeAffinity does two things: (1) once KSail stamps the
+      # `ksail.io/autoscaled` label, it keeps the warm buffer on the cheap
+      # autoscaler pools; (2) the `+(nodeAffinity)` add-anchor in
+      # prefer-baseline-nodes.yaml then leaves these pods untouched instead of
+      # biasing them toward the baseline. It is SOFT (preferred), so while the
+      # label is still absent (the policy notes it is inert today) the pods are
+      # not stuck Pending — they schedule wherever they fit, which is what lets
+      # the autoscaler boot the first spare node from a cold start.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: ksail.io/autoscaled
+                    operator: Exists
+      containers:
+        - name: pause
+          # Upstream Kubernetes pause image — sleeps until signalled, no logic.
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          # PSS restricted-compliant (validate-pod-security enforces this).
+          # pause needs no writes, no privileges and no root.
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault


### PR DESCRIPTION
## Spare Room — over-provisioning buffer for instant traffic spikes

Adds a prod-only **over-provisioning ("spare room")** buffer so the cluster always has an empty, warmed-up Hetzner node ready. A spike then schedules **instantly** instead of waiting ~2–3 min for the Hetzner API to boot a server.

### How it works
1. Low-priority `pause` pods (do nothing) **reserve ~one autoscaler node's worth** of capacity.
2. Because that reservation won't fit on the busy baseline workers, the Cluster Autoscaler boots one cost-optimized `autoscale-cx*` node to hold it — a warm, near-empty server.
3. A real (higher-priority) pod **preempts** a pause pod and takes its warm node immediately; the evicted pause pod goes Pending and triggers a **background scale-up** that refills the buffer.

Net steady state: baseline workers **+ one warm spare node**, always ready.

### What's here — `k8s/providers/hetzner/infrastructure/overprovisioning/`
| File | Purpose |
|---|---|
| `priority-class.yaml` | `PriorityClass` value **−1** |
| `replicaset.yaml` | bare ReplicaSet of `registry.k8s.io/pause:3.10` pods |
| `namespace.yaml` | dedicated `overprovisioning` ns (PSA restricted) |
| `kustomization.yaml` | wires the three |

Plus one line wiring `overprovisioning/` into the **hetzner** infrastructure overlay (autoscaling is Hetzner/prod-only).

### Design decisions (grounded in this repo's policies)
- **Priority −1, not lower.** Below `0` (so any real pod preempts the buffer) but **above the cluster-autoscaler `--expendable-pods-priority-cutoff` (default −10)** — pods below that cutoff neither trigger scale-up nor keep a node from scaling down, which would defeat the buffer. `preemptionPolicy: Never` (a pause pod waits/​is-evicted, never evicts others).
- **Bare ReplicaSet, not a Deployment** — deliberately. `auto-vpa` generates a `synchronize: true` VPA for every Deployment/StatefulSet/DaemonSet; a VPA would right-size these idle pods' **requests down to ~0 and collapse the reservation**, and `synchronize: true` means our own `updateMode: Off` VPA can't durably override it. A ReplicaSet is matched by none of those kinds, so no VPA is generated. It also avoids `validate-replica-floor` (a 3-replica HA floor is meaningless for a capacity buffer). The pod still fully satisfies the **PSS restricted** enforce policy.
- **Sized 2 CPU / 4Gi.** Fits a fresh `cx33` (4 vCPU/8 GB) *after* its per-node kube-system DaemonSets (~0.3 CPU/1.5 GB) so the autoscaler picks the cheapest pool, yet too large to squeeze onto the loaded baseline workers so it reliably forces a new node. Tunable (one warm node per replica), bounded by `ksail.prod.yaml`'s `maxNodesTotal: 10`.
- **Soft `nodeAffinity` toward `ksail.io/autoscaled`.** Keeps the buffer on cheap autoscaler capacity once KSail stamps that (currently inert) label, and stops `prefer-baseline-nodes` from biasing the pause pods onto the baseline. Soft, so it does **not** strand the pods Pending today while the label is absent.

### FinOps trade-off
This intentionally runs counter to `prefer-baseline-nodes.yaml` (which keeps autoscaler pools at zero to minimize spend): it buys spike latency back by paying for ~one extra `cx33` (~€5/mo) 24/7. Scale the buffer up/down by tuning `replicas` or the per-pod request.

### Validation
- `ksail --config ksail.prod.yaml workload validate` → **`providers/hetzner/infrastructure/overprovisioning` validated ✔**.
- `kubectl kustomize` of the dir and of the full hetzner infrastructure overlay both build cleanly.
- The one unrelated `ksail validate` error (`coroot.com/v1` `notificationIntegrations` not in the datreeio CRD catalog) is **pre-existing** in `coroot/patches/coroot-patch.yaml` — untouched here.

### Notes
- Draft, and **platform is mid prod-incident** — this is a non-urgent enhancement; promote/merge whenever the incident has settled. The full Talos+Docker system-test runs in CI on this k8s change.
- Future hardening (optional): pin the buffer to autoscaler nodes with a *required* affinity once KSail actually stamps `ksail.io/autoscaled` on its node-group templates (today that label is inert, so a required affinity would strand the pods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
