### PR TITLE
fix(cluster-policies): drop removed v2beta HelmRelease APIs from Kyverno match

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/flux/enforce-flux-best-practices.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/flux/enforce-flux-best-practices.yaml
@@ -66,9 +66,12 @@ spec:
         any:
           - resources:
               kinds:
+                # v2 only: the v2beta1/v2beta2 APIs were removed from the
+                # cluster (Flux ≥ 2.6 serves only helm.toolkit.fluxcd.io/v2).
+                # Matching the dead versions makes Kyverno's GVK→GVR lookup
+                # fail on every admission review and background scan
+                # ("unable to convert GVK to GVR ... resource not found").
                 - helm.toolkit.fluxcd.io/v2/HelmRelease
-                - helm.toolkit.fluxcd.io/v2beta2/HelmRelease
-                - helm.toolkit.fluxcd.io/v2beta1/HelmRelease
       validate:
         message: >-
           Flux HelmRelease must set the recommended reliability fields:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Every `infrastructure` apply logs (via Kyverno admission warnings surfaced in kustomize-controller):

```
the kind defined in the all match resource is invalid: unable to convert GVK to GVR for kinds helm.toolkit.fluxcd.io/v2beta2/HelmRelease, err: resource not found
```

## Root cause

The `enforce-flux-best-practices` ClusterPolicy matches `helm.toolkit.fluxcd.io/v2beta2/HelmRelease` and `v2beta1/HelmRelease` alongside `v2`. Those beta APIs were removed in Flux ≥ 2.6 — the cluster (kustomize-controller v1.8.5) serves only `helm.toolkit.fluxcd.io/v2` (verified with `kubectl api-versions`). Kyverno fails the GVK→GVR lookup for the dead versions on every admission review and background scan.

## Fix

Match only the served `v2` API, with a comment explaining why.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅, `k8s/clusters/prod/` ✅

Note: a second pre-existing Kyverno warning ('matching on replicas but not including the scale subresource', from `validate-replica-floor`) is deliberately **not** touched here — adding `/scale` matching would change admission behavior for HPA/KEDA scale operations and needs its own considered change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)