### PR TITLE
fix(openbao): route clients to the active service so sealed standbys stop 503ing

### DIFF
--- a/k8s/bases/apps/fleetdm/mysql-static-cred-generator.yaml
+++ b/k8s/bases/apps/fleetdm/mysql-static-cred-generator.yaml
@@ -23,7 +23,9 @@ spec:
   path: "database/static-creds/fleet"
   method: GET
   provider:
-    server: "http://openbao.openbao.svc.cluster.local:8200"
+    # openbao-active = unsealed Raft leader only; the plain `openbao` Service
+    # also round-robins onto sealed-but-Ready standbys (503 "Vault is sealed").
+    server: "http://openbao-active.openbao.svc.cluster.local:8200"
     auth:
       kubernetes:
         mountPath: "kubernetes"

--- a/k8s/bases/apps/umami/db-rotated-external-secret.yaml
+++ b/k8s/bases/apps/umami/db-rotated-external-secret.yaml
@@ -13,7 +13,9 @@ spec:
   path: "database/static-creds/umami"
   method: GET
   provider:
-    server: "http://openbao.openbao.svc.cluster.local:8200"
+    # openbao-active = unsealed Raft leader only; the plain `openbao` Service
+    # also round-robins onto sealed-but-Ready standbys (503 "Vault is sealed").
+    server: "http://openbao-active.openbao.svc.cluster.local:8200"
     auth:
       kubernetes:
         mountPath: "kubernetes"

--- a/k8s/bases/apps/wedding-app/secretstore.yaml
+++ b/k8s/bases/apps/wedding-app/secretstore.yaml
@@ -22,7 +22,9 @@ metadata:
 spec:
   provider:
     vault:
-      server: "http://openbao.openbao.svc.cluster.local:8200"
+      # openbao-active = unsealed Raft leader only; the plain `openbao` Service
+      # also round-robins onto sealed-but-Ready standbys (503 "Vault is sealed").
+      server: "http://openbao-active.openbao.svc.cluster.local:8200"
       path: "secret"
       version: "v2"
       auth:

--- a/k8s/bases/infrastructure/cluster-secret-stores/cluster-secret-store.yaml
+++ b/k8s/bases/infrastructure/cluster-secret-stores/cluster-secret-store.yaml
@@ -5,7 +5,13 @@ metadata:
 spec:
   provider:
     vault:
-      server: "http://openbao.openbao.svc.cluster.local:8200"
+      # openbao-active routes only to the unsealed Raft leader (labelled by
+      # service_registration "kubernetes"). The plain `openbao` Service also
+      # includes sealed standbys — they are deliberately Ready (HTTP
+      # readinessProbe with sealedcode=204, see the openbao HelmRelease), so
+      # round-robin logins intermittently hit a sealed node and fail with
+      # 503 "Vault is sealed".
+      server: "http://openbao-active.openbao.svc.cluster.local:8200"
       path: "secret"
       version: "v2"
       auth:

--- a/k8s/bases/infrastructure/controllers/openbao/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/httproute.yaml
@@ -20,7 +20,13 @@ spec:
     - vault.${domain}
   rules:
     - backendRefs:
-        - name: openbao-ui
+        # openbao-active routes only to the unsealed Raft leader. The chart's
+        # openbao-ui Service selects every server pod, including sealed-but-Ready
+        # standbys (readinessProbe sealedcode=204), so the UI would round-robin
+        # onto a sealed node. Trade-off: with NO active node (all sealed, DR),
+        # the UI is unreachable — recovery is CLI-driven anyway
+        # (docs/dr/openbao-raft-ha-migration.md).
+        - name: openbao-active
           port: 8200
       filters:
         - type: ResponseHeaderModifier

--- a/k8s/bases/infrastructure/vault-backup/cronjob.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cronjob.yaml
@@ -30,8 +30,12 @@ spec:
             - name: snapshot
               image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
               env:
+                # openbao-active = unsealed Raft leader only. This job asserts
+                # "an unsealed active node exists" — against the plain `openbao`
+                # Service it round-robins across all pods and fails spuriously
+                # when it lands on a sealed-but-Ready standby.
                 - name: BAO_ADDR
-                  value: http://openbao.openbao.svc.cluster.local:8200
+                  value: http://openbao-active.openbao.svc.cluster.local:8200
               command:
                 - /bin/sh
                 - -ec


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Since the 3-node Raft HA cutover (#1907), sealed standbys are **deliberately Ready** (HTTP readinessProbe with `sealedcode=204`, required to break the cold-bootstrap deadlock documented in the openbao HelmRelease). The plain `openbao` Service therefore round-robins traffic across **all** pods, including sealed ones.

Observed on prod today (openbao-1/2 rescheduled and came back sealed):

- `ClusterSecretStore/openbao` and `SecretStore/wedding-app/openbao` flapping `InvalidProviderConfig` ↔ `Valid` with `503 * Vault is sealed` (thousands of events over 8h)
- `ExternalSecret/umami/umami-db-rotated` generator failures → `apps` Kustomization health-check timeouts
- `vault-snapshot` CronJob failing spuriously whenever it lands on a sealed pod

## Fix

Point every OpenBao client at the chart's `openbao-active` Service, which selects only the unsealed Raft leader (via `service_registration "kubernetes"` pod labels):

- `ClusterSecretStore/openbao`, `SecretStore/wedding-app/openbao`
- `VaultDynamicSecret` generators (umami, fleetdm)
- `vault-backup` CronJob (`BAO_ADDR`) — this job asserts an unsealed node exists, so active-only is the semantically correct target
- UI `HTTPRoute` backend (trade-off noted in-file: with zero active nodes the UI is unreachable; recovery is CLI-driven per `docs/dr/openbao-raft-ha-migration.md`)

No NetworkPolicy changes needed — same backend pods and port, only the Service selector differs.

## ⚠️ Merge ordering

Merge **after** completing the in-flight file→raft cutover on prod (openbao-0 currently still runs the old file-storage revision and carries **no** `openbao-active` label — switching clients before the cutover completes would leave `openbao-active` without endpoints). Sibling PR makes the vault-config init/unseal flow deterministic.

## Validation

- `ksail workload validate`: ✅ 314 files
- `ksail --config ksail.prod.yaml workload validate`: ✅ 90 kustomizations, 1 pre-existing failure (stale `coroot.com/v1` schema in the datreeio CRDs catalog — `notificationIntegrations` from #1767 not in the catalog; unrelated to this change)