### PR TITLE
fix(velero): pin aws plugin at v1.14.0 — v1.14.1 breaks R2 uploads (empty x-amz-tagging)

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -35,7 +35,15 @@ spec:
       repository: velero/velero
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.14.1
+        # PINNED at v1.14.0 — do NOT bump to v1.14.1. Its AWS SDK update
+        # serializes the always-set-but-empty PutObject Tagging field as a
+        # literal empty `x-amz-tagging` header, and Cloudflare R2 rejects any
+        # tagging header with `501 NotImplemented` — every backup then fails
+        # at the final metadata upload ("error putting object .../velero-backup.json").
+        # Upstream fix (skip the header when no tags are configured) is open
+        # but unreleased: velero-io/velero-plugin-for-aws#299 / #303.
+        # Safe to bump again once a release ships one of those PRs.
+        image: velero/velero-plugin-for-aws:v1.14.0
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /target


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Every Velero backup fails at the final metadata upload:

```
rpc error: ... error putting object velero/prod/backups/velero-daily-full-20260610021729/velero-backup.json:
operation error S3: PutObject, https response error StatusCode: 501,
api error NotImplemented: Header 'x-amz-tagging' with value '' not implemented
```

(`velero-daily-full-20260610021729`: phase `Failed`, 9 errors. The kopia DataUploads themselves succeed — they bypass the plugin.)

## Root cause

`velero-plugin-for-aws` sets `PutObjectInput.Tagging` **unconditionally** from the (unset → empty) `tagging` BSL config key. The AWS SDK bump in **v1.14.1** started serializing that non-nil empty string as a literal empty `x-amz-tagging` header, and **Cloudflare R2 implements no object tagging** — it rejects any `x-amz-tagging` with `501 NotImplemented` ([R2 S3 compat matrix](https://developers.cloudflare.com/r2/api/s3/api/)).

Confirmed upstream: [velero-plugin-for-aws#303](https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/303) ("skip x-amz-tagging header when tagging is empty", approved but unmerged) — a commenter pins the regression to the v1.14.0→v1.14.1 dependency bump; on [#299](https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/299) another user with the same 501 confirms "*I was able to fix it by going back to 1.14.0*".

Why it went unnoticed since the Renovate bump (#1573, 05-26): the BSL was `FailedValidation` (bucket/creds, fixed ~06-08) until two days ago, so **no backup had ever reached PutObject on v1.14.1** — first real upload attempt was 06-09, which is exactly when the `Failed` phases start.

## Fix

Pin the plugin initContainer at `v1.14.0` with a do-not-bump comment referencing the upstream PRs. Same minor version → fully compatible with the velero 1.18.1 server from chart 12.0.2; `checksumAlgorithm: ""` handling is unchanged. Safe to bump again once a release ships #299/#303.

## Validation

- `ksail workload validate`: ✅ 314 files
- Expect the nightly `velero-daily-full` (02:17) to reach `Completed`/`PartiallyFailed` instead of `Failed` after this lands. (Separate issue: a few DataUploads were Canceled around Longhorn rebuild churn on the scaled-to-zero volumes — tracked in the session handoff, not addressed here.)