### PR TITLE
fix(longhorn): enable offline replica rebuilding for scale-to-zero volumes

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -44,6 +44,15 @@ spec:
       # Restrict Longhorn system-managed pods (instance-managers, etc.)
       # to storage nodes. Prevents ~100Mi overhead per non-storage node.
       systemManagedComponentsNodeSelector: "node.longhorn.io/create-default-disk:true"
+      # Rebuild degraded replicas of DETACHED volumes too. KEDA scale-to-zero
+      # apps (actual-budget, headlamp, ...) keep their volumes detached for
+      # days; when an autoscaled node holding a replica leaves, the volume
+      # stays degraded indefinitely because normal rebuilds only run while
+      # attached (observed 2026-06-10: actual-budget at 2/3 replicas,
+      # robustness unknown, plus nightly Velero CSI-snapshot DataUploads
+      # timing out against it). Longhorn briefly attaches the volume in
+      # maintenance mode, rebuilds, and detaches again.
+      offlineReplicaRebuilding: true
 
     persistence:
       # Longhorn is the default StorageClass (replaces hcloud for new PVCs).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

KEDA scale-to-zero apps (actual-budget, headlamp) keep their Longhorn volumes **detached** for days at a time. Longhorn only rebuilds degraded replicas of *attached* volumes, so when an autoscaled node holding a replica leaves, the volume stays degraded until someone next opens the app.

Observed on prod (2026-06-10):

- `actual-budget-actualbudget-data` volume: `detached`, robustness `unknown`, **2/3 replicas**, with repeated `FailedRebuilding` event storms (including instance-manager `out of ports` errors from the retry churn)
- `headlamp` volume: `detached`, robustness `unknown`
- last night's Velero CSI-snapshot DataUpload against the degraded volume failed with `timeout on preparing data upload`

## Fix

Enable `offline-replica-rebuilding` (deployed Longhorn v1.12.0 supports it; the live setting exists and is `false`). Longhorn then attaches degraded detached volumes in maintenance mode, rebuilds the missing replica, and detaches again — no app scale-up involved. Chart 1.12.0 maps `defaultSettings.offlineReplicaRebuilding` → `offline-replica-rebuilding` (verified in `templates/default-setting.yaml`).

Hetzner-overlay-only change (Longhorn doesn't run on local/CI).

## Validation

- `ksail --config ksail.prod.yaml workload validate`: ✅ 90 kustomizations, 1 pre-existing failure (stale `coroot.com/v1` datreeio catalog schema — unrelated, predates this PR)
