### PR TITLE
fix(cilium): roll agent/operator/envoy pods when cilium-config changes

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -20,6 +20,19 @@ spec:
   timeout: 10m
   # https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/values.yaml
   values:
+    # Roll the agent DaemonSet whenever the cilium-config ConfigMap changes.
+    # Cilium agents read their config ONLY at startup; without this, a Helm
+    # values change updates the ConfigMap and nothing else — the fix is
+    # "live" in Git and in the CM while every agent keeps running the old
+    # config until its next unrelated restart. Bit hard on 2026-06-10:
+    # #1944 (encryption-strict-egress-allow-remote-node-identities, the
+    # cross-node black-hole fix) was merged 16h earlier and had taken effect
+    # on ZERO nodes (all agents predated the merge), so the bug it fixed was
+    # still dropping cross-node flows (KEDA scaler liveness kills, operator
+    # -> scaler i/o timeouts). Agent restarts are designed to be
+    # datapath-non-disruptive (eBPF state persists), and the DS rolls one
+    # node at a time per updateStrategy.
+    rollOutCiliumPods: true
     securityContext:
       capabilities:
         ciliumAgent:
@@ -74,6 +87,8 @@ spec:
           enabled: false
     operator:
       replicas: ${cilium_replicas:=2}
+      # Restart on cilium-config changes (same rationale as rollOutCiliumPods).
+      rollOutPods: true
       # memory 256Mi -> 128Mi: live prod usage is 36-77Mi across both
       # replicas (2026-06-03). 128Mi keeps the operator in Burstable QoS
       # (request > 0 -- the BestEffort escape that matters) with ~1.7x
@@ -115,6 +130,8 @@ spec:
         cpu: 200m
         memory: 512Mi
     envoy:
+      # Restart on config changes (same rationale as rollOutCiliumPods).
+      rollOutPods: true
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — config fixes that never deploy

Cilium components read their configuration **only at startup**. A Helm values change that only touches the `cilium-config` ConfigMap changes no pod template, so no pod restarts — the change lands in Git, Flux reports Ready, the ConfigMap is updated, and **nothing actually changes on any node**.

This bit hard today: [#1944](https://github.com/devantler-tech/platform/pull/1944) (`encryption-strict-egress-allow-remote-node-identities: true`, the fix for the cross-node black-hole — "prod's #1 reliability bug") merged 2026-06-10 00:14. Sixteen hours later it was active on **zero nodes**:

- every cilium agent pod's `startTime` predates the merge (oldest 06-06, newest 06-09 22:00)
- the live DaemonSet template has no config-checksum annotation, so it can never auto-roll
- `cilium-health status` from `prod-worker-2` still shows **2/10** node reachability (a control-plane agent sees 10/10) — the exact pre-#1944 signature
- still-live fallout observed today: KEDA HTTP external-scaler liveness kills (**98/91/30 restarts** per replica since 06-07, `NOT_SERVING` probe events), `keda-operator → external-scaler` `dial tcp ...:9090: i/o timeout`, HPA `FailedComputeMetricsReplicas`

## Fix

Enable the chart's built-in answer (already used for hubble relay/ui in this file):

- `rollOutCiliumPods: true` — agent DaemonSet
- `operator.rollOutPods: true`
- `envoy.rollOutPods: true`

These add a config-checksum annotation to the pod templates, so ConfigMap changes become ordinary rolling restarts (agent restarts are datapath-non-disruptive — eBPF state persists; the DS rolls per its `updateStrategy`).

## ⚠️ One-time live action still needed

Merging this PR re-renders the pod templates (checksum annotation appears) and therefore triggers the overdue rolling restart **on merge**, finally activating #1944. If you want the fix active sooner: `kubectl -n kube-system rollout restart ds/cilium ds/cilium-envoy deploy/cilium-operator`.

## Validation

- `ksail workload validate`: ✅ 314 files
- prod overlay: only the pre-existing stale coroot schema failure (datreeio catalog, fix in flight upstream)
