### PR TITLE
fix(cilium): disable broken node-to-node WireGuard encryption (host traffic black-hole)

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -142,10 +142,10 @@ spec:
           # over peak, while freeing ~64Mi of reserved-unused request on every
           # node (~256Mi across the workers, which sat at 98-99% memory requests).
           memory: 64Mi
-    # Transparent WireGuard encryption for all pod-to-pod and node-to-node
-    # traffic.  KubeSpan (Talos-layer WireGuard between nodes) is not
-    # enabled in this cluster, so without this setting inter-node pod
-    # traffic would transit the Hetzner private network in cleartext.
+    # Transparent WireGuard encryption for pod-to-pod traffic.  KubeSpan
+    # (Talos-layer WireGuard between nodes) is not enabled in this cluster,
+    # so without this setting inter-node pod traffic would transit the
+    # Hetzner private network in cleartext.
     # SPIRE mutual authentication below provides workload *identity*; this
     # block provides on-the-wire *encryption*. They are independent and
     # complementary.
@@ -157,7 +157,31 @@ spec:
     encryption:
       enabled: true
       type: wireguard
-      nodeEncryption: true
+      # nodeEncryption (host-to-host encryption, upstream beta) is OFF —
+      # it silently BLACK-HOLES host-to-remote-node traffic in this
+      # tunnel-routing topology. Diagnosed live 2026-06-10: node IPs sit in
+      # the ipcache with encryptkey=255, host egress to them is steered into
+      # the WireGuard datapath and never emerges (no 51871 datagrams on any
+      # NIC, no drop events) — EXCEPT control planes, which the chart's
+      # default node-encryption-opt-out-labels
+      # (node-role.kubernetes.io/control-plane) exempts, hence the telltale
+      # asymmetry: worker->CP host flows work, worker->worker are dead.
+      # That killed cilium-health (4240) and, critically, the SPIRE
+      # mesh-auth handshakes (4250) between all non-CP node pairs, so every
+      # auth-gated pod flow between worker-class nodes black-holed once its
+      # auth-cache entry expired (KEDA scaler liveness kills, ESO->OpenBao
+      # 503s/timeouts, OpenBao raft joins). Active since the 06-06 agent
+      # restart picked up #1804; #1944 addressed a different vector
+      # (strict-mode plaintext drops) and did not fix this.
+      #
+      # Security posture: pod-to-pod traffic (the actual workload data)
+      # stays WireGuard-encrypted and fail-closed via strictMode (hetzner
+      # patch). Host-to-host traffic is cluster control-plane chatter that
+      # is mTLS/TLS at the application layer anyway (SPIRE mesh-auth IS
+      # mTLS, kubelet/apiserver are TLS). Re-evaluate once upstream
+      # stabilizes node encryption under tunnel routing
+      # (cilium/cilium#37919 and the encryption-wireguard known limitations).
+      nodeEncryption: false
     authentication:
       enabled: true
       mutual:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## TL;DR

`encryption.nodeEncryption: true` (upstream **beta**) silently black-holes **host→remote-node** traffic on this cluster. That includes the SPIRE mesh-auth handshake port (**4250**) between all non-control-plane node pairs — so every mutual-auth-gated pod flow between worker-class nodes dies as soon as its auth-cache entry expires. This has been the root cause behind three days of "mystery" degradation, and it currently **blocks the OpenBao recovery** (raft followers can't join: `failed to get raft challenge`). Disable nodeEncryption; keep pod-to-pod WireGuard + strict mode.

## Live diagnosis (2026-06-10, prod)

1. From `prod-worker-2`: `cilium-health` reaches **CPs only** (4/10); from a CP agent: 10/10. Direct probes from a worker agent: `10.0.1.2:4250` (CP) **OPEN**, `10.0.1.5:4250` / `10.0.1.8:4250` (worker/autoscale) **timeout** — same for 4240.
2. `talosctl pcap` during probes: the working CP-bound flow appears as **plaintext TCP on eth1**; the broken worker-bound flow produces **zero packets on eth0/eth1 of either node — not even WireGuard datagrams or handshakes**, and no drop events in `cilium monitor` on either side. The packet dies inside the source's WG datapath.
3. The ipcache explains the asymmetry (from a worker agent):
   ```
   10.0.1.5/32   identity=6 (remote-node)     encryptkey=255   ← black-holed
   10.0.1.8/32   identity=6 (remote-node)     encryptkey=255   ← black-holed
   10.0.1.2/32   identity=7 (kube-apiserver)  encryptkey=0     ← plaintext, works
   ```
   Control planes escape via the chart's default `node-encryption-opt-out-labels` (`node-role.kubernetes.io/control-plane`) — hence "only CPs reachable".
4. Timeline fits exactly: #1804 merged 06-05, **activated when the agents restarted 06-06 ~21:10** (config-only changes didn't roll pods until #1969) — the KEDA scaler restart storm (98/91/30 per replica) starts 06-07. Today's #1969 roll wiped auth caches and made the latent breakage acute: ESO→OpenBao logins time out, `ClusterSecretStore` flaps `InvalidProviderConfig`, and **openbao raft followers retry-join every 2s and fail** (`failed to get raft challenge`; direct pod-to-pod `wget` between openbao pods on two autoscale nodes times out).
5. #1944 was a fix for a different vector (strict-mode plaintext drops to remote-node identities) and demonstrably did not resolve this.

## Fix

`nodeEncryption: false` in the base cilium HelmRelease (in-file comment carries the full diagnosis):

- **Pod-to-pod WireGuard stays on** — the actual workload data remains encrypted on the wire, fail-closed via the hetzner strict-mode patch.
- Host-to-host chatter (4240 health, 4250 mesh-auth, kubelet/apiserver) is mTLS/TLS at the application layer anyway — the mesh-auth handshake **is** mTLS.
- Re-evaluate when upstream stabilizes node encryption under tunnel routing ([encryption-wireguard docs / limitations](https://docs.cilium.io/en/stable/security/network/encryption-wireguard/), [cilium#37919](https://github.com/cilium/cilium/issues/37919)).

Thanks to #1969 (`rollOutCiliumPods`), merging this rolls the agents automatically — expected effects within minutes: cilium-health 10/10 from workers, KEDA scaler stops flapping, ESO reaches OpenBao, raft followers join and the vault-config Job completes the re-init.

## Validation

- `ksail workload validate`: ✅ 314 files
- prod overlay: only the pre-existing stale coroot datreeio-catalog schema failure (fix already submitted upstream)
