### PR TITLE
fix(velero): make the R2 credentials stub create-only so Flux stops clobbering real creds

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/velero-r2-credentials.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/velero-r2-credentials.yaml
@@ -10,11 +10,21 @@
 # This empty stub breaks the cycle.  Once the ExternalSecret in the
 # `infrastructure` Flux Kustomization reconciles, it overwrites this
 # Secret with the real R2 credentials (creationPolicy: Owner).
+#
+# ssa: IfNotPresent makes the stub create-only. Without it, every
+# infrastructure-controllers reconcile re-applies PLACEHOLDER over the
+# ESO-written real credentials; ESO normally wins the ping-pong back
+# within a minute, but whenever the ExternalSecret is wedged (e.g. the
+# 2026-06-10 OpenBao data loss) the placeholder sticks — the BSL goes
+# Unavailable and every kopia maintenance job fails with
+# "Credential access key has length 11, should be 32".
 apiVersion: v1
 kind: Secret
 metadata:
   name: velero-r2-credentials
   namespace: velero
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 type: Opaque
 stringData:
   cloud: |


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

[`velero-r2-credentials.yaml`](https://github.com/devantler-tech/platform/blob/main/k8s/bases/infrastructure/controllers/velero/velero-r2-credentials.yaml) is a bootstrap stub (`aws_access_key_id=PLACEHOLDER`) that breaks the Velero chart's `existingSecret` deadlock on fresh installs. Because it sits in the `infrastructure-controllers` Kustomization **without any SSA hint, Flux re-applies the PLACEHOLDER values over the ESO-written real credentials on every reconcile**. ESO normally wins the ping-pong back within its refresh interval — but whenever the ExternalSecret is wedged (today: the 2026-06-10 OpenBao data loss left it in `SecretSyncedError`), the placeholder sticks.

Observed on prod right now:
- `BackupStorageLocation default` → `Unavailable: ... Credential access key has length 11, should be 32` (11 = `len("PLACEHOLDER")`)
- every `*-default-kopia-maintain-job` pod failing every ~5 minutes with the same error

## Fix

Add `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` to the stub: Flux still creates it when missing (bootstrap deadlock stays solved), but never patches the live Secret again, so the ExternalSecret's real values persist even while ESO is degraded.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅

Part of the 2026-06-10 OpenBao incident remediation (see the companion vault-seed / vault-config / vault-snapshot PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)