### PR TITLE
fix(vault-seed): re-push SOPS-sourced seeds hourly so OpenBao KV self-heals

### DIFF
--- a/k8s/bases/infrastructure/vault-seed/push-secrets.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secrets.yaml
@@ -1,6 +1,14 @@
 # PushSecrets seed OpenBao from SOPS-decrypted K8s Secrets.
 # These push externally-sourced credentials that cannot be randomly generated.
 # Randomly-generatable secrets are handled by push-generated-secrets.yaml.
+#
+# refreshInterval 1h (not "0" = push-once): the source Secrets are durable
+# (SOPS-decrypted by Flux, or generated in-cluster) and authoritative, so a
+# periodic re-push is always a no-op while OpenBao is healthy — and it is
+# what re-seeds the KV store automatically after OpenBao data loss. With
+# push-once semantics the 2026-06-10 vault re-initialization left every
+# consumer ExternalSecret in SecretSyncedError ("Secret does not exist")
+# with no self-healing path.
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
@@ -8,7 +16,7 @@ metadata:
   name: seed-r2-credentials
   namespace: flux-system
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
@@ -37,7 +45,7 @@ metadata:
   name: seed-cloudflare
   namespace: flux-system
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
@@ -57,7 +65,7 @@ metadata:
   name: seed-fleetdm
   namespace: flux-system
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
@@ -77,7 +85,7 @@ metadata:
   name: seed-github-app
   namespace: flux-system
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
@@ -101,15 +109,15 @@ spec:
 # (infra-ghcr-readonly) — a platform secret, not a tenant secret. Source key
 # `ghcr_dockerconfigjson` lives in variables-base-secret.enc.yaml (shared,
 # cluster-independent — the same org token both clusters use) and holds the full
-# `{"auths":{"ghcr.io":{...}}}` document. refreshInterval "0" = push once;
-# re-apply to update after a token rotation.
+# `{"auths":{"ghcr.io":{...}}}` document. Re-pushed hourly, so a rotated
+# token (or a re-initialized vault) converges without manual re-apply.
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: seed-ghcr
   namespace: flux-system
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
@@ -139,16 +147,16 @@ spec:
 # OpenBao's seal status; it does not itself upload to R2.
 # Recovery procedure documented in docs/dr/crypto-custody.md.
 #
-# refreshInterval "0" means push once; if the in-cluster Secret is ever
-# rotated (manual ops), the PushSecret can be re-applied to update
-# OpenBao.
+# Re-pushed hourly from the in-cluster Secret (which Velero owns and
+# never rotates on its own), so a re-initialized vault re-learns the
+# password without manual re-apply.
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: seed-velero-repo-credentials
   namespace: velero
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore

--- a/k8s/providers/hetzner/infrastructure/vault-seed/seed-hcloud.yaml
+++ b/k8s/providers/hetzner/infrastructure/vault-seed/seed-hcloud.yaml
@@ -9,7 +9,10 @@ metadata:
   name: seed-hcloud
   namespace: flux-system
 spec:
-  refreshInterval: "0"
+  # 1h, not "0" (push-once): re-pushing hourly from the durable SOPS source
+  # is what re-seeds the key automatically after OpenBao data loss — see
+  # k8s/bases/infrastructure/vault-seed/push-secrets.yaml.
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

All `seed-*` PushSecrets use `refreshInterval: "0"` — push once, never again. When the 2026-06-10 incident re-initialized OpenBao with an **empty KV store** (see incident summary in #1979), nothing re-seeded it:

- 12 ExternalSecrets across the cluster went `SecretSyncedError` ("Secret does not exist")
- the `infrastructure` Kustomization health-gates on three of them (`velero/velero-r2-credentials`, `openbao/vault-config-oidc`, `cert-manager/cloudflare-api-token`) and has been timing out every 20m since ~16:30 UTC
- `apps` and `infrastructure-overprovisioning` are blocked on it, and every CD run since fails at "Trigger Flux reconciliation"

## Fix

`refreshInterval: 1h` on the seven SOPS-sourced seeds (6 in `push-secrets.yaml` + the hetzner-only `seed-hcloud`). Their sources (`variables-base`/`variables-cluster`, SOPS-decrypted by Flux; the Velero-owned `velero-repo-credentials`) are durable and authoritative, so:

- healthy vault → hourly re-push is a no-op (same values)
- wiped/re-initialized vault → KV re-seeds automatically within the hour, ExternalSecrets recover, the wedge clears
- bonus: a rotated GHCR token / R2 key now converges without the documented manual "re-apply" step

**Merging this PR is part of the live recovery**: once applied, the seeds repopulate `infrastructure/{backup,dns,oidc,ghcr,hcloud}/*` and `apps/fleetdm/license` and unblock the wedged ExternalSecrets. The *generated* secrets (dex client secret etc.) are handled in a companion PR.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)