### PR TITLE
fix(vault-seed): cache generated secrets in K8s Secrets and push from the cache

### DIFF
--- a/k8s/bases/infrastructure/vault-seed/generators.yaml
+++ b/k8s/bases/infrastructure/vault-seed/generators.yaml
@@ -1,7 +1,8 @@
 # ESO Password generators for secrets that can be randomly generated.
-# Each generator defines the password spec; PushSecrets in
-# push-generated-secrets.yaml reference these via generatorRef to seed
-# OpenBao on first reconciliation.
+# Each generator defines the password spec; the `generated-*`
+# ExternalSecrets in push-generated-secrets.yaml run them exactly once
+# (refreshInterval "0") to materialize a durable cache Secret, which the
+# PushSecrets then mirror into OpenBao hourly.
 ---
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: Password

--- a/k8s/bases/infrastructure/vault-seed/push-generated-secrets.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-generated-secrets.yaml
@@ -1,6 +1,39 @@
-# PushSecrets that use ESO Password generators to seed OpenBao with
-# randomly-generated secrets on first reconciliation.
-# refreshInterval: "0" ensures values are generated once and never rotated.
+# Randomly-generated secrets, seeded into OpenBao via a durable K8s cache.
+#
+# Two-step per secret:
+#   1. An ExternalSecret with a generatorRef source (refreshInterval "0")
+#      runs the ESO Password generator EXACTLY ONCE and persists the value
+#      in a `generated-*` K8s Secret in this namespace — the durable cache.
+#   2. A PushSecret mirrors the cache Secret into OpenBao hourly
+#      (refreshInterval 1h), exactly like push-umami-db-superuser and the
+#      SOPS-sourced seeds in push-secrets.yaml.
+#
+# Why not push straight from the generator (the pre-2026-06-10 design)?
+# A generatorRef-selector PushSecret produces a NEW random value on every
+# sync, so it had to be push-once (refreshInterval "0") — and push-once
+# means a re-initialized/wiped vault is never re-seeded: after the
+# 2026-06-10 OpenBao data loss every consumer ExternalSecret sat in
+# SecretSyncedError with no self-healing path, because the generated
+# values existed nowhere but the wiped vault. With the cache Secret as
+# the system of record, the hourly re-push is a no-op while the vault is
+# healthy and an automatic restore after data loss — values never rotate.
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-dex-client-secret
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-dex-client-secret
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: dex-client-secret
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
@@ -8,15 +41,13 @@ metadata:
   name: push-dex-client-secret
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: dex-client-secret
+    secret:
+      name: generated-dex-client-secret
   data:
     - match:
         secretKey: password
@@ -24,21 +55,36 @@ spec:
           remoteKey: infrastructure/oidc/dex
           property: client-secret
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-flux-web-client-secret
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-flux-web-client-secret
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: flux-web-client-secret
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-flux-web-client-secret
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: flux-web-client-secret
+    secret:
+      name: generated-flux-web-client-secret
   data:
     - match:
         secretKey: password
@@ -46,21 +92,36 @@ spec:
           remoteKey: infrastructure/oidc/flux-web
           property: client-secret
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-oauth2-proxy-cookie-secret
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-oauth2-proxy-cookie-secret
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: oauth2-proxy-cookie-secret
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-oauth2-proxy-cookie-secret
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: oauth2-proxy-cookie-secret
+    secret:
+      name: generated-oauth2-proxy-cookie-secret
   data:
     - match:
         secretKey: password
@@ -68,21 +129,36 @@ spec:
           remoteKey: infrastructure/oidc/oauth2-proxy
           property: cookie-secret
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-fleetdm-mysql-root-password
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-fleetdm-mysql-root-password
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: fleetdm-mysql-root-password
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-fleetdm-mysql-passwords
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: fleetdm-mysql-root-password
+    secret:
+      name: generated-fleetdm-mysql-root-password
   data:
     - match:
         secretKey: password
@@ -90,21 +166,36 @@ spec:
           remoteKey: apps/fleetdm/mysql
           property: mysql-root-password
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-fleetdm-mysql-replication-password
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-fleetdm-mysql-replication-password
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: fleetdm-mysql-replication-password
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-fleetdm-mysql-replication-password
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: fleetdm-mysql-replication-password
+    secret:
+      name: generated-fleetdm-mysql-replication-password
   data:
     - match:
         secretKey: password
@@ -112,21 +203,36 @@ spec:
           remoteKey: apps/fleetdm/mysql
           property: mysql-replication-password
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-fleetdm-mysql-password
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-fleetdm-mysql-password
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: fleetdm-mysql-password
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-fleetdm-mysql-password
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: fleetdm-mysql-password
+    secret:
+      name: generated-fleetdm-mysql-password
   data:
     - match:
         secretKey: password
@@ -134,21 +240,36 @@ spec:
           remoteKey: apps/fleetdm/mysql
           property: mysql-password
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-fleetdm-redis-password
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-fleetdm-redis-password
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: fleetdm-redis-password
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-fleetdm-redis-password
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: fleetdm-redis-password
+    secret:
+      name: generated-fleetdm-redis-password
   data:
     - match:
         secretKey: password
@@ -156,21 +277,36 @@ spec:
           remoteKey: apps/fleetdm/redis
           property: redis-password
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-fleetdm-server-private-key
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-fleetdm-server-private-key
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: fleetdm-server-private-key
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-fleetdm-server-key
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: fleetdm-server-private-key
+    secret:
+      name: generated-fleetdm-server-private-key
   data:
     - match:
         secretKey: password
@@ -178,21 +314,36 @@ spec:
           remoteKey: apps/fleetdm/server
           property: private-key
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-umami-app-secret
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-umami-app-secret
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: umami-app-secret
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-umami-app-secret
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: umami-app-secret
+    secret:
+      name: generated-umami-app-secret
   data:
     - match:
         secretKey: password
@@ -200,21 +351,36 @@ spec:
           remoteKey: apps/umami/app
           property: app-secret
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-umami-admin-password
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-umami-admin-password
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: umami-admin-password
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-umami-admin-password
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: umami-admin-password
+    secret:
+      name: generated-umami-admin-password
   data:
     - match:
         secretKey: password
@@ -222,21 +388,36 @@ spec:
           remoteKey: apps/umami/admin
           property: password
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-umami-ascoachingogvaner-password
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-umami-ascoachingogvaner-password
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: umami-ascoachingogvaner-password
+---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: push-umami-ascoachingogvaner-password
   namespace: openbao
 spec:
-  refreshInterval: "0"
+  refreshInterval: 1h
   secretStoreRefs:
     - name: openbao
       kind: ClusterSecretStore
   selector:
-    generatorRef:
-      apiVersion: generators.external-secrets.io/v1alpha1
-      kind: Password
-      name: umami-ascoachingogvaner-password
+    secret:
+      name: generated-umami-ascoachingogvaner-password
   data:
     - match:
         secretKey: password


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

The generated secrets (dex / flux-web client secrets, oauth2-proxy cookie secret, fleetdm bootstrap passwords, umami app/admin/tenant passwords) were pushed **straight from ESO Password generators**. A `generatorRef`-selector PushSecret produces a *new random value on every sync*, so they had to be push-once (`refreshInterval: "0"`) — which made OpenBao the only place the values existed. When the 2026-06-10 incident re-initialized the vault with an empty KV store (context in #1979/#1980), they were unrecoverable, and every consumer ExternalSecret (`vault-config-oidc`, `headlamp-oidc`, `actual-budget-oidc`, `umami-admin`, …) wedged in `SecretSyncedError` with no self-healing path.

## Fix

Each generated secret becomes two steps (the proven `push-umami-db-superuser` pattern):

1. a `generated-*` **ExternalSecret** runs the Password generator **exactly once** (`refreshInterval: "0"`) and persists the value in a durable cache Secret in the `openbao` namespace
2. the existing **PushSecret** mirrors that cache Secret into OpenBao hourly (`refreshInterval: 1h`, selector switched from `generatorRef` to the cache Secret)

Healthy vault → hourly push is a no-op; values never rotate. Wiped vault → KV re-seeds within the hour from the cache.

## ⚠️ One-time effect on the current incident

Because the old generated values died with the wiped vault, the caches will generate **fresh values** on first reconcile. All consumers converge automatically via their ExternalSecrets (SSO clients, cookie secret → existing sessions reset; fleetdm has no pods yet, harmless), **except**:

- **umami admin password**: umami stores the hash in its DB, and the provision job can only rotate from the default `umami` password. After this merges, the admin password must be updated once in the umami UI (log in with the *old* value from the current `umami/umami-admin` Secret, set it to the new value from `openbao/generated-umami-admin-password`). The provision-tenants CronJob then goes green again.

## Validation

- `kubectl kustomize` local + prod ✅
- `ksail workload validate` → 314 files validated ✅
- `kubectl apply --dry-run=client` on the changed file against live CRDs ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)