### PR TITLE
fix(vault-config): refuse to auto-init when openbao-unseal already holds keys

### DIFF
--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -127,6 +127,27 @@ spec:
               done
 
               if [ "$ANY_INITIALIZED" = "false" ]; then
+                # Data-loss guard: keys in openbao-unseal mean a cluster was
+                # initialized before. If on top of that NO pod reports an
+                # initialized barrier, the raft data is missing or unreadable —
+                # auto-initializing here would silently bring up an EMPTY vault
+                # and overwrite the previous unseal key + root token (exactly
+                # how the 2026-06-10 incident destroyed the whole KV store).
+                # Fail loudly instead and make the operator acknowledge the
+                # data loss explicitly before a fresh init is allowed.
+                if [ -f /openbao/unseal/unseal-key ]; then
+                  echo "ERROR: no pod reports an initialized vault, but the openbao-unseal"
+                  echo "Secret still holds keys from a previously initialized cluster."
+                  echo "Refusing to auto-initialize: that would create an empty vault and"
+                  echo "overwrite the old keys, making any surviving data unrecoverable."
+                  echo ""
+                  echo "Recover the data first (Velero restore / reattach the old data"
+                  echo "PVCs) and re-run this Job. If the data loss is confirmed and a"
+                  echo "fresh vault is intended, acknowledge it explicitly with:"
+                  echo "  kubectl delete secret openbao-unseal -n openbao"
+                  echo "and let the next Job run initialize from scratch."
+                  exit 1
+                fi
                 echo "No initialized pod found — running bao operator init on openbao-0..."
                 INIT_OUTPUT=$(BAO_ADDR="$(addr 0)" bao operator init -key-shares=1 -key-threshold=1)
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

The `vault-init` init container auto-runs `bao operator init` whenever **no pod reports an initialized barrier**. That state is ambiguous:

- fresh install → auto-init is exactly right
- **data loss** (raft dir missing/unreadable, e.g. after a storage-backend cutover gone wrong) → auto-init silently brings up an **empty vault**, and `store-keys` then overwrites the previous unseal key + root token in `openbao-unseal`, making any surviving data unrecoverable

The second case is precisely how the 2026-06-10 incident destroyed the entire KV store: the standalone→raft deploy flip-flop (#1907 deployed pre-merge at 06:43 UTC, reverted by a main deploy at 13:08, re-applied at 14:57) left `openbao-0`'s data dir without a raft db; when the pods were rolled, the Job saw "uninitialized", initialized a blank vault over it at 17:48 UTC, and replaced the old keys.

## Fix

If no pod is initialized **but the `openbao-unseal` Secret already holds keys from a previous cluster**, the Job now fails loudly with recovery instructions instead of initializing. A fresh init requires explicit operator acknowledgement of the data loss:

```
kubectl delete secret openbao-unseal -n openbao
```

Unaffected flows: fresh installs (no Secret → init proceeds), Velero restores (Secret + data PVCs both restored → pods report initialized → init skipped), and the current prod cluster (pods report initialized → init skipped).

## Validation

- `kubectl kustomize` local + prod ✅

Companion to #1979/#1980/#1981 (2026-06-10 OpenBao incident remediation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)