### PR TITLE
feat(openbao): make the vault-snapshot CronJob take real raft snapshots

### DIFF
--- a/k8s/bases/infrastructure/vault-backup/cronjob.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cronjob.yaml
@@ -1,6 +1,11 @@
-# Daily backup verification of OpenBao data. Vault data is persisted on a
-# PVC and backed up by Velero. This job logs vault health and seal status
-# for monitoring.
+# Daily OpenBao raft snapshot to the vault-snapshots PVC (newest 14 kept),
+# plus a health/seal-status check. Until 2026-06-10 this job ONLY did the
+# health check despite its name — when the vault was wiped that day there
+# was no snapshot to restore from. A raft snapshot pairs with the
+# openbao-unseal Secret: restore via
+#   bao operator raft snapshot restore <file>
+# then unseal with the key that was current when the snapshot was taken
+# (docs/dr/openbao-raft-ha-migration.md).
 # Authenticates via Kubernetes auth (vault-snapshot role).
 apiVersion: batch/v1
 kind: CronJob
@@ -26,16 +31,23 @@ spec:
             runAsUser: 100
             runAsGroup: 1000
             fsGroup: 1000
+          volumes:
+            - name: snapshots
+              persistentVolumeClaim:
+                claimName: vault-snapshots
           containers:
             - name: snapshot
               image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
               env:
-                # openbao-active = unsealed Raft leader only. This job asserts
-                # "an unsealed active node exists" — against the plain `openbao`
-                # Service it round-robins across all pods and fails spuriously
-                # when it lands on a sealed-but-Ready standby.
+                # openbao-active = unsealed Raft leader only. Snapshots must be
+                # taken from the leader — against the plain `openbao` Service
+                # this round-robins across all pods and fails spuriously when
+                # it lands on a sealed-but-Ready standby.
                 - name: BAO_ADDR
                   value: http://openbao-active.openbao.svc.cluster.local:8200
+              volumeMounts:
+                - name: snapshots
+                  mountPath: /snapshots
               command:
                 - /bin/sh
                 - -ec
@@ -52,10 +64,20 @@ spec:
                   STATUS=$(bao status -format=json)
                   echo "$STATUS"
 
-                  SEALED=$(echo "$STATUS" | grep -o '"sealed":[a-z]*' | cut -d: -f2)
-                  if [ "$SEALED" = "true" ]; then
+                  if echo "$STATUS" | grep -q '"sealed": true'; then
                     echo "ERROR: Vault is sealed!"
                     exit 1
                   fi
-
                   echo "Vault is unsealed and healthy."
+
+                  SNAP="/snapshots/openbao-$(date -u +%Y%m%d-%H%M%S).snap"
+                  echo "Saving raft snapshot to $SNAP..."
+                  bao operator raft snapshot save "$SNAP"
+                  ls -l "$SNAP"
+
+                  # Retention: keep the newest 14 snapshots
+                  ls -1t /snapshots/openbao-*.snap 2>/dev/null | tail -n +15 | while read -r OLD; do
+                    echo "Pruning $OLD"
+                    rm -f "$OLD"
+                  done
+                  echo "Snapshot complete."

--- a/k8s/bases/infrastructure/vault-backup/kustomization.yaml
+++ b/k8s/bases/infrastructure/vault-backup/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - serviceaccount.yaml
+  - pvc.yaml
   - cronjob.yaml
   - networkpolicy.yaml

--- a/k8s/bases/infrastructure/vault-backup/pvc.yaml
+++ b/k8s/bases/infrastructure/vault-backup/pvc.yaml
@@ -1,0 +1,16 @@
+# Dedicated volume for OpenBao raft snapshots (written by the
+# vault-snapshot CronJob, newest 14 retained). Uses the cluster's default
+# StorageClass. Snapshots on this PVC are the first-line restore source
+# after OpenBao data loss; Velero's daily namespace backup carries them
+# off-cluster alongside the openbao-unseal Secret they pair with.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-snapshots
+  namespace: openbao
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -411,6 +411,11 @@ spec:
               path "sys/health" {
                 capabilities = ["read"]
               }
+              # Raft snapshot export for the vault-snapshot CronJob
+              # (GET /v1/sys/storage/raft/snapshot).
+              path "sys/storage/raft/snapshot" {
+                capabilities = ["read"]
+              }
               POLICY
 
               bao policy write vault-admin - <<'POLICY'


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause / gap

Despite its name, the `vault-snapshot` CronJob **never snapshots anything** — its entire script is a `bao status` health check. When the 2026-06-10 incident wiped the OpenBao KV store (#1979 has the timeline), there was **no snapshot to restore from**: the only off-pod copy would have been Velero's namespace backup, which has been failing for weeks on broken R2 credentials.

## Fix

After the existing health check, the job now runs

```
bao operator raft snapshot save /snapshots/openbao-<utc-timestamp>.snap
```

against the `openbao-active` Service (leader-only, as before), onto a new dedicated `vault-snapshots` PVC (5Gi, default StorageClass), keeping the newest 14 snapshots. The `vault-snapshot-readonly` policy in the vault-config Job gains `read` on `sys/storage/raft/snapshot` (the snapshot export endpoint). ServiceAccount, auth role, schedule (03:30 daily) and CiliumNetworkPolicy are unchanged.

Restore path: `bao operator raft snapshot restore <file>` + unseal with the `openbao-unseal` key that was current when the snapshot was taken — which is also why #1982 refuses to overwrite those keys on silent re-init. Velero's daily namespace backup carries the PVC off-cluster once its R2 credentials work again.

Note: this PR touches `vault-config/job.yaml` in a different section than #1982 — they merge cleanly in either order.

## Validation

- `kubectl kustomize` local + prod ✅
- `ksail workload validate` → 315 files validated ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)