### PR TITLE
chore(renovate): exclude velero-plugin-for-aws v1.14.1 and gate future bumps on review

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -197,6 +197,14 @@
       "addLabels": [
         "kubernetes"
       ]
+    },
+    {
+      "description": "velero-plugin-for-aws is PINNED at v1.14.0 (k8s/bases/infrastructure/controllers/velero/helm-release.yaml): v1.14.1's AWS SDK update serializes the always-set-but-empty PutObject Tagging field as a literal empty x-amz-tagging header, which Cloudflare R2 rejects with 501 NotImplemented — every backup then fails at the final metadata upload. Exclude exactly v1.14.1 and keep automerge OFF for this image so the next release is only merged after a maintainer confirms it ships the upstream fix (velero-io/velero-plugin-for-aws#299 / #303); CI cannot catch this regression because the system-test cluster has no R2 backend. automerge:false placed last so it overrides the minor/patch automerge defaults above.",
+      "matchPackageNames": [
+        "velero/velero-plugin-for-aws"
+      ],
+      "allowedVersions": "!/^v?1\\.14\\.1$/",
+      "automerge": false
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

7cb3b66e pinned `velero/velero-plugin-for-aws` at **v1.14.0** because v1.14.1 breaks every backup against Cloudflare R2: its AWS SDK update serializes the always-set-but-empty PutObject `Tagging` field as a literal empty `x-amz-tagging` header, and R2 rejects any tagging header with `501 NotImplemented` — each backup fails at the final `velero-backup.json` upload. The upstream fix ([velero-io/velero-plugin-for-aws#299](https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/299) / [#303](https://github.com/vmware-tanzu/velero-plugin-for-aws/pull/303)) is unreleased.

Renovate immediately re-proposed the broken version in #1974.

## Fix

A `packageRules` entry that:
- excludes exactly `v1.14.1` (`allowedVersions: "!/^v?1\\.14\\.1$/"`) — merging the rule makes Renovate close #1974 on its next run
- keeps `automerge: false` for this image: the CI system-test cluster has no R2 backend, so no pipeline can catch this regression — only a maintainer confirming the release notes ship the upstream fix should merge the next bump

## Validation

- `python3 -c "json.load(...)"` → JSON valid ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)