### PR TITLE
fix(openbao): allow raft peers to reach the leader API port and add peer egress

### DIFF
--- a/k8s/bases/infrastructure/controllers/openbao/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/networkpolicy.yaml
@@ -7,13 +7,21 @@ spec:
   endpointSelector: {}
   ingress:
     # Raft peering: the 3 openbao pods form the Integrated Storage cluster and
-    # gossip on the cluster port (8201). Allow openbao -> openbao on 8201.
+    # gossip on the cluster port (8201) — but the retry_join bootstrap
+    # challenge goes to the LEADER'S API PORT (8200, the leader_api_addr in
+    # the HCL), and standbys also forward client requests there. With only
+    # 8201 open, followers with empty data dirs could never join: every
+    # retry_join died with `dial tcp <leader>:8200: i/o timeout`, leaving
+    # openbao-1/2 sealed and uninitialized forever (observed live during the
+    # 2026-06-10 incident). Allow openbao -> openbao on BOTH ports.
     - fromEndpoints:
         - matchLabels:
             app.kubernetes.io/name: openbao
             k8s:io.kubernetes.pod.namespace: openbao
       toPorts:
         - ports:
+            - port: "8200"
+              protocol: TCP
             - port: "8201"
               protocol: TCP
     # Allow same-namespace clients (vault-config Jobs, UI),
@@ -42,6 +50,20 @@ spec:
             - port: "8200"
               protocol: TCP
   egress:
+    # Raft peering, mirror of the ingress rule above: the presence of ANY
+    # egress rule puts these pods in default-deny egress, so without an
+    # explicit openbao -> openbao allow the join/gossip SYN is dropped at
+    # the SOURCE pod even though ingress on the peer permits it.
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: openbao
+            k8s:io.kubernetes.pod.namespace: openbao
+      toPorts:
+        - ports:
+            - port: "8200"
+              protocol: TCP
+            - port: "8201"
+              protocol: TCP
     # Kube API for Kubernetes auth token review
     - toEntities:
         - kube-apiserver


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

Two gaps in the `allow-openbao` CiliumNetworkPolicy make it impossible for an OpenBao follower with an empty data dir to **ever** join the raft cluster:

1. **Ingress** openbao→openbao only opens the cluster port (**8201**) — but the `retry_join` bootstrap challenge targets the **leader's API port 8200** (`leader_api_addr = http://openbao-N.openbao-internal:8200` in the HCL), and standbys also forward client requests there.
2. **Egress**: the policy has egress rules (which switches the pods to default-deny egress) but **no openbao→openbao allow at all** — even 8201 gossip is dropped at the source pod.

Live evidence on prod right now — openbao-1/2 loop forever, sealed and uninitialized:

```
[ERROR] core: failed to get raft challenge: leader_addr=http://openbao-0.openbao-internal:8200
        error="... Put .../v1/sys/storage/raft/bootstrap/challenge": dial tcp 10.244.12.12:8200: i/o timeout"
```

Same-pod traffic bypasses policy, which is why a node can reach only *itself* (503 "Vault is sealed") — and why the cluster "works" today as an accidental single node on openbao-0. This is very likely the reason the #1907 raft cutover never fully converged (the "half-migrated" wedge that preceded the 2026-06-10 incident).

## Fix

Allow openbao→openbao on **8200 + 8201, both directions** (ingress rule extended, mirrored egress rule added). ESO / vault-config / gateway access is unchanged.

After deploy, openbao-1/2 join the leader on their next retry and the recurring vault-config Job unseals them — restoring real 3-node HA.

## Validation

- `kubectl kustomize` local + prod ✅
- `kubectl apply --dry-run=server` on the policy ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)