### PR TITLE
ci: dump OpenBao pod labels, Service endpoints and server logs on system-test failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,23 @@ jobs:
             kubectl describe job -n "$ns" "$name" 2>&1 | tail -50
           done
           echo "::endgroup::"
+          echo "::group::OpenBao state"
+          # The vault seeding chain (ClusterSecretStore, PushSecrets,
+          # vault-config Job) all route through the openbao-active Service,
+          # whose endpoints depend on OpenBao's Kubernetes service
+          # registration labelling the active pod (openbao-active=true).
+          # When that chain wedges, the generic dumps above miss the three
+          # facts that identify the break: pod labels, Service endpoints,
+          # and the OpenBao server log (2026-06-10 post-mortems had none
+          # of them). Dump all three.
+          kubectl get pods -n openbao --show-labels
+          kubectl get svc -n openbao -o wide
+          kubectl get endpointslices -n openbao -o wide
+          for pod in $(kubectl get pods -n openbao -l app.kubernetes.io/name=openbao -o name); do
+            echo "--- $pod server log ---"
+            kubectl logs -n openbao "$pod" --tail=150 2>&1 | sed 's/^/  /'
+          done
+          echo "::endgroup::"
 
       - name: 🔥 Delete cluster
         if: always()


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Every system test today (all six remediation PRs **and** the unrelated Renovate PRs #1971/#1972/#1974, and the tenant-DNS PR run at 19:24) fails identically: the `infrastructure` Kustomization times out on the 21 resources of the vault seeding chain, all erroring with

```
dial tcp <openbao-active ClusterIP>:8200: connect: no route to host
```

i.e. the `openbao-active` Service has **zero backends** in the test cluster — `openbao-0` is initialized and unsealed (the vault-config init container confirms it), yet never carries the `openbao-active=true` label that OpenBao's Kubernetes service registration must set. This started with today's openbao active-service cutover (#1964/#1965/#1907) and is **pre-existing on main**, not caused by the open PRs.

The existing 🩺 diagnose step dumps neither pod labels, nor Service endpoints, nor the OpenBao server log — the three facts needed to pin why the label is missing. This PR adds an "OpenBao state" group with all three; its own system-test run on this PR will produce the first actionable dump.

## Validation

- YAML parses (yq) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)