### PR TITLE
fix(vault-seed): seed OIDC client/cookie secrets from the SOPS bootstrap source

### DIFF
--- a/k8s/bases/infrastructure/vault-seed/generators.yaml
+++ b/k8s/bases/infrastructure/vault-seed/generators.yaml
@@ -7,42 +7,6 @@
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: Password
 metadata:
-  name: dex-client-secret
-  namespace: openbao
-spec:
-  length: 32
-  digits: 8
-  symbols: 0
-  noUpper: false
-  allowRepeat: true
----
-apiVersion: generators.external-secrets.io/v1alpha1
-kind: Password
-metadata:
-  name: flux-web-client-secret
-  namespace: openbao
-spec:
-  length: 32
-  digits: 8
-  symbols: 0
-  noUpper: false
-  allowRepeat: true
----
-apiVersion: generators.external-secrets.io/v1alpha1
-kind: Password
-metadata:
-  name: oauth2-proxy-cookie-secret
-  namespace: openbao
-spec:
-  length: 32
-  digits: 8
-  symbols: 0
-  noUpper: false
-  allowRepeat: true
----
-apiVersion: generators.external-secrets.io/v1alpha1
-kind: Password
-metadata:
   name: fleetdm-mysql-root-password
   namespace: openbao
 spec:

--- a/k8s/bases/infrastructure/vault-seed/push-generated-secrets.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-generated-secrets.yaml
@@ -1,4 +1,9 @@
 # Randomly-generated secrets, seeded into OpenBao via a durable K8s cache.
+# Only values with NO external system of record belong here (umami / fleetdm
+# app passwords). OIDC client/cookie secrets do NOT: dex and oauth2-proxy
+# consume them from the SOPS bootstrap secret via Flux substitution, so the
+# vault copy must be seeded from that same source — see the seed-* OIDC
+# PushSecrets in push-secrets.yaml.
 #
 # Two-step per secret:
 #   1. An ExternalSecret with a generatorRef source (refreshInterval "0")
@@ -17,117 +22,6 @@
 # values existed nowhere but the wiped vault. With the cache Secret as
 # the system of record, the hourly re-push is a no-op while the vault is
 # healthy and an automatic restore after data loss — values never rotate.
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: generated-dex-client-secret
-  namespace: openbao
-spec:
-  refreshInterval: "0"
-  target:
-    name: generated-dex-client-secret
-    creationPolicy: Owner
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: Password
-          name: dex-client-secret
----
-apiVersion: external-secrets.io/v1alpha1
-kind: PushSecret
-metadata:
-  name: push-dex-client-secret
-  namespace: openbao
-spec:
-  refreshInterval: 1h
-  secretStoreRefs:
-    - name: openbao
-      kind: ClusterSecretStore
-  selector:
-    secret:
-      name: generated-dex-client-secret
-  data:
-    - match:
-        secretKey: password
-        remoteRef:
-          remoteKey: infrastructure/oidc/dex
-          property: client-secret
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: generated-flux-web-client-secret
-  namespace: openbao
-spec:
-  refreshInterval: "0"
-  target:
-    name: generated-flux-web-client-secret
-    creationPolicy: Owner
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: Password
-          name: flux-web-client-secret
----
-apiVersion: external-secrets.io/v1alpha1
-kind: PushSecret
-metadata:
-  name: push-flux-web-client-secret
-  namespace: openbao
-spec:
-  refreshInterval: 1h
-  secretStoreRefs:
-    - name: openbao
-      kind: ClusterSecretStore
-  selector:
-    secret:
-      name: generated-flux-web-client-secret
-  data:
-    - match:
-        secretKey: password
-        remoteRef:
-          remoteKey: infrastructure/oidc/flux-web
-          property: client-secret
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: generated-oauth2-proxy-cookie-secret
-  namespace: openbao
-spec:
-  refreshInterval: "0"
-  target:
-    name: generated-oauth2-proxy-cookie-secret
-    creationPolicy: Owner
-  dataFrom:
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: Password
-          name: oauth2-proxy-cookie-secret
----
-apiVersion: external-secrets.io/v1alpha1
-kind: PushSecret
-metadata:
-  name: push-oauth2-proxy-cookie-secret
-  namespace: openbao
-spec:
-  refreshInterval: 1h
-  secretStoreRefs:
-    - name: openbao
-      kind: ClusterSecretStore
-  selector:
-    secret:
-      name: generated-oauth2-proxy-cookie-secret
-  data:
-    - match:
-        secretKey: password
-        remoteRef:
-          remoteKey: infrastructure/oidc/oauth2-proxy
-          property: cookie-secret
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/k8s/bases/infrastructure/vault-seed/push-secrets.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secrets.yaml
@@ -131,6 +131,75 @@ spec:
           remoteKey: infrastructure/ghcr/auth
           property: dockerconfigjson
 ---
+# OIDC client/cookie secrets — single source of truth is the SOPS bootstrap
+# secret (variables-cluster), NOT a generator. Dex's staticClients and
+# oauth2-proxy consume these very values via Flux post-build substitution
+# (${dex_client_secret} / ${flux_web_client_secret} /
+# ${oauth2_proxy_cookie_secret}), while headlamp / actual-budget / the
+# OpenBao OIDC auth method read them back from these vault paths. When the
+# vault copy was generated independently (the pre-2026-06-10 design), the
+# two copies could never match — dex rejected every vault-sourced client
+# secret. Seeding from the same SOPS key makes both sides identical.
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: seed-dex-client-secret
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: openbao
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: variables-cluster
+  data:
+    - match:
+        secretKey: dex_client_secret
+        remoteRef:
+          remoteKey: infrastructure/oidc/dex
+          property: client-secret
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: seed-flux-web-client-secret
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: openbao
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: variables-cluster
+  data:
+    - match:
+        secretKey: flux_web_client_secret
+        remoteRef:
+          remoteKey: infrastructure/oidc/flux-web
+          property: client-secret
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: seed-oauth2-proxy-cookie-secret
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: openbao
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: variables-cluster
+  data:
+    - match:
+        secretKey: oauth2_proxy_cookie_secret
+        remoteRef:
+          remoteKey: infrastructure/oidc/oauth2-proxy
+          property: cookie-secret
+---
 # Velero kopia repository password
 # ---------------------------------
 # Velero auto-generates a random password in the `velero-repo-credentials`


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

The same logical secret has **two unrelated values**:

- **dex** (staticClients) and **oauth2-proxy** consume `${dex_client_secret}` / `${flux_web_client_secret}` / `${oauth2_proxy_cookie_secret}` directly from the `variables-cluster` SOPS secret via Flux post-build substitution
- **headlamp**, **actual-budget** and the **OpenBao OIDC auth method** read the same logical secrets from the vault paths `infrastructure/oidc/{dex,flux-web,oauth2-proxy}` — which were seeded by an **independent Password generator**

Verified live on prod just now: `sha256(variables-cluster.dex_client_secret) ≠ sha256(vault-synced dex-client-secret)` → dex rejects every vault-sourced consumer. This predates the 2026-06-10 incident (the generator never knew about the SOPS value), and the post-incident regeneration (#1981) re-rolled the dice.

## Fix

Replace the three generator-based pushes with `seed-*` PushSecrets that mirror the `variables-cluster` keys into the same vault paths (hourly, like every other SOPS-sourced seed). Drop the now-unused Password generators and cache ExternalSecrets (Flux prunes them; the cache Secrets are GC'd with their owners). The truly generated secrets (umami / fleetdm) keep the #1981 cache pattern — they have no external system of record.

After merge I'll re-run the vault-config Job once so the OpenBao OIDC auth method picks up the corrected `oidc_client_secret`.

## Validation

- `kubectl kustomize` local + prod ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)