### PR TITLE
ci: probe the OpenBao label-patch 422 with kubectl on system-test failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,27 @@ jobs:
             echo "--- $pod server log ---"
             kubectl logs -n openbao "$pod" --tail=150 2>&1 | sed 's/^/  /'
           done
+          # Label-patch probe: OpenBao's service registration updates pod
+          # labels with RFC 6902 `replace` ops and on the 2026-06-10 runs the
+          # apiserver rejected every update with a bare 422 (OpenBao does not
+          # log the response body), freezing the labels at their startup
+          # values so openbao-active never gained endpoints. Replay the same
+          # operation with kubectl, which prints the apiserver's full
+          # explanation of WHAT is invalid, plus a server-side dry-run apply
+          # of the unmodified pod to surface latent object-validation errors.
+          echo "--- label patch probe (single replace, current value) ---"
+          CUR=$(kubectl get pod openbao-0 -n openbao -o jsonpath='{.metadata.labels.openbao-active}')
+          kubectl patch pod openbao-0 -n openbao --type=json \
+            -p "[{\"op\":\"replace\",\"path\":\"/metadata/labels/openbao-active\",\"value\":\"$CUR\"}]" 2>&1 | sed 's/^/  /'
+          echo "--- label patch probe (batch replace, all openbao-* labels) ---"
+          kubectl get pod openbao-0 -n openbao -o json | jq -r '
+            .metadata.labels | to_entries
+            | map(select(.key | startswith("openbao-")))
+            | map({op: "replace", path: ("/metadata/labels/" + .key), value: .value})' \
+            | kubectl patch pod openbao-0 -n openbao --type=json --patch-file=/dev/stdin 2>&1 | sed 's/^/  /'
+          echo "--- pod self-validation (server-side dry-run re-apply) ---"
+          kubectl get pod openbao-0 -n openbao -o json \
+            | kubectl replace --dry-run=server -f - 2>&1 | tail -5 | sed 's/^/  /'
           echo "::endgroup::"
 
       - name: 🔥 Delete cluster


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What #1986's first dump revealed

The repo-wide system-test failure is now narrowed to one precise mechanism:

- `openbao-0` is initialized + unsealed, and the **initial** service-registration label write succeeds (`openbao-active=false`, `openbao-sealed=true`, … all present; the *standby* Service has endpoints)
- every subsequent state **update** patch is rejected by the apiserver with **HTTP 422**, retried every 5s forever:

  ```
  [WARN] service_registration.kubernetes: unable to update state for due to PATCH
  https://10.96.0.1:443/api/v1/namespaces/openbao/pods/openbao-0 ... resp statuscode: 422, will retry
  ```

- so the labels freeze at their startup values, `openbao-active` never gains endpoints (`<unset>` in the EndpointSlice dump), and the whole vault seeding chain times out with `connect: no route to host`

OpenBao logs only the status code — not the 422 response body that names the invalid field. Prod (k8s v1.36.1 / Talos 1.13.3) accepts identical patches; the CI cluster (v1.36.0 / Talos 1.13.4) rejects them.

## This PR

Extends the `OpenBao state` diagnostics group with a probe that replays the same RFC 6902 `replace` via kubectl (single label + the full `openbao-*` batch, using current values → semantically a no-op), which prints the apiserver's full explanation, plus a server-side dry-run re-apply of the unmodified pod to catch latent object-validation errors. This PR's own failing system test will produce the answer.

## Validation

- YAML parses (yq) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)