### PR TITLE
fix(keda): spread http-add-on interceptor and scaler replicas across nodes

### DIFF
--- a/k8s/bases/infrastructure/controllers/keda-http-add-on/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/keda-http-add-on/helm-release.yaml
@@ -32,7 +32,33 @@ spec:
       privileged: false
     scaler:
       replicas: ${keda_scaler_replicas:=1}
+      # Soft hostname spread: the scaler's queue pinger polls every interceptor
+      # admin endpoint and reports NOT_SERVING (liveness kill) while any one of
+      # them is unreachable, so losing a node that holds several replicas of
+      # either component degrades all scale-to-zero routing at once. The default
+      # scheduler skew tolerance (maxSkew 3) happily co-locates replicas — on
+      # prod it packed 2 of 3 interceptors onto a single short-lived autoscaler
+      # node. ScheduleAnyway keeps this a preference so single-node local/CI
+      # clusters still schedule.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keda-http-add-on
+              app.kubernetes.io/component: scaler
     interceptor:
       replicas:
         min: ${keda_interceptor_min_replicas:=1}
         max: 3
+      # Same rationale as the scaler above: the interceptor is on the request
+      # path of every scale-to-zero UI, so its replicas must not share a node.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keda-http-add-on
+              app.kubernetes.io/component: interceptor


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

On prod, 2 of 3 `keda-add-ons-http-interceptor` replicas were co-located on a single short-lived autoscaler node (`autoscale-cx33-78d4e4c568a5d877`). The interceptor sits on the request path of every scale-to-zero UI, and the external scaler's queue pinger polls every interceptor admin endpoint — it reports `NOT_SERVING` (and gets liveness-killed) while any one of them is unreachable. Losing that one node would therefore have degraded all scale-to-zero routing at once.

Context: the external scaler's chronic restarts (~2-4/hr since June 7, 233 total) stopped after #1975's cilium node-encryption fix rolled out (zero restarts 18:36–21:21 UTC, confirmed via Coroot Prometheus). This PR addresses the remaining availability gap, not the (already fixed) network root cause.

## Fix

Add soft (`whenUnsatisfiable: ScheduleAnyway`) hostname `topologySpreadConstraints` to both the interceptor and scaler via chart values, so replicas land on distinct nodes whenever capacity allows. The default scheduler spread (maxSkew 3) tolerates the observed co-location; maxSkew 1 does not. Soft strength keeps single-node local/CI clusters schedulable.

## Validation

- `ksail workload validate` — ✅ 315 files validated
- `ksail --config ksail.prod.yaml workload validate` — ✅ except the pre-existing, unrelated datreeio coroot_v1 schema failure (upstream datreeio/CRDs-catalog#896)
- `helm template` against `keda-add-ons-http@0.14.1` confirms both Deployments render the constraints with matching pod labels (`app.kubernetes.io/component: interceptor|scaler`, `app.kubernetes.io/instance: keda-http-add-on` verified against live prod pod labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)