### PR TITLE
fix(observability): disable Coroot latency SLO on auth-proxy

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
@@ -4,6 +4,15 @@ kind: Deployment
 metadata:
   name: auth-proxy
   namespace: oauth2-proxy
+  annotations:
+    # Disable Coroot's latency SLO for this proxy (availability SLO stays).
+    # auth-proxy fans out to the KEDA-interceptor-fronted scale-to-zero UIs,
+    # so its inbound latency SLI is dominated by intentional cold-start holds
+    # (the interceptor parks the request until the target wakes — 10s+),
+    # which at ~600 requests/day makes the default 99%-under-500ms SLO a
+    # permanent false-critical. Warm-path health is still covered by the
+    # availability SLO here and by the per-app SLOs behind the proxy.
+    coroot.com/slo-latency-objective: 0%
 spec:
   replicas: ${auth_proxy_replicas:=2}
   strategy:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`auth-proxy` is the only application Coroot shows as **critical**, 24/7, on an otherwise green prod overview. Root cause (verified against Coroot's bundled Prometheus, 24h window):

- p50 latency through the proxy is **145 ms** — the warm path is healthy.
- ~600 requests/day, of which **28 took >10 s**, all clustered in evening browsing windows (e.g. 22:00–00:00 UTC June 9/10), i.e. the first hits on idle scale-to-zero UIs.

auth-proxy fans out to the KEDA-interceptor-fronted scale-to-zero apps, and the interceptor intentionally parks a cold-start request until the target Deployment wakes (10 s+). Against the default Coroot SLO (99% under 500 ms) this by-design behaviour makes the proxy a permanent false-critical — alarm fatigue that masks real incidents. No latency threshold can fix it honestly: even the largest bucket (10 s) sits at 95.3% compliance.

## Fix

Annotate the Deployment with `coroot.com/slo-latency-objective: 0%` ([Coroot SLO docs](https://docs.coroot.com/inspections/slo/)) to disable only the latency SLO. The proxy's availability SLO and the per-app SLOs behind it keep covering real health, and the warm-path signal lives with the apps where a regression is actionable.

## Validation

- `ksail workload validate` — ✅ 315 files validated
- `kubectl kustomize k8s/clusters/prod/` — ✅ builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)