### PR TITLE
docs: truth up fleetdm status (parked 2026-06-03) and add missing umami to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ A high-level inventory of what Flux reconciles onto the cluster. The manifests l
 
 **Apps** ([`k8s/bases/apps/`](k8s/bases/apps))
 
-- Homepage (dashboard), Headlamp (Kubernetes UI), FleetDM (device management), Actual Budget (budgeting), `whoami` (debug)
+- Homepage (dashboard), Headlamp (Kubernetes UI), Umami (analytics), Actual Budget (budgeting), `whoami` (debug)
+- FleetDM (device management) is parked — disabled 2026-06-03; its manifests are retained for re-enabling (see [`k8s/bases/apps/kustomization.yaml`](k8s/bases/apps/kustomization.yaml))
 - **Tenants** — apps deployed from their own repositories (`ascoachingogvaner`, `wedding-app`); see [`docs/TENANTS.md`](docs/TENANTS.md)
 
 ## Structure

--- a/docs/progressive-delivery.md
+++ b/docs/progressive-delivery.md
@@ -72,7 +72,7 @@ Promotion vs rollback is gated on:
 
 | Workload | Reason |
 | --- | --- |
-| whoami, headlamp, actual-budget, fleetdm, hubble-ui | KEDA **HTTP add-on** (scale-to-zero). whoami keeps scale-to-zero by choice; headlamp = single-pod in-memory OIDC; actual-budget = single-writer file DB — none can run concurrent canary pods. |
+| whoami, headlamp, actual-budget, fleetdm (parked), hubble-ui | KEDA **HTTP add-on** (scale-to-zero). whoami keeps scale-to-zero by choice; headlamp = single-pod in-memory OIDC; actual-budget = single-writer file DB — none can run concurrent canary pods. fleetdm is disabled since 2026-06-03. |
 | openbao | StatefulSet — Flagger only manages Deployments / DaemonSets. |
 | coroot UI, hubble-ui | Operator-reconciled Deployments — the operator fights Flagger for ownership. |
 | dex, oauth2-proxy, flux-operator | Critical SSO / GitOps — too risky to canary. |

--- a/docs/secret-rotation.md
+++ b/docs/secret-rotation.md
@@ -4,6 +4,11 @@ Status: **proposal** (2026-05-27). Goal: automated rotation of platform secrets,
 preferring **OpenBao-native** mechanisms. This document is the design; each phase
 ships as its own reviewed PR.
 
+> **Note (2026-06-03):** the fleetdm app — the flagship for Phases 1–2 — is
+> currently **disabled** (`k8s/bases/apps/kustomization.yaml`); its OpenBao
+> plumbing is intentionally left idle for re-enabling. The fleetdm phases below
+> stay as written and apply when (or in the branch where) the app returns.
+
 ## Current state
 
 - **OpenBao = KV v2 + Kubernetes auth only** (configured by the `vault-config`


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

Three docs claimed fleetdm is a running app; it has been **disabled since 2026-06-03** ([k8s/bases/apps/kustomization.yaml](https://github.com/devantler-tech/platform/blob/main/k8s/bases/apps/kustomization.yaml)) with manifests and OpenBao plumbing intentionally retained for re-enabling.

- **README.md** — apps list no longer presents FleetDM as deployed (now a separate "parked" line), and **Umami was missing from the list entirely** — added.
- **docs/secret-rotation.md** — status note: the fleetdm Phases 1–2 stay as written and apply when the app returns (an active `feat/fleetdm-mysql-static-role-rotation` branch exists, so the design text is deliberately NOT removed).
- **docs/progressive-delivery.md** — exclusion table marks fleetdm as parked.

Deliberately **not** done: deleting `k8s/bases/apps/fleetdm/` or the idle vault-config plumbing — the kustomization comment says it's retained for re-enable, and in-flight rotation work depends on it.

Docs-only; no manifests touched, so no overlay validation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)