### PR TITLE
fix(velero): give VGDP micro-pods explicit tiny requests so they fit saturated nodes

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -115,6 +115,11 @@ spec:
         type: RollingUpdate
         rollingUpdate:
           maxUnavailable: 1
+      # Explicit (tiny) resources for the per-volume VGDP micro-service pods —
+      # see node-agent-configmap.yaml for why the Kyverno-stamped 128Mi default
+      # request gets them rejected on memory-saturated nodes.
+      extraArgs:
+        - --node-agent-configmap=node-agent-config
 
     # Daily backup of every namespace that has PVCs. 14-day retention
     # matches the 24h RPO target. Long-term retention is handled by R2

--- a/k8s/bases/infrastructure/controllers/velero/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - helm-release.yaml
   - networkpolicy.yaml
   - velero-r2-credentials.yaml
+  - node-agent-configmap.yaml

--- a/k8s/bases/infrastructure/controllers/velero/node-agent-configmap.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/node-agent-configmap.yaml
@@ -1,0 +1,33 @@
+# Velero node-agent configuration (read via --node-agent-configmap, see
+# nodeAgent.extraArgs in helm-release.yaml).
+#
+# podResources sets EXPLICIT resources on the VGDP micro-service pods that
+# Velero spawns per volume (PodVolumeBackup/PodVolumeRestore/DataUpload/
+# DataDownload). Without it those pods declare no resources, so the
+# add-resource-defaults Kyverno policy (and the namespace LimitRange) stamp the
+# platform default of 128Mi memoryRequest into them. fs-backup pods are pinned
+# to the node of the pod whose volume they read, bypassing the scheduler — and
+# on workers whose requestable memory is ~100% allocated, kubelet admission
+# rejects them ("Node didn't have enough resource: memory"), cancelling that
+# volume's backup (12 of 99 volumes on the 2026-06-11 daily run).
+#
+# Requests are deliberately tiny: they are admission accounting only, and the
+# most saturated node has had ~12MiB of unrequested memory left. Limits match
+# the platform defaults the Kyverno policy would have stamped, so runtime
+# behaviour is unchanged — the pods just no longer need a 128Mi reservation to
+# be admitted. Velero requires request <= limit for any pair that is set.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-agent-config
+  namespace: velero
+data:
+  node-agent-config.json: |
+    {
+      "podResources": {
+        "cpuRequest": "5m",
+        "cpuLimit": "500m",
+        "memoryRequest": "8Mi",
+        "memoryLimit": "512Mi"
+      }
+    }


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The 2026-06-11 daily backup — the first run after the v1.14.0 plugin pin landed — improved from `Failed` to **`PartiallyFailed`**: 87/99 PodVolumeBackups and 9/10 DataUploads completed, but 12 volumes were `Canceled` with:

```
expose error: Pod is in abnormal state [Failed], message [Pod was rejected: Node didn't have enough resource: memory, requested: 134217728, used: 7450967334, capacity: 7463321600]
```

Root cause chain:
1. Velero 1.18 runs each volume backup in a per-volume **VGDP micro-service pod** that declares **no resources**.
2. The `add-resource-defaults` Kyverno policy (and the namespace LimitRange) therefore stamp the platform default **128Mi memoryRequest** into them.
3. fs-backup pods are **pinned to the source pod's node** (no scheduler involvement), and several workers sit at ~100% requested memory (one had ~12MiB unrequested) → kubelet admission rejects the pod → that volume's backup is canceled.

The June 9/10 runs show the same mechanism across openbao, CNPG, flux controllers, dex, etc. — which volumes fail is a lottery of node saturation.

## Fix

A `node-agent-config` ConfigMap wired via `nodeAgent.extraArgs: --node-agent-configmap` ([Velero node-agent ConfigMap docs](https://velero.io/docs/main/supported-configmaps/node-agent-configmap/) — `podResources` explicitly applies to PodVolumeBackup/PodVolumeRestore/DataUpload/DataDownload pods):

- **Requests 5m / 8Mi** — admission accounting only; small enough to fit even the most saturated node.
- **Limits 500m / 512Mi** — identical to what the Kyverno policy stamps today, so runtime behaviour is unchanged. (Today's completed volumes already ran under these limits.)

Explicit values are never overwritten by the Kyverno `+()` anchors or the LimitRange, which only fill in missing fields.

## Validation

- `ksail workload validate` — ✅ 316 files validated
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — ✅ both build
- `helm template` against velero chart 12.0.2 renders `--node-agent-configmap=node-agent-config` in the node-agent DaemonSet args — ✅
- ConfigMap JSON payload validated with `jq` — ✅

## Verification after merge

The next `velero-daily-full` (02:17 UTC) should complete with 0 canceled PodVolumeBackups; #1994's heartbeat will then watch this continuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)