### PR TITLE
fix(security): harden vault jobs, flux netpol, and SSO cookie flags

### DIFF
--- a/k8s/bases/infrastructure/controllers/flux-operator/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/flux-operator/networkpolicy.yaml
@@ -16,13 +16,6 @@ spec:
         - ports:
             - port: "9080"
               protocol: TCP
-    # Webhook notifications
-    - fromEntities:
-        - world
-      toPorts:
-        - ports:
-            - port: "80"
-              protocol: TCP
     # Intra-namespace (controller-to-controller communication)
     - fromEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -90,6 +90,12 @@ spec:
         # always return a public email, and the real gate is now
         # allowed_groups -- so don't additionally gate on the email domain.
         email_domains = ["*"]
+        # Pin the session-cookie flags explicitly rather than relying on
+        # oauth2-proxy defaults: HTTPS-only, no JavaScript access, and Lax
+        # (Strict would break the IdP redirect back from Dex/GitHub).
+        cookie_secure = true
+        cookie_httponly = true
+        cookie_samesite = "lax"
         cookie_domains=[".${domain}"]
         whitelist_domains = ["${domain}", ".${domain}"]
         redirect_url = "https://oauth2-proxy.${domain}/oauth2/callback"

--- a/k8s/bases/infrastructure/vault-backup/cronjob.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cronjob.yaml
@@ -27,10 +27,16 @@ spec:
         spec:
           serviceAccountName: vault-snapshot
           restartPolicy: OnFailure
+          # The full restricted-PSS context is set explicitly (not left to the
+          # add-security-context Kyverno mutation) so the pod stays hardened
+          # even when created before the webhook is active on fresh bring-up.
           securityContext:
             runAsUser: 100
             runAsGroup: 1000
             fsGroup: 1000
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           volumes:
             - name: snapshots
               persistentVolumeClaim:
@@ -38,6 +44,15 @@ spec:
           containers:
             - name: snapshot
               image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
               env:
                 # openbao-active = unsealed Raft leader only. Snapshots must be
                 # taken from the leader — against the plain `openbao` Service

--- a/k8s/bases/infrastructure/vault-backup/init-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/init-job.yaml
@@ -33,10 +33,16 @@ spec:
     spec:
       serviceAccountName: vault-snapshot
       restartPolicy: OnFailure
+      # The full restricted-PSS context is set explicitly (not left to the
+      # add-security-context Kyverno mutation) so the pod stays hardened
+      # even when created before the webhook is active on fresh bring-up.
       securityContext:
         runAsUser: 100
         runAsGroup: 1000
         fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
         - name: snapshots
           persistentVolumeClaim:
@@ -44,6 +50,15 @@ spec:
       containers:
         - name: snapshot
           image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
             # openbao-active = unsealed Raft leader only (same rationale as
             # the CronJob in cronjob.yaml).

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -60,10 +60,16 @@ spec:
     spec:
       serviceAccountName: vault-config
       restartPolicy: OnFailure
+      # The full restricted-PSS context is set explicitly (not left to the
+      # add-security-context Kyverno mutation) so the pod stays hardened
+      # even when created before the webhook is active on fresh bring-up.
       securityContext:
         runAsUser: 100
         runAsGroup: 1000
         fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
         - name: unseal-keys
           secret:
@@ -80,6 +86,15 @@ spec:
         # --- 1. Auto-init + unseal ---
         - name: vault-init
           image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           # No BAO_ADDR env: the script addresses each pod explicitly through
           # the openbao-internal headless Service (publishNotReadyAddresses:
           # true, so per-pod DNS resolves even before readiness).
@@ -232,6 +247,15 @@ spec:
         # --- 2. Persist credentials in K8s Secret (only on fresh init) ---
         - name: store-keys
           image: alpine/k8s:1.36.1@sha256:692239d739589247c4a791205ed9619c28ae85a21286e19a6211c04a62c56668
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: shared
               mountPath: /shared
@@ -260,6 +284,15 @@ spec:
       containers:
         - name: vault-config
           image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: BAO_ADDR
               # openbao-active = unsealed Raft leader only. Configuration

--- a/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/coredns/deployment.yaml
@@ -101,7 +101,12 @@ spec:
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
+      # No runAsNonRoot: the upstream CoreDNS image runs as root, and the
+      # NET_BIND_SERVICE capability it needs to bind :53 is not effective
+      # for non-root users without ambient capabilities.
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccount: coredns
       serviceAccountName: coredns
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Low-risk security hardening sweep from a full repo security audit (Kyverno policies, netpol coverage, pod security, supply chain, secrets hygiene). Every change here is **behavior-preserving by design** — nothing that could wedge prod.

### 1. Explicit restricted-PSS security contexts on the OpenBao jobs
`vault-backup/cronjob.yaml`, `vault-backup/init-job.yaml`, `vault-config/job.yaml` (pod level + every container/initContainer): `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`.

These pods already run with exactly this context — the `add-security-context` Kyverno mutation injects it at admission (the `openbao` namespace is not excluded), and both jobs have run green with it in prod. Making it explicit closes the fresh-bring-up window where pods can be created before the Kyverno webhook is active (a gap the policy's own comments document), and makes the manifests the audit-clean source of truth.

### 2. Drop dead `world:80` ingress allow from the flux-system CNP
The rule was labeled "Webhook notifications", but no `Receiver` resources exist anywhere in the repo, nothing in flux-system listens on pod port 80 (the notification-controller webhook receiver target port would be 9292), and the Flux web UI is reached via the KEDA interceptor on 9080. The rule allowed any external host to reach flux-system pods on port 80 — dead permissive surface that misleads audits.

### 3. Pin oauth2-proxy session-cookie flags
`cookie_secure = true`, `cookie_httponly = true`, `cookie_samesite = "lax"` set explicitly in the configFile. Secure/httponly match oauth2-proxy's upstream defaults; `lax` matches modern-browser default behavior (`strict` would break the IdP redirect back from Dex/GitHub). Pure auditability — no flow change.

### 4. CoreDNS (docker provider, local/CI only): pod-level `seccompProfile: RuntimeDefault`
kube-system is excluded from the Kyverno mutation so nothing else injects it. `runAsNonRoot` deliberately omitted — the upstream image runs as root and `NET_BIND_SERVICE` is not effective for non-root without ambient capabilities.

## Validation

- `ksail workload validate` — ✅ green, 318 files
- `ksail --config ksail.prod.yaml workload validate` — ✅ except the **pre-existing** datreeio coroot schema gap (`notificationIntegrations not allowed`, fixed upstream by datreeio/CRDs-catalog#896, unrelated to this PR)
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — ✅ both build
- Rendered output spot-checked: security contexts, cookie flags, and netpol rule removal all present in the built layers

## Deliberately NOT done (higher value, higher risk — needs a human call)

- **FQDN-pinning `world:443` egress** (fleetdm, umami, openbao, headlamp, actual-budget…): real exfiltration-surface reduction, but depends on the Cilium DNS proxy and complete knowledge of each app's external endpoints (R2 bucket hosts live in encrypted secrets). A wrong list breaks logins/backups.
- **Kyverno `verifyImages` admission policy for first-party images**: defense-in-depth on top of the existing Talos `ImageVerificationConfig` + Flux cosign verify, but adds a GHCR-availability dependency to pod admission; the `image-verification` Kubescape exception documents the current two-layer approach as intentional.
- **`:latest`/digest-pinning validation policy**: would fire on third-party charts → warning noise on a healthy cluster.