### PR TITLE
perf(observability): relax Coroot metric resolution 15s -> 30s

### DIFF
--- a/k8s/bases/apps/homepage/canary.yaml
+++ b/k8s/bases/apps/homepage/canary.yaml
@@ -36,14 +36,14 @@ spec:
           namespace: flagger-system
         thresholdRange:
           min: 99
-        interval: 1m
+        interval: 2m
       - name: latency-p99
         templateRef:
           name: coroot-request-duration
           namespace: flagger-system
         thresholdRange:
           max: 2000
-        interval: 1m
+        interval: 2m
     webhooks:
       - name: acceptance-test
         type: pre-rollout

--- a/k8s/bases/apps/umami/canary.yaml
+++ b/k8s/bases/apps/umami/canary.yaml
@@ -66,14 +66,14 @@ spec:
           namespace: flagger-system
         thresholdRange:
           min: 99
-        interval: 1m
+        interval: 2m
       - name: latency-p99
         templateRef:
           name: coroot-request-duration
           namespace: flagger-system
         thresholdRange:
           max: 500
-        interval: 1m
+        interval: 2m
     webhooks:
       - name: acceptance-test
         type: pre-rollout

--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -29,7 +29,15 @@ spec:
   # as Admin, mirroring the old single-operator "everyone -> Grafana Admin".
   authAnonymousRole: Admin
 
-  metricsRefreshInterval: 15s
+  # Metric resolution. The operator default is 15s; 30s halves the bundled
+  # Prometheus ingest, the node-agent scrape volume, and Coroot's continuous
+  # query load on a memory-constrained cluster, while staying at the
+  # conventional Prometheus scrape interval. Coupled setting: the Flagger
+  # canary metric windows (canary*.yaml `metrics[].interval`) are sized to
+  # keep >=4 samples per rate() window (Prometheus best practice), so they
+  # must be >= 4x this value — currently 2m. Don't raise this without
+  # widening those windows.
+  metricsRefreshInterval: 30s
   cacheTTL: 30d
 
   # The Coroot app's own state (users, custom dashboards, UI-configured

--- a/k8s/bases/infrastructure/flagger/canary-opencost.yaml
+++ b/k8s/bases/infrastructure/flagger/canary-opencost.yaml
@@ -53,14 +53,14 @@ spec:
           namespace: flagger-system
         thresholdRange:
           min: 99
-        interval: 1m
+        interval: 2m
       - name: latency-p99
         templateRef:
           name: coroot-request-duration
           namespace: flagger-system
         thresholdRange:
           max: 1000
-        interval: 1m
+        interval: 2m
     webhooks:
       - name: acceptance-test
         type: pre-rollout


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

- `metricsRefreshInterval: 15s` → `30s` on the Coroot CR ([coroot.yaml](k8s/bases/infrastructure/coroot/coroot.yaml)) — this is the metric **resolution**: it drives the bundled Prometheus scrape interval, the eBPF node-agent export volume, and Coroot's continuous query load. 15s is the coroot-operator default (`DefaultMetricRefreshInterval`), so we were running at the default.
- Flagger canary `metrics[].interval` 1m → 2m on the three canaries (homepage, umami, opencost). The MetricTemplates wrap `rate(...[{{ interval }}])`, and Prometheus best practice is ≥4 samples per rate window: 1m windows were sized to 15s resolution (4×); 2m restores the same 4× ratio at 30s. **Canary analysis cadence (`analysis.interval: 1m`), thresholds, and iteration counts are unchanged** — promotion and rollback speed stay the same; each check just evaluates a 2m trailing window.

## Why 30s (best practice reasoning)

- Halves Prometheus ingest + scrape + Coroot query load on a memory-constrained cluster; 30s is the conventional production Prometheus scrape interval (kube-prometheus default).
- 60s was considered and rejected: canary windows would need 4m (slower failure detection during rollouts), sub-minute spikes disappear from incident forensics, and the marginal savings beyond halving are small.
- A comment on the CR now documents the 4× coupling so a future resolution change doesn't silently starve the canary queries.

No prod overlay overrides `metricsRefreshInterval`, so the base change takes effect everywhere.

## Validation

- `ksail workload validate` — ✅ 318 files validated
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — ✅ both build
- Prod `ksail --config ksail.prod.yaml workload validate` still fails only on the pre-existing datreeio CRDs-catalog Coroot schema gap (datreeio/CRDs-catalog#896), unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)