### PR TITLE
chore(infrastructure): trim warm standbys to 2 on off-path controllers

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -23,11 +23,14 @@
 #     and testkube (operator-managed singletons);
 #   * single-replica-only controllers: external-dns (chart has no replicaCount;
 #     >1 = duplicate Cloudflare writes), origin-ca-issuer (disabled) and
-#     flagger-loadtester (ephemeral per-canary test helper).
+#     flagger-loadtester (ephemeral per-canary test helper);
+#   * cost-tuned warm standbys (2026-06-11): VPA recommender/updater and kyverno
+#     reports/cleanup -- leader-elected, off every serving path, prod runs 2
+#     replicas (active + warm standby) with a maxUnavailable: 1 PDB.
 #
-# The leader-election controllers that USED to be exempt (cloudnative-pg,
+# The other leader-election controllers that USED to be exempt (cloudnative-pg,
 # reloader, trust-manager, hcloud CCM/CSI, snapshot-controller, kyverno
-# background/reports/cleanup, flagger) now run 3 replicas for HA instead.
+# background, flagger) now run 3 replicas for HA instead.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -95,6 +98,17 @@ spec:
                 - external-dns
                 - origin-ca-issuer
                 - flagger-loadtester
+          # Cost-tuned warm standbys (2026-06-11): leader-elected controllers
+          # off every serving path run 2 replicas in prod (active + one warm
+          # standby) with a maxUnavailable: 1 PDB, which still rides out a
+          # node drain. A third standby bought no extra availability -- only
+          # ~1 pod of requests each on a request-saturated cluster.
+          - resources:
+              names:
+                - vertical-pod-autoscaler-vpa-recommender
+                - vertical-pod-autoscaler-vpa-updater
+                - kyverno-reports-controller
+                - kyverno-cleanup-controller
       preconditions:
         all:
           # Durable opt-out on the pod template (charts expose podLabels more

--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -126,12 +126,25 @@ spec:
                 - patch
     reportsController:
       replicas: ${kyverno_reports_replicas:=1}
+      # The chart auto-enables this PDB whenever replicas > 1, defaulting to
+      # minAvailable: 1. Flip it to the drain-safe house pattern
+      # (maxUnavailable: 1, #1880/#1882); minAvailable must be nulled because
+      # the chart refuses to render both fields. Unlike the admission
+      # controller's PDB, this one is not ksail-bootstrap-owned, so there is
+      # no server-side-apply conflict.
+      podDisruptionBudget:
+        minAvailable: null
+        maxUnavailable: 1
       podSecurityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
     cleanupController:
       replicas: ${kyverno_cleanup_replicas:=1}
+      # Same drain-safe PDB flip as the reportsController above.
+      podDisruptionBudget:
+        minAvailable: null
+        maxUnavailable: 1
       podSecurityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -28,6 +28,11 @@ spec:
       # --leader-elect (extraArgs is a map -> --leader-elect=true).
       extraArgs:
         leader-elect: true
+      podDisruptionBudget:
+        # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 never
+        # deadlocks a node drain regardless of replica count, and at the
+        # prod 2-replica floor it keeps one recommender up through a drain.
+        maxUnavailable: 1
       podSecurityContext:
         runAsUser: 65534
         runAsGroup: 65534
@@ -46,6 +51,9 @@ spec:
       # updaters would double-evict pods. VPA 1.6.0 supports --leader-elect.
       extraArgs:
         leader-elect: true
+      podDisruptionBudget:
+        # Drain-safe PDB pattern (#1880/#1882) -- see the recommender block.
+        maxUnavailable: 1
       podSecurityContext:
         runAsUser: 65534
         runAsGroup: 65534

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -126,14 +126,23 @@ data:
   # VPA recommender computes resource recommendations; admission controller
   # applies them at pod start. Updater evicts pods to apply new resource
   # recommendations continuously.
-  # 3 replicas for HA; recommender/updater are leader-elected (helm-release
-  # extraArgs leader-elect: true), so one is active and the rest warm standbys.
-  vpa_recommender_replicas: "3"
-  vpa_updater_replicas: "3"
-  # --- Kyverno (3 replicas for HA; these controllers are leader-elected) ---
+  # 2 replicas: recommender/updater are leader-elected (helm-release
+  # extraArgs leader-elect: true) and sit on no serving path — a failover
+  # gap only delays the next recommendation/eviction cycle. Active + one
+  # warm standby with a maxUnavailable: 1 PDB (helm-release) still rides
+  # out a node drain; a third standby bought no availability, only ~1 pod
+  # of requests on a request-saturated cluster (cost trim, 2026-06-11).
+  vpa_recommender_replicas: "2"
+  vpa_updater_replicas: "2"
+  # --- Kyverno (leader-elected controllers) ---
+  # background stays 3: it executes the generate/mutate-existing rules the
+  # platform leans on (e.g. propagate-reloader-to-flagger-primary).
   kyverno_background_replicas: "3"
-  kyverno_reports_replicas: "3"
-  kyverno_cleanup_replicas: "3"
+  # reports/cleanup run 2 (active + warm standby, maxUnavailable: 1 PDB):
+  # report generation and cleanup are best-effort background work off every
+  # serving path — same cost trim as the VPA standbys above.
+  kyverno_reports_replicas: "2"
+  kyverno_cleanup_replicas: "2"
   # --- Flagger (3 replicas for HA; gated by leaderElection.enabled) ---
   flagger_replicas: "3"
   # --- OpenBao secrets vault ---


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Drops prod replicas 3 → 2 for four leader-elected controllers that sit on no serving path, while making their drain-survival guarantee explicit via PDBs:

| Controller | Replicas | PDB before | PDB after |
|---|---|---|---|
| VPA recommender | 3 → 2 | **none** | `maxUnavailable: 1` |
| VPA updater | 3 → 2 | **none** | `maxUnavailable: 1` |
| kyverno reports-controller | 3 → 2 | chart-auto `minAvailable: 1` | `maxUnavailable: 1` (house pattern, #1880/#1882) |
| kyverno cleanup-controller | 3 → 2 | chart-auto `minAvailable: 1` | `maxUnavailable: 1` (house pattern, #1880/#1882) |

`kyverno_background_replicas` stays 3 — the background controller executes the generate/mutate-existing rules the platform leans on (e.g. `propagate-reloader-to-flagger-primary`). `vpa_admission_replicas` stays 3 (admission webhook path).

The four Deployments are name-exempted from `validate-replica-floor` (Audit) so PolicyReports stay clean, with the rationale documented in the policy.

## Why

Owner-approved cost trim (2026-06-11): the cluster is at its 10-node Hetzner account cap, and request saturation is what keeps autoscaler nodes alive. These controllers are leader-elected active/standby — a failover only delays the next recommendation/eviction cycle or report/cleanup pass, so the third standby bought no availability, only ~1 pod of requests each. Condition for the trim was that the PDBs still ride out a node drain: at 2 replicas + `maxUnavailable: 1`, exactly one pod is evictable at a time and one always survives.

Net effect: 4 fewer always-on pods plus their VPA-assigned requests, easing the saturation that pins autoscale nodes up.

## Notes

- The VPA chart rendered **no PDB at all** for recommender/updater before this change (only the admission controller had one) — this PR strictly improves their disruption posture despite the replica drop.
- Kyverno's chart refuses to render both PDB fields, so `minAvailable` is explicitly nulled where `maxUnavailable: 1` is set. Unlike the admission controller's PDB (ksail-bootstrap-owned, SSA conflict), reports/cleanup PDBs are Flux-owned — no conflict.
- Deployment names in the policy exemption follow the charts' fullname templates: `vertical-pod-autoscaler-vpa-recommender` / `-updater` (Fairwinds `vpa` chart), `kyverno-reports-controller` / `kyverno-cleanup-controller`.

## Validation

- `ksail workload validate` — ✅ 318 files validated
- `ksail --config ksail.prod.yaml workload validate` — 90 kustomizations, 1 pre-existing failure: datreeio `coroot_v1` schema gap (upstream datreeio/CRDs-catalog#896, unrelated)
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — ✅ both build

🤖 Generated with [Claude Code](https://claude.com/claude-code)