### PR TITLE
fix(vault-backup): bound hung snapshot runs and pin backup cron schedules to UTC

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/backup-heartbeat-cronjob.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/backup-heartbeat-cronjob.yaml
@@ -51,7 +51,10 @@ spec:
   # 07:00 UTC: ~4h40m after the velero-daily-full schedule (17 2 * * *) so even
   # a slow full backup has finished. A backup still InProgress by then also
   # withholds the ping — a backup that slow is itself worth the alert.
+  # timeZone pins that UTC contract explicitly instead of inheriting
+  # kube-controller-manager's local TZ.
   schedule: "0 7 * * *"
+  timeZone: Etc/UTC
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 1

--- a/k8s/bases/infrastructure/vault-backup/cronjob.yaml
+++ b/k8s/bases/infrastructure/vault-backup/cronjob.yaml
@@ -14,12 +14,23 @@ metadata:
   namespace: openbao
 spec:
   schedule: "30 3 * * *"
+  # Pin the cron evaluation to UTC instead of inheriting kube-controller-manager's
+  # local TZ: the 03:30 slot is sequenced between the velero-daily-full backup
+  # (02:17 UTC) and the velero-backup-heartbeat check (07:00 UTC).
+  timeZone: Etc/UTC
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       backoffLimit: 3
+      # Backstop for a hung run: the bao auth/status/snapshot-save calls have no
+      # client-side timeout and can hang forever on a half-open connection, and
+      # the PVC can wedge attaching — with concurrencyPolicy: Forbid a run that
+      # never finishes would silently block every future daily snapshot. 30m is
+      # ~10x a slow run including the OnFailure retries; on expiry the Job fails
+      # and the next day's schedule gets a clean start.
+      activeDeadlineSeconds: 1800
       template:
         metadata:
           labels:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Two small resilience/explicitness fixes on the backup CronJobs, found during a best-practice audit:

### 1. `activeDeadlineSeconds: 1800` on the vault-snapshot Job
The snapshot script's `bao` auth/status/snapshot-save calls have no client-side timeout and can hang forever on a half-open connection, and the snapshots PVC can wedge attaching. A run that never finishes never *fails* — and with `concurrencyPolicy: Forbid` it then silently blocks **every future daily OpenBao snapshot**. After the 2026-06-10 KV wipe, this CronJob is the restore lifeline, so a silent wedge here is exactly the failure mode we can't afford. 30m is ~10x a slow run including the OnFailure retries; on expiry the Job fails and the next day's schedule starts clean. (Deliberately NOT adding `startingDeadlineSeconds`: leaving it unset gives unlimited catch-up after a missed 03:30 window, which is what a daily backup wants.)

### 2. Explicit `timeZone: Etc/UTC` on both absolute-time backup CronJobs
vault-snapshot (03:30) and velero-backup-heartbeat (07:00) are sequenced against the velero-daily-full schedule (02:17 UTC) — the heartbeat's comment even documents "07:00 UTC". Without `timeZone` the schedule inherits kube-controller-manager's local TZ; pinning Etc/UTC makes the documented contract explicit with zero behavior change. The interval-based CronJobs (`*/15`, `*/30`, `* * * * *`) are TZ-independent and left alone.

## Validation

- `ksail workload validate` — ✅ 318 files green
- `ksail --config ksail.prod.yaml workload validate` — ✅ except the pre-existing datreeio coroot schema gap (datreeio/CRDs-catalog#896, unrelated)
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — ✅ both build

Note: touches `vault-backup/cronjob.yaml` which #2012 also edits — the hunks don't overlap (spec/jobTemplate level here vs pod/container securityContext there), so merge order doesn't matter.