### PR TITLE
chore(deps): digest-pin pause and keep vendored KubeVirt/CDI bumps human-reviewed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -205,6 +205,16 @@
       ],
       "allowedVersions": "!/^v?1\\.14\\.1$/",
       "automerge": false
+    },
+    {
+      "description": "KubeVirt and CDI ship as VENDORED upstream operator manifests (k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml, .../cdi/cdi-operator.yaml) — thousands of lines of CRDs, RBAC and the operator Deployment vendored as one unit from each release's published asset. The kubernetes manager only sees the `image:` lines inside them, so a Renovate bump rewrites the operator image alone and silently skews it against the CRDs/RBAC vendored next to it; the system-test would still pass bring-up (operators tolerate startup skew) so automerge would land the skew unseen. Keep the update PR as the new-release signal but require a maintainer to re-vendor the full manifest from the matching release before merging. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
+      "matchPackageNames": [
+        "quay.io/kubevirt/**"
+      ],
+      "automerge": false,
+      "addLabels": [
+        "vendored-manifest"
+      ]
     }
   ],
   "ignorePaths": [

--- a/k8s/providers/hetzner/infrastructure-overprovisioning/replicaset.yaml
+++ b/k8s/providers/hetzner/infrastructure-overprovisioning/replicaset.yaml
@@ -94,7 +94,9 @@ spec:
       containers:
         - name: pause
           # Upstream Kubernetes pause image — sleeps until signalled, no logic.
-          image: registry.k8s.io/pause:3.10
+          # Digest-pinned like every other raw pod image in the repo; Renovate's
+          # kubernetes manager keeps tag and digest updated together.
+          image: registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a
           resources:
             requests:
               cpu: "2"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Two update-automation hygiene fixes from a best-practice audit:

### 1. Digest-pin the overprovisioning `pause` image
`registry.k8s.io/pause:3.10` in `k8s/providers/hetzner/infrastructure-overprovisioning/replicaset.yaml` was the **only raw, non-vendored pod image in the repo without a digest pin** — every sibling raw manifest (openbao snapshot jobs, coroot pricing/heartbeat curl, velero heartbeat, docker-provider traefik/minio/registry) pins `tag@sha256`, and Renovate's kubernetes manager maintains those pairs (e.g. the traefik digest bump in #1987). Pinned to the upstream manifest-list digest `sha256:ee6521f2…` (verified against registry.k8s.io).

### 2. Renovate: no automerge for `quay.io/kubevirt/**`
KubeVirt and CDI ship as **vendored upstream operator manifests** (`kubevirt-operator.yaml`, `cdi-operator.yaml` — thousands of lines of CRDs + RBAC + operator Deployment vendored as one unit). Renovate's kubernetes manager only sees the `image:` lines inside them, so a bump rewrites the operator image alone and silently skews it against the CRDs/RBAC vendored next to it. With the repo's major/minor/patch automerge defaults, that skew would land unseen — the system test still passes bring-up because operators tolerate startup skew. The new packageRule (placed last, so it overrides the automerge defaults) keeps the update PR as the new-release signal but requires a maintainer to re-vendor the full release manifest before merging — same pattern as the existing velero-plugin-for-aws and Talos rules.

## Validation

- `ksail workload validate` — ✅ 318 files green
- `ksail --config ksail.prod.yaml workload validate` — ✅ `providers/hetzner/infrastructure-overprovisioning validated`; only failure is the pre-existing datreeio coroot schema gap (datreeio/CRDs-catalog#896, unrelated)
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — ✅ both build
- `jq . .github/renovate.json` — ✅ valid JSON
