### PR TITLE
feat(security): admission-layer image controls (cosign verify + latest-tag ban)

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/disallow-latest-tag.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/disallow-latest-tag.yaml
@@ -1,0 +1,101 @@
+# Mutable image references defeat both verification layers (Talos
+# ImageVerificationConfig and verify-image-signatures verify whatever the
+# tag points at TODAY) and make rollbacks/incident forensics guesswork.
+# Requires every container image to carry a tag, and forbids the ':latest'
+# tag specifically. A tag+digest reference (img:1.2.3@sha256:…) passes both
+# rules — the digest is what actually pins it.
+#
+# Audit ONLY for now: third-party chart images can't be enumerated
+# statically, and an Enforce policy that trips on one would wedge its
+# HelmRelease mid-upgrade (the enforce-flux-best-practices failure mode).
+# Flip validationFailureAction to Enforce once prod PolicyReports
+# (`kubectl get polr -A | grep disallow-latest-tag`) show zero violations.
+#
+# Namespace exclusions mirror validate-pod-security: infrastructure
+# namespaces that run third-party system charts by design.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-latest-tag
+  annotations:
+    policies.kyverno.io/title: Disallow Latest Tag
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Requires container images to use an explicit tag and forbids the
+      mutable ':latest' tag, so what runs is reproducible and the
+      signature-verification layers gate immutable references.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: require-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - flux-system
+                - longhorn-system
+                - local-path-storage
+                - kubescape
+                - kubevirt
+                - cdi
+                - observability
+                - velero
+      validate:
+        message: >-
+          An explicit image tag is required — a tagless reference silently
+          resolves to the mutable ':latest'.
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - image: "*:*"
+            =(initContainers):
+              - image: "*:*"
+            containers:
+              - image: "*:*"
+    - name: validate-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - flux-system
+                - longhorn-system
+                - local-path-storage
+                - kubescape
+                - kubevirt
+                - cdi
+                - observability
+                - velero
+      validate:
+        message: >-
+          The mutable ':latest' tag is not allowed — pin a version tag so
+          rollbacks and signature verification reference immutable images.
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - image: "!*:latest"
+            =(initContainers):
+              - image: "!*:latest"
+            containers:
+              - image: "!*:latest"

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-image-signatures.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-image-signatures.yaml
@@ -1,0 +1,114 @@
+# Admission-layer cosign verification of FIRST-PARTY images
+# (ghcr.io/devantler-tech/*) — the third verification layer, complementing:
+#   1. Flux OCI *manifest* verification (apps' sync.yaml verify.provider:
+#      cosign) — gates the GitOps artifacts, not container images.
+#   2. Talos ImageVerificationConfig (talos/cluster/image-verification.yaml)
+#      — gates the image bytes containerd pulls, with the SAME two signing
+#      identities as below. Keep both files in sync when identities change.
+# This layer rejects a Pod spec referencing an unsigned/tampered first-party
+# image at admission, before any node attempts a pull — and unlike the Talos
+# layer it also covers clusters whose nodes lack the verification patch.
+#
+# FAIL-OPEN for everything else, exactly like the Talos config: images that
+# match no imageReferences pattern are admitted without verification, so
+# third-party chart images (Cilium, Longhorn, Coroot, …) are unaffected.
+# This is intentionally NOT a deny-all-unsigned control; kubescape C-0237
+# stays exempted (security-exceptions/image-verification.yaml) because
+# third-party images remain unverified.
+#
+# Operational dependencies (both self-heal via controller retries if absent
+# during bring-up — the policy lands in the `infrastructure` layer AFTER the
+# first-party controllers are admitted by `infrastructure-controllers`):
+#   - the `ghcr-auth` dockerconfigjson Secret in the kyverno namespace
+#     (external-secrets/external-secrets.yaml) — signature manifests of
+#     private images need authenticated GHCR reads
+#   - kyverno egress to ghcr.io + Sigstore (networkpolicy.yaml)
+# Trade-off accepted by design: creating/restarting a FIRST-PARTY pod while
+# GHCR is unreachable is denied until the (1h TTL) verification cache warms.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-signatures
+  annotations:
+    policies.kyverno.io/title: Verify First-Party Image Signatures
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Requires keyless cosign signatures from the devantler-tech release
+      pipelines on all ghcr.io/devantler-tech/* container images at Pod
+      admission. Third-party images are not matched and admit unverified.
+    # Verify once, at Pod admission, instead of also generating autogen rules
+    # for Deployments/CronJobs/…: controller specs are applied by Flux and
+    # would add a registry dependency to every HelmRelease upgrade, while the
+    # Pod-level check already guarantees nothing unverified can run.
+    pod-policies.kyverno.io/autogen-controllers: none
+spec:
+  validationFailureAction: Enforce
+  # Admission-only: background scans would re-fetch signatures from GHCR on
+  # every scan interval for pods that were already verified at admission.
+  background: false
+  # Default 10s is tight for a cold cosign fetch (manifest + signature blob
+  # + TUF metadata); verified results are cached so only the first admission
+  # of an image pays this.
+  webhookTimeoutSeconds: 30
+  rules:
+    # ksail images (incl. ksail-operator) — signed by ksail's OWN release
+    # pipeline, a different keyless identity than publish-app.yaml. Kyverno
+    # applies the first rule whose imageReferences match, so this specific
+    # rule must precede the catch-all (mirrors the Talos rule order).
+    - name: verify-ksail-images
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/devantler-tech/ksail*"
+          required: true
+          # Images are referenced by tag (Renovate-managed); do not demand
+          # digest refs and do not rewrite pod specs to digests (digest
+          # mutation would fight Flux drift detection and Flagger).
+          verifyDigest: false
+          mutateDigest: false
+          imageRegistryCredentials:
+            secrets:
+              - ghcr-auth
+          attestors:
+            - entries:
+                - keyless:
+                    issuer: https://token.actions.githubusercontent.com
+                    subjectRegExp: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
+                    rekor:
+                      url: https://rekor.sigstore.dev
+    # First-party APP images (wedding-app, ascoachingogvaner, …) — signed by
+    # the shared reusable-workflows/publish-app.yaml identity, the same one
+    # their Flux OCIRepository verify blocks pin.
+    - name: verify-app-images
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/devantler-tech/*"
+          skipImageReferences:
+            - "ghcr.io/devantler-tech/ksail*"
+          required: true
+          verifyDigest: false
+          mutateDigest: false
+          imageRegistryCredentials:
+            secrets:
+              - ghcr-auth
+          attestors:
+            - entries:
+                - keyless:
+                    issuer: https://token.actions.githubusercontent.com
+                    subjectRegExp: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
+                    rekor:
+                      url: https://rekor.sigstore.dev

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -8,12 +8,14 @@ resources:
   - best-practices/add-security-context.yaml
   - best-practices/auto-vpa.yaml
   - best-practices/disable-default-sa-automount.yaml
+  - best-practices/disallow-latest-tag.yaml
   - best-practices/propagate-reloader-to-flagger-primary.yaml
   - best-practices/restrict-tenant-secret-stores.yaml
   - best-practices/validate-host-restrictions.yaml
   - best-practices/validate-pdb-drain-safe.yaml
   - best-practices/validate-pod-security.yaml
   - best-practices/validate-replica-floor.yaml
+  - best-practices/verify-image-signatures.yaml
   - flux/enforce-flux-best-practices.yaml
   - flux/helm-release-enable-tests.yaml
   - flux/helm-release-install-crds.yaml

--- a/k8s/bases/infrastructure/controllers/kyverno/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/networkpolicy.yaml
@@ -19,7 +19,23 @@ spec:
     # Kube API for policy enforcement
     - toEntities:
         - kube-apiserver
-    # DNS resolution
+    # Image signature verification (verify-image-signatures ClusterPolicy):
+    # cosign signature manifests live on ghcr.io with blobs served from the
+    # GitHub CDN, and the Sigstore TUF trust root refreshes from its CDN.
+    # Rekor inclusion proofs normally verify offline via the bundled SET,
+    # but keep the log reachable for entries without a bundle.
+    - toFQDNs:
+        - matchName: "ghcr.io"
+        - matchName: "pkg-containers.githubusercontent.com"
+        - matchName: "tuf-repo-cdn.sigstore.dev"
+        - matchName: "rekor.sigstore.dev"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # DNS resolution. rules.dns engages Cilium's L7 DNS proxy so the toFQDNs
+    # allow-list above can be enforced; matchPattern "*" leaves resolution
+    # itself unrestricted (the FQDN list constrains where traffic may go).
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: kube-system
@@ -30,3 +46,6 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"

--- a/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
+++ b/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
@@ -30,3 +30,30 @@ spec:
       remoteRef:
         key: infrastructure/backup/r2
         property: secret_access_key
+---
+# GHCR pull credentials for Kyverno's verify-image-signatures ClusterPolicy:
+# signature manifests of PRIVATE first-party images need authenticated GHCR
+# reads. Same OpenBao path and shape as the per-app ghcr-auth pull secrets.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ghcr-auth
+  namespace: kyverno
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-auth
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .dockerconfigjson }}"
+  data:
+    - secretKey: dockerconfigjson
+      remoteRef:
+        key: infrastructure/ghcr/auth
+        property: dockerconfigjson


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds the two admission-layer image controls from the security audit follow-up, bundled in one PR because they share the cluster-policies kustomization (separate PRs would conflict on it).

### 1. `verify-image-signatures` — **Enforce**

Keyless-cosign verification of **first-party images** (`ghcr.io/devantler-tech/*`) at Pod admission — the third verification layer:

| Layer | Gates | File |
|---|---|---|
| Flux OCI verify | GitOps *manifest* artifacts | apps' `sync.yaml` |
| Talos `ImageVerificationConfig` | image bytes containerd pulls | `talos/cluster/image-verification.yaml` |
| **this policy** | **Pod specs at admission** | `cluster-policies/best-practices/verify-image-signatures.yaml` |

The two rules mirror the Talos config's identities exactly (ksail images → ksail's `cd.yaml` release identity; everything else → `reusable-workflows/publish-app.yaml`), with the same specific-before-catch-all ordering and the same **fail-open** posture for non-matching third-party images — kubescape C-0237 stays exempted because third-party images remain unverified.

Design choices:
- **`autogen-controllers: none`** — verification happens once, at Pod admission. Deployment/CronJob specs applied by Flux gain no registry dependency, so HelmRelease upgrades can't be blocked by a GHCR hiccup; only actual pod creation can.
- **`verifyDigest`/`mutateDigest` off** — images are tag-referenced (Renovate-managed); digest mutation would fight HelmRelease drift detection and Flagger's primary copies.
- **`webhookTimeoutSeconds: 30`** for cold signature fetches; verified results are cached (~1h), so steady-state admissions don't touch the registry.
- Supporting wiring: a `ghcr-auth` dockerconfigjson **ExternalSecret in the kyverno namespace** (signature manifests of private images need authenticated reads; same OpenBao path as the per-app pull secrets) and kyverno netpol egress to `ghcr.io`, the GitHub CDN, and Sigstore TUF/Rekor — FQDN-pinned, consistent with #2019.

**Accepted trade-off (as discussed):** creating/restarting a *first-party* pod while GHCR is unreachable is denied until connectivity returns. Third-party/infrastructure pods are never affected. Bring-up ordering is safe: the policy lands in the `infrastructure` layer *after* `infrastructure-controllers` admits the first-party controllers, and a missing `ghcr-auth` secret during bootstrap just retries until ESO syncs it.

### 2. `disallow-latest-tag` — **Audit (flip to Enforce after a clean report)**

Requires an explicit image tag and forbids `:latest` on `containers`, `initContainers`, and `ephemeralContainers` (tag+digest refs pass — the digest pins them). Audit-first is deliberate: third-party chart images can't be enumerated statically from the repo, and an Enforce policy tripping on one would wedge its HelmRelease mid-upgrade — the exact `enforce-flux-best-practices` failure mode this repo has hit before. Once prod PolicyReports show zero violations (`kubectl get polr -A | grep disallow-latest-tag`), flip `validationFailureAction` to Enforce. Namespace exclusions mirror `validate-pod-security`.

## Validation

- `ksail workload validate` — ✅ green, 320 files (both new policies pass the Kyverno CRD schema)
- `ksail --config ksail.prod.yaml workload validate` — ✅ except the pre-existing datreeio coroot schema gap (CRDs-catalog#896, unrelated)
- `kubectl kustomize` of both cluster overlays + the cluster-policies layer — ✅
- The CI system test exercises the full bring-up with the policy active, including verified admission of the ksail-operator image in the docker cluster