### PR TITLE
fix(velero): skip emptyDir pod volumes in the nightly backup

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/velero/volume-policies-configmap.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/velero/volume-policies-configmap.yaml
@@ -30,6 +30,19 @@ data:
             - longhorn
         action:
           type: snapshot
+      # emptyDir pod volumes → skip. emptyDir never survives pod recreation, so
+      # backing it up has zero restore value — yet defaultVolumesToFsBackup was
+      # spawning a VGDP micro-pod for every agent scratch dir (kubescape
+      # node-agent clamav dirs, coroot-node-agent tmp, CNPG shm/scratch-data,
+      # openbao tmp/home, homepage config/logs). On memory-saturated nodes those
+      # micro-pods end up pod-phase Failed and each stuck PodVolumeBackup holds
+      # the nightly backup open until the 4h timeout (PartiallyFailed). Real
+      # data is unaffected: PVCs never match volumeTypes: emptyDir.
+      - conditions:
+          volumeTypes:
+            - emptyDir
+        action:
+          type: skip
       # No rule for hcloud or any other StorageClass: unmatched volumes fall
       # back to defaultVolumesToFsBackup: true → Kopia file-system backup. This
       # keeps openbao (hcloud, which has no CSI snapshot support) and any future


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause

The nightly `velero-daily-full` backup has never fully succeeded (FailedValidation ×7 → Failed ×2 → PartiallyFailed today). Today's run (`velero-daily-full-20260611021752`, 5 errors / 11 warnings) timed out after 4h with `timed out waiting for all PodVolumeBackups to complete`. 12 PodVolumeBackups were canceled with `expose error: Pod is in abnormal state [Failed]` — and every one of them targeted an **emptyDir**: kubescape node-agent `clamrun`/`profiles`/`data`, coroot-node-agent `tmp`, openbao `tmp`/`home`, homepage `config`, CNPG `shm`/`scratch-data`.

`defaultVolumesToFsBackup: true` spawns a VGDP micro-pod per pod volume; on memory-saturated nodes these go pod-phase Failed (eviction class — #2008 merged today addresses the requests side), and each stuck PVB holds the backup open until the 4h `fsBackupTimeout`.

## Fix

Add a `volumeTypes: [emptyDir] → skip` rule to the prod volume policy. emptyDir content never survives pod recreation, so backing it up has zero restore value. Velero v1.18 evaluates volume policies against **pod volumes** (not just PVs) — verified against `internal/resourcepolicies/volume_types_conditions.go` at v1.18.1 (`emptyDir` is a SupportedVolume) and `resource_policies.go` (`data.PodVolume` path).

Real data is unaffected:
- Longhorn PVCs still take the CSI-snapshot + datamover route (first rule).
- openbao `data`/`audit` (hcloud PVCs, no CSI snapshots) never match `volumeTypes: emptyDir` and keep the Kopia FSB fallback.

This complements #2008: fewer micro-pods to schedule, and no junk PVBs left to hold the backup at the timeout.

## Validation

- `ksail workload validate` — ✅ 318 files validated
- `ksail --config ksail.prod.yaml workload validate` — only the pre-existing datreeio coroot schema failure (upstream CRDs-catalog #896), untouched by this change
- `kubectl kustomize k8s/clusters/local/` + `k8s/clusters/prod/` — ✅ both build
- server-side noop dry-run of the changed ConfigMap — ✅