### PR TITLE
fix(flux): resolve external registries absolute-first in source-controller (ndots 1)

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -63,3 +63,23 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/part-of: flux
+      # source-controller polls external registries (ghcr.io OCI artifacts +
+      # Helm repo indexes) on every interval; with the default ndots:5 each
+      # lookup walks the four-entry search path first, producing thousands of
+      # guaranteed-NXDOMAIN queries per hour against CoreDNS (Coroot flags this
+      # as a DNS warning on the app). ndots:1 makes any dotted name resolve
+      # absolute-first; the search path remains a fallback, and Flux's own
+      # in-cluster URLs are already trailing-dot FQDNs
+      # (source-controller.flux-system.svc.cluster.local.), so nothing relies
+      # on search-path expansion.
+      - target:
+          kind: Deployment
+          name: source-controller
+          namespace: flux-system
+        patch: |
+          - op: add
+            path: /spec/template/spec/dnsConfig
+            value:
+              options:
+                - name: ndots
+                  value: "1"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Symptom

Coroot flags `flux-system/source-controller` with a **DNS warning**: ~1.4k empty DNS responses per window. The per-domain table shows they are all `ghcr.io.<search_path_suffix>` — i.e. `ghcr.io` expanded through the pod search path (`flux-system.svc.cluster.local`, `svc.cluster.local`, `cluster.local`) before the absolute query.

## Root cause

Kubernetes defaults pods to `ndots:5`, so every external lookup (`ghcr.io` has 1 dot < 5) tries all search-path expansions first — each one a guaranteed NXDOMAIN, ×2 for A+AAAA. source-controller is the platform's busiest DNS client (it polls every OCIRepository/HelmRepository on interval), so this multiplies into thousands of junk queries per hour against CoreDNS.

## Fix

A FluxInstance kustomize patch (hetzner overlay, same mechanism as the existing topology-spread patch) sets `dnsConfig: {options: [{name: ndots, value: "1"}]}` on the source-controller Deployment:

- any dotted name resolves **absolute-first**; the search path remains a fallback, so in-cluster dotted names still resolve;
- Flux's own in-cluster URLs are already trailing-dot FQDNs (`source-controller.flux-system.svc.cluster.local.` — visible in every artifact URL), so nothing relies on search-path expansion;
- scoped to source-controller only (the flagged app); easy to extend to the other three controllers later if wanted.

## Validation

- `kubectl kustomize k8s/clusters/local/` + `k8s/clusters/prod/` — ✅ both build
- `ksail --config ksail.prod.yaml workload validate` — only the pre-existing datreeio coroot schema failure (upstream CRDs-catalog #896)
- JSON6902 patch verified to render `dnsConfig` correctly against a Deployment fixture