### PR TITLE
feat(ha): add drain-safe PDB to the OpenBao Raft cluster

### DIFF
--- a/k8s/bases/infrastructure/controllers/openbao/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - helm-repository.yaml
   - httproute.yaml
   - networkpolicy.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/infrastructure/controllers/openbao/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/openbao/pod-disruption-budget.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: openbao
+  namespace: openbao
+spec:
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue
+  # #1880): it never deadlocks a node drain regardless of replica count. On
+  # the 3-replica prod Raft cluster it additionally guarantees quorum (2 of
+  # 3 voters) through any voluntary disruption — previously nothing stopped
+  # two simultaneous evictions from breaking quorum and sealing the vault.
+  # Local/CI runs a single replica; maxUnavailable: 1 still permits that
+  # pod's eviction, so drains never block there either.
+  maxUnavailable: 1
+  selector:
+    # The openbao chart's server StatefulSet selector labels (vault-helm
+    # fork): scoped to component=server so the PDB never matches injector
+    # or CSI pods if those are ever enabled.
+    matchLabels:
+      app.kubernetes.io/name: openbao
+      app.kubernetes.io/instance: openbao
+      component: server


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Adds a standalone `PodDisruptionBudget` for the OpenBao server StatefulSet ([pod-disruption-budget.yaml](k8s/bases/infrastructure/controllers/openbao/pod-disruption-budget.yaml)) — the openbao chart (vault-helm fork) ships no PDB template, and the PDB-completion sweep (#1991) didn't cover it.

- `maxUnavailable: 1` — the platform-wide drain-safe pattern (#1880/#1882). On the 3-replica prod Raft cluster this guarantees quorum (2 of 3 voters) through any voluntary disruption; previously two simultaneous evictions could break quorum and seal the vault. At the local/CI single-replica floor it still permits the pod's eviction, so drains never deadlock.
- Selector is scoped to the chart's server labels (`app.kubernetes.io/name: openbao`, `instance: openbao`, `component: server`) so injector/CSI pods are never matched if enabled later.

**Note on the requested `MaxAvailable: 5`:** the PDB API has no `maxAvailable` field — only `minAvailable` and `maxUnavailable`, and they are mutually exclusive. `maxUnavailable: 1` alone expresses the intended guarantee (at most one member down voluntarily, quorum preserved); the `validate-pdb-drain-safe` audit policy also flags `minAvailable`-style PDBs as drain-unsafe, so this stays on the convention.

## Validation

- `ksail workload validate` — ✅ 302 files validated
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — ✅ both build

🤖 Generated with [Claude Code](https://claude.com/claude-code)