### PR TITLE
feat(autoscaling): scale on request rate past the VPA ceiling, cap replicas at 3

### DIFF
--- a/docs/progressive-delivery.md
+++ b/docs/progressive-delivery.md
@@ -63,7 +63,8 @@ Promotion vs rollback is gated on:
   canary). Its old route's HSTS header is re-added via `service.headers`; the
   `gethomepage.dev/*` tile annotations are not reproducible on a Flagger route.
 - **homepage** — blue/green (it's the root dashboard behind oauth2-proxy). High
-  blast radius; the primary runs 1 replica (was 2) since Flagger owns replicas.
+  blast radius; replicas are owned by a KEDA `ScaledObject` via `autoscalerRef`
+  (primary scales 2-3 on Coroot request rate — see "KEDA apps" below).
 - **opencost** — blue/green infra workload. ⚠️ Headlamp's cost plugin uses the
   `opencost:http-ui` **named** port via the apiserver proxy; `portDiscovery` may
   not preserve that name — watch the Headlamp cost panel after rollout.
@@ -85,10 +86,11 @@ Promotion vs rollback is gated on:
    Flagger generates the route from the Canary's `gatewayRefs` + `hosts`. Re-add
    any response-header filters via `spec.service.headers`. Blue/green keeps the
    existing route untouched.
-3. **Let Flagger own replicas** — add a HelmRelease postRenderer that strips
-   `/spec/replicas` from the Deployment, otherwise Flux re-applies the chart's
-   replica count and fights Flagger's scale-to-zero of the canary (flapping). See
-   any onboarded app's `helm-release.yaml`.
+3. **Let Flagger (or its KEDA `autoscalerRef`) own replicas** — omit the
+   chart's `replicaCount` value and do not pin `/spec/replicas` in a
+   postRenderer, otherwise Flux re-applies the chart's replica count and fights
+   Flagger's scale-to-zero of the canary (flapping). See any onboarded app's
+   `helm-release.yaml`.
 4. **Add the `Canary`** — copy umami's (weighted) or homepage's (blue/green),
    referencing the two `MetricTemplate`s and a loadtester acceptance + load-test
    webhook on `<app>-canary`.
@@ -98,26 +100,34 @@ Promotion vs rollback is gated on:
 6. **Place the Canary** in the apps layer (app) or the `infrastructure` layer
    (infra component) — never in `infrastructure/controllers`.
 
-### KEDA apps (documented pattern — not currently used)
+### KEDA apps (used by homepage + umami)
 
 Flagger's KEDA integration is for **core `keda.sh ScaledObject`**, NOT the
 `http.keda.sh HTTPScaledObject` (HTTP add-on) this platform uses for scale-to-zero.
-To canary a plain-ScaledObject app, reference it from the Canary and let Flagger
-manage the `-primary` scaler:
+Homepage and Umami use it: each app's `scaled-object.yaml` scales 2-3 replicas
+on Coroot's inbound request-rate series — a metric auto-vpa does **not**
+control, so vertical (VPA, up to `maxAllowed`) and horizontal scaling never
+fight. The Canary references the ScaledObject and Flagger manages the
+`-primary` scaler:
 
 ```yaml
 spec:
   autoscalerRef:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
-    name: myapp-so
-    primaryScalerQueries:      # rewrite each trigger query for the primary
+    name: myapp-so          # Flagger clones it to myapp-so-primary and pauses
+    primaryScalerQueries:   # the source's scaler at 0 between rollouts.
       requests: sum(rate(container_http_inbound_requests_total{...primary...}[1m]))
 ```
 
+The trigger must be **named** (Flagger matches `primaryScalerQueries` by
+trigger name), and the source query must exclude `-primary-` pods — reuse the
+vowel-free hash regex described under "Measuring the canary".
+
 Onboarding a HTTP-add-on app (whoami/headlamp/…) this way means **replacing its
 `HTTPScaledObject` with a `ScaledObject`**, giving up HTTP cold-start
-scale-to-zero — a deliberate trade not taken here.
+scale-to-zero — a deliberate trade not taken for those apps. Homepage and Umami
+were never interceptor-fronted, so they gave nothing up.
 
 ## Measuring the canary
 

--- a/k8s/bases/apps/fleetdm/http-scaled-object.yaml
+++ b/k8s/bases/apps/fleetdm/http-scaled-object.yaml
@@ -11,9 +11,13 @@ spec:
     name: fleet
     service: fleetdm-service
     port: 8080
+  # 0..3: scale-to-zero up to the platform replica ceiling
+  # (validate-replica-ceiling). Vertical growth (auto-vpa) comes first; the
+  # extra replicas absorb what one max-sized pod cannot. Fleet's web tier is
+  # stateless (state lives in MySQL/Redis), so 3 concurrent pods are safe.
   replicas:
     min: 0
-    max: 2
+    max: 3
   # Longer cooldown for FleetDM — enrolled devices check in periodically.
   # 15 minutes of silence before scale-to-zero.
   scaledownPeriod: 900

--- a/k8s/bases/apps/homepage/canary.yaml
+++ b/k8s/bases/apps/homepage/canary.yaml
@@ -6,10 +6,11 @@
 # new version. The public path (httproute.yaml -> oauth2-proxy -> auth-proxy ->
 # homepage apex Service) is untouched and always resolves to the primary.
 #
-# ⚠️ High blast radius (platform front page) — watch the first rollout. The
-# HelmRelease postRenderer pins the source replicas to 3, so Flagger runs the
-# primary at 3 for HA. Latency threshold is generous because Homepage is a
-# single-threaded Next.js SSR app that bursts under load.
+# ⚠️ High blast radius (platform front page) — watch the first rollout.
+# Replicas are owned by the KEDA ScaledObject referenced below (autoscalerRef):
+# the primary scales 2-3 on request rate (see scaled-object.yaml). Latency
+# threshold is generous because Homepage is a single-threaded Next.js SSR app
+# that bursts under load.
 apiVersion: flagger.app/v1beta1
 kind: Canary
 metadata:
@@ -21,6 +22,17 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: homepage
+  # The KEDA ScaledObject (scaled-object.yaml) owns replica count on BOTH
+  # sides: Flagger clones it to homepage-primary — rewriting the Prometheus
+  # query below for primary pods (the source query's vowel-free hash regex
+  # cannot match "-primary-") — and pauses the source's scaler at 0 between
+  # rollouts. Replaces the old postRenderer replicas pin (see helm-release.yaml).
+  autoscalerRef:
+    apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    name: homepage
+    primaryScalerQueries:
+      http-requests-per-second: 'sum(rate(container_http_inbound_requests_total{container_id=~"/k8s/homepage/homepage-primary-[bcdfghjklmnpqrstvwxz2-9]+-[a-z0-9]+/.*"}[2m]))'
   progressDeadlineSeconds: 600
   service:
     port: 80

--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -25,15 +25,13 @@ spec:
               kind: Deployment
               name: homepage
             patch: |
-              # Flagger copies the source Deployment's replicas onto the primary.
-              # Pin it to 3 for an HA primary (require-three-replicas) instead of
-              # removing it (which left the primary at the chart default of 1).
-              # Flux drift detection ignores /spec/replicas, so Flagger's
-              # between-rollout scale-to-zero of this source is not fought. See
-              # canary.yaml.
-              - op: replace
-                path: /spec/replicas
-                value: 3
+              # Replicas are deliberately NOT pinned here: the KEDA ScaledObject
+              # (scaled-object.yaml) owns them through the Canary's autoscalerRef
+              # — the primary scales 2-3 on request rate and Flagger pauses the
+              # source's scaler at 0 between rollouts. The chart's replicas
+              # default (1) only exists for the instant before Flagger/KEDA
+              # reconcile; Flux drift detection ignores /spec/replicas, so
+              # neither controller is fought. See canary.yaml.
               - op: add
                 path: /metadata/annotations/configmap.reloader.stakater.com~1reload
                 value: homepage
@@ -134,9 +132,9 @@ spec:
   # ---
   # https://github.com/M0NsTeRRR/helm-charts/blob/main/charts/homepage/values.yaml
   values:
-    # replicaCount intentionally omitted — the postRenderer above pins the
-    # source Deployment's replicas to 3, which Flagger copies onto the primary
-    # (so the primary runs 3 for HA).
+    # replicaCount intentionally omitted — replicas are owned by the KEDA
+    # ScaledObject (scaled-object.yaml) through the Canary's autoscalerRef;
+    # the primary scales 2-3 on request rate.
     # Homepage is a single-threaded Next.js server: it idles near ~3m CPU but
     # bursts hard on every load — server-rendering the page, polling ~14
     # service statuses against kube-apiserver, and aggregating the cluster /

--- a/k8s/bases/apps/homepage/kustomization.yaml
+++ b/k8s/bases/apps/homepage/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - namespace.yaml
   - pod-disruption-budget.yaml
   - networkpolicy.yaml
+  - scaled-object.yaml

--- a/k8s/bases/apps/homepage/scaled-object.yaml
+++ b/k8s/bases/apps/homepage/scaled-object.yaml
@@ -1,0 +1,49 @@
+---
+# Request-rate horizontal scaling for Homepage, complementing auto-vpa: VPA owns
+# the VERTICAL axis (in-place CPU/memory resize up to maxAllowed, 3 CPU / 6Gi),
+# so the horizontal trigger is a metric VPA does not control — inbound HTTP
+# request rate from Coroot's eBPF node-agent, served by its bundled Prometheus
+# (the same series the Flagger MetricTemplates gate on). When right-sized pods
+# can no longer absorb the load, RPS-per-pod crosses the threshold and a replica
+# is added, up to the platform ceiling of 3 (validate-replica-ceiling).
+#
+# Flagger owns this ScaledObject's lifecycle (canary.yaml's autoscalerRef): it
+# clones it to `homepage-primary` targeting the primary Deployment (rewriting
+# the query via primaryScalerQueries) and pauses THIS one at 0 replicas outside
+# canary analysis — the source Deployment stays scaled to zero between
+# rollouts, exactly as before.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: homepage
+  # 2..3: two right-sized replicas survive a node drain (PDB maxUnavailable: 1);
+  # the third comes back under sustained load. 3 is the platform replica
+  # ceiling — past it, growth is VPA's job (bigger pods, not more of them).
+  minReplicaCount: 2
+  maxReplicaCount: 3
+  # If Prometheus is unreachable, fail HIGH to the old static HA count rather
+  # than freezing on the last scaling decision.
+  fallback:
+    failureThreshold: 3
+    replicas: 3
+  triggers:
+    # The trigger MUST be named — Flagger matches primaryScalerQueries by name.
+    - type: prometheus
+      name: http-requests-per-second
+      metadata:
+        serverAddress: http://coroot-prometheus.observability.svc.cluster.local:9090
+        # Per-pod target (AverageValue): the 3rd replica appears when sustained
+        # load exceeds 2 pods × 10 rps. Homepage is a single-threaded Next.js
+        # SSR app (~14 /api/* polls per dashboard refresh), so 10 rps/pod is
+        # real work, while a couple of open dashboard tabs stay on 2. Tune
+        # against live data in coroot-prometheus. The vowel-free hash regex
+        # excludes homepage-primary-* pods, same trick as the Flagger
+        # MetricTemplates (docs/progressive-delivery.md "Measuring the canary").
+        threshold: "10"
+        query: 'sum(rate(container_http_inbound_requests_total{container_id=~"/k8s/homepage/homepage-[bcdfghjklmnpqrstvwxz2-9]+-[a-z0-9]+/.*"}[2m]))'

--- a/k8s/bases/apps/umami/canary.yaml
+++ b/k8s/bases/apps/umami/canary.yaml
@@ -19,8 +19,17 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: umami-umami
-  # No autoscalerRef — Umami uses VPA, not HPA/ScaledObject. Flagger manages the
-  # canary's replicas (the chart's replicas field is stripped in the HelmRelease).
+  # VPA owns per-pod sizing; the KEDA ScaledObject (scaled-object.yaml) owns
+  # replica count on a metric VPA does not control (request rate). Flagger
+  # clones it to umami-umami-primary — rewriting the Prometheus query below for
+  # primary pods (the source query's vowel-free hash regex cannot match
+  # "-primary-") — and pauses the source's scaler at 0 between rollouts.
+  autoscalerRef:
+    apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    name: umami-umami
+    primaryScalerQueries:
+      http-requests-per-second: 'sum(rate(container_http_inbound_requests_total{container_id=~"/k8s/umami/umami-umami-primary-[bcdfghjklmnpqrstvwxz2-9]+-[a-z0-9]+/.*"}[2m]))'
   progressDeadlineSeconds: 600
   service:
     port: 80

--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -16,20 +16,17 @@ spec:
         kind: HelmRepository
         name: umami
   postRenderers:
-    # Flagger copies the source (umami-umami) Deployment's replicas onto the
-    # primary. Pin it to 3 for an HA primary (require-three-replicas) instead of
-    # removing it (which left the primary at the chart default of 1). Flux drift
-    # detection ignores /spec/replicas, so Flagger's between-rollout
-    # scale-to-zero of this source is not fought. See k8s/bases/apps/umami/canary.yaml.
+    # Replicas are deliberately NOT pinned here: the KEDA ScaledObject
+    # (scaled-object.yaml) owns them through the Canary's autoscalerRef — the
+    # primary scales 2-3 on request rate and Flagger pauses the source's scaler
+    # at 0 between rollouts. Flux drift detection ignores /spec/replicas, so
+    # neither controller is fought. See k8s/bases/apps/umami/canary.yaml.
     - kustomize:
         patches:
           - target:
               kind: Deployment
               name: umami-umami
             patch: |
-              - op: replace
-                path: /spec/replicas
-                value: 3
               # OpenBao rotates the umami DB password out of band (7-day static
               # role), refreshed into the umami-db-rotated Secret. The app reads it
               # into DATABASE_URL at startup, so a running pod keeps a stale
@@ -46,8 +43,9 @@ spec:
                 value: umami-db-rotated
   # https://github.com/helmforgedev/charts/blob/main/charts/umami/values.yaml
   values:
-    # replicaCount intentionally omitted — Flagger manages canary replicas
-    # (see the postRenderer above).
+    # replicaCount intentionally omitted — replicas are owned by the KEDA
+    # ScaledObject (scaled-object.yaml) through the Canary's autoscalerRef;
+    # the primary scales 2-3 on request rate.
     serviceAccount:
       # Umami needs no Kubernetes API access.
       automountServiceAccountToken: false

--- a/k8s/bases/apps/umami/kustomization.yaml
+++ b/k8s/bases/apps/umami/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
   # httproute.yaml removed — Flagger generates and owns Umami's HTTPRoute from
   # canary.yaml (Gateway API weighted canary).
   - canary.yaml
+  - scaled-object.yaml
   - networkpolicy.yaml
   - provision-cronjob.yaml

--- a/k8s/bases/apps/umami/scaled-object.yaml
+++ b/k8s/bases/apps/umami/scaled-object.yaml
@@ -1,0 +1,49 @@
+---
+# Request-rate horizontal scaling for Umami, complementing auto-vpa: VPA owns
+# the VERTICAL axis (in-place CPU/memory resize up to maxAllowed, 3 CPU / 6Gi),
+# so the horizontal trigger is a metric VPA does not control — inbound HTTP
+# request rate from Coroot's eBPF node-agent, served by its bundled Prometheus
+# (the same series the Flagger MetricTemplates gate on). When right-sized pods
+# can no longer absorb the load, RPS-per-pod crosses the threshold and a replica
+# is added, up to the platform ceiling of 3 (validate-replica-ceiling).
+#
+# Flagger owns this ScaledObject's lifecycle (canary.yaml's autoscalerRef): it
+# clones it to `umami-umami-primary` targeting the primary Deployment (rewriting
+# the query via primaryScalerQueries) and pauses THIS one at 0 replicas outside
+# canary analysis — the source Deployment stays scaled to zero between
+# rollouts, exactly as before. Scaling the web tier is safe: state lives in the
+# CloudNativePG cluster, the pods are stateless.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: umami-umami
+  namespace: umami
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: umami-umami
+  # 2..3: two right-sized replicas survive a node drain (PDB maxUnavailable: 1);
+  # the third comes back under sustained load. 3 is the platform replica
+  # ceiling — past it, growth is VPA's job (bigger pods, not more of them).
+  minReplicaCount: 2
+  maxReplicaCount: 3
+  # If Prometheus is unreachable, fail HIGH to the old static HA count rather
+  # than freezing on the last scaling decision.
+  fallback:
+    failureThreshold: 3
+    replicas: 3
+  triggers:
+    # The trigger MUST be named — Flagger matches primaryScalerQueries by name.
+    - type: prometheus
+      name: http-requests-per-second
+      metadata:
+        serverAddress: http://coroot-prometheus.observability.svc.cluster.local:9090
+        # Per-pod target (AverageValue): the 3rd replica appears when sustained
+        # load exceeds 2 pods × 50 rps. Umami's /api/send ingest calls are
+        # cheap, so the per-pod target is higher than Homepage's SSR. Tune
+        # against live data in coroot-prometheus. The vowel-free hash regex
+        # excludes umami-umami-primary-* pods, same trick as the Flagger
+        # MetricTemplates (docs/progressive-delivery.md "Measuring the canary").
+        threshold: "50"
+        query: 'sum(rate(container_http_inbound_requests_total{container_id=~"/k8s/umami/umami-umami-[bcdfghjklmnpqrstvwxz2-9]+-[a-z0-9]+/.*"}[2m]))'

--- a/k8s/bases/apps/whoami/http-scaled-object.yaml
+++ b/k8s/bases/apps/whoami/http-scaled-object.yaml
@@ -11,9 +11,12 @@ spec:
     name: whoami
     service: whoami
     port: 80
+  # 0..3: scale-to-zero up to the platform replica ceiling
+  # (validate-replica-ceiling). Vertical growth (auto-vpa) comes first; the
+  # extra replicas absorb what one max-sized pod cannot.
   replicas:
     min: 0
-    max: 2
+    max: 3
   scaledownPeriod: 300
   scalingMetric:
     requestRate:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-ceiling.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-ceiling.yaml
@@ -1,0 +1,150 @@
+# Flags any controller or autoscaler ceiling that would run MORE than 3 pods of
+# one Deployment, StatefulSet or ReplicaSet — the inverse of
+# validate-replica-floor, fixing the platform's pod-count band at exactly 3:
+# floor 3 for static HA workloads, ceiling 3 for everything that scales. Past 3
+# right-sized replicas, growth is the VERTICAL axis's job — auto-vpa raises
+# per-pod CPU/memory in place up to maxAllowed (3 CPU / 6Gi) — so extra pods
+# only multiply fixed per-pod overhead on a memory-tight cluster.
+#
+# A PodDisruptionBudget CANNOT express this: a PDB has only minAvailable /
+# maxUnavailable and gates voluntary EVICTIONS — it never caps how many pods a
+# controller creates. The ceiling therefore lives on workload spec.replicas and
+# on the autoscaler ceilings (HPA maxReplicas, ScaledObject maxReplicaCount,
+# HTTPScaledObject replicas.max), which is exactly what this policy audits.
+#
+# Audit, not Enforce — same rationale as validate-replica-floor: replica counts
+# are owned by KEDA, Flagger and the HPA controller at runtime, and an
+# admission deny would fight them mid-scale. Violations surface in Kyverno's
+# PolicyReports for a human to fix (or exempt) deliberately. DaemonSets are out
+# of scope by construction: their pod count is the node count.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-replica-ceiling
+  annotations:
+    policies.kyverno.io/title: Validate Replica Ceiling
+    policies.kyverno.io/category: Best Practices, Autoscaling
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Deployment, StatefulSet, ReplicaSet, HorizontalPodAutoscaler, ScaledObject, HTTPScaledObject
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Flags workloads declaring more than 3 replicas and autoscalers whose
+      ceiling exceeds 3. The platform scales vertically first (auto-vpa, up to
+      maxAllowed) and horizontally only to 3 pods per workload. Intentional
+      exceptions opt out with the
+      platform.devantler.tech/replica-ceiling: exempt label.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: cap-workload-replicas
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - ReplicaSet
+      exclude:
+        any:
+          # Durable opt-out: label the workload itself.
+          - resources:
+              selector:
+                matchLabels:
+                  platform.devantler.tech/replica-ceiling: exempt
+      preconditions:
+        all:
+          # Durable opt-out on the pod template (charts expose podLabels more
+          # widely than top-level workload labels).
+          - key: "{{ request.object.spec.template.metadata.labels.\"platform.devantler.tech/replica-ceiling\" || '' }}"
+            operator: NotEquals
+            value: exempt
+      validate:
+        message: >-
+          {{ request.object.kind }} '{{ request.object.metadata.name }}' declares
+          {{ request.object.spec.replicas || `1` }} replicas; the platform
+          ceiling is 3 pods per workload — scale vertically instead (auto-vpa
+          raises per-pod resources up to maxAllowed). If this workload genuinely
+          needs more pods, add the label
+          'platform.devantler.tech/replica-ceiling: exempt'.
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.replicas || `1` }}"
+                operator: GreaterThan
+                value: 3
+    - name: cap-hpa-max-replicas
+      match:
+        any:
+          - resources:
+              kinds:
+                - HorizontalPodAutoscaler
+      exclude:
+        any:
+          - resources:
+              selector:
+                matchLabels:
+                  platform.devantler.tech/replica-ceiling: exempt
+      validate:
+        message: >-
+          HorizontalPodAutoscaler '{{ request.object.metadata.name }}' allows
+          scaling to {{ request.object.spec.maxReplicas }} replicas; the
+          platform ceiling is 3 pods per workload (scale vertically first —
+          see auto-vpa).
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.maxReplicas }}"
+                operator: GreaterThan
+                value: 3
+    # KEDA defaults maxReplicaCount to 100 when unset, so an unset ceiling is
+    # itself a violation — both rules below default the missing field to 100.
+    - name: cap-scaledobject-max-replicas
+      match:
+        any:
+          - resources:
+              kinds:
+                - ScaledObject
+      exclude:
+        any:
+          - resources:
+              selector:
+                matchLabels:
+                  platform.devantler.tech/replica-ceiling: exempt
+      validate:
+        message: >-
+          ScaledObject '{{ request.object.metadata.name }}' allows scaling to
+          {{ request.object.spec.maxReplicaCount || `100` }} replicas (KEDA
+          defaults to 100 when maxReplicaCount is unset); the platform ceiling
+          is 3 pods per workload (scale vertically first — see auto-vpa).
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.maxReplicaCount || `100` }}"
+                operator: GreaterThan
+                value: 3
+    - name: cap-httpscaledobject-max-replicas
+      match:
+        any:
+          - resources:
+              kinds:
+                - HTTPScaledObject
+      exclude:
+        any:
+          - resources:
+              selector:
+                matchLabels:
+                  platform.devantler.tech/replica-ceiling: exempt
+      validate:
+        message: >-
+          HTTPScaledObject '{{ request.object.metadata.name }}' allows scaling
+          to {{ request.object.spec.replicas.max || `100` }} replicas (the
+          add-on defaults to 100 when replicas.max is unset); the platform
+          ceiling is 3 pods per workload (scale vertically first — see
+          auto-vpa).
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.replicas.max || `100` }}"
+                operator: GreaterThan
+                value: 3

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - best-practices/validate-host-restrictions.yaml
   - best-practices/validate-pdb-drain-safe.yaml
   - best-practices/validate-pod-security.yaml
+  - best-practices/validate-replica-ceiling.yaml
   - best-practices/validate-replica-floor.yaml
   - best-practices/verify-image-signatures.yaml
   - flux/enforce-flux-best-practices.yaml

--- a/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
@@ -50,6 +50,16 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
+    # KEDA's operator polls the bundled Prometheus for ScaledObject triggers
+    # (request-rate horizontal scaling of the Flagger-managed apps,
+    # homepage/umami — the complement to auto-vpa's vertical axis).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: keda
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
   egress:
     # Kube API for the cluster-agent's service discovery / kube-state inventory.
     - toEntities:

--- a/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/keda/networkpolicy.yaml
@@ -105,6 +105,17 @@ spec:
         - ports:
             - port: "9080"
               protocol: TCP
+    # KEDA operator -> Coroot's bundled Prometheus, for ScaledObject prometheus
+    # triggers (request-rate horizontal scaling of the Flagger-managed apps,
+    # homepage/umami). Same endpoint Flagger and OpenCost query; Coroot's
+    # netpol allows this namespace in on :9090.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
     # DNS resolution
     - toEndpoints:
         - matchLabels:


### PR DESCRIPTION
## Summary

Implements "scale vertically up to a sane limit, then horizontally" and codifies the 3-pod-per-workload ceiling.

### Why the PDB ask landed elsewhere

`PodDisruptionBudget` has **no `maxAvailable` field** — its API is only `minAvailable` / `maxUnavailable`, and a PDB only gates *voluntary evictions*; it cannot cap how many pods a controller creates. The repo's PDBs already follow the drain-safe `maxUnavailable: 1` house pattern (completed by #1991), so no PDB was changed here. The "never more than three pods per Deployment/StatefulSet/ReplicaSet" rule is instead enforced where replica counts actually live:

- **autoscaler ceilings** — every scaler now tops out at 3, and
- **`validate-replica-ceiling`** — a new Audit-mode Kyverno ClusterPolicy (inverse of `validate-replica-floor`) flagging any Deployment/StatefulSet/ReplicaSet declaring >3 replicas and any HPA / ScaledObject / HTTPScaledObject whose ceiling exceeds 3 (including KEDA's implicit default of 100 when the ceiling is unset). Audit, not Enforce, for the same reason as the floor policy: replicas are owned by KEDA/Flagger/HPA at runtime and an admission deny would fight them. Escape hatch: `platform.devantler.tech/replica-ceiling: exempt`.

### Horizontal scaling on a metric that complements VPA

The vertical axis already exists: `auto-vpa` right-sizes every workload **in place** up to `maxAllowed` (3 CPU / 6Gi) — that is the "sane limit". The horizontal trigger must therefore be a metric VPA does *not* control, or the two fight. The platform's established answer is **HTTP request rate**, and this PR completes it:

| Workload | Before | After |
|---|---|---|
| homepage | pinned 3 replicas, no scaler | KEDA `ScaledObject` 2–3 on Coroot RPS, via Flagger `autoscalerRef` |
| umami | pinned 3 replicas, no scaler (`# No autoscalerRef`) | same pattern, 2–3 on RPS |
| whoami, fleetdm | HTTPScaledObject 0–2 | ceiling raised to 3 |
| headlamp, actual-budget, infra UIs | max 1 | unchanged — single-writer PVC / in-memory-session apps cannot run concurrent pods (vertical-only) |

For homepage/umami this uses the pattern `docs/progressive-delivery.md` documented but never used: a named `prometheus` trigger on `container_http_inbound_requests_total` (Coroot's eBPF node-agent series, same source as the Flagger MetricTemplates), referenced from the `Canary` via `autoscalerRef`. Flagger clones each ScaledObject to `<name>-primary` (query rewritten for `-primary-` pods via `primaryScalerQueries`; the source query's vowel-free hash regex can't match `-primary-`) and pauses the source's scaler at 0 between rollouts — preserving today's behavior. The obsolete postRenderer replicas pins were removed; `fallback: replicas: 3` fails **high** to the old static HA count if Prometheus is unreachable.

The mechanics: when sustained load outgrows what right-sized pods absorb, RPS-per-pod crosses the per-pod threshold (homepage 10 rps — single-threaded Next.js SSR; umami 50 rps — cheap `/api/send` ingest) and the 2→3 scale-out fires. Thresholds are marked for tuning against live `coroot-prometheus` data. Two replicas still survive a node drain (PDB `maxUnavailable: 1` + topology spread); the steady-state drop from 3→2 returns memory on a memory-tight cluster.

Network path: `allow-keda` gains egress to `observability:9090` and `allow-coroot` gains the matching ingress — mirroring the existing Flagger/OpenCost rules.

### Open question on the "5"

The request said `maxAvailable: 5` but also "never more than three pods" — since the field doesn't exist, I implemented the explicit 3-pod rule throughout. If 5 was meant as the autoscaler ceiling instead, it's a one-line change in each scaler plus the policy's three `value: 3` comparisons.

## Validation

- `ksail workload validate`: **green** (304 files)
- `ksail --config ksail.prod.yaml workload validate`: sole failure is the **pre-existing** upstream datreeio CRDs-catalog coroot schema gap (`notificationIntegrations` — fixed by CRDs-catalog#896), unrelated
- `kubectl kustomize` of both cluster overlays + `providers/hetzner/{apps,infrastructure}` and `bases/infrastructure/controllers`: all build; ScaledObjects, `autoscalerRef`s, netpol rules, and the new ClusterPolicy verified in the rendered output
- Existing prod state audited: nothing currently exceeds 3 replicas (kyverno HA = 3, overprovisioning RS = 1), so the Audit policy starts clean

⚠️ Watch the first prod reconcile: Flagger will create the two `-primary` ScaledObjects and KEDA takes over primary replica counts (expected steady-state 2 unless RPS demands 3). The PromQL is written against Coroot's documented schema but not validated against live data — same caveat as the existing MetricTemplates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)