### PR TITLE
fix(flux): drop the docker FluxInstance 'medium' profile to stop CI control-plane starvation

### DIFF
--- a/k8s/providers/docker/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -1,6 +1,15 @@
-# Extends the KSail-bootstrapped FluxInstance to increase controller
-# concurrency and lower the dependency requeue interval for faster
-# parallel reconciliation in Docker (local) clusters.
+# Extends the KSail-bootstrapped FluxInstance to lower the dependency
+# requeue interval for faster reconciliation in Docker (local/CI) clusters.
+#
+# No spec.cluster.size profile is set: this overlay's primary consumer is the
+# CI system test on a 4-vCPU GitHub-hosted runner, where the 'medium' profile
+# (--concurrent=10 on kustomize- and helm-controller) made bootstrap install
+# ~25 HelmReleases at once and starved etcd/the apiserver — leader-election
+# leases timed out and reconciliation collapsed ("etcdserver: request timed
+# out"). The default profile keeps Flux's stock concurrency (4) and resource
+# limits, and renders manifests that differ from the KSail-bootstrapped
+# instance only in the kustomize-controller patch below, so helm-controller
+# and source-controller are not restarted mid-bootstrap.
 ---
 apiVersion: fluxcd.controlplane.io/v1
 kind: FluxInstance
@@ -20,7 +29,6 @@ spec:
     type: kubernetes
     multitenant: false
     networkPolicy: true
-    size: medium
   kustomize:
     patches:
       - target:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

The CI system test (Talos + Docker, 1 CP + 3 workers as containers on a 4-vCPU GitHub-hosted runner) flakes at a meaningful rate with control-plane starvation. On 2026-06-11 it killed 3 of 4 attempts on one branch ([27361178852](https://github.com/devantler-tech/platform/actions/runs/27361178852) attempt 1, [27365000194](https://github.com/devantler-tech/platform/actions/runs/27365000194) attempts 1–2) while content-identical re-runs passed — load lottery, not content.

Failure signature (from the failed-attempt logs):

- kustomize-/helm-controller: `Failed to update lease … etcdserver: request timed out`, `Error retrieving lease lock … Client.Timeout exceeded` against `10.96.0.1:443`, ending in `leader election lost` and controller crash-restarts
- `kubectl get nodes` from the runner itself times out (`the server was unable to return a response in the time allotted`)
- HelmReleases stuck on `HelmChart … latest generation of object has not been reconciled` (source-controller starved)
- Timing: always right after `infrastructure-controllers` starts applying its ~25 HelmReleases (reconcile trigger 18:23:42 → sustained etcd timeouts 18:29–18:45 in run 27365000194/attempt 2)

## Root cause

[#1503](https://github.com/devantler-tech/platform/pull/1503) (2026-05-09) set `spec.cluster.size: medium` on the docker-overlay FluxInstance "for faster parallel reconciliation". Per flux-operator's profiles, `medium` =`--concurrent=10` on kustomize- and helm-controller plus 2-CPU limits each. Two compounding effects on a 4-vCPU runner:

1. **Thundering herd** — helm-controller installs up to 10 heavyweight charts simultaneously (kyverno, kubescape, tetragon, velero, coroot-operator, keda, openbao, cnpg, …) while kustomize-controller applies the whole infra layer at 10-way concurrency. The pod-start/image-pull/admission-webhook storm starves the single-member etcd (`etcdserver: request timed out` = backend commit latency, not raft).
2. **Mid-bootstrap controller roll** — KSail bootstraps the FluxInstance with no `cluster.size`, so when `infrastructure-controllers` applies this manifest the rendered controller Deployments change and flux-operator **rolls kustomize-, helm- and source-controller in the middle of the herd**. The failed-run logs show a fresh kustomize-controller acquiring its lease 5 min into reconcile and losing leadership 80 s later; every restart re-queues all in-flight work at the higher concurrency.

All recorded instances of this flake (the PR #1779-era "~15 HelmReleases at once → etcdserver: request timed out" note included) post-date #1503.

## Fix

Drop `size: medium` (no profile). Effects:

- Controllers run at Flux's stock concurrency (4) and stock limits (1 CPU/1Gi) — the operating point every pre-#1503 docker cluster bootstrapped at. (`small` was rejected: it *lowers* memory limits to 512Mi, below Flux defaults — an OOM risk for kustomize-controller, which server-side-applies the ~480KB kubevirt bundle.)
- The rendered manifests now differ from the KSail-bootstrapped instance only in the kustomize-controller `--requeue-dependency=5s` patch (retained — it's a cheap latency win), so **only kustomize-controller rolls once post-bootstrap; helm- and source-controller no longer restart mid-herd**.
- Prod is untouched (hetzner overlay keeps `size: large`; appropriate on 3× CX33).

## Alternatives evaluated

- **Fewer workers / worker container limits (ksail.yaml)** — viable follow-up lever (each worker adds a kubelet + one replica of every DaemonSet), but it changes local-dev parity and the ksail Cluster spec has no per-node CPU/memory knobs for the Docker provider, so true CP isolation isn't reachable today. The ksail-cluster action does support a `config:` input if a CI-specific config is ever wanted.
- **etcd tuning (talos-local patches)** — `etcdserver: request timed out` on a *single-member* etcd is backend fsync/CPU pressure; heartbeat/election tuning targets multi-member raft and doesn't apply.
- **Kustomization-level dependsOn batching** — much larger blast radius across overlays; revisit only if flakes persist after this.

## Validation

- `ksail workload validate` — ✅ 304 files validated, no failures
- `ksail --config ksail.prod.yaml workload validate` — only the pre-existing Coroot datreeio-schema failure (upstream [CRDs-catalog #896](https://github.com/datreeio/CRDs-catalog/pull/896)); unrelated, this PR touches only the docker overlay
- `kubectl kustomize k8s/clusters/local/` and `…/prod/` — ✅ both build; rendered local FluxInstance no longer carries a size profile
- The system-test job on this PR exercises the change end-to-end (one green run is necessary but not sufficient — the flake is a lottery; watch the rate over subsequent k8s PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
