### PR TITLE
feat(autoscaling): scale the over-provisioning buffer with cluster-proportional-autoscaler

### DIFF
--- a/k8s/clusters/prod/overprovisioning-flux-kustomization.yaml
+++ b/k8s/clusters/prod/overprovisioning-flux-kustomization.yaml
@@ -14,6 +14,9 @@
 #
 # `wait: false` means this Kustomization is Ready once the buffer manifests
 # APPLY cleanly — pod schedulability is explicitly not a health signal here.
+# The directory also carries the cluster-proportional-autoscaler HelmRelease
+# that scales the buffer's ReplicaSet with cluster size; the helm-controller
+# health-gates that release on its own, independent of this `wait: false`.
 # This is the one sanctioned exception to the `enforce-flux-best-practices`
 # Kyverno policy's `wait: true` rule; the policy excludes this Kustomization by
 # name (see bases/infrastructure/cluster-policies/flux/).

--- a/k8s/providers/hetzner/infrastructure-overprovisioning/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure-overprovisioning/helm-release.yaml
@@ -1,0 +1,108 @@
+---
+# cluster-proportional-autoscaler (CPA) — sizes the over-provisioning buffer
+# proportionally to cluster size instead of a hard-coded replica count.
+#
+# WHY: the buffer ReplicaSet's replica count is its only sizing knob (one warm
+# node per replica). A fixed count is either too small when the cluster runs
+# hot or pure waste when it idles. CPA watches the schedulable node count and
+# scales the `overprovisioning` ReplicaSet on the linear curve under
+# config.linear below: 1 warm node up to 8 nodes, 2 from 9 — i.e. the buffer
+# only widens once autoscaled capacity is already in play and the cluster is
+# approaching ksail.prod.yaml's maxNodesTotal: 10 ceiling.
+#
+# WHY THIS DIRECTORY (not infrastructure/controllers): the chart renders its
+# Role — `replicasets/scale` get/update — into the namespace of
+# `options.target`, so running the release in the `overprovisioning` namespace
+# keeps controller, RBAC and target co-located. The namespace is created by
+# this same Kustomization; a controllers-layer placement would race namespace
+# creation on a fresh bootstrap (infrastructure-controllers reconciles before
+# this Kustomization's dependsOn chain creates the namespace). It also keeps
+# the whole buffer stack in one directory, to be retired together when native
+# Cluster Autoscaler capacity buffers (CapacityBuffer CRD) replace the balloon
+# pattern.
+#
+# OWNERSHIP: CPA, not Flux, owns the target ReplicaSet's `spec.replicas` — the
+# field is deliberately absent from replicaset.yaml (HPA-style server-side
+# apply ownership split), so Flux never reverts CPA's scaling decisions.
+#
+# install/upgrade remediation and drift detection are merged in by the shared
+# components referenced from kustomization.yaml, like every other HelmRelease.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cluster-proportional-autoscaler
+  namespace: overprovisioning
+spec:
+  chart:
+    spec:
+      chart: cluster-proportional-autoscaler
+      version: 1.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: cluster-proportional-autoscaler
+  interval: 10m0s
+  timeout: 5m
+  # https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/blob/master/charts/cluster-proportional-autoscaler/values.yaml
+  values:
+    image:
+      # The chart's appVersion (1.8.6, 2023) lags the image releases; pin the
+      # current image explicitly (registry.k8s.io tags carry the `v` prefix).
+      tag: v1.10.3
+    options:
+      # kind/name of the workload CPA scales: the buffer ReplicaSet in this
+      # directory. The chart derives --namespace and the Role's namespace from
+      # options.namespace (defaulting to the release namespace) — set it
+      # explicitly so the wiring survives a future release-namespace move.
+      target: replicaset/overprovisioning
+      namespace: overprovisioning
+    config:
+      # replicas = max(min, min(max,
+      #   ceil(cores/coresPerReplica), ceil(nodes/nodesPerReplica)))
+      # Only nodesPerReplica is set, so only the node term applies:
+      # 1-8 schedulable nodes -> 1 warm node, 9+ -> 2. The steady state
+      # (6 static + 1 buffer = 7) stays at 1; the second warm node (~€5/mo
+      # while it exists) appears only when the cluster runs hot.
+      # includeUnschedulableNodes: false keeps cordoned/draining nodes (Talos
+      # rolls) from inflating the count. preventSinglePointFailure concerns
+      # the target's availability — meaningless for a capacity buffer, and at
+      # `true` it would force 2 warm nodes 24/7.
+      linear:
+        nodesPerReplica: 8
+        min: 1
+        max: 2
+        includeUnschedulableNodes: false
+        preventSinglePointFailure: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+    # The namespace enforces restricted PSA at admission (see namespace.yaml),
+    # so the pod carries a fully specified restricted securityContext instead
+    # of leaning on the Kyverno add-security-context webhook.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+  postRenderers:
+    # The chart exposes no way to add Deployment labels, so stamp the
+    # validate-replica-floor opt-out here: CPA has no leader election and is
+    # an intentional singleton (two instances would race scale updates).
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: cluster-proportional-autoscaler
+            patch: |
+              - op: add
+                path: /metadata/labels/platform.devantler.tech~1replica-floor
+                value: exempt

--- a/k8s/providers/hetzner/infrastructure-overprovisioning/helm-repository.yaml
+++ b/k8s/providers/hetzner/infrastructure-overprovisioning/helm-repository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cluster-proportional-autoscaler
+  namespace: overprovisioning
+spec:
+  url: https://kubernetes-sigs.github.io/cluster-proportional-autoscaler

--- a/k8s/providers/hetzner/infrastructure-overprovisioning/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure-overprovisioning/kustomization.yaml
@@ -5,3 +5,16 @@ resources:
   - namespace.yaml
   - priority-class.yaml
   - replicaset.yaml
+  # cluster-proportional-autoscaler scales the buffer ReplicaSet with cluster
+  # size — controller, RBAC and target are co-located in this namespace and
+  # retired together when native CA capacity buffers replace the balloon
+  # pattern. See helm-release.yaml for the placement rationale.
+  - helm-repository.yaml
+  - helm-release.yaml
+  - networkpolicy.yaml
+components:
+  # Same platform-wide HelmRelease policy the provider overlays apply: drift
+  # detection + install/upgrade remediation defaults, merged into the CPA
+  # HelmRelease above at build time.
+  - ../../../bases/components/helmrelease-drift-detection
+  - ../../../bases/components/helmrelease-flux-defaults

--- a/k8s/providers/hetzner/infrastructure-overprovisioning/networkpolicy.yaml
+++ b/k8s/providers/hetzner/infrastructure-overprovisioning/networkpolicy.yaml
@@ -1,0 +1,31 @@
+---
+# Egress lockdown for the cluster-proportional-autoscaler pod — it only ever
+# talks to the Kubernetes API (node watches, ReplicaSet /scale updates),
+# mirroring the per-workload entity-pinned egress policies used across the
+# hetzner overlay. Ingress is left unspecified: the pod serves nothing.
+# The buffer's pause pods are deliberately NOT selected — they make no
+# connections at all and need no policy.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cluster-proportional-autoscaler
+  namespace: overprovisioning
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cluster-proportional-autoscaler
+  egress:
+    # Kube API for node watches and scaling the buffer ReplicaSet.
+    - toEntities:
+        - kube-apiserver
+    # DNS resolution (client-go fallback paths).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/k8s/providers/hetzner/infrastructure-overprovisioning/replicaset.yaml
+++ b/k8s/providers/hetzner/infrastructure-overprovisioning/replicaset.yaml
@@ -38,8 +38,10 @@
 # allocatable to guarantee it still fits a brand-new cx33 (otherwise the
 # autoscaler would jump to a pricier cx43). 2 CPU / 4Gi is also far too large to
 # squeeze onto the already-loaded baseline workers, so it reliably forces a new
-# node. Scale the buffer by raising replicas (one warm node per replica) or the
-# per-pod request — bounded by ksail.prod.yaml's maxNodesTotal: 10.
+# node. The buffer WIDTH (replica count ≈ warm-node count) is owned by the
+# cluster-proportional-autoscaler (helm-release.yaml in this directory) and
+# scales with cluster size; tune its config.linear curve there, or the per-pod
+# request here — bounded by ksail.prod.yaml's maxNodesTotal: 10.
 #
 # === FinOps trade-off ===
 # This intentionally runs counter to `prefer-baseline-nodes.yaml`, which keeps
@@ -57,8 +59,13 @@ metadata:
     app.kubernetes.io/component: cluster-buffer
     app.kubernetes.io/part-of: platform
 spec:
-  # One warm spare node. Raise to widen the buffer (N replicas ≈ N warm nodes).
-  replicas: 1
+  # spec.replicas is deliberately ABSENT: the cluster-proportional-autoscaler
+  # (helm-release.yaml in this directory) owns the replica count and scales it
+  # with cluster size (1 warm node up to 8 schedulable nodes, 2 from 9).
+  # Omitting the field keeps Flux's server-side apply from ever owning it, so
+  # CPA's writes stick instead of being reverted on each reconcile — the
+  # documented Flux pattern for HPA-managed workloads. The API server defaults
+  # a freshly created ReplicaSet to 1 replica until CPA's first sync.
   selector:
     matchLabels:
       app.kubernetes.io/name: overprovisioning


### PR DESCRIPTION
## What

Adds the kubernetes-sigs [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) (CPA, chart 1.1.0, image `v1.10.3`) to size the over-provisioning buffer proportionally to cluster size, instead of the hard-coded `replicas: 1`:

- **1 warm node** up to 8 schedulable nodes (steady state: 6 static + 1 buffer = 7 → stays 1)
- **2 warm nodes** from 9 nodes — i.e. only when autoscaled capacity is already in play and the cluster approaches `maxNodesTotal: 10` (~€5/mo extra only while hot)
- `includeUnschedulableNodes: false` so cordoned/draining nodes (Talos rolls) don't inflate the count

## Design decisions

- **Release lives in the `overprovisioning` namespace, not `infrastructure/controllers`** — the chart renders its `replicasets/scale` Role into the target's namespace, so controller, RBAC and target stay co-located; the namespace is created by this same Flux Kustomization (a controllers-layer placement would race namespace creation on fresh bootstrap); and the whole buffer stack retires together in the capacity-buffers end state (below).
- **`spec.replicas` removed from the buffer ReplicaSet** — CPA owns the field. Omitting it keeps Flux's server-side apply from ever owning it, so CPA's writes stick (the documented Flux pattern for HPA-managed workloads).
- Shared `helmrelease-drift-detection` + `helmrelease-flux-defaults` components are attached to the kustomization, so the HelmRelease gets the platform-wide remediation/drift policy like every other HR.
- Restricted-PSA-compliant securityContext (the namespace enforces `restricted`), entity-pinned egress CNP (kube-apiserver + DNS only), and a `postRenderer` stamping the `validate-replica-floor` exempt label (CPA has no leader election — intentional singleton).

## Context: phase 1 of the capacity-buffers migration

This is phase 1 of replacing the balloon-pod overprovisioning pattern with native Cluster Autoscaler **capacity buffers** (`CapacityBuffer` CRD, `autoscaling.x-k8s.io/v1beta1`, shipped in CA 1.35 which the KSail-pinned chart 9.57.0 already deploys, flag-gated). A companion KSail PR adds a `capacityBuffers` knob (flags + CRD + RBAC); once that lands and is enabled in prod, the balloon ReplicaSet, PriorityClass, this CPA release, the dedicated Flux Kustomization and its Kyverno exemption all retire in favour of a single CapacityBuffer CR. CPA cannot scale a CR (it targets deployment/rc/replicaset only), so it is an interim, not permanent, resident.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅ and `k8s/clusters/prod/` ✅
- `ksail workload validate` ✅ (308 files)
- `ksail --config ksail.prod.yaml workload validate`: `providers/hetzner/infrastructure-overprovisioning` ✅ — the run's only failure is the **pre-existing** `providers/hetzner/infrastructure` coroot schema issue (datreeio/CRDs-catalog [#896](https://github.com/datreeio/CRDs-catalog/pull/896)), untouched by this PR
- Rendered output inspected: components merged (driftDetection, retries, `remediateLastFailure: true`), ReplicaSet has no `spec.replicas`, postRenderer patch present
- Image tag `v1.10.3` verified to exist on `registry.k8s.io/cpa/cluster-proportional-autoscaler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)