### PR TITLE
fix(cluster-policies): port image verification to ImageValidatingPolicy so cosign v3 bundles verify

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-image-signatures.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-image-signatures.yaml
@@ -9,106 +9,167 @@
 # image at admission, before any node attempts a pull — and unlike the Talos
 # layer it also covers clusters whose nodes lack the verification patch.
 #
+# ImageValidatingPolicy, NOT ClusterPolicy verifyImages: both signing
+# pipelines run cosign v3, which attaches signatures in the new Sigstore
+# bundle format as OCI referrers (sha256-<digest> fallback tags on GHCR,
+# descriptor artifactType application/vnd.oci.empty.v1+json) and writes NO
+# legacy .sig tags. ClusterPolicy verifyImages cannot read that format with
+# either `type: Cosign` (legacy tags only) or `type: SigstoreBundle` (filters
+# referrer descriptors by a bundle artifactType cosign v3 does not set), so
+# it denies every matched pod with "no matching signatures found" — IVPOL is
+# the engine path with cosign v3 support (kyverno#14652). The bundled
+# transparency-log entry verifies offline against the public Sigstore TUF
+# root, so admission needs egress to ghcr.io + tuf-repo-cdn.sigstore.dev
+# only — no Rekor round-trip.
+#
+# Do NOT set spec.webhookConfiguration: a per-policy timeout switches Kyverno
+# to per-policy "finegrained" webhook registrations, which are broken for
+# multiple IVPOLs in v1.18.1 (one concatenated URL path; every admission then
+# fails with "policy not evaluated"). Both policies therefore share the
+# default 10s webhook timeout.
+#
 # FAIL-OPEN for everything else, exactly like the Talos config: images that
-# match no imageReferences pattern are admitted without verification, so
-# third-party chart images (Cilium, Longhorn, Coroot, …) are unaffected.
-# This is intentionally NOT a deny-all-unsigned control; kubescape C-0237
-# stays exempted (security-exceptions/image-verification.yaml) because
-# third-party images remain unverified.
+# match no matchImageReferences rule are skipped, even when passed to the
+# verification functions, so third-party chart images (Cilium, Longhorn,
+# Coroot, …) are unaffected. This is intentionally NOT a deny-all-unsigned
+# control; kubescape C-0237 stays exempted
+# (security-exceptions/image-verification.yaml) because third-party images
+# remain unverified.
 #
 # Operational dependencies (both self-heal via controller retries if absent
-# during bring-up — the policy lands in the `infrastructure` layer AFTER the
-# first-party controllers are admitted by `infrastructure-controllers`):
+# during bring-up — the policies land in the `infrastructure` layer AFTER
+# the first-party controllers are admitted by `infrastructure-controllers`):
 #   - the `ghcr-auth` dockerconfigjson Secret in the kyverno namespace
 #     (external-secrets/external-secrets.yaml) — signature manifests of
 #     private images need authenticated GHCR reads
-#   - kyverno egress to ghcr.io + Sigstore (networkpolicy.yaml)
+#   - kyverno egress to ghcr.io + the Sigstore TUF CDN (networkpolicy.yaml)
 # Trade-off accepted by design: creating/restarting a FIRST-PARTY pod while
-# GHCR is unreachable is denied until the (1h TTL) verification cache warms.
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+# GHCR is unreachable (or verification exceeds the 10s webhook timeout) is
+# denied until the owning controller retries.
+#
+# ksail images (incl. ksail-operator) — signed by ksail's OWN release
+# pipeline, a different keyless identity than publish-app.yaml.
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
 metadata:
-  name: verify-image-signatures
+  name: verify-ksail-images
   annotations:
-    policies.kyverno.io/title: Verify First-Party Image Signatures
+    policies.kyverno.io/title: Verify ksail Image Signatures
     policies.kyverno.io/category: Supply Chain Security
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Requires keyless cosign signatures from the devantler-tech release
-      pipelines on all ghcr.io/devantler-tech/* container images at Pod
-      admission. Third-party images are not matched and admit unverified.
-    # Verify once, at Pod admission, instead of also generating autogen rules
-    # for Deployments/CronJobs/…: controller specs are applied by Flux and
-    # would add a registry dependency to every HelmRelease upgrade, while the
-    # Pod-level check already guarantees nothing unverified can run.
-    pod-policies.kyverno.io/autogen-controllers: none
+      Requires keyless cosign signatures from the ksail release pipeline on
+      all ghcr.io/devantler-tech/ksail* container images at Pod admission.
 spec:
-  validationFailureAction: Enforce
-  # Admission-only: background scans would re-fetch signatures from GHCR on
-  # every scan interval for pods that were already verified at admission.
-  background: false
-  # Default 10s is tight for a cold cosign fetch (manifest + signature blob
-  # + TUF metadata); verified results are cached so only the first admission
-  # of an image pays this.
-  webhookTimeoutSeconds: 30
-  rules:
-    # ksail images (incl. ksail-operator) — signed by ksail's OWN release
-    # pipeline, a different keyless identity than publish-app.yaml. Kyverno
-    # applies the first rule whose imageReferences match, so this specific
-    # rule must precede the catch-all (mirrors the Talos rule order).
-    - name: verify-ksail-images
-      match:
-        any:
-          - resources:
-              kinds:
-                - Pod
-              operations:
-                - CREATE
-      verifyImages:
-        - imageReferences:
-            - "ghcr.io/devantler-tech/ksail*"
-          required: true
-          # Images are referenced by tag (Renovate-managed); do not demand
-          # digest refs and do not rewrite pod specs to digests (digest
-          # mutation would fight Flux drift detection and Flagger).
-          verifyDigest: false
-          mutateDigest: false
-          imageRegistryCredentials:
-            secrets:
-              - ghcr-auth
-          attestors:
-            - entries:
-                - keyless:
-                    issuer: https://token.actions.githubusercontent.com
-                    subjectRegExp: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
-                    rekor:
-                      url: https://rekor.sigstore.dev
-    # First-party APP images (wedding-app, ascoachingogvaner, …) — signed by
-    # the shared reusable-workflows/publish-app.yaml identity, the same one
-    # their Flux OCIRepository verify blocks pin.
-    - name: verify-app-images
-      match:
-        any:
-          - resources:
-              kinds:
-                - Pod
-              operations:
-                - CREATE
-      verifyImages:
-        - imageReferences:
-            - "ghcr.io/devantler-tech/*"
-          skipImageReferences:
-            - "ghcr.io/devantler-tech/ksail*"
-          required: true
-          verifyDigest: false
-          mutateDigest: false
-          imageRegistryCredentials:
-            secrets:
-              - ghcr-auth
-          attestors:
-            - entries:
-                - keyless:
-                    issuer: https://token.actions.githubusercontent.com
-                    subjectRegExp: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
-                    rekor:
-                      url: https://rekor.sigstore.dev
+  failurePolicy: Fail
+  validationActions: [Deny]
+  evaluation:
+    admission:
+      enabled: true
+    # Background scans would re-fetch signatures from GHCR on every scan
+    # interval for pods that were already verified at admission.
+    background:
+      enabled: false
+  # Verify once, at Pod admission; no autogen rules for Deployments/CronJobs
+  # (spec.autogen unset): controller specs are applied by Flux and would add
+  # a registry dependency to every HelmRelease upgrade, while the Pod-level
+  # check already guarantees nothing unverified can run.
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: [v1]
+        operations: [CREATE]
+        resources: [pods]
+  matchImageReferences:
+    - glob: ghcr.io/devantler-tech/ksail*
+  credentials:
+    secrets: [ghcr-auth]
+  validationConfigurations:
+    required: true
+    # Images are referenced by tag (Renovate-managed); do not demand digest
+    # refs and do not rewrite pod specs to digests (digest mutation would
+    # fight Flux drift detection and Flagger).
+    verifyDigest: false
+    mutateDigest: false
+  attestors:
+    # Attestor names are CEL identifiers (referenced as attestors.<name> in
+    # the validation expression) — no hyphens.
+    - name: ksailcd
+      cosign:
+        keyless:
+          identities:
+            - issuer: https://token.actions.githubusercontent.com
+              subjectRegExp: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
+  validations:
+    # The filter mirrors matchImageReferences so only in-scope images reach
+    # verifyImageSignatures — unmatched images (third-party sidecars in the
+    # same pod) must not be required to carry a ksail signature.
+    - expression: >-
+        (images.containers + images.initContainers + images.ephemeralContainers)
+        .filter(image, image.startsWith('ghcr.io/devantler-tech/ksail'))
+        .map(image, verifyImageSignatures(image, [attestors.ksailcd]))
+        .all(e, e > 0)
+      message: >-
+        ksail image is not signed by the ksail release pipeline
+        (keyless cosign, ksail cd.yaml tag identity)
+---
+# First-party APP images (wedding-app, ascoachingogvaner, …) — signed by the
+# shared reusable-workflows/publish-app.yaml identity, the same one their
+# Flux OCIRepository verify blocks pin. The match EXCLUDES ksail images:
+# a matched image is verified by this policy's attestor before the CEL
+# expression runs, so letting ksail images match here would fail them
+# against the wrong identity.
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: verify-app-images
+  annotations:
+    policies.kyverno.io/title: Verify First-Party App Image Signatures
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Requires keyless cosign signatures from the devantler-tech publish-app
+      release pipeline on all non-ksail ghcr.io/devantler-tech/* container
+      images at Pod admission. Third-party images admit unverified.
+spec:
+  failurePolicy: Fail
+  validationActions: [Deny]
+  evaluation:
+    admission:
+      enabled: true
+    background:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: [v1]
+        operations: [CREATE]
+        resources: [pods]
+  matchImageReferences:
+    # The expression variable for image references is `ref`.
+    - expression: >-
+        ref.startsWith('ghcr.io/devantler-tech/') &&
+        !ref.startsWith('ghcr.io/devantler-tech/ksail')
+  credentials:
+    secrets: [ghcr-auth]
+  validationConfigurations:
+    required: true
+    verifyDigest: false
+    mutateDigest: false
+  attestors:
+    - name: publishapp
+      cosign:
+        keyless:
+          identities:
+            - issuer: https://token.actions.githubusercontent.com
+              subjectRegExp: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
+  validations:
+    - expression: >-
+        (images.containers + images.initContainers + images.ephemeralContainers)
+        .filter(image, image.startsWith('ghcr.io/devantler-tech/') && !image.startsWith('ghcr.io/devantler-tech/ksail'))
+        .map(image, verifyImageSignatures(image, [attestors.publishapp]))
+        .all(e, e > 0)
+      message: >-
+        first-party app image is not signed by the publish-app release
+        pipeline (keyless cosign, reusable-workflows publish-app.yaml
+        identity)

--- a/k8s/bases/infrastructure/controllers/kyverno/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/networkpolicy.yaml
@@ -19,11 +19,11 @@ spec:
     # Kube API for policy enforcement
     - toEntities:
         - kube-apiserver
-    # Image signature verification (verify-image-signatures ClusterPolicy):
-    # cosign signature manifests live on ghcr.io with blobs served from the
-    # GitHub CDN, and the Sigstore TUF trust root refreshes from its CDN.
-    # Rekor inclusion proofs normally verify offline via the bundled SET,
-    # but keep the log reachable for entries without a bundle.
+    # Image signature verification (verify-image-signatures.yaml
+    # ImageValidatingPolicies): cosign signature manifests live on ghcr.io
+    # with blobs served from the GitHub CDN, and the Sigstore TUF trust root
+    # refreshes from its CDN. Rekor inclusion proofs verify offline via the
+    # bundled SET; the log stays reachable as a fallback.
     - toFQDNs:
         - matchName: "ghcr.io"
         - matchName: "pkg-containers.githubusercontent.com"

--- a/k8s/bases/infrastructure/controllers/kyverno/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/networkpolicy.yaml
@@ -23,9 +23,15 @@ spec:
     # ImageValidatingPolicies): cosign signature manifests live on ghcr.io
     # with blobs served from the GitHub CDN, and the Sigstore TUF trust root
     # refreshes from its CDN. Rekor inclusion proofs verify offline via the
-    # bundled SET; the log stays reachable as a fallback.
+    # bundled SET; the log stays reachable as a fallback. github.com is
+    # required because GHCR answers the OCI referrers API with a 303 redirect
+    # to https://github.com/-/v2/packages/... — with it blocked, the
+    # redirect-following referrers lookup dies (webhook deadline / "no
+    # signatures found") instead of falling back to the sha256-<digest> tag
+    # scheme, denying every first-party pod.
     - toFQDNs:
         - matchName: "ghcr.io"
+        - matchName: "github.com"
         - matchName: "pkg-containers.githubusercontent.com"
         - matchName: "tuf-repo-cdn.sigstore.dev"
         - matchName: "rekor.sigstore.dev"

--- a/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
+++ b/k8s/bases/infrastructure/external-secrets/external-secrets.yaml
@@ -31,9 +31,10 @@ spec:
         key: infrastructure/backup/r2
         property: secret_access_key
 ---
-# GHCR pull credentials for Kyverno's verify-image-signatures ClusterPolicy:
-# signature manifests of PRIVATE first-party images need authenticated GHCR
-# reads. Same OpenBao path and shape as the per-app ghcr-auth pull secrets.
+# GHCR pull credentials for Kyverno's image-verification policies
+# (verify-image-signatures.yaml ImageValidatingPolicies): signature manifests
+# of PRIVATE first-party images need authenticated GHCR reads. Same OpenBao
+# path and shape as the per-app ghcr-auth pull secrets.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Root cause — why every merge-queue run fails

The `verify-image-signatures` ClusterPolicy (#2020, merged 2026-06-11 17:04) can **never pass for any matched image**: both signing pipelines (ksail `cd.yaml`, reusable-workflows `publish-app.yaml`) run **cosign v3**, which attaches signatures in the new Sigstore **bundle format** as OCI referrers (`sha256-<digest>` fallback tags on GHCR, descriptor artifactType `application/vnd.oci.empty.v1+json`) and writes **no legacy `.sig` tags**. ClusterPolicy `verifyImages` reads neither variant — `type: Cosign` only looks for legacy tags, and `type: SigstoreBundle` filters referrer descriptors by a bundle artifactType cosign v3 doesn't set (both verified empirically, see below).

The policy merged green because it only bites at Pod CREATE. That evening node churn evicted the tenant-app pods, and from the 20:15 queue run onward every first-party pod admission is denied (`mutate.kyverno.svc-fail`), `wedding-app` / `ascoachingogvaner` Deployments stall `Failed`, the prod `apps` Kustomization health check times out after 20m, and **every merge-queue Deploy-to-Prod run fails** (5 consecutive failures, nothing has merged since #2025).

## Fix

Replace the ClusterPolicy with two `policies.kyverno.io/v1` **ImageValidatingPolicies** — the Kyverno engine path with cosign v3 bundle support (kyverno#14652) — preserving the design exactly: same two keyless identities, pods-only (no autogen), admission-only (no background), `ghcr-auth` credentials, no digest pinning, fail-open for third-party images. Scoping notes baked into comments:

- the app policy's match **excludes ksail images via a CEL `ref.` expression** — matched images are verified before the validation expression runs, so a glob that swallowed ksail images would fail them against the wrong identity;
- validation expressions cover `containers + initContainers + ephemeralContainers`;
- **no `spec.webhookConfiguration`**: a per-policy timeout flips Kyverno to per-policy "finegrained" webhooks, which are broken for multiple IVPOLs in v1.18.1 (concatenated URL path → every admission fails "policy not evaluated").

Comment-only updates in the kyverno netpol and the kyverno `ghcr-auth` ExternalSecret to point at the IVPOLs.

## Validation

On a throwaway kind cluster running the **exact prod chart (kyverno 3.8.1 / v1.18.1)** with the shipped file:

| case | result |
|---|---|
| `wedding-app:1.10.0` (signed, private) | ✅ admitted |
| `ksail:v7.55.0` (signed) | ✅ admitted |
| `wedding-app:sha-1c279c9` (pre-signing tag) | ❌ denied with policy message |
| unsigned first-party **initContainer** | ❌ denied |
| `busybox:1.36` (third-party) | ✅ admitted unverified (fail-open) |

Also: `cosign verify` passes for all three deployed images against the exact policy identities; `kubectl kustomize` local+prod build; `ksail workload validate` green (304 files); prod-config validate fails only on the pre-existing datreeio coroot schema gap (datreeio/CRDs-catalog#896). The datreeio catalog already carries the `imagevalidatingpolicy_v1.json` schema.

## Risk & contingency

Verification adds ~1–5s to first-party pod admission (registry + TUF round-trips; bounded by the shared 10s ivpol webhook timeout, fail-closed — same trade-off the ClusterPolicy design accepted). Prod evidence this fits: source-controller performs the identical sigstore bundle verification against GHCR on every OCIRepository reconcile. If prod admissions were ever to exceed the timeout persistently, the fallback lever is `failurePolicy: Ignore` on the IVPOLs.

Merging this PR heals prod via the queue's own deploy: Flux applies the IVPOLs, prunes the ClusterPolicy, the stalled ReplicaSets' next retry admits, and the `apps` health gate goes green.

Closes the merge-queue outage; once merged, re-queue #2037 #2036 #2035 #2033 #2023 #1996 #1991 (and let Renovate re-queue #2032).

🤖 Generated with [Claude Code](https://claude.com/claude-code)