### PR TITLE
feat(autoscaler): use [LeastNodes, LeastWaste] expander priority chain

### DIFF
--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -22,18 +22,18 @@ Cluster Autoscaler (dynamic workers, managed by KSail)
 ├── Pool: autoscale-cx43 → 0-4 × CX43 (8 vCPU, 16 GB)
 ├── Pool: autoscale-cx53 → 0-4 × CX53 (16 vCPU, 32 GB)
 ├── maxNodesTotal: 10 (total cluster nodes incl. baseline: 6 static + 4 autoscaler)
-└── Expander: LeastWaste
+└── Expander: LeastNodes
 ```
 
 - **Horizontal scaling** — autoscaler adds workers when pods are Pending due
   to insufficient resources, and removes underutilized workers after a
   configurable cooldown.
 - **Vertical scaling** — multiple node pools with different server types.
-  The `LeastWaste` expander picks the pool left with the least idle CPU and
-  memory after scheduling the pending pod — the cheapest adequate type in a
-  linearly-priced family. (`Price` is **not supported on Hetzner**: the
-  cluster-autoscaler hcloud provider implements no pricing API, so KSail
-  rejects it and the autoscaler crashes on startup.) See
+  The `LeastNodes` expander picks the pool that satisfies the pending pods with
+  the fewest total new nodes — it prefers the largest adequate type, so a burst
+  consolidates onto fewer, bigger servers. (`Price` is **not supported on
+  Hetzner**: the cluster-autoscaler hcloud provider implements no pricing API,
+  so KSail rejects it and the autoscaler crashes on startup.) See
   [cluster-autoscaler FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 - **KSail integration** — KSail installs the Cluster Autoscaler Helm chart,
   generates the worker config secret (`cluster-autoscaler-config`), and
@@ -68,7 +68,7 @@ spec:
     autoscaler:
       node:
         enabled: true
-        expander: LeastWaste
+        expander: LeastNodes
         maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:
@@ -123,9 +123,11 @@ spec:
   autoscaler validation becomes `maxNodesTotal ≤ serverLimit` (`10 ≤ 10`);
   until it ships, the old validation (`CP + workers + min(maxNodesTotal, Σ
   pool.max)`) rejects this config, so the KSail change must land first.
-- **Expander** — `LeastWaste` (current) picks the node group left with the
-  least idle capacity after scheduling — the cheapest adequate type in a
-  linearly-priced family. (`Price` is unsupported on Hetzner.)
+- **Expander** — `LeastNodes` (current) picks the pool that scales up with the
+  fewest total new nodes, preferring the largest adequate type to keep the node
+  count down. `LeastWaste` (the other cost-aware option) instead minimizes idle
+  CPU/memory per node; KSail's `expander` holds a single value, so there is no
+  LeastNodes-then-LeastWaste chain. (`Price` is unsupported on Hetzner.)
 - **Scale-down** — underutilized nodes are removed after 10 minutes.
 
 ### Adding more pools

--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -22,18 +22,21 @@ Cluster Autoscaler (dynamic workers, managed by KSail)
 ├── Pool: autoscale-cx43 → 0-4 × CX43 (8 vCPU, 16 GB)
 ├── Pool: autoscale-cx53 → 0-4 × CX53 (16 vCPU, 32 GB)
 ├── maxNodesTotal: 10 (total cluster nodes incl. baseline: 6 static + 4 autoscaler)
-└── Expander: LeastNodes
+└── Expander: [LeastNodes, LeastWaste] (priority chain)
 ```
 
 - **Horizontal scaling** — autoscaler adds workers when pods are Pending due
   to insufficient resources, and removes underutilized workers after a
   configurable cooldown.
 - **Vertical scaling** — multiple node pools with different server types.
-  The `LeastNodes` expander picks the pool that satisfies the pending pods with
-  the fewest total new nodes — it prefers the largest adequate type, so a burst
-  consolidates onto fewer, bigger servers. (`Price` is **not supported on
-  Hetzner**: the cluster-autoscaler hcloud provider implements no pricing API,
-  so KSail rejects it and the autoscaler crashes on startup.) See
+  The expander is an ordered priority chain, `[LeastNodes, LeastWaste]`
+  (upstream `--expander=least-nodes,least-waste`). `LeastNodes` runs first and
+  keeps the pools that satisfy the pending pods with the fewest total new nodes
+  — preferring the largest adequate type so a burst consolidates onto fewer,
+  bigger servers; `LeastWaste` then breaks any tie by least idle CPU/memory.
+  (`Price` is **not supported on Hetzner**: the cluster-autoscaler hcloud
+  provider implements no pricing API, so KSail rejects it and the autoscaler
+  crashes on startup.) See
   [cluster-autoscaler FAQ](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 - **KSail integration** — KSail installs the Cluster Autoscaler Helm chart,
   generates the worker config secret (`cluster-autoscaler-config`), and
@@ -68,7 +71,7 @@ spec:
     autoscaler:
       node:
         enabled: true
-        expander: LeastNodes
+        expander: [LeastNodes, LeastWaste]
         maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:
@@ -97,7 +100,7 @@ spec:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `enabled` | `false` | Enable/disable node autoscaling |
-| `expander` | `LeastWaste` | Node selection strategy: `LeastWaste`, `LeastNodes`, `Random` (`Price` is unsupported on Hetzner — no pricing API) |
+| `expander` | `LeastWaste` | Node selection strategy: `LeastWaste`, `LeastNodes`, `Random` (`Price` is unsupported on Hetzner — no pricing API). Accepts a single value or an ordered priority chain, e.g. `[LeastNodes, LeastWaste]` (requires KSail expander-list support; scalar-only up to v7.57.0) |
 | `maxNodesTotal` | `0` (unlimited) | Hard ceiling on total cluster nodes, including the static baseline (see [ksail#5017](https://github.com/devantler-tech/ksail/issues/5017)) |
 | `scaleDownUnneededTime` | `10m` | Time before an underutilized node is eligible for removal |
 | `pools[].name` | — | DNS-1123 pool identifier |
@@ -123,11 +126,14 @@ spec:
   autoscaler validation becomes `maxNodesTotal ≤ serverLimit` (`10 ≤ 10`);
   until it ships, the old validation (`CP + workers + min(maxNodesTotal, Σ
   pool.max)`) rejects this config, so the KSail change must land first.
-- **Expander** — `LeastNodes` (current) picks the pool that scales up with the
-  fewest total new nodes, preferring the largest adequate type to keep the node
-  count down. `LeastWaste` (the other cost-aware option) instead minimizes idle
-  CPU/memory per node; KSail's `expander` holds a single value, so there is no
-  LeastNodes-then-LeastWaste chain. (`Price` is unsupported on Hetzner.)
+- **Expander** — `[LeastNodes, LeastWaste]` (current) is an ordered priority
+  chain. `LeastNodes` runs first and keeps the pools that scale up with the
+  fewest total new nodes (preferring the largest adequate type to keep the node
+  count down); `LeastWaste` then breaks any remaining tie by least idle
+  CPU/memory. The list form needs KSail expander-list support — releases up to
+  v7.57.0 are scalar-only and reject a list, so the pinned `KSAIL_VERSION` must
+  be bumped to a release that ships it first. (`Price` is unsupported on
+  Hetzner.)
 - **Scale-down** — underutilized nodes are removed after 10 minutes.
 
 ### Adding more pools

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -30,12 +30,17 @@ spec:
     # (autoscaler nodes are compute-only). CAX/ARM is cheaper but needs an ARM
     # Talos image — not applicable to this x86 cluster.
     #
-    # expander: LeastWaste — selects the node group leaving the least idle
-    # CPU/memory, i.e. the cheapest adequate type in this linearly-priced
-    # family. "Price" would be the direct cost optimizer, but the Hetzner
+    # expander: LeastNodes — on scale-up, picks the pool that meets the pending
+    # pods with the FEWEST total new nodes, i.e. it prefers the largest adequate
+    # type (cx53 > cx43 > cx33), consolidating a burst onto fewer, bigger
+    # servers. Trade-off vs LeastWaste: coarser granularity — a small spike can
+    # boot a whole large node and leave more idle headroom. KSail's expander is
+    # a SINGLE enum (Price|LeastWaste|LeastNodes|Random), so it can't also carry
+    # a LeastWaste secondary tiebreaker the way upstream cluster-autoscaler's
+    # comma-separated --expander chain (e.g. least-nodes,least-waste) can.
+    # "Price" would be the direct cost optimizer, but the Hetzner
     # cluster-autoscaler provider does not implement the pricing API, so KSail
-    # rejects Price+Hetzner (and the autoscaler would crash on startup);
-    # LeastWaste is the supported cost-targeting choice.
+    # rejects Price+Hetzner (and the autoscaler would crash on startup).
     #
     # maxNodesTotal is the HARD CEILING ON TOTAL CLUSTER NODES, INCLUDING the
     # static baseline. 10 = the Hetzner account cap: 6 static (3 control-planes
@@ -54,7 +59,7 @@ spec:
     autoscaler:
       node:
         enabled: true
-        expander: LeastWaste
+        expander: LeastNodes
         maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -30,14 +30,17 @@ spec:
     # (autoscaler nodes are compute-only). CAX/ARM is cheaper but needs an ARM
     # Talos image — not applicable to this x86 cluster.
     #
-    # expander: LeastNodes — on scale-up, picks the pool that meets the pending
-    # pods with the FEWEST total new nodes, i.e. it prefers the largest adequate
-    # type (cx53 > cx43 > cx33), consolidating a burst onto fewer, bigger
-    # servers. Trade-off vs LeastWaste: coarser granularity — a small spike can
-    # boot a whole large node and leave more idle headroom. KSail's expander is
-    # a SINGLE enum (Price|LeastWaste|LeastNodes|Random), so it can't also carry
-    # a LeastWaste secondary tiebreaker the way upstream cluster-autoscaler's
-    # comma-separated --expander chain (e.g. least-nodes,least-waste) can.
+    # expander: [LeastNodes, LeastWaste] — an ordered priority chain (upstream
+    # cluster-autoscaler --expander=least-nodes,least-waste). LeastNodes runs
+    # FIRST: on scale-up it keeps the node groups that meet the pending pods
+    # with the FEWEST total new nodes (preferring the largest adequate type,
+    # cx53 > cx43 > cx33, to consolidate a burst onto fewer, bigger servers).
+    # LeastWaste is the tiebreaker: among the groups LeastNodes leaves tied,
+    # pick the one with the least idle CPU/memory.
+    # NB this list form requires KSail's expander-list support ("feat: support a
+    # priority list of expanders"); the scalar-only releases up to v7.57.0
+    # reject a list, so the pinned KSAIL_VERSION (ci.yaml/cd.yaml) must be bumped
+    # to a release that ships it before this validates / deploys.
     # "Price" would be the direct cost optimizer, but the Hetzner
     # cluster-autoscaler provider does not implement the pricing API, so KSail
     # rejects Price+Hetzner (and the autoscaler would crash on startup).
@@ -59,7 +62,7 @@ spec:
     autoscaler:
       node:
         enabled: true
-        expander: LeastNodes
+        expander: [LeastNodes, LeastWaste]
         maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:


### PR DESCRIPTION
## What

Set the prod Cluster Autoscaler `expander` in `ksail.prod.yaml` to an ordered **priority chain** — `[LeastNodes, LeastWaste]` — with `LeastNodes` highest priority and `LeastWaste` as the tiebreaker. Also merges current `main` (ksail **v7.57.0** bump + reusable-workflow dep bumps) into the branch. Docs in `docs/node-autoscaling.md` updated to match.

## Why

Prefer the fewest total nodes on scale-up (`LeastNodes` keeps the node groups that add the fewest new nodes, favouring the largest adequate CX type), then break ties by least idle CPU/memory (`LeastWaste`). This mirrors upstream cluster-autoscaler's `--expander=least-nodes,least-waste`.

## ⚠️ Blocked on a ksail release — do not merge yet

The list form requires KSail's **expander-list support** (`feat: support a priority list of expanders`, which changes the field from a scalar `AutoscalerExpander` to `AutoscalerExpanderList`). That feature is **not yet released**: it lives on a ksail feature branch and is absent from ksail `main` and every tag up to **v7.57.0** (the version this branch now pins). The scalar-only releases reject a list at config load:

```
load config: 'spec.Cluster.Autoscaler.Node.Expander'
expected type 'v1alpha1.AutoscalerExpander', got unconvertible type '[]interface {}'
```

So `ksail workload validate` and the CD deploy **will fail** until `KSAIL_VERSION` (`ci.yaml`/`cd.yaml`) is bumped to a release that ships the feature.

**Merge order:**
1. Release the ksail expander-list feature (e.g. v7.58.0).
2. Let Renovate bump `KSAIL_VERSION` here (or rebase onto the bump).
3. Then this PR validates and is safe to merge.

## Validation

`ksail --config ksail.prod.yaml workload validate` — **currently fails** with the unconvertible-type error above (expected: pinned ksail is scalar-only). Re-validate after the feature release is pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)