### PR TITLE
fix(ascoachingogvaner): route SecretStore to openbao-active

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/secretstore.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/secretstore.yaml
@@ -21,7 +21,9 @@ metadata:
 spec:
   provider:
     vault:
-      server: "http://openbao.openbao.svc.cluster.local:8200"
+      # openbao-active = unsealed Raft leader only; the plain `openbao` Service
+      # also round-robins onto sealed-but-Ready standbys (503 "Vault is sealed").
+      server: "http://openbao-active.openbao.svc.cluster.local:8200"
       path: "secret"
       version: "v2"
       auth:


### PR DESCRIPTION
## What

Points the tenant `ascoachingogvaner` namespaced `openbao` SecretStore at `openbao-active` instead of the plain `openbao` Service.

## Why

The plain `openbao` Service round-robins onto sealed-but-Ready standby pods (their readiness probe returns 204 even when sealed), so logins through it intermittently hit a sealed node and fail with `503 "Vault is sealed"`. wedding-app's namespaced store (#1964) and the shared `openbao` ClusterSecretStore both already use `openbao-active` (the unsealed Raft leader) for exactly this reason. #1973 added this store afterward and reused the stale address — this aligns it.

This is a latent fix (the tenant-owned external-dns ExternalSecret that reads through this store would flap, not the cert-manager `simply-credentials` one, which uses the ClusterSecretStore). Found while investigating the simply.com DNS secret-store warnings.

## Validation

- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` both pass (323 files).
- Rendered store confirms `server: http://openbao-active.openbao.svc.cluster.local:8200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)