### PR TITLE
fix(config): scale leader-elected/stateless controllers from 3 to 2

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-pdb-drain-safe.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-pdb-drain-safe.yaml
@@ -70,7 +70,7 @@ spec:
                 - kyverno-admission-controller
                 # hcloud-csi-controller is also ksail-installed (Hetzner CSI) and
                 # keeps minAvailable: 1; its drain-safety comes from the HA PR's
-                # replica bump to 3, not maxUnavailable.
+                # replica bump to 2, not maxUnavailable.
                 - hcloud-csi-controller
           # Longhorn manages these PDBs itself: longhorn-manager creates a
           # minAvailable: 1 PDB per instance-manager that still hosts replicas

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -13,31 +13,31 @@ data:
   issuer_name: letsencrypt-prod
   # Per-env prefixes inside the shared R2 bucket.
   r2_prefix_velero: velero/prod
-  # --- Critical controllers (3 replicas for HA; above the require-replica-floor minimum) ---
+  # --- Critical controllers (2 replicas for HA; the require-replica-floor minimum) ---
   # With VPA updateMode=InPlaceOrRecreate, single-replica services get 502s during
-  # eviction. The replica-floor (#1898/#1900) wants 3 so a maxUnavailable: 1 PDB +
-  # topology spread survive a node drain AND a concurrent failure with zero
-  # downtime (2 only survives the drain). These run leader election or are
-  # stateless/admission webhooks, so the third replica is a cheap warm standby.
+  # eviction. The replica-floor (#1898/#1900) wants 2 so a maxUnavailable: 1 PDB +
+  # topology spread keep one pod serving through a node drain. These run leader
+  # election or are stateless/admission webhooks, so the second replica is a cheap
+  # warm standby (3-replica HA, to also survive a concurrent failure, is opt-in).
   # cert_manager_replicas drives the controller, webhook AND cainjector; the keda
   # vars drive the operator, admission webhooks, HTTP scaler and interceptor floor.
-  cert_manager_replicas: "3"
-  metrics_server_replicas: "3"
-  vpa_admission_replicas: "3"
-  keda_operator_replicas: "3"
-  keda_webhooks_replicas: "3"
-  keda_scaler_replicas: "3"
-  keda_interceptor_min_replicas: "3"
-  # --- Leader-elected operators (3 replicas for HA; above the require-replica-floor minimum) ---
-  # One replica is active; the rest are warm standbys that take over on a node
+  cert_manager_replicas: "2"
+  metrics_server_replicas: "2"
+  vpa_admission_replicas: "2"
+  keda_operator_replicas: "2"
+  keda_webhooks_replicas: "2"
+  keda_scaler_replicas: "2"
+  keda_interceptor_min_replicas: "2"
+  # --- Leader-elected operators (2 replicas for HA; the require-replica-floor minimum) ---
+  # One replica is active; the other is a warm standby that takes over on a node
   # failure/drain. velero stays 1 — its chart hardcodes replicas: 1 and it has
   # no leader election (multiple servers would double-run backups); cilium
   # operator is 2 (chart-managed, leader-elected).
-  trust_manager_replicas: "3"
-  reloader_replicas: "3"
+  trust_manager_replicas: "2"
+  reloader_replicas: "2"
   cilium_replicas: "2"
   velero_replicas: "1"
-  cloudnative_pg_replicas: "3"
+  cloudnative_pg_replicas: "2"
   # KEDA-managed apps: HelmRelease replicas are the initial value only;
   # KEDA HTTPScaledObject overrides at runtime. Setting the initial to 1
   # saves memory until the first KEDA reconciliation.
@@ -67,24 +67,24 @@ data:
   actual_budget_replicas_min: "0"
   actual_budget_replicas_max: "1"
   hubble_ui_replicas: "1"
-  # Auth chain: 3 replicas for HA (above the require-replica-floor minimum). User-facing auth
-  # must survive a node drain + a concurrent failure; also prevents 502s during VPA
-  # InPlaceOrRecreate evictions.
-  dex_replicas: "3"
-  oauth2_proxy_replicas: "3"
-  auth_proxy_replicas: "3"
+  # Auth chain: 2 replicas for HA (the require-replica-floor minimum). User-facing
+  # auth survives a node drain; also prevents 502s during VPA InPlaceOrRecreate
+  # evictions.
+  dex_replicas: "2"
+  oauth2_proxy_replicas: "2"
+  auth_proxy_replicas: "2"
   # --- Hetzner Cloud ---
   hetzner_lb_location: "fsn1"
   hetzner_lb_type: "lb11"
   hcloud_network: "prod-network"
   # --- Contact ---
   admin_email: "ned@devantler.tech"
-  # Leader-elected controllers: 3 replicas for HA (above the require-replica-floor minimum).
-  hcloud_ccm_replicas: "3"
-  hcloud_csi_controller_replicas: "3"
+  # Leader-elected controllers: 2 replicas for HA (the require-replica-floor minimum).
+  hcloud_ccm_replicas: "2"
+  hcloud_csi_controller_replicas: "2"
   # external-snapshotter control plane (kube-system snapshot-controller);
   # leader-elected, so extra replicas are warm standbys.
-  snapshot_controller_replicas: "3"
+  snapshot_controller_replicas: "2"
   # --- Longhorn distributed storage ---
   # All 3 static workers carry Longhorn disks (labeled with
   # node.longhorn.io/create-default-disk=true). Replica count matches the
@@ -130,29 +130,30 @@ data:
   # extraArgs leader-elect: true) and sit on no serving path — a failover
   # gap only delays the next recommendation/eviction cycle. Active + one
   # warm standby with a maxUnavailable: 1 PDB (helm-release) still rides
-  # out a node drain; a third standby bought no availability, only ~1 pod
-  # of requests on a request-saturated cluster (cost trim, 2026-06-11).
+  # out a node drain.
   vpa_recommender_replicas: "2"
   vpa_updater_replicas: "2"
   # --- Kyverno (leader-elected controllers) ---
-  # background stays 3: it executes the generate/mutate-existing rules the
-  # platform leans on (e.g. propagate-reloader-to-flagger-primary).
-  kyverno_background_replicas: "3"
+  # background runs 2 (active + warm standby): it executes the generate/mutate-
+  # existing rules the platform leans on (e.g. propagate-reloader-to-flagger-
+  # primary), so keep a standby for it even though it is off every serving path.
+  kyverno_background_replicas: "2"
   # reports/cleanup run 2 (active + warm standby, maxUnavailable: 1 PDB):
   # report generation and cleanup are best-effort background work off every
-  # serving path — same cost trim as the VPA standbys above.
+  # serving path.
   kyverno_reports_replicas: "2"
   kyverno_cleanup_replicas: "2"
-  # --- Flagger (3 replicas for HA; gated by leaderElection.enabled) ---
-  flagger_replicas: "3"
+  # --- Flagger (2 replicas for HA; gated by leaderElection.enabled) ---
+  flagger_replicas: "2"
   # --- OpenBao secrets vault ---
-  # 3-node Raft HA (quorum minimum; tolerates 1 failure). See the cutover
-  # runbook docs/dr/openbao-raft-ha-migration.md.
+  # 3-node Raft HA (quorum minimum; tolerates 1 failure). Stays 3 regardless of
+  # the require-replica-floor minimum — Raft needs an odd member count, and 2
+  # tolerates zero failures. See the cutover runbook
+  # docs/dr/openbao-raft-ha-migration.md.
   openbao_replicas: "3"
   openbao_storage_size: 10Gi
-  # --- External Secrets Operator (3 replicas for HA; above the require-replica-floor minimum) ---
+  # --- External Secrets Operator (2 replicas for HA; the require-replica-floor minimum) ---
   # Drives the controller, webhook and cert-controller. Controller + cert-controller
-  # are leader-elected and the webhook is stateless, so the third replica is a warm
-  # standby that keeps the operator available through a node drain + failure.
-  external_secrets_replicas: "3"
-
+  # are leader-elected and the webhook is stateless, so the second replica is a warm
+  # standby that keeps the operator available through a node drain.
+  external_secrets_replicas: "2"

--- a/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/hcloud-csi/helm-release.yaml
@@ -39,8 +39,8 @@ spec:
         # default PDB) during bootstrap BEFORE Flux, so flipping to maxUnavailable
         # conflicts at server-side apply ("minAvailable and maxUnavailable cannot
         # be both set"). Drain-safety here comes from running >=2 replicas -- the
-        # HA PR bumps hcloud_csi_controller_replicas to 3, making minAvailable: 1
-        # drain-safe (it bounds disruption to 1 of 3). Exempt from
+        # HA PR bumps hcloud_csi_controller_replicas to 2, making minAvailable: 1
+        # drain-safe (it bounds disruption to 1 of 2). Exempt from
         # validate-pdb-drain-safe.
         minAvailable: 1
       affinity:

--- a/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
@@ -46,7 +46,7 @@ spec:
     webhook:
       enabled: false
     controller:
-      # Leader-elected; 3 replicas for HA (above the require-replica-floor minimum) -- one
+      # Leader-elected; 2 replicas for HA (the require-replica-floor minimum) -- one
       # active while a backup takes CSI snapshots, the rest warm standbys.
       replicaCount: ${snapshot_controller_replicas:=1}
       resources:


### PR DESCRIPTION
> Stacked on #2054 (the floor change). Merge #2054 first; GitHub will retarget this to `main` automatically once it lands.

## What

Drops ~19 prod controllers from 3 → 2 replicas in the cluster config-map, now that the HA replica floor is 2 (#2054). These were pinned at 3 only to clear the old floor.

**Scaled to 2:** cert-manager, metrics-server, VPA admission, KEDA (operator / webhooks / scaler / interceptor floor), trust-manager, reloader, cloudnative-pg operator, dex / oauth2-proxy / auth-proxy (auth chain), hcloud CCM, hcloud CSI controller, snapshot-controller, kyverno background, flagger, external-secrets.

**Deliberately left at 3:**
- `openbao` — Raft quorum needs an odd member count; 2 nodes tolerate *zero* failures (strictly worse than 3).
- `longhorn_replica_count` — volume **data** replication across the 3 storage workers, not a Deployment replica count.

## Why

Active + one warm standby with the platform's `maxUnavailable: 1` PDB still rides out a node drain; the third replica only added tolerance for a *concurrent second* failure. On a cluster already at its node cap, ~19 fewer pods is real memory/cost back.

## Safety

- Audited every PDB: all are `maxUnavailable: 1` or `minAvailable: 1` — both drain-safe at 2 replicas (1 eviction allowed, 1 stays). No `minAvailable: 2` anywhere, so no drain deadlock.
- Comments that asserted "3 replicas for HA" / "bump to 3" updated to match (config-map, snapshot-controller, hcloud-csi, validate-pdb-drain-safe).
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` both pass (323 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)