### PR TITLE
fix(openbao): move vault-snapshots PVC to hcloud to unwedge infrastructure

### DIFF
--- a/k8s/bases/infrastructure/vault-backup/pvc.yaml
+++ b/k8s/bases/infrastructure/vault-backup/pvc.yaml
@@ -1,20 +1,48 @@
-# Dedicated volume for OpenBao raft snapshots (written by the
-# vault-snapshot CronJob, newest 14 retained). Uses the cluster's default
-# StorageClass. Snapshots on this PVC are the first-line restore source
-# after OpenBao data loss: the vault-config Job restores from the newest
-# one automatically when it finds an uninitialized cluster alongside a
-# surviving openbao-unseal Secret. Off-cluster durability comes from the
-# CronJob's mirror container (S3/R2), NOT from Velero — Velero's
-# file-system backup only captures volumes mounted by running pods, and
-# nothing mounts this PVC outside the CronJob's brief daily run.
+# Dedicated volume for OpenBao raft snapshots (written by the vault-snapshot
+# CronJob + vault-snapshot-init Job, newest 14 retained). Snapshots on this
+# PVC are the first-line restore source after OpenBao data loss: the
+# vault-config Job restores from the newest one automatically when it finds an
+# uninitialized cluster alongside a surviving openbao-unseal Secret.
+#
+# StorageClass is hcloud (Hetzner Cloud Volumes), NOT the default longhorn:
+# this PVC is mounted only by short-lived, node-mobile pods (the vault-config
+# Job, the vault-snapshot-init Job, and the daily vault-snapshot CronJob) that
+# the scheduler places on whatever node has room — frequently an autoscaled
+# compute node that holds none of the volume's replicas. A Longhorn RWO volume
+# then has to start an engine on that node and attach across the network to its
+# replicas; on autoscaled nodes that repeatedly timed out
+# ("FailedAttachVolume ... code = DeadlineExceeded"), leaving the vault-config
+# Job Pending until its 1h activeDeadlineSeconds, failing the `infrastructure`
+# Kustomization health check, and wedging the whole infrastructure -> apps
+# dependency chain. hcloud volumes attach via the Hetzner API to any node in
+# the location (every prod node is in fsn1), so the attach no longer depends on
+# cross-node Longhorn connectivity — the same reason openbao's own data/audit
+# PVCs and spire-server already use hcloud (#1818).
+#
+# Off-cluster durability still comes from the CronJob/init-job S3/R2 mirror, so
+# discarding the old Longhorn volume on migration is safe: the snapshot history
+# lives in R2 and vault-snapshot-init takes a fresh baseline immediately.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vault-snapshots
   namespace: openbao
+  annotations:
+    # storageClassName (and a storage bump) are immutable on a bound PVC, so
+    # Flux cannot patch the longhorn -> hcloud migration in place. Let Flux
+    # delete-and-recreate the PVC instead — the same mechanism the vault-config
+    # and vault-snapshot-init Jobs already use, and safe here because the old
+    # volume's data is disposable (durable copy is in R2; see comment above).
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   accessModes:
     - ReadWriteOnce
+  # Hetzner Cloud Volumes attach reliably via the API to any node in the
+  # location, unlike a Longhorn RWO volume mounted by node-mobile Jobs.
+  storageClassName: hcloud
   resources:
     requests:
-      storage: 5Gi
+      # Hetzner Cloud Volumes have a 10Gi minimum (openbao's own data/audit
+      # PVCs round up to it too); raft snapshots are a few MB each, so this is
+      # comfortably oversized.
+      storage: 10Gi

--- a/k8s/bases/infrastructure/vault-backup/pvc.yaml
+++ b/k8s/bases/infrastructure/vault-backup/pvc.yaml
@@ -1,48 +1,22 @@
-# Dedicated volume for OpenBao raft snapshots (written by the vault-snapshot
-# CronJob + vault-snapshot-init Job, newest 14 retained). Snapshots on this
-# PVC are the first-line restore source after OpenBao data loss: the
-# vault-config Job restores from the newest one automatically when it finds an
-# uninitialized cluster alongside a surviving openbao-unseal Secret.
-#
-# StorageClass is hcloud (Hetzner Cloud Volumes), NOT the default longhorn:
-# this PVC is mounted only by short-lived, node-mobile pods (the vault-config
-# Job, the vault-snapshot-init Job, and the daily vault-snapshot CronJob) that
-# the scheduler places on whatever node has room — frequently an autoscaled
-# compute node that holds none of the volume's replicas. A Longhorn RWO volume
-# then has to start an engine on that node and attach across the network to its
-# replicas; on autoscaled nodes that repeatedly timed out
-# ("FailedAttachVolume ... code = DeadlineExceeded"), leaving the vault-config
-# Job Pending until its 1h activeDeadlineSeconds, failing the `infrastructure`
-# Kustomization health check, and wedging the whole infrastructure -> apps
-# dependency chain. hcloud volumes attach via the Hetzner API to any node in
-# the location (every prod node is in fsn1), so the attach no longer depends on
-# cross-node Longhorn connectivity — the same reason openbao's own data/audit
-# PVCs and spire-server already use hcloud (#1818).
-#
-# Off-cluster durability still comes from the CronJob/init-job S3/R2 mirror, so
-# discarding the old Longhorn volume on migration is safe: the snapshot history
-# lives in R2 and vault-snapshot-init takes a fresh baseline immediately.
+# Dedicated volume for OpenBao raft snapshots (written by the
+# vault-snapshot CronJob, newest 14 retained). Uses the cluster's default
+# StorageClass (the hetzner overlay pins it to hcloud — see
+# k8s/providers/hetzner/infrastructure/vault-snapshots-hcloud-patch.yaml).
+# Snapshots on this PVC are the first-line restore source after OpenBao data
+# loss: the vault-config Job restores from the newest one automatically when
+# it finds an uninitialized cluster alongside a surviving openbao-unseal
+# Secret. Off-cluster durability comes from the CronJob's mirror container
+# (S3/R2), NOT from Velero — Velero's file-system backup only captures volumes
+# mounted by running pods, and nothing mounts this PVC outside the CronJob's
+# brief daily run.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: vault-snapshots
   namespace: openbao
-  annotations:
-    # storageClassName (and a storage bump) are immutable on a bound PVC, so
-    # Flux cannot patch the longhorn -> hcloud migration in place. Let Flux
-    # delete-and-recreate the PVC instead — the same mechanism the vault-config
-    # and vault-snapshot-init Jobs already use, and safe here because the old
-    # volume's data is disposable (durable copy is in R2; see comment above).
-    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   accessModes:
     - ReadWriteOnce
-  # Hetzner Cloud Volumes attach reliably via the API to any node in the
-  # location, unlike a Longhorn RWO volume mounted by node-mobile Jobs.
-  storageClassName: hcloud
   resources:
     requests:
-      # Hetzner Cloud Volumes have a 10Gi minimum (openbao's own data/audit
-      # PVCs round up to it too); raft snapshots are a few MB each, so this is
-      # comfortably oversized.
-      storage: 10Gi
+      storage: 5Gi

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -68,4 +68,9 @@ patches:
   # (the `infrastructure` layer); the strategic-merge patch matches on the
   # embedded coroot.com/v1 Coroot/coroot identity, so no explicit target.
   - path: coroot/patches/coroot-patch.yaml
+  # Prod-only: migrate the OpenBao raft-snapshot PVC from the default longhorn
+  # StorageClass to hcloud so node-mobile snapshot Jobs can attach it reliably
+  # (see the file header). Self-identifies via PersistentVolumeClaim/openbao/
+  # vault-snapshots, so no explicit target is needed.
+  - path: vault-snapshots-hcloud-patch.yaml
 

--- a/k8s/providers/hetzner/infrastructure/vault-snapshots-hcloud-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/vault-snapshots-hcloud-patch.yaml
@@ -1,0 +1,37 @@
+# Prod-only: pin the OpenBao raft-snapshot PVC to the hcloud StorageClass.
+#
+# The vault-config Job, vault-snapshot-init Job and daily vault-snapshot
+# CronJob all mount this RWO volume, and the scheduler places those short-lived
+# pods on whatever node has room — frequently an autoscaled compute node that
+# holds none of the volume's replicas. On the default longhorn StorageClass
+# that forces a cross-node engine attach which repeatedly timed out
+# ("FailedAttachVolume ... code = DeadlineExceeded"), leaving the vault-config
+# pod Pending until its 1h activeDeadlineSeconds, failing the `infrastructure`
+# Kustomization health check and wedging the whole infrastructure -> apps chain.
+# hcloud volumes attach via the Hetzner API to any node in the location (all
+# prod nodes are in fsn1), so the attach no longer depends on cross-node
+# Longhorn connectivity — the same reason openbao's own data/audit PVCs and
+# spire-server already use hcloud (#1818). Off-cluster durability is unchanged
+# (the CronJob/init-job R2 mirror), so discarding the old Longhorn volume on
+# migration is safe.
+#
+# Lives in the hetzner overlay (not the base) because the hcloud StorageClass
+# only exists on this provider — the Talos+Docker base/local cluster keeps the
+# default StorageClass. storageClassName and a storage bump are immutable on a
+# bound PVC, so the force annotation lets Flux delete-and-recreate it.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-snapshots
+  namespace: openbao
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  # Hetzner Cloud Volumes attach reliably via the API to any node in the
+  # location, unlike a Longhorn RWO volume mounted by node-mobile Jobs.
+  storageClassName: hcloud
+  resources:
+    requests:
+      # Hetzner Cloud Volumes have a 10Gi minimum (openbao's own data/audit
+      # PVCs round up to it too); raft snapshots are a few MB each.
+      storage: 10Gi


### PR DESCRIPTION
## Problem

Production is wedged. Four Flux Kustomizations are failing, all tracing to one root cause:

| Kustomization | State |
|---|---|
| `flux-system/infrastructure` | `False` — health check failed: `Job/openbao/vault-config` 'Failed' |
| `flux-system/apps` | `False` — `DependencyNotReady` (infrastructure) |
| `flux-system/infrastructure-overprovisioning` | `False` — `DependencyNotReady` (infrastructure) |
| `ascoachingogvaner/ascoachingogvaner` | `False` — `Deployment/ascoachingogvaner/external-dns` Failed (its platform-side SecretStore + external-dns RBAC live in the wedged `apps` layer, so they never applied) |

## Root cause

The `vault-config` Job (plus the `vault-snapshot-init` Job and the daily `vault-snapshot` CronJob) mount the RWO `vault-snapshots` PVC, which used the default **longhorn** StorageClass. These short-lived pods get scheduled on whatever node has room — often an autoscaled compute node (e.g. `autoscale-cx53-…`) that holds **none** of the volume's three replicas (all on `autoscale-cx33-*`). Longhorn then has to start an engine on that node and attach across the network to the replicas, which repeatedly timed out:

```
FailedAttachVolume  ...  rpc error: code = DeadlineExceeded
volume pvc-e55c00f4-… failed to attach to node autoscale-cx53-…
```

The pod stayed `Pending` for the full 1h `activeDeadlineSeconds`, the Job hit `DeadlineExceeded`, the infra health check failed, and the whole infra → apps chain wedged. Notably **every hcloud-backed volume** (openbao's own `data`/`audit`, spire, coroot) attaches fine on the same nodes — only this Longhorn volume wedged.

## Fix

Migrate `vault-snapshots` to the **hcloud** StorageClass. Hetzner Cloud Volumes attach via the Hetzner API to any node in the location (all prod nodes are in `fsn1`), so the attach no longer depends on cross-node Longhorn connectivity. Same fix already used for openbao's `data`/`audit` PVCs and spire-server (#1818).

Because `hcloud` only exists on the Hetzner provider, the override is a **hetzner-overlay patch**, not a base change — the Talos+Docker base/local cluster keeps the default StorageClass (the base must build on both providers):

- `k8s/bases/infrastructure/vault-backup/pvc.yaml` — stays provider-neutral (default SC, 5Gi).
- `k8s/providers/hetzner/infrastructure/vault-snapshots-hcloud-patch.yaml` (new) — sets `storageClassName: hcloud`, `storage: 10Gi` (Hetzner's 10Gi minimum), and `kustomize.toolkit.fluxcd.io/force: enabled` so Flux can delete-and-recreate the PVC (`storageClassName` is immutable on a bound PVC).

Discarding the existing Longhorn volume is safe: off-cluster durability is the R2 mirror (per the CronJob/init-job design), and `vault-snapshot-init` takes a fresh baseline immediately.

## Heals the cascade once reconciled

infra Ready → `apps` + `infrastructure-overprovisioning` unblock → the `ascoachingogvaner` SecretStore + external-dns RBAC apply (fixing the external-dns crashloop) → the already-merged floor=2 policy (#2054) + kubescape-namespace exemption finally apply live.

The force-recreate converges on its own once the wedged `vault-config` pod releases the PVC (at its deadline + TTL). An operator can accelerate it with a one-time `kubectl -n openbao delete job vault-config vault-snapshot-init` (and the old PVC if it lingers `Terminating`) — the same one-time step #1818 needed.

## Validation

- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` build ✔
- `ksail workload validate` → 323 files validated ✔
- prod infra overlay renders the PVC with `storageClassName: hcloud`, `storage: 10Gi`, force annotation ✔
- **docker/local infra overlay renders the PVC with the default StorageClass + 5Gi (no hcloud)** ✔ — fixes the earlier System Test break

🤖 Generated with [Claude Code](https://claude.com/claude-code)