### PR TITLE
fix(longhorn): enable replica-auto-balance to survive worker rolls

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -35,6 +35,21 @@ spec:
       # Match the number of workers so every volume is replicated across
       # all available nodes.
       defaultReplicaCount: ${longhorn_replica_count:=3}
+      # Redistribute replicas onto fresh nodes as the worker pool changes.
+      # With auto-balance disabled (the Longhorn default), a worker roll — the
+      # cx33→cx43 server-type migration, a Talos version bump, or autoscaler
+      # churn — deletes each replaced node's replicas without ever rebuilding
+      # them onto the replacement node. With only a handful of storage nodes
+      # a one-at-a-time roll then walks every replica of an RWO volume onto
+      # already-removed nodes before any rebuild catches up, and the volume
+      # goes `faulted` (data loss). Observed 2026-06-16: umami-db, wedding-db
+      # and kubescape storage all faulted during a full worker roll.
+      # best-effort keeps replicas spread evenly across the live nodes
+      # (matching defaultReplicaCount above), so each step of a rolling
+      # replacement rebuilds redundancy onto the new node and always leaves a
+      # healthy replica behind. (Use least-effort if rebuild churn on frequent
+      # autoscaler scale-ups becomes a concern.)
+      replicaAutoBalance: best-effort
       # Reclaim space from deleted volumes automatically.
       autoDeletePodWhenVolumeDetachedUnexpectedly: true
       # Only create default disks on nodes explicitly labeled for storage.


### PR DESCRIPTION
## What

Enable Longhorn `replicaAutoBalance: best-effort` on the prod (hetzner) Longhorn HelmRelease.

## Why — root cause

During the 2026-06-16 worker roll (cx33→cx43, #2041), every RWO Longhorn volume whose replicas all sat on the replaced workers went `faulted`:

- `umami-db-2`, `umami-db-3`, `wedding-db-1/2/3`, `kubescape/storage` — all `faulted`
- `umami-db-1` survived (degraded) → umami recoverable (and it has daily R2 backups)
- **`wedding-db` lost all 3 instances and had no backup configured → data loss**

`replica-auto-balance` was disabled (the chart default). With only a few storage nodes, a rolling node replacement deletes each node's replicas without rebuilding them onto the replacement node; the next node is replaced before redundancy is restored, so every replica of a volume ends up on an already-removed node and the volume faults. The roll itself is expected — it's driven via `ksail cluster update --force`, which bypasses PodDisruptionBudgets during drains — so the storage layer has to tolerate it.

## What this changes

Sets `defaultSettings.replicaAutoBalance: best-effort` so Longhorn redistributes replicas evenly across the live nodes as the pool changes (matching the existing `defaultReplicaCount` "one replica per worker" intent). Each step of a rolling replacement then rebuilds redundancy onto the new node and always leaves a healthy replica behind.

`least-effort` is the lower-churn alternative if `best-effort` triggers too many rebuilds on frequent autoscaler scale-ups; called out inline in the manifest.

## Validation

- `ksail --config ksail.prod.yaml workload validate` → **323 files validated** (incl. `controllers/longhorn/helm-release.yaml`)
- `kubectl kustomize` builds clean: longhorn dir (renders `replicaAutoBalance: best-effort`), full hetzner controllers (5743 lines), `clusters/prod`, `clusters/local`

## Scope

Prod-only (hetzner overlay) — that's where the fault occurred; the local/docker provider doesn't run Longhorn. This is one piece of a broader prod incident investigated this session; the CD-pipeline fix, the in-progress node roll, and faulted-volume recovery are being handled by the maintainer directly (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
