### PR TITLE
fix(longhorn): keep replicas off ephemeral autoscaler nodes

### DIFF
--- a/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-longhorn-to-baseline-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-longhorn-to-baseline-nodes.yaml
@@ -1,0 +1,84 @@
+# Keep Longhorn replicas off the ephemeral cluster-autoscaler nodes.
+#
+# Why: ksail.prod.yaml provisions the `autoscale-cx*` pools as compute-only
+# burst capacity that scales back to zero — but KSail boots them from the SAME
+# Talos worker config as the static baseline workers, so they inherit
+# `node.longhorn.io/create-default-disk=true` (talos/workers/node-labels.yaml)
+# and Longhorn treats them as storage nodes. When the autoscaler scales such a
+# node down, every replica it held is destroyed; a volume whose replicas all
+# sat on now-removed autoscaler nodes goes `faulted` — data loss, not just
+# degraded. Observed 2026-06-16: wedding-db (0/3 instances), umami-db, the
+# kubescape storage PVC and the openbao vault-snapshots volume all faulted
+# after the `autoscale-cx33-*` nodes holding their replicas were scaled down.
+# `replicaAutoBalance: best-effort` (longhorn/helm-release.yaml) keeps replicas
+# spread across the *live* nodes but cannot help once a volume's only replicas
+# leave together on a scale-down — the autoscaler nodes must not host replicas
+# in the first place.
+#
+# The intent in ksail.prod.yaml is explicit: "the static workers are the
+# guaranteed baseline and the only Longhorn storage nodes (autoscaler nodes are
+# compute-only)". This policy enforces that intent. The proper long-term fix is
+# for KSail to stamp a distinguishing label on its autoscaler pools (the
+# `ksail.io/autoscaled=true` label prefer-baseline-nodes is also waiting on);
+# until that lands the node-name prefix (`autoscale-*` vs `prod-worker-*`,
+# guaranteed by KSail's pool naming) is the only discriminator between an
+# ephemeral autoscaler node and a static baseline worker.
+#
+# Mechanism: set `spec.allowScheduling: false` on the Longhorn Node CR of every
+# `autoscale-*` node, so Longhorn never places a new replica there. Existing
+# replicas drain back onto the three static workers via best-effort
+# auto-balance, leaving every RWO volume with its full 3-way redundancy on
+# stable nodes (defaultReplicaCount: 3 == 3 static workers). Baseline workers
+# (`prod-worker-*`) and control planes never match, so their scheduling is
+# unchanged.
+#
+# Admission-time mutate on CREATE + UPDATE: a new autoscaler node's Longhorn
+# Node CR is patched the moment Longhorn creates it, and any later spec write
+# re-asserts the setting. allowScheduling is a mutable Longhorn field, so —
+# unlike the immutable Pod `spec.affinity` that forces prefer-baseline-nodes to
+# CREATE-only — mutating on UPDATE is safe and idempotent here. Longhorn Node
+# CRs that already exist when this policy first lands are not retroactively
+# patched (that would need a mutateExisting rule plus extra background-controller
+# RBAC on longhorn.io/nodes); they are reconciled once operationally and then
+# recycle into policy-covered nodes.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-longhorn-to-baseline-nodes
+  annotations:
+    policies.kyverno.io/title: Restrict Longhorn To Baseline Nodes
+    policies.kyverno.io/category: Best Practices, High Availability
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Node
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Sets allowScheduling: false on the Longhorn Node CR of every ephemeral
+      cluster-autoscaler node (name prefix autoscale-) so Longhorn keeps replicas
+      on the static baseline workers only. Prevents the data-loss volume faulting
+      that occurs when the autoscaler scales a replica-holding node down.
+spec:
+  # Admission-time mutate only (no mutateExisting target), so background scanning
+  # has nothing to do.
+  background: false
+  rules:
+    - name: disable-longhorn-scheduling-on-autoscaler-nodes
+      match:
+        any:
+          - resources:
+              kinds:
+                - longhorn.io/v1beta2/Node
+              operations:
+                - CREATE
+                - UPDATE
+      preconditions:
+        all:
+          # KSail names every autoscaler-pool node `autoscale-<pool>-<hash>`;
+          # static baseline workers are `prod-worker-N`. Only the former are
+          # ephemeral, so only they are excluded from Longhorn storage.
+          - key: "{{ starts_with(request.object.metadata.name, 'autoscale-') }}"
+            operator: Equals
+            value: true
+      mutate:
+        patchStrategicMerge:
+          spec:
+            allowScheduling: false

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -20,6 +20,12 @@ resources:
   # the hetzner overlay because autoscaling is Hetzner/prod-only; see the file
   # header for the `ksail.io/autoscaled` node-label contract it depends on.
   - cluster-policies/prefer-baseline-nodes.yaml
+  # Prod-only: keep Longhorn replicas off the ephemeral `autoscale-cx*` nodes
+  # (they share the baseline worker's Talos config and so inherit the storage
+  # label). Without this, the autoscaler scaling a replica-holding node down
+  # faults the volume — observed 2026-06-16. Hetzner overlay because autoscaling
+  # is Hetzner/prod-only; see the file header.
+  - cluster-policies/restrict-longhorn-to-baseline-nodes.yaml
   # Prod-only: reconcile Coroot's node Custom Cloud Pricing to Hetzner rates
   # (Coroot otherwise prices non-AWS/GCP/Azure nodes at the GCP-C4 fallback,
   # ~16x the real bill). Lives in this `infrastructure` layer because it targets


### PR DESCRIPTION
## Problem (root cause of the 2026-06-16 volume faulting)

`ksail.prod.yaml` provisions the `autoscale-cx*` pools as **compute-only** burst capacity and states the intent plainly: *"the static workers are the guaranteed baseline and the only Longhorn storage nodes (autoscaler nodes are compute-only)."*

But KSail boots autoscaler nodes from the **same Talos worker config** as the static baseline workers, so they inherit `node.longhorn.io/create-default-disk=true` (`talos/workers/node-labels.yaml`) and Longhorn treats them as storage nodes. Live confirmation:

| Node | Longhorn `create-default-disk` | Ephemeral? |
|---|---|---|
| `prod-worker-1/2/3` (cx43) | `true` | no — static baseline |
| `autoscale-cx33-…`, `autoscale-cx53-…` | `true` | **yes — autoscaler-managed** |

When the cluster-autoscaler scales an `autoscale-*` node down, every Longhorn replica it held is destroyed. A volume whose replicas all sat on now-removed autoscaler nodes goes **`faulted` — data loss, not just degraded.**

**Observed on prod 2026-06-16** (3 `autoscale-cx33-*` nodes scaled down ~06:26):
- `wedding-app/wedding-db` CNPG cluster **0/3 ready** (all 3 instance PVCs faulted) — full DB outage
- `umami/umami-db` degraded (1/3), `kubescape` storage PVC faulted, `headlamp` + `actual-budget` volumes unknown
- `openbao/vault-snapshots` volume stuck → `vault-snapshot-init` job blocked → **`flux-system/infrastructure` Kustomization stuck → `apps` + `infrastructure-overprovisioning` blocked**

`replicaAutoBalance: best-effort` (added the same day) keeps replicas spread across the *live* nodes but cannot save a volume whose only replicas leave together on a scale-down — **the autoscaler nodes must not host replicas in the first place.**

## Fix

A Kyverno mutate `ClusterPolicy` (`restrict-longhorn-to-baseline-nodes`, Hetzner overlay alongside `prefer-baseline-nodes`) that sets `spec.allowScheduling: false` on the **Longhorn `Node` CR** of every `autoscale-*` node. Longhorn then keeps replicas on the three static workers only (matching `defaultReplicaCount: 3`), so each RWO volume retains full 3-way redundancy on stable nodes. Baseline workers (`prod-worker-*`) and control planes never match.

- Admission-time mutate on **CREATE + UPDATE** — safe because `allowScheduling` is a *mutable* Longhorn field (unlike the immutable Pod `spec.affinity` that forces `prefer-baseline-nodes` to CREATE-only).
- Node-name prefix is the only discriminator available today; the proper long-term fix is for KSail to stamp `ksail.io/autoscaled=true` on its pools (the same label `prefer-baseline-nodes` is waiting on). Filed as a follow-up.

## Validation

- **kyverno CLI v1.18.1 unit tests:** `autoscale-cx33-…` → `allowScheduling: false` (pass); `prod-worker-1` → skipped, unchanged.
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.
- `ksail --config ksail.prod.yaml workload validate` → 324 files validated (incl. this policy).

## Not covered here (operational / separate)

- **Longhorn Node CRs that already exist** when this lands are not retroactively patched (admission-only; a `mutateExisting` rule would need extra background-controller RBAC on `longhorn.io/nodes`). The 2 current autoscaler nodes should be set `allowScheduling: false` once by hand; they then recycle into policy-covered nodes.
- **Recovering the already-faulted volumes** (wedding-db restore from CNPG/Velero backup, clearing the stuck `vault-snapshots` PVC, pruning 3 stale Longhorn node objects) is live remediation, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)