### PR TITLE
feat(wedding-app): add wedding-db backup R2 credentials

### DIFF
--- a/k8s/bases/apps/wedding-app/db-backup-external-secret.yaml
+++ b/k8s/bases/apps/wedding-app/db-backup-external-secret.yaml
@@ -1,0 +1,47 @@
+# R2 credentials for wedding-db's CNPG barmanObjectStore backup (the backup
+# block + ScheduledBackup live in the wedding-app tenant repo's deploy/). Projects
+# the shared backup R2 key/secret from OpenBao (infrastructure/backup/r2 — the
+# same path umami-db's backup and Velero's velero-r2-credentials read) into a
+# Secret in the wedding-app namespace, where CNPG's backup s3Credentials must
+# live (it can only reference a Secret in the Cluster's own namespace).
+#
+# This is a PLATFORM-side resource: reconciled by flux-system (the registration
+# dir), never by the tenant ServiceAccount. The shared bucket credential is
+# platform-owned, so it uses the cluster-scoped `openbao` ClusterSecretStore —
+# the `restrict-tenant-secret-stores` Kyverno policy carves out
+# flux-system-applied ExternalSecrets while still blocking a tenant from pointing
+# its OWN ExternalSecret at the ClusterSecretStore. Mirrors
+# ghcr-auth-externalsecret.yaml and apps/umami/db-backup-external-secret.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: wedding-db-backup-r2
+  namespace: wedding-app
+  labels:
+    app.kubernetes.io/managed-by: ksail
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: wedding-db-backup-r2
+    creationPolicy: Owner
+    template:
+      # REGION is a constant ("auto") rather than a fetched secret — CNPG's
+      # s3Credentials.region must point at a Secret key, and barman-cloud/boto3
+      # need a region for SigV4 signing. "auto" is R2's environment-independent
+      # convention (the same value Velero's BackupStorageLocation uses).
+      data:
+        ACCESS_KEY_ID: "{{ .ACCESS_KEY_ID }}"
+        SECRET_ACCESS_KEY: "{{ .SECRET_ACCESS_KEY }}"
+        REGION: "auto"
+  data:
+    - secretKey: ACCESS_KEY_ID
+      remoteRef:
+        key: infrastructure/backup/r2
+        property: access_key_id
+    - secretKey: SECRET_ACCESS_KEY
+      remoteRef:
+        key: infrastructure/backup/r2
+        property: secret_access_key

--- a/k8s/bases/apps/wedding-app/kustomization.yaml
+++ b/k8s/bases/apps/wedding-app/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - db-backup-external-secret.yaml
   - ghcr-auth-externalsecret.yaml
   - namespace.yaml
   - rolebinding.yaml


### PR DESCRIPTION
## Why

`wedding-db` (CNPG) ran with `bootstrap: initdb` and **no backup configured**. When its Longhorn replicas faulted on 2026-06-16 (autoscaler node scale-down), it was nearly unrecoverable — the only copies were uncoordinated Velero CSI snapshots. This closes that DR gap by giving wedding-db the same R2 barman backup umami-db already has.

## What this PR does

Provisions the `wedding-db-backup-r2` Secret in the `wedding-app` namespace (CNPG `s3Credentials` must live in the Cluster's own namespace). It's a **platform-side** ExternalSecret reconciled by flux-system, projecting the shared `infrastructure/backup/r2` OpenBao creds via the cluster-scoped `openbao` ClusterSecretStore — the `restrict-tenant-secret-stores` carve-out for flux-system-applied ExternalSecrets (a tenant's own SecretStore can't reach the shared infra path). Mirrors `apps/umami/db-backup-external-secret.yaml` and `ghcr-auth-externalsecret.yaml`.

**No new OpenBao seed needed** — `infrastructure/backup/r2` already backs umami-db and Velero.

## Pairs with

[devantler-tech/wedding-app#116](https://github.com/devantler-tech/wedding-app/pull/116) (the Cluster `backup` block + `ScheduledBackup`). **Merge this one first** so the Secret exists before the Cluster references it.

## ⚠️ Follow-up: inline barman is deprecated

The paired Cluster uses inline `spec.backup.barmanObjectStore`, which CNPG 1.29 **deprecates** and **removes in 1.30.0** in favour of the Barman Cloud Plugin. I used inline for consistency with umami-db and because the plugin/`ObjectStore` CRD isn't installed here. **Recommended follow-up:** install the barman-cloud plugin and migrate both umami-db and wedding-db before the CNPG 1.30 upgrade.

## Validation

- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` build
- `ksail --config ksail.prod.yaml workload validate` (incl. this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)