### PR TITLE
feat(cnpg): install barman-cloud plugin

### DIFF
--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - cert-manager/
   - cilium/
   - cloudnative-pg/
+  - plugin-barman-cloud/
   - coroot/
   - dex/
   - external-secrets/

--- a/k8s/bases/infrastructure/controllers/plugin-barman-cloud/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/plugin-barman-cloud/helm-release.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plugin-barman-cloud
+  namespace: cnpg-system
+  labels:
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  # CNPG-I Barman Cloud Plugin — the supported replacement for the in-tree
+  # spec.backup.barmanObjectStore, which CNPG deprecated in 1.26 and removes in
+  # 1.30.0. Clusters opt in via spec.plugins + an ObjectStore CR
+  # (barmancloud.cnpg.io) instead of an inline backup block; see apps/umami and
+  # apps/wedding-app for the migrated consumers.
+  #
+  # The chart ships the ObjectStore CRD and its own cert-manager Issuer +
+  # server/client Certificates for the mTLS channel between the plugin and the
+  # operator, so it must come up after cert-manager and the CNPG operator (both
+  # in this controller set). Reuses the shared `cloudnative-pg` HelmRepository.
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+    - name: cloudnative-pg
+      namespace: cnpg-system
+  interval: 10m
+  timeout: 10m
+  chart:
+    spec:
+      chart: plugin-barman-cloud
+      version: 0.7.0
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+  # Chart defaults install into the release namespace (cnpg-system) with a single
+  # replica; raise replicaCount once the operator↔plugin path is verified if HA
+  # is wanted (the operator retries, so a brief plugin restart only delays
+  # backups, it does not drop the database).

--- a/k8s/bases/infrastructure/controllers/plugin-barman-cloud/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/plugin-barman-cloud/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml
+  - networkpolicy.yaml

--- a/k8s/bases/infrastructure/controllers/plugin-barman-cloud/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/plugin-barman-cloud/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+# cnpg-system runs under a default-deny baseline (see add-default-deny), so the
+# plugin needs an explicit allow. The plugin Deployment serves the CNPG-I gRPC
+# API on :9090, which the CloudNativePG operator calls; it reads ObjectStore CRs
+# and backup Secrets from the API server. The actual object-store I/O (WAL push,
+# base backups, restore) runs in the barman-cloud sidecar injected into each
+# PostgreSQL instance pod, so R2 egress is governed by the consuming app's own
+# policy (e.g. apps/umami/networkpolicy.yaml), not this one.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-plugin-barman-cloud
+  namespace: cnpg-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: plugin-barman-cloud
+  ingress:
+    # CNPG-I gRPC from the CloudNativePG operator (same namespace).
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: cloudnative-pg
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+  egress:
+    # Kube API: read ObjectStore CRs + backup Secrets, drive Backup objects.
+    - toEntities:
+        - kube-apiserver
+    # DNS resolution.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP


### PR DESCRIPTION
## Why

The CNPG-I **Barman Cloud Plugin** is the supported replacement for the in-tree `spec.backup.barmanObjectStore`, which CloudNativePG **deprecated in 1.26** and **removes in 1.30.0**. This installs the plugin so umami-db and wedding-db can migrate off the in-tree barman.

## What

`k8s/bases/infrastructure/controllers/plugin-barman-cloud/` — HelmRelease (chart `plugin-barman-cloud` 0.7.0 → app v0.13.0, from the shared `cloudnative-pg` HelmRepository) + a Cilium NetworkPolicy, in `cnpg-system`.

- The chart ships the `ObjectStore` CRD (`barmancloud.cnpg.io`) and its own cert-manager Issuer + server/client Certificates (operator↔plugin mTLS) → `dependsOn` cert-manager + cloudnative-pg.
- NetworkPolicy allows operator→plugin gRPC on `:9090` and API/DNS egress. Object-store (R2) egress stays governed by each app's own policy — the WAL/backup I/O runs in the sidecar injected into the Postgres pods, not in this Deployment. *(If the plugin Deployment itself needs object-store egress for restore coordination, that's a one-line add — flagged for review.)*

**Installing the plugin alone changes no existing Cluster.**

## Migration order

1. **This PR** (install plugin) ← merge first
2. [#2074](https://github.com/devantler-tech/platform/pull/2074) migrate umami-db · [#2075](https://github.com/devantler-tech/platform/pull/2075) wedding-db ObjectStore
3. [wedding-app#117](https://github.com/devantler-tech/wedding-app/pull/117) switch wedding-db Cluster

(The earlier inline-barman PRs #2072 / wedding-app#116 already merged; these four supersede that approach with the plugin.)

## Validation

- `kubectl kustomize k8s/clusters/{prod,local}` build; controllers path builds
- `ksail --config ksail.prod.yaml workload validate`
- ⚠️ The plugin/ObjectStore CRD only exists after this merges, so the consumer PRs should be `kubectl apply --dry-run=server`-checked against the live CRD before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)