### PR TITLE
refactor(umami): migrate db backup to barman-cloud plugin

### DIFF
--- a/k8s/bases/apps/umami/db-object-store.yaml
+++ b/k8s/bases/apps/umami/db-object-store.yaml
@@ -1,0 +1,33 @@
+# Barman Cloud Plugin ObjectStore for umami-db — the plugin-based replacement
+# for the in-tree spec.backup.barmanObjectStore (deprecated in CNPG 1.26,
+# removed in 1.30; plugin installed in infrastructure/controllers/plugin-barman-cloud).
+# Translated 1:1 from the previous inline block: same R2 destination, same
+# `umami-db-backup-r2` credentials (db-backup-external-secret.yaml), same gzip
+# compression. retentionPolicy moves from the Cluster's spec.backup to here.
+# The Cluster opts in via spec.plugins (postgres-cluster.yaml); the daily base
+# backup is driven by db-scheduled-backup.yaml. r2_* are Flux-substituted from
+# variables-base (umami is prod-only). Egress to R2 is opened in networkpolicy.yaml.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: umami-db
+  namespace: umami
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://${r2_bucket}/cnpg/umami-db
+    endpointURL: ${r2_endpoint}
+    s3Credentials:
+      accessKeyId:
+        name: umami-db-backup-r2
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: umami-db-backup-r2
+        key: SECRET_ACCESS_KEY
+      region:
+        name: umami-db-backup-r2
+        key: REGION
+    wal:
+      compression: gzip
+    data:
+      compression: gzip

--- a/k8s/bases/apps/umami/db-scheduled-backup.yaml
+++ b/k8s/bases/apps/umami/db-scheduled-backup.yaml
@@ -1,8 +1,9 @@
-# Daily base backup of umami-db to R2 via the cluster's barmanObjectStore
-# (postgres-cluster.yaml). Combined with continuous WAL archiving (auto-enabled
-# by barmanObjectStore), this gives point-in-time recovery within the 30d
-# retention window. `immediate: true` seeds the first backup as soon as this is
-# applied so the cluster is not left backup-less waiting for the first 03:00 tick.
+# Daily base backup of umami-db to R2 via the Barman Cloud Plugin (the cluster's
+# spec.plugins + db-object-store.yaml). Combined with continuous WAL archiving
+# (routed through the plugin's isWALArchiver), this gives point-in-time recovery
+# within the 30d retention window. `immediate: true` seeds the first backup as
+# soon as this is applied so the cluster is not left backup-less waiting for the
+# first 03:00 tick.
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
@@ -13,6 +14,8 @@ spec:
   schedule: "0 0 3 * * *"
   immediate: true
   backupOwnerReference: self
-  method: barmanObjectStore
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   cluster:
     name: umami-db

--- a/k8s/bases/apps/umami/kustomization.yaml
+++ b/k8s/bases/apps/umami/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - db-superuser-pushsecret.yaml
   - db-rotated-external-secret.yaml
   - db-backup-external-secret.yaml
+  - db-object-store.yaml
   - db-scheduled-backup.yaml
   - helm-repository.yaml
   - helm-release.yaml

--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -79,30 +79,18 @@ spec:
     limits:
       memory: 512Mi
   # Off-cluster DB backup to Cloudflare R2 (continuous WAL archiving + base
-  # backups, so PITR is possible). This is the in-tree barmanObjectStore — still
-  # supported on CNPG 1.29.x but deprecated in favour of the Barman Cloud Plugin;
-  # a future operator major (Renovate-gated to manual review) is the trigger to
-  # migrate. Credentials come from `umami-db-backup-r2` (db-backup-external-secret.yaml,
-  # OpenBao infrastructure/backup/r2 — the SAME R2 creds Velero uses); the daily
-  # base backup is driven by db-scheduled-backup.yaml. r2_* are Flux-substituted
-  # from variables-base (prod values; umami is prod-only). Egress to R2 is opened
-  # in networkpolicy.yaml.
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      destinationPath: s3://${r2_bucket}/cnpg/umami-db
-      endpointURL: ${r2_endpoint}
-      s3Credentials:
-        accessKeyId:
-          name: umami-db-backup-r2
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: umami-db-backup-r2
-          key: SECRET_ACCESS_KEY
-        region:
-          name: umami-db-backup-r2
-          key: REGION
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
+  # backups, so PITR is possible) via the Barman Cloud Plugin — the supported
+  # replacement for the in-tree spec.backup.barmanObjectStore, which CNPG
+  # deprecated in 1.26 and removes in 1.30. The R2 destination, the
+  # `umami-db-backup-r2` credentials (db-backup-external-secret.yaml, OpenBao
+  # infrastructure/backup/r2 — the SAME creds Velero uses) and retention now live
+  # in the ObjectStore CR (db-object-store.yaml); the daily base backup is driven
+  # by db-scheduled-backup.yaml. Egress to R2 is opened in networkpolicy.yaml
+  # (the plugin injects a barman-cloud sidecar into these instance pods, so the
+  # existing R2 egress still applies). isWALArchiver routes WAL archiving through
+  # the plugin.
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: umami-db


### PR DESCRIPTION
## Why

Move umami-db off the **deprecated** in-tree `spec.backup.barmanObjectStore` (removed in CNPG 1.30) to the Barman Cloud Plugin, following the [official migration guide](https://cloudnative-pg.io/plugin-barman-cloud/docs/migration/).

## What (translated 1:1, same R2 store + creds)

- **`db-object-store.yaml`** — new `ObjectStore` CR: the inline `barmanObjectStore` → `spec.configuration`, `retentionPolicy` → `spec.retentionPolicy`.
- **Cluster** — removed `spec.backup`; added `spec.plugins: [{name: barman-cloud.cloudnative-pg.io, isWALArchiver: true, parameters: {barmanObjectName: umami-db}}]`.
- **ScheduledBackup** — `method: barmanObjectStore` → `method: plugin` (+ `pluginConfiguration`).

Same object store + credentials, so backup history / PITR is continuous.

## ⚠️ Order + live impact

- **Needs [#2073](https://github.com/devantler-tech/platform/pull/2073) (install plugin) merged & reconciled first** — otherwise the Cluster references a plugin/ObjectStore that doesn't exist yet.
- Per the guide, promoting this triggers a **one-time rolling update** of the live umami-db Cluster to inject the barman-cloud sidecar. umami-db runs 3 instances, so it rolls one at a time and stays available — but it is a live-DB change, hence draft.
- Recommend a `kubectl apply --dry-run=server` of the ObjectStore + Cluster against the live plugin CRD (post-#2073) before promoting.

## Validation

- umami path + `k8s/clusters/{prod,local}` build; `ksail --config ksail.prod.yaml workload validate` (the ObjectStore CRD is plugin-provided, so kubeconform skips its schema until #2073 is live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)