### PR TITLE
feat(wedding-app): add wedding-db barman-cloud plugin ObjectStore

### DIFF
--- a/k8s/bases/apps/wedding-app/db-object-store.yaml
+++ b/k8s/bases/apps/wedding-app/db-object-store.yaml
@@ -1,0 +1,39 @@
+# Barman Cloud Plugin ObjectStore for the wedding-db tenant database — the
+# plugin-based replacement for the in-tree spec.backup.barmanObjectStore that the
+# wedding-app repo's Cluster previously used (deprecated in CNPG 1.26, removed in
+# 1.30; plugin installed in infrastructure/controllers/plugin-barman-cloud).
+#
+# PLATFORM-side (registration dir, reconciled by flux-system): the R2 destination
+# and the shared-bucket credentials are platform-owned, so they live here next to
+# the db-backup-external-secret.yaml that provisions `wedding-db-backup-r2` — the
+# tenant's own (namespaced) SecretStore cannot reach infrastructure/backup/r2, and
+# barmancloud.cnpg.io is outside the tenant's cnpg-tenant-edit RBAC anyway. The
+# tenant's Cluster (wedding-app repo deploy/cluster.yaml) opts in by referencing
+# this ObjectStore by name via spec.plugins. r2_* are Flux-substituted from
+# variables-base. Same R2 store + creds + retention as the old inline block.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: wedding-db
+  namespace: wedding-app
+  labels:
+    app.kubernetes.io/managed-by: ksail
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://${r2_bucket}/cnpg/wedding-db
+    endpointURL: ${r2_endpoint}
+    s3Credentials:
+      accessKeyId:
+        name: wedding-db-backup-r2
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: wedding-db-backup-r2
+        key: SECRET_ACCESS_KEY
+      region:
+        name: wedding-db-backup-r2
+        key: REGION
+    wal:
+      compression: gzip
+    data:
+      compression: gzip

--- a/k8s/bases/apps/wedding-app/kustomization.yaml
+++ b/k8s/bases/apps/wedding-app/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - db-backup-external-secret.yaml
+  - db-object-store.yaml
   - ghcr-auth-externalsecret.yaml
   - namespace.yaml
   - rolebinding.yaml


### PR DESCRIPTION
## Why

Move the wedding-db tenant database off the **deprecated** in-tree `barmanObjectStore` (removed in CNPG 1.30) to the Barman Cloud Plugin. This is the platform-side half (the shared R2 creds + `barmancloud.cnpg.io` are outside the tenant's reach); the wedding-app repo's Cluster references it via `spec.plugins`.

## What

`k8s/bases/apps/wedding-app/db-object-store.yaml` — an `ObjectStore` translated 1:1 from the inline block merged in #116: same `s3://platform-backups/cnpg/wedding-db` destination, same `wedding-db-backup-r2` creds (already shipped via #2072), `retentionPolicy: 30d` → `spec.retentionPolicy`.

## Order

- Needs **[#2073](https://github.com/devantler-tech/platform/pull/2073) (install plugin)** first.
- Pairs with **[wedding-app: switch Cluster to plugin]** — merge this ObjectStore before/with it so the Cluster's `barmanObjectName` resolves.

## Validation

- wedding-app path + `k8s/clusters/{prod,local}` build; `ksail --config ksail.prod.yaml workload validate` (ObjectStore CRD is plugin-provided → kubeconform skips schema until #2073 is live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)