### PR TITLE
fix(wedding-app): allow CNPG egress to Cloudflare R2 for barman backups

### DIFF
--- a/k8s/bases/apps/wedding-app/networkpolicy.yaml
+++ b/k8s/bases/apps/wedding-app/networkpolicy.yaml
@@ -32,10 +32,26 @@ spec:
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: wedding-app
+    # CNPG → Cloudflare R2 (S3) for barman-cloud WAL archiving + base backups
+    # (the wedding-db CloudNativePG cluster). Pinned by FQDN instead of
+    # world:443 so a compromised pod cannot exfiltrate to arbitrary external
+    # services; the R2 pattern matches any account host without committing the
+    # account id. Mirrors umami/allow-umami, which archives to the same
+    # platform-backups bucket — without this rule the namespace default-deny
+    # drops the DB's R2 traffic and barman WAL archive/restore hangs until it
+    # times out (wedding-db-2 stalled in recovery for hours on exactly this).
+    - toFQDNs:
+        - matchPattern: "*.r2.cloudflarestorage.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # Kube API (for CNPG operator managing the cluster)
     - toEntities:
         - kube-apiserver
-    # DNS resolution
+    # DNS resolution. rules.dns engages Cilium's L7 DNS proxy so the toFQDNs
+    # allow-list above can be enforced; matchPattern "*" leaves resolution
+    # itself unrestricted (the FQDN list constrains where traffic may go).
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: kube-system
@@ -46,3 +62,6 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"


### PR DESCRIPTION
## Problem

`wedding-db` (CloudNativePG) has been crash-looping in recovery for hours and `wedding-app` is down (its pods `EHOSTUNREACH` to the DB). The DB's `barman-cloud-wal-restore` fails with **"Could not connect to the endpoint URL"** for `*.r2.cloudflarestorage.com` after a ~10-minute (613 s) hang — a TCP **timeout**, not an auth or DNS error.

## Root cause

`wedding-app`'s `allow-wedding-app` CiliumNetworkPolicy permits egress only to: intra-namespace, `kube-apiserver`, and `kube-dns:53`. With the namespace's `default-deny`, **the CNPG pods have no route to Cloudflare R2 on 443**, so every WAL archive/restore is silently dropped and hangs to timeout.

A/B proof: `umami/allow-umami` — same shape (web app + a CNPG cluster, archiving to the **same** `platform-backups` R2 bucket) — **does** carry a `toFQDNs: *.r2.cloudflarestorage.com:443` egress rule and archives successfully (`ContinuousArchiving=working`). wedding-app simply never got the matching rule (umami's own comment even says it "mirrors the wedding-app policy").

## Fix

Add the R2 FQDN egress rule to `allow-wedding-app`, mirroring umami — FQDN-pinned (not `world:443`, so a compromised pod still can't exfiltrate to arbitrary hosts) plus the `rules.dns` L7 DNS proxy that Cilium requires to enforce `toFQDNs`.

## Validation

- `kubectl kustomize k8s/providers/hetzner/apps/` builds; the rendered `allow-wedding-app` now contains the `*.r2.cloudflarestorage.com:443` egress rule.
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.

## Scope & caveats

- This fixes the **network** half of the outage. **Data recovery is separate and still blocked**: every Velero backup for ~2 weeks is `PartiallyFailed`/`Failed` (kopia/CSI data-mover timeouts), so there is currently no clean backup to restore wedding-db from — being tracked/fixed separately.
- Complementary to in-flight #2075 (wedding-db barman-cloud-plugin ObjectStore), which does not touch the network policy.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — interactive, maintainer-directed prod-platform investigation.
