### PR TITLE
fix(velero): widen data-mover prepare timeout to unblock daily backups

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -120,6 +120,16 @@ spec:
       # request gets them rejected on memory-saturated nodes.
       extraArgs:
         - --node-agent-configmap=node-agent-config
+        # Memory-saturated cluster: the data-mover exposer pods that move
+        # Longhorn CSI snapshots to R2 cannot all be scheduled within the
+        # default 30m prepare window, so a chunk of each daily run's DataUploads
+        # fail with "timeout on preparing data upload" (node never assigned) —
+        # 4 of 7 on 2026-06-16, and every daily backup PartiallyFailed since
+        # 06-10. The volume snapshots themselves complete; only the data-mover
+        # prepare step starves. Widen the window so queued DataUploads wait for
+        # a node slot to free as earlier ones finish, instead of timing out.
+        # Off-peak daily backup (02:17), so a longer prepare window is free.
+        - --data-mover-prepare-timeout=2h
 
     # Daily backup of every namespace that has PVCs. 14-day retention
     # matches the 24h RPO target. Long-term retention is handled by R2


### PR DESCRIPTION
## Problem — production DR is broken

Every `velero-daily-full` backup has been **`PartiallyFailed` since 2026-06-10** (and `FailedValidation`/`Failed` before that) — i.e. **there is no clean cluster backup for ~2 weeks**. This also means the planned wedding-db restore has nothing intact to restore from.

## Root cause

Per the 2026-06-16 run, the CSI `VolumeSnapshot`s themselves **all reach `ReadyToUse`**, but the Velero **data-mover** step starves:

- **4 of 7 `DataUpload`s failed** with `message: "timeout on preparing data upload"` and **`node: -`** (no node was ever assigned), while the other 3 `Completed` on whichever workers had room.
- The node-agent runs with **default timeouts** (`--data-mover-prepare-timeout` = 30m).

On this deliberately memory-saturated cluster, the per-volume data-mover exposer pods can't **all** be scheduled within the 30-minute prepare window, so the ones that don't get a node slot in time fail. (This is the same memory-admission pressure the existing `node-agent-config` `podResources` tweak was added for — it fixed admission accounting, but the prepare window is still too short when several volumes queue behind the few that fit.)

## Fix

Raise `--data-mover-prepare-timeout` to **2h** (via the node-agent `extraArgs`). Queued `DataUpload`s then wait for a node slot to free as earlier ones finish, instead of timing out at 30m. The daily run is off-peak (02:17), so a longer prepare window costs nothing.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/` builds; the rendered `velero` HelmRelease now carries `--data-mover-prepare-timeout=2h`.
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.

## Caveat — confirm against the next run

This targets the observed *prepare-timeout* failure mode and is low-risk (it only lengthens a wait; it adds no resource reservation). **It should be validated against the next nightly backup.** If `DataUpload`s still fail after this, the binding constraint is raw worker memory, and the next levers are node-agent `loadConcurrency` (serialize fewer concurrent data movements) or adding worker memory — but those are heavier, capacity-budget calls best made after seeing whether the timeout alone clears it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — interactive, maintainer-directed prod-platform investigation.
