### PR TITLE
chore(cluster-policies): exempt nine single-by-design controllers from replica-floor

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -115,6 +115,39 @@ spec:
                 - vertical-pod-autoscaler-vpa-updater
                 - kyverno-reports-controller
                 - kyverno-cleanup-controller
+          # Triaged 2026-06-16 (interactive prod sweep): controller-managed or
+          # single-by-design controllers a floor of 3 is *wrong* for, and that
+          # this memory-saturated cluster can't absorb tripling. Each is a SPOF
+          # only for its own idempotent, retried control loop -- never a
+          # request-serving path:
+          #   * Longhorn-owned: longhorn-driver-deployer, csi-snapshotter
+          #     (longhorn-manager / the chart owns their replica count).
+          #   * single-controller operators (leader election makes >1 a hot
+          #     standby at best, all off the serving path): cluster-autoscaler,
+          #     ksail-operator, tetragon-operator,
+          #     keda-add-ons-http-controller-manager.
+          #   * single-by-design adapters/approvers: keda-operator-metrics-
+          #     apiserver (KEDA's standard 1-replica metrics adapter) and
+          #     kubelet-serving-cert-approver (off every serving path).
+          #   * spire-server: HA needs a shared external datastore, not just
+          #     replicas (its StatefulSet uses the built-in datastore) -- a
+          #     deliberate single-node posture; revisit for HA separately.
+          # Left flagged ON PURPOSE (real signal, not exempted): flagger -- the
+          # comment above intends 3 for HA but it runs flagger_replicas:=1, a
+          # genuine HA gap to close by raising that var when memory allows; and
+          # the cert-manager simply-dns-webhook, part of the in-flight tenant-TLS
+          # rework.
+          - resources:
+              names:
+                - cluster-autoscaler-hetzner-cluster-autoscaler
+                - ksail-operator
+                - tetragon-operator
+                - keda-add-ons-http-controller-manager
+                - keda-operator-metrics-apiserver
+                - kubelet-serving-cert-approver
+                - longhorn-driver-deployer
+                - csi-snapshotter
+                - spire-server
       preconditions:
         all:
           # Durable opt-out on the pod template (charts expose podLabels more


### PR DESCRIPTION
## What

`validate-replica-floor` is an **Audit** policy that deliberately surfaces under-replicated Deployments/StatefulSets so a human triages each one (exempt vs. scale). The cluster had **~11 untriaged violations** generating hundreds of `PolicyViolation` events. This triages them.

## Exempted (9) — controller-managed or single-by-design

Each is a SPOF only for its **own idempotent, retried control loop**, never a request-serving path, and a floor of 3 is *wrong* (not missing) for it — also, this cluster is memory-saturated and can't absorb tripling them:

| Workload | Why exempt |
|---|---|
| `longhorn-driver-deployer`, `csi-snapshotter` | longhorn-manager / the chart owns their replica count |
| `cluster-autoscaler-hetzner-cluster-autoscaler`, `ksail-operator`, `tetragon-operator`, `keda-add-ons-http-controller-manager` | single-controller operators; leader election makes >1 a hot standby at best, all off the serving path |
| `keda-operator-metrics-apiserver` | KEDA's standard 1-replica metrics adapter |
| `kubelet-serving-cert-approver` | off every serving path |
| `spire-server` | HA needs a shared external datastore, not just replicas (StatefulSet uses the built-in datastore) — deliberate single-node posture; revisit for HA separately |

This mirrors the policy's existing `external-dns` / `origin-ca-issuer` / warm-standby exemption blocks.

## Left flagged on purpose (real signal, not exempted)

- **`flagger`** — the policy's own comment says it "now runs 3 replicas for HA," but it actually runs `flagger_replicas:=1`. That's a **genuine HA gap**, not a false positive — close it by raising the var (when memory allows) rather than exempting.
- **`simply-dns-webhook`** (cert-manager) — part of the in-flight tenant-TLS rework; its replica posture is best decided there.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/cluster-policies/` builds; all 9 names render under the `validate-replica-floor` exclude.
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.

Audit-only and fully reversible — no admission impact.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — interactive, maintainer-directed prod-platform investigation.
