### PR TITLE
fix(cluster-policies): stop reloader-primary policy erroring on no-target deployments

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/propagate-reloader-to-flagger-primary.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/propagate-reloader-to-flagger-primary.yaml
@@ -51,6 +51,24 @@ spec:
           - resources:
               kinds:
                 - Deployment
+      exclude:
+        any:
+          # A Flagger PRIMARY is never a canary SOURCE: it inherits the reloader
+          # annotation (this rule copies it onto the primary), so it would
+          # re-match and target a non-existent "<name>-primary-primary",
+          # erroring in PolicyReports (observed: umami-umami-primary).
+          - resources:
+              names:
+                - "?*-primary"
+          # Apps that use Reloader directly with no Flagger canary, so no
+          # "<name>-primary" target exists -- the mutate-existing target fails to
+          # resolve and errors ("deployments.apps headlamp-primary not found")
+          # instead of the intended harmless no-op the header comment describes.
+          # (fleetdm/fleet carries no reloader annotation today; add it here if
+          # that changes.)
+          - resources:
+              names:
+                - headlamp
       preconditions:
         all:
           - key: "{{ request.object.metadata.annotations.\"secret.reloader.stakater.com/reload\" || '' }}"


### PR DESCRIPTION
## Problem

`propagate-reloader-to-flagger-primary` (a `mutateExisting` rule that copies a Flagger canary source's `secret.reloader.stakater.com/reload` annotation onto its `<name>-primary`) emits **2 persistent `error` results** in PolicyReports:

- `deployments.apps "umami-umami-primary-primary" not found` — the **primary** inherits the annotation (this rule copies it there), then re-matches the rule and targets a `<primary>-primary` that can't exist.
- `deployments.apps "headlamp-primary" not found` — `headlamp` uses Reloader **directly** (no Flagger canary), so there's no `<name>-primary` target at all.

The header comment already states these should be a "harmless no-op," but Kyverno reports a hard error when a named mutate-existing target doesn't resolve.

## Fix

Add an `exclude` for:
- `?*-primary` — a primary is never a canary *source*, so it should never trigger the copy. (Sources like `umami-umami` don't end in `-primary`, so real propagation is unaffected.)
- `headlamp` — the current non-Flagger app carrying the annotation. The header comment already names `fleetdm`/`headlamp` as the non-Flagger cases; `fleet` has no reloader annotation today.

The intended behaviour is preserved: `umami-umami` → `umami-umami-primary` propagation still fires (that's what prevents the umami Prisma `P1000` crash-loop the policy exists for); only the two error‑producing no-ops are removed.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/cluster-policies/` builds; both exclude names render under the policy.
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.
- The CI Talos system-test exercises Kyverno admission of the policy.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — interactive, maintainer-directed prod-platform investigation.
