### PR TITLE
fix(coroot): raise memory limit headroom to stop OOMKills

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -14,6 +14,22 @@ spec:
   storage:
     className: hcloud
     size: 2Gi
+  # Coroot's own pod is bursty (trace/log ingestion) and auto-vpa governs it.
+  # With no explicit resources it gets the default ~4:1 limit:request, so the
+  # VPA-set ~1Gi request lands a ~4.1Gi limit -- which a node-churn ingestion
+  # spike blew through, OOMKilling coroot-coroot-0 twice on 2026-06-16. Pin an
+  # explicit block (same pattern as clickhouse below): the request stays ~1Gi
+  # (no extra reservation on this memory-tight cluster) but the limit rises to
+  # 6Gi (the VPA's existing maxAllowed), giving ~50% more burst headroom before
+  # the OOM kill. auto-vpa runs controlledValues:RequestsAndLimits, so it
+  # preserves this 6:1 ratio when it sets the request from live usage.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 6Gi
   prometheus:
     # 14d metrics retention (matches the old kube-prometheus-stack posture).
     retention: 14d


### PR DESCRIPTION
## Problem

`observability/coroot-coroot-0` **OOMKilled twice on 2026-06-16** (currently `Running`, so it self-recovers, but it flaps).

## Root cause

The main `coroot` container has **no explicit resources**, so the platform's `auto-vpa` governs it with the default ~4:1 limit:request ratio. Live, that's a VPA-recommended **~1.05Gi request → ~4.1Gi limit**. The VPA's `maxAllowed` is **6Gi but isn't being hit** (the recommendation is only ~1Gi) — so a node-churn trace/log **ingestion spike above 4.1Gi** is what triggers the OOM, not a too-low VPA cap. Raising the cap wouldn't help; the *limit headroom* is the lever.

## Fix

Pin an explicit `spec.resources` on the Coroot CR (the same pattern the CR already uses for ClickHouse):

- **request stays ~1Gi** — so there's **no extra memory reservation** on this memory-saturated cluster (it competes with e.g. the Velero data-mover pods).
- **limit rises 4.1Gi → 6Gi** (the VPA's existing `maxAllowed`) — ~50% more burst headroom before the kill.

`auto-vpa` runs `controlledValues: RequestsAndLimits`, so it preserves this 6:1 ratio when it sets the request from live usage (per the existing ClickHouse comment).

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/` builds; the rendered Coroot CR carries the new `resources` block.
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.
- Worth confirming after reconcile that the live `coroot-coroot-0` pod limit lands at ~6Gi as intended (VPA-applied).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — interactive, maintainer-directed prod-platform investigation.
