### PR TITLE
fix(cert-manager): allow Simply DNS-01 solver egress to api.simply.com

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/networkpolicy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/networkpolicy.yaml
@@ -7,9 +7,7 @@ spec:
   # The solver is an aggregated API server: cert-manager reaches it *through*
   # the kube-apiserver, so ingress arrives from the apiserver/host entities on
   # the solver's HTTPS port (443) — the namespace-wide allow-cert-manager
-  # policy only admits 10250/6443 for cert-manager's own webhook. Egress
-  # (api.simply.com over world:443, kube-apiserver, DNS) is already covered by
-  # allow-cert-manager, whose endpointSelector spans the namespace.
+  # policy only admits 10250/6443 for cert-manager's own webhook.
   endpointSelector:
     matchLabels:
       app: simply-dns-webhook
@@ -19,6 +17,23 @@ spec:
         - kube-apiserver
         - remote-node
         - host
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+  egress:
+    # The Simply.com DNS API, for creating/removing the _acme-challenge TXT
+    # records during DNS-01. allow-cert-manager FQDN-pins only its *own*
+    # ClusterIssuers' APIs (Let's Encrypt + Cloudflare) — it does NOT allow
+    # api.simply.com — so the Simply solver's provider API must be allow-listed
+    # here. Without it the egress is default-denied: the API call fails and the
+    # solver (simply-com-client) nil-dereferences the absent HTTP response and
+    # crashes instead of presenting the challenge, so the certificate never
+    # issues. Kube-API and DNS egress are already covered namespace-wide by
+    # allow-cert-manager, whose kube-dns rule (matchPattern "*") also provides
+    # the L7 DNS visibility this toFQDNs rule relies on for enforcement.
+    - toFQDNs:
+        - matchName: "api.simply.com"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Problem

The cert-manager Simply DNS-01 solver (`simply-dns-webhook`) cannot reach the Simply.com API, so the tenant TLS certificate for `ascoachingogvaner.dk` (and any future Simply-backed cert) never issues.

The solver pod runs in `cert-manager`, which is under a `default-deny` CiliumNetworkPolicy. Egress is allow-listed by `allow-cert-manager`, which FQDN-pins **only** `acme-v02.api.letsencrypt.org` and `api.cloudflare.com` (its own ClusterIssuers' APIs). It does **not** allow `api.simply.com`, and `allow-simply-dns-webhook` previously opened *ingress* only — its comment incorrectly claimed egress to `api.simply.com` was "already covered by allow-cert-manager."

With egress default-denied, the solver's call to `https://api.simply.com/2/...` fails, and `simply-com-client` v1.0.1 then **nil-dereferences the absent HTTP response and panics** (`getRecords`, client.go:189), so the DNS-01 `_acme-challenge` TXT is never published:

```
main.(*SimplyDnsSolver).Present     /workspace/main.go:65
  → simply-com-client.GetRecord     client.go:145
    → simply-com-client.getRecords  client.go:189   ← nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
```

Result: `Certificate ascoachingogvaner-dk` stays `Ready=False`, the gateway TLS listeners `https-ascoachingogvaner-dk` / `https-www-ascoachingogvaner-dk` stay `Programmed=False`, and HTTPS for the domain is down (apex falls back to the old host / fails TLS).

## Fix

Add an FQDN-pinned egress allow for `api.simply.com:443` to the solver's own `allow-simply-dns-webhook` policy (the Hetzner overlay, where the Simply solver actually runs) — consistent with the per-provider FQDN-pinning `allow-cert-manager` already uses for Let's Encrypt + Cloudflare. The misleading "already covered" comment is corrected. Kube-API and DNS egress remain covered namespace-wide by `allow-cert-manager` (whose `kube-dns` rule with `matchPattern "*"` also supplies the L7 DNS visibility this `toFQDNs` rule needs).

## Validation

- `kustomize build k8s/providers/hetzner/infrastructure/controllers` renders cleanly.
- After apply, the solver presents the challenge, the `_acme-challenge` TXT publishes at Simply, and `Certificate ascoachingogvaner-dk` goes `Ready=True`.

## Notes

A defensive upstream fix for the panic itself — so a failed/blocked request surfaces as a clean error instead of crashing the solver — is filed separately against `runnerm/simply-com-client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
