### PR TITLE
fix(kubescape): restore scanner egress for regolibrary + image registries

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
@@ -40,6 +40,37 @@ spec:
         - matchName: "api.github.com"
         - matchName: "objects.githubusercontent.com"
         - matchName: "raw.githubusercontent.com"
+        # Config scan: the Regolibrary controls/frameworks bundle is a GitHub
+        # release asset. github.com (above) 302-redirects the download to this
+        # release-asset CDN; without it the fetch times out and EVERY config
+        # scan fails ("open .../allcontrols.json: no such file or directory"),
+        # so the cluster has no posture/compliance scanning at all.
+        - matchName: "release-assets.githubusercontent.com"
+        # Vuln scan: kubevuln builds an SBOM per workload image, so it pulls
+        # manifests + layer blobs from every registry the cluster runs images
+        # from (docker.io, quay.io, ghcr.io, registry.k8s.io, reg.kyverno.io).
+        # Without these every image fails with "creating SBOM, skipping scan:
+        # ... i/o timeout" and vulnerabilityScan reports nothing. Each registry
+        # serves blobs from its own CDN, so the API host alone is not enough.
+        # ghcr.io (GitHub Container Registry) — blobs on the GitHub package CDN:
+        - matchName: "ghcr.io"
+        - matchName: "pkg-containers.githubusercontent.com"
+        # docker.io — registry v2 + token endpoints; blobs on the Cloudflare CDN:
+        - matchName: "index.docker.io"
+        - matchName: "registry-1.docker.io"
+        - matchName: "auth.docker.io"
+        - matchName: "production.cloudflare.docker.com"
+        # quay.io — registry + its documented blob CDN hosts:
+        - matchName: "quay.io"
+        - matchName: "cdn01.quay.io"
+        - matchName: "cdn02.quay.io"
+        - matchName: "cdn03.quay.io"
+        # registry.k8s.io — redirects blob pulls to its Google Artifact Registry
+        # backing store (*.pkg.dev); add the S3 mirror host if logs show one:
+        - matchName: "registry.k8s.io"
+        - matchPattern: "*.pkg.dev"
+        # reg.kyverno.io — Kyverno's image registry:
+        - matchName: "reg.kyverno.io"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Problem

The `kubescape` namespace runs under a default-deny Cilium egress policy (`allow-kubescape`) whose `toFQDNs` allow-list was missing every host the scanners actually need. As a result **all of Kubescape's scanning is silently broken on prod** — the result CRDs exist but every summary is empty/zero. This is a security blind spot (no posture/compliance scanning, no vulnerability data), not a clean cluster.

Confirmed from live logs on `admin@prod`:

**1. Config / posture scan** — the Regolibrary controls/frameworks bundle is a GitHub *release asset*. `github.com` (already allowed) 302-redirects the download to `release-assets.githubusercontent.com`, which was **blocked**:

```
failed to get policies from github release ... Get "https://release-assets.githubusercontent.com/...": dial tcp 185.199.108.133:443: i/o timeout
...
failed to scan. reason: 'open /home/nonroot/.kubescape/allcontrols.json: no such file or directory'
```

→ every config scan dies; **zero** compliance/posture results.

**2. Vulnerability scan** — `kubevuln` builds an SBOM per workload image, pulling manifests + layer blobs from every registry the cluster runs (`docker.io`, `quay.io`, `ghcr.io`, `registry.k8s.io`, `reg.kyverno.io`), all **blocked**:

```
creating SBOM, skipping scan ... Get "https://ghcr.io/v2/": i/o timeout
                            ... Get "https://registry.k8s.io/v2/": i/o timeout
                            ... Get "https://index.docker.io/v2/": i/o timeout
```

→ every image skipped; **zero** vulnerability results.

All four capabilities are intentionally enabled in the HelmRelease (`configurationScan`, `vulnerabilityScan`, `continuousScan`, `runtimeDetection`), so this is purely an egress gap.

## Fix

Extend the `allow-kubescape` `toFQDNs` allow-list with:

- `release-assets.githubusercontent.com` — regolibrary release-asset CDN (config scan).
- Image registries + their blob CDNs for SBOM building (vuln scan): ghcr.io + `pkg-containers.githubusercontent.com`; docker.io (`index.docker.io`, `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com`); quay.io + `cdn0{1,2,3}.quay.io`; `registry.k8s.io` + `*.pkg.dev`; `reg.kyverno.io`.

Still **FQDN-pinned (never `world:443`)**, so the anti-exfiltration posture the policy documents is preserved. Hosts are each registry's published firewall allow-list. Per the policy's existing comment, the list should be extended further only if a scan component logs a *new* blocked host — most likely an S3 mirror for `registry.k8s.io` (noted inline).

## Validation

- `kubectl kustomize k8s/bases/infrastructure/controllers/kubescape/` builds; all 22 FQDN entries render.
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` both pass (322 files validated).
- Functional confirmation (config/vuln results populate) happens after merge + reconcile; the regolibrary host is confirmed exact from the logs above.

> Investigated interactively against `admin@prod`. Static validation only — no cluster was mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)