### PR TITLE
fix(cert-manager): use public resolvers for DNS-01 self-check

### DIFF
--- a/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cert-manager/helm-release.yaml
@@ -23,6 +23,23 @@ spec:
     crds: CreateReplace
   # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   values:
+    # DNS-01 self-check resolvers. Before asking the CA to validate, cert-manager
+    # must itself observe the ACME `_acme-challenge` TXT record. By default it
+    # resolves through the in-cluster chain (CoreDNS -> the node's upstream
+    # resolver), which on this cluster does NOT observe freshly-created TXT
+    # records in tenant zones: a www.ascoachingogvaner.dk challenge record that
+    # was already live on all authoritative nameservers (ns1/2/3.simply.com) AND
+    # on every public resolver (1.1.1.1/8.8.8.8/9.9.9.9) still failed
+    # cert-manager's self check ("DNS record ... not yet propagated")
+    # indefinitely, blocking ascoachingogvaner.dk issuance (apex took ~3h; www
+    # never completed). The zone's 3600s SOA negative-cache (minimum) TTL makes
+    # the in-cluster path pathologically slow/stale. Query public recursive
+    # resolvers directly instead (reachable via the allow-cert-manager world:53
+    # egress). This is cert-manager's documented remedy for unreliable
+    # in-cluster self-check DNS; it affects only the self check, never the
+    # authoritative CA-side validation, and is fully reversible.
+    dns01RecursiveNameservers: "1.1.1.1:53,8.8.8.8:53,9.9.9.9:53"
+    dns01RecursiveNameserversOnly: true
     # Restricted PSS baseline: add runAsNonRoot to container SCs (chart leaves it unset, which fails validate-container-security).
     containerSecurityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
## Problem

`Certificate/ascoachingogvaner-dk` (apex + `www.ascoachingogvaner.dk`) takes **hours** to issue and renew. During this run the apex challenge took ~3h and `www` ~4h to validate, which kept `Kustomization/ascoachingogvaner` (and the parent `flux-system/apps`) un-Ready and the site without a valid `www` cert for that whole window.

> **Update:** the cert eventually self-issued (after ~4h) and the Kustomizations are now Ready — confirming the diagnosis below (it *does* converge once DNS negative-caches clear). The fix targets the **recurring** multi-hour convergence, which repeats on every ~60-day Let's Encrypt renewal and risks a renewal failing to complete before expiry → outage.

## Root cause — cert-manager's self-check, not the solver

Verified live on `admin@prod` while the `www` challenge was pending:

1. The `simply-dns-webhook` solver **does** create the `_acme-challenge.www` TXT record correctly. (The "Record not found" line in its log is just the `GetRecord`-before-`AddRecord` probe — a red herring.)
2. The record was live and correct on **all three authoritative nameservers** (`ns1/2/3.simply.com`) **and** on **every public resolver** (`1.1.1.1`, `8.8.8.8`, `9.9.9.9`) — value matched the challenge key.
3. Yet cert-manager logged, every ~10s for hours:
   ```
   propagation check failed err="DNS record for \"www.ascoachingogvaner.dk\" not yet propagated"
   ```

cert-manager's DNS-01 self-check resolves through the **in-cluster chain** (CoreDNS → the node's upstream resolver), which does not observe freshly-created TXT records in these tenant zones for a long time. The zone's **SOA negative-cache (minimum) TTL is 3600s**, so the in-cluster path stays stale for up to an hour per attempt; combined with the present→check→cleanup retry loop, convergence stretches into hours.

## Fix

Point cert-manager's self-check at public recursive resolvers directly:

```yaml
dns01RecursiveNameservers: "1.1.1.1:53,8.8.8.8:53,9.9.9.9:53"
dns01RecursiveNameserversOnly: true
```

- These resolvers were **verified to serve the record**, and are already reachable via the existing `allow-cert-manager` `world:53` egress.
- cert-manager's **documented remedy** for unreliable in-cluster self-check DNS.
- Affects **only** cert-manager's pre-flight self-check — authoritative CA-side (Let's Encrypt) validation is unchanged.
- All platform certs use **public** DNS zones (Simply, Cloudflare), so none rely on split-horizon resolution.
- Fully **reversible** by removing the two values.

## Alternatives considered

- *Lower the zone's SOA negative-cache TTL* — provider-side (Simply), not GitOps-controllable.
- *Wildcard cert (`*.ascoachingogvaner.dk`)* — halves the challenge count but doesn't fix the self-check staleness, and lives in the tenant repo.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/controllers/cert-manager/` builds; both values render.
- `ksail --config ksail.prod.yaml workload validate` passes (322 files).
- Functional confirmation (issuance/renewal converges in minutes, not hours) happens after merge + reconcile.

> Investigated interactively against `admin@prod` — static validation only, no cluster mutation. This area is in-flight tenant-TLS work; opening as a draft for review since it changes a cluster-wide cert-manager behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)