### PR TITLE
feat(rbac): add cilium-tenant-edit ClusterRole for tenant self-management

### DIFF
--- a/k8s/bases/infrastructure/cluster-roles/cilium-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/cilium-tenant-edit.yaml
@@ -1,0 +1,35 @@
+# Aggregate ClusterRole that extends the built-in 'edit' ClusterRole with
+# Cilium network-policy verbs, so a self-service tenant whose ServiceAccount is
+# bound to 'edit' can manage its own CiliumNetworkPolicy resources in its
+# namespace — owning the allow-lists its app needs (Gateway ingress, DB/DNS and
+# external egress) from its own deploy artifact, instead of the platform
+# carrying tenant-specific network rules in each registration dir.
+#
+# The platform keeps the security FLOOR regardless: the `add-default-deny`
+# Kyverno policy still generates the deny-all + allow-dns CiliumNetworkPolicies
+# in every namespace, and (in prod) the cluster-wide `require-mutual-auth`
+# CiliumClusterwideNetworkPolicy still applies — neither of which a namespaced
+# tenant policy can override. Tenants only layer ALLOWs on top, scoped to their
+# own namespace.
+#
+# Grants only the NAMESPACED `ciliumnetworkpolicies` — never the cluster-scoped
+# `ciliumclusterwidenetworkpolicies`, which remain platform territory.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-tenant-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["cilium.io"]
+    resources:
+      - ciliumnetworkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/k8s/bases/infrastructure/cluster-roles/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster-reader.yaml
+  - cilium-tenant-edit.yaml
   - cnpg-tenant-edit.yaml
   - external-secrets-tenant-edit.yaml
   - gateway-tenant-edit.yaml


### PR DESCRIPTION
## What

Adds a `cilium-tenant-edit` aggregate-to-`edit` ClusterRole granting tenants the **namespaced** `ciliumnetworkpolicies` verbs — mirroring the existing `cnpg-tenant-edit`, `external-secrets-tenant-edit`, and `gateway-tenant-edit` roles.

## Why

Today every per-tenant `CiliumNetworkPolicy` lives on the platform in `k8s/bases/apps/<tenant>/networkpolicy.yaml`. They are pure tenant-specific allow-lists (app ports, egress to FQDNs like `api.simply.com` / `*.r2.cloudflarestorage.com`), so **every time a tenant's app needs a new egress, someone has to edit the platform repo** — and tenants can't fix it themselves because no role grants them `ciliumnetworkpolicies` (the built-in `edit` role covers standard `networking.k8s.io` NetworkPolicy, not Cilium CRDs).

This is the enabling change to let tenants own their network policies in their own `deploy/` artifacts (least-privilege, scoped to their namespace), which the `gitops-tenant-template` already ships a `deploy/networkpolicy.yaml` for but which currently can't apply.

## Security floor unchanged

- `add-default-deny` Kyverno policy still generates the deny-all + allow-dns `CiliumNetworkPolicy` in every namespace.
- The prod cluster-wide `require-mutual-auth` `CiliumClusterwideNetworkPolicy` still applies — a namespaced tenant policy can't override it.
- Only the **namespaced** `ciliumnetworkpolicies` is granted — never the cluster-scoped `ciliumclusterwidenetworkpolicies`.

Tenants only layer *allows* on top of the platform-enforced floor.

## Rollout (this is step 1 of 4)

1. **This PR** — add the role (additive, zero risk, **merge first**).
2. Tenant PRs (`ascoachingogvaner`, `wedding-app`) — add the `CiliumNetworkPolicy` (+ namespaced `SecretStore`) into each tenant's `deploy/`, release. Both copies coexist harmlessly (different names → union of allows).
3. Platform PR — remove the now-duplicated per-tenant `networkpolicy.yaml` / `external-dns-networkpolicy.yaml` / `secretstore.yaml` from the registration dirs and update `docs/TENANTS.md`. **Merge last**, after the tenant releases reconcile.

## Validation

- `ksail workload validate` ✔ (319 files, local config)
- `ksail --config ksail.prod.yaml workload validate` ✔ (319 files, prod config)
- `cilium-tenant-edit.yaml` validated in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)