### PR TITLE
fix(overprovisioning): disable CapacityBuffer until KSail ships the CRD

### DIFF
--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -45,7 +45,20 @@ resources:
   # every CI/CD deploy) red for ~30h on 2026-06-09/10 — the native buffer creates
   # no real pods, so nothing sits Pending and it rides along here like any other
   # resource. Hetzner/prod-only (the autoscaler pools are Hetzner).
-  - overprovisioning/
+  #
+  # TEMPORARILY DISABLED (2026-06-16): the CapacityBuffer CRD
+  # (autoscaling.x-k8s.io/v1beta1) is installed by KSail only from a release that
+  # contains ksail#5277, but the pinned KSAIL_VERSION (7.58.3, ci.yaml/cd.yaml)
+  # predates it (5277 merged after the 7.58.3 release). So the CapacityBuffer CR
+  # fails server-side apply ("no matches for kind CapacityBuffer in version
+  # autoscaling.x-k8s.io/v1beta1"), which wedged the whole `infrastructure`
+  # Kustomization (and its `apps` dependent) — exactly the deploy-ordering gate
+  # that ksail.prod.yaml warns about. Re-enable this line once a KSail release
+  # with #5277 ships AND KSAIL_VERSION is bumped + deployed (so the CRD +
+  # controller exist before this CR reconciles). No over-provisioning headroom
+  # until then, which is acceptable — the old balloon-pod buffer was already
+  # removed in #2087.
+  # - overprovisioning/
   #
   # NOTE: tenant-owned custom-domain TLS (the ascoachingogvaner.dk Certificate +
   # its simply.com DNS01 solver credential) is NOT a platform resource at all —


### PR DESCRIPTION
## ⚠️ Active breakage — `infrastructure` + `apps` reconciliation frozen

The `infrastructure` Flux Kustomization is `Ready=False` on prod and blocking its `apps` dependent:

```
CapacityBuffer/overprovisioning/overprovisioning dry-run failed:
no matches for kind "CapacityBuffer" in version "autoscaling.x-k8s.io/v1beta1"
```

Existing workloads keep running, but **no new changes reconcile to the infra or apps layers** (this also blocks #2090 from taking effect once merged).

## Root cause — deploy-ordering gate violation

[#2087](https://github.com/devantler-tech/platform/pull/2087) (merged 17:21) replaced the balloon-pod overprovisioning with a native cluster-autoscaler **`CapacityBuffer`** CR. That CRD + controller are installed by **KSail**, but only from a release containing **[ksail#5277](https://github.com/devantler-tech/ksail/pull/5277)** (merged `2026-06-16T07:58`, *after* the latest release `v7.58.3` cut `2026-06-15T23:35`). The pinned **`KSAIL_VERSION` is still `7.58.3`** (`ci.yaml`/`cd.yaml`), so:

- the `CapacityBuffer` CRD does **not** exist on the cluster (`kubectl api-resources | grep -i capacitybuffer` → empty),
- the CR's server-side apply fails, wedging the whole `wait: true` infra layer.

This is exactly the gate `ksail.prod.yaml` warns about ("the pinned `KSAIL_VERSION` … must be bumped").

## Fix

Comment out the `overprovisioning/` include so the premature CR is no longer applied → `infrastructure` (and `apps`) reconcile again. The manifests stay in the repo.

**Re-enable** (uncomment the one line) once a KSail release containing #5277 is out **and** `KSAIL_VERSION` is bumped + deployed — so the CRD + controller exist before this CR reconciles. No over-provisioning headroom until then, which is acceptable (the old balloon-pod buffer was already removed in #2087).

> Alternative the maintainer may prefer: cut a KSail release with #5277, bump `KSAIL_VERSION`, and deploy — that satisfies the gate without this interim revert. This PR is the quick unblock if that release isn't imminent.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/` renders **no** `CapacityBuffer` and **no** `overprovisioning` namespace.
- `ksail --config ksail.prod.yaml workload validate` passes.

> Found during an interactive prod sweep against `admin@prod` — static validation only, no cluster mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)