### PR TITLE
fix(kubescape): allow registry.k8s.io S3 mirror for vuln scans

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
@@ -66,9 +66,13 @@ spec:
         - matchName: "cdn02.quay.io"
         - matchName: "cdn03.quay.io"
         # registry.k8s.io — redirects blob pulls to its Google Artifact Registry
-        # backing store (*.pkg.dev); add the S3 mirror host if logs show one:
+        # backing store (*.pkg.dev) and, for EU clients, to its prod S3 mirror
+        # buckets — kubevuln logged i/o timeouts pulling e.g. vpa-recommender from
+        # prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com.
+        # The pattern is scoped to the registry's own prod buckets (not all of S3):
         - matchName: "registry.k8s.io"
         - matchPattern: "*.pkg.dev"
+        - matchPattern: "prod-registry-k8s-io-*.s3.dualstack.*.amazonaws.com"
         # reg.kyverno.io — Kyverno's image registry:
         - matchName: "reg.kyverno.io"
       toPorts:


### PR DESCRIPTION
## Problem

Follow-up to [#2088](https://github.com/devantler-tech/platform/pull/2088). With the registry egress merged, kubevuln now builds SBOMs for most images and **vulnerability scanning is producing real data** — but a few `registry.k8s.io` images (e.g. `vpa-recommender`) still fail:

```
creating SBOM, skipping scan ... Get "https://registry.k8s.io/v2/": ... i/o timeout
```

`registry.k8s.io` serves its manifest from `registry.k8s.io` (allowed) but redirects blob pulls to a backing store — `*.pkg.dev` (already allowed) for some, and **for EU clients to its prod S3 mirror buckets**, which were not allowed. Verified from kubevuln logs on `admin@prod`:

```
https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com
```

#2088's own comment anticipated exactly this ("add the S3 mirror host if logs show one").

## Fix

Add a `matchPattern` **scoped to the registry's own prod buckets** so the anti-exfiltration posture is preserved (not a blanket `*.amazonaws.com`):

```yaml
- matchPattern: "prod-registry-k8s-io-*.s3.dualstack.*.amazonaws.com"
```

## Validation

- `kubectl kustomize k8s/bases/infrastructure/controllers/kubescape/` builds; pattern renders.
- `ksail --config ksail.prod.yaml workload validate` passes.

> Note: config/posture scanning is still not populating its CRDs — but that's a *separate* issue (the scanner attempts to submit to the hardcoded `report.armo.cloud` despite `keepLocal: true`, and the submit failure aborts local persistence). That's an operator-config / disconnect concern, **not** an egress one — see the sweep report. Intentionally NOT addressed here.

> Found during an interactive prod sweep against `admin@prod` — static validation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)