### PR TITLE
fix(umami): migrate ascoachingogvaner website to ascoachingogvaner.dk

### DIFF
--- a/k8s/bases/apps/umami/provision-cronjob.yaml
+++ b/k8s/bases/apps/umami/provision-cronjob.yaml
@@ -109,7 +109,7 @@ spec:
                     secretKeyRef:
                       name: umami-admin
                       key: password
-                # One-time BOOTSTRAP password for the AS Coaching og Vaner customer's
+                # One-time BOOTSTRAP password for the AS - Coaching, vaner og ro customer's
                 # read-only login, OpenBao-generated (apps/umami/ascoachingogvaner) and
                 # referenced by the member's `passwordEnv` in TENANTS below. Used only
                 # at account creation; the customer changes it on first login and owns
@@ -143,7 +143,7 @@ spec:
                       {
                         "team": "ascoachingogvaner",
                         "websites": [
-                          { "id": "5e76b00b-67e5-4aef-b4df-17fca43e9a33", "name": "AS Coaching og Vaner", "domain": "ascoachingogvaner.platform.devantler.tech" }
+                          { "id": "5e76b00b-67e5-4aef-b4df-17fca43e9a33", "name": "AS - Coaching, vaner og ro", "domain": "ascoachingogvaner.dk" }
                         ],
                         "members": [
                           { "username": "ascoachingogvaner", "passwordEnv": "ASCOACHINGOGVANER_PASSWORD", "accountRole": "view-only", "teamRole": "team-view-only" }
@@ -207,10 +207,23 @@ spec:
                     // is what crashed every run, leaving Umami with no websites.)
                     const w = g.ok ? await g.json() : null;
                     if (w && w.id) {
-                      if (w.teamId === teamId) { console.log('website ok:', s.domain); return; }
-                      const t = await fetch(base + '/api/websites/' + s.id + '/transfer', { method: 'POST', headers: H(token), body: JSON.stringify({ teamId }) });
-                      if (!t.ok) throw new Error('transfer website ' + s.domain + ' failed: ' + t.status + ' ' + (await t.text()));
-                      console.log('website moved to team:', s.domain);
+                      // Move a pre-existing personal site into its team.
+                      if (w.teamId !== teamId) {
+                        const t = await fetch(base + '/api/websites/' + s.id + '/transfer', { method: 'POST', headers: H(token), body: JSON.stringify({ teamId }) });
+                        if (!t.ok) throw new Error('transfer website ' + s.domain + ' failed: ' + t.status + ' ' + (await t.text()));
+                        console.log('website moved to team:', s.domain);
+                      }
+                      // Reconcile name/domain so TENANTS stays the source of truth for an
+                      // existing site too (Umami updates via POST to the website id) — e.g. a
+                      // domain migration applies on the next tick instead of a hand-edit in
+                      // the Umami UI. Guarded so a steady-state tick stays a no-op.
+                      if (w.name !== s.name || w.domain !== s.domain) {
+                        const u = await fetch(base + '/api/websites/' + s.id, { method: 'POST', headers: H(token), body: JSON.stringify({ name: s.name, domain: s.domain }) });
+                        if (!u.ok) throw new Error('update website ' + s.domain + ' failed: ' + u.status + ' ' + (await u.text()));
+                        console.log('website updated:', s.domain);
+                      } else {
+                        console.log('website ok:', s.domain);
+                      }
                       return;
                     }
                     const c = await fetch(base + '/api/websites', { method: 'POST', headers: H(token), body: JSON.stringify({ id: s.id, name: s.name, domain: s.domain, teamId }) });


### PR DESCRIPTION
## Summary

Companion to the tenant change [ascoachingogvaner#60](https://github.com/devantler-tech/ascoachingogvaner/pull/60), which migrates the site's canonical domain to **https://ascoachingogvaner.dk** and retires `ascoachingogvaner.platform.devantler.tech`. The Umami **website** for that tenant is provisioned declaratively here, so it needs updating too.

`k8s/bases/apps/umami/provision-cronjob.yaml`:

1. **Domain** — the `ascoachingogvaner` website (id `5e76b00b…`) `domain` → `ascoachingogvaner.dk`.
2. **Name** — aligned to the real company name **"AS - Coaching, vaner og ro"** (was "AS Coaching og Vaner"; the homepage-dashboard annotation already uses the full name, so this removes the last inconsistency). *Easy to drop if you'd rather keep the old label — it's a one-line revert.*
3. **Provisioner reconciles name/domain** — `ensureWebsite()` previously set `name`/`domain` only on **create**: for an id that already exists it checked team ownership and returned, so a changed `name`/`domain` in `TENANTS` was **silently never applied**. It now reconciles those fields on existing sites too (Umami updates via `POST /api/websites/:id`), guarded so a steady-state tick stays a no-op. Without this, items 1–2 would only be aspirational config — the live website would keep the old values until someone hand-edited it in the Umami UI.

## Why the provisioner change is needed (not just the config edit)

The file header already calls `TENANTS` the "declarative source of truth", but it wasn't for the mutable fields. This makes that true and lets the migration take effect on the next `*/15` reconcile with no manual step. It's the reason a config-only edit here would be misleading.

## Validation

- `kubectl kustomize k8s/clusters/{prod,local}/` ✅ · `k8s/bases/apps/umami/` ✅ (18 res) · `k8s/providers/hetzner/apps/` ✅ (66 res)
- Extracted the rendered provisioning script → `node --check` ✅ (syntax valid)
- Extracted the rendered `TENANTS` env → `JSON.parse` ✅; ascoaching entry is `{"id":"5e76b00b…","name":"AS - Coaching, vaner og ro","domain":"ascoachingogvaner.dk"}`

Note: the full Talos+Docker system test doesn't bring up Umami (apps are opt-in on the docker provider), so the provisioner path isn't exercised by CI — hence the local `node --check` / JSON validation above. Analytics continuity is unaffected: data is keyed by website-id (unchanged), so history is preserved; only the displayed domain/name move.

## Sequencing

Independent of the tenant PR for *correctness* (different surfaces), but ideally land after [ascoachingogvaner#60](https://github.com/devantler-tech/ascoachingogvaner/pull/60) so the Umami `domain` matches where the site actually serves.

---

Draft per repo convention. Merging cuts a `fix` release and deploys to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
