### PR TITLE
fix(talos): disable grubUseUKICmdline so extraKernelArgs passes Talos 1.13.4 validation

### DIFF
--- a/talos/cluster/apparmor.yaml
+++ b/talos/cluster/apparmor.yaml
@@ -2,3 +2,21 @@ machine:
   install:
     extraKernelArgs:
       - security=apparmor
+    # MUST stay false while extraKernelArgs is set above.
+    #
+    # Talos >= 1.13.4 rejects a machine config that sets BOTH
+    # install.extraKernelArgs and install.grubUseUKICmdline=true:
+    #   "install.extraKernelArgs and install.grubUseUKICmdline can't be used together"
+    # and grubUseUKICmdline defaults to TRUE here — KSail generates this cluster's
+    # config with the Talos >=1.12 version contract, and that contract's default
+    # for grubUseUKICmdline is true (gated at >1.11). Without this explicit
+    # override the freshly-generated config carries extraKernelArgs + the
+    # defaulted grubUseUKICmdline:true, so the v1.13.4 installer fails validation
+    # mid-upgrade and `ksail cluster update` aborts on the first node.
+    #
+    # grubUseUKICmdline controls whether the legacy GRUB bootloader reuses the
+    # UKI's baked-in kernel cmdline instead of building one on the host. This
+    # cluster boots GRUB on Hetzner (no SecureBoot/UKI), so the cmdline MUST be
+    # built host-side to carry security=apparmor — which is exactly what
+    # grubUseUKICmdline:false selects.
+    grubUseUKICmdline: false


### PR DESCRIPTION
## Problem

`ksail --config ksail.prod.yaml cluster update` aborts mid-upgrade when Talos goes **v1.13.3 → v1.13.4** (Renovate [#2089](https://github.com/devantler-tech/platform/pull/2089)):

```
167.233.75.202: Error: machine configuration is invalid: 1 error occurred:
  * install.extraKernelArgs and install.grubUseUKICmdline can't be used together
✗ distribution upgrade to pinned version v1.13.4 failed: ... talos upgrade failed
```

## Root cause — an interaction, not one side alone

1. **KSail emits `grubUseUKICmdline: true`.** KSail generates the prod machine config with the Talos **`TalosVersion1_12` version contract** (`pkg/fsutil/configmanager/talos/configs.go`). Talos's `VersionContract.GrubUseUKICmdlineDefault()` returns `true` for any contract `> 1.11`, so every generated config carries `machine.install.grubUseUKICmdline: true`. Confirmed locally: `talosctl gen config` emits `grubUseUKICmdline: true` in the install section.
2. **This repo adds `extraKernelArgs`.** `talos/cluster/apparmor.yaml` patches in `install.extraKernelArgs: [security=apparmor]`.
3. **Talos v1.13.4 added a new validation** that rejects both together (`config/types/v1alpha1/v1alpha1_validation.go`): it fails iff `len(extraKernelArgs) > 0 && GrubUseUKICmdline()`. v1.13.3 had no such check, which is why the cluster ran fine until the bump.
4. During `cluster update`, the **distribution (OS) upgrade runs first** and the v1.13.4 installer validates the **config already committed on the node** (which has both fields) → rejected on the first node.

## Fix

Pin `machine.install.grubUseUKICmdline: false` in `talos/cluster/apparmor.yaml`, co-located with the `extraKernelArgs` that require it. This cluster boots **GRUB on Hetzner (no SecureBoot/UKI)**, so the kernel cmdline must be built host-side to carry `security=apparmor` — exactly what `grubUseUKICmdline: false` selects. AppArmor enforcement is preserved.

### Validation (`talosctl`)
```
BASELINE  grubUseUKICmdline: true    extraKernelArgs: null
FIXED     grubUseUKICmdline: false   extraKernelArgs: ["security=apparmor"]
talosctl validate --config merged-fixed.yaml --mode metal  →  valid for metal mode ✔
```
With `grubUseUKICmdline: false`, `GrubUseUKICmdline()` returns false, so the v1.13.4 validation cannot fire regardless of `extraKernelArgs`.

## ⚠️ Deploy ordering — this PR must deploy BEFORE the v1.13.4 bump

KSail's `cluster update` runs the **OS upgrade before** it reconciles machine config, so the two changes **cannot ride the same deploy** — the upgrade would re-validate the still-stale on-node config and fail again.

1. **Merge this PR first** (Talos stays pinned at v1.13.3). Its prod deploy runs `cluster update`: version reconcile is a no-op, and the config reconcile applies `grubUseUKICmdline: false` to every node (`NO_REBOOT`), correcting the **committed** config.
2. **Then** merge Renovate [#2089](https://github.com/devantler-tech/platform/pull/2089) (v1.13.4). Its deploy validates the now-corrected committed config → upgrade succeeds.

## Follow-up (KSail, not this repo)
Two latent KSail behaviors made this sharp and are worth an upstream issue:
- **Ordering:** `cluster update` upgrades the OS before applying the reconciled machine config, so a config change that is a *prerequisite* for the upgrade can never self-heal in one run (hence the two-step deploy above).
- **Footgun:** the `≥1.12` contract default `grubUseUKICmdline: true` collides with the still-supported (though deprecated) `extraKernelArgs` for **any** KSail user on Talos ≥1.13.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)