### PR TITLE
fix(cnpg): allow operator egress to barman-cloud plugin gRPC

### DIFF
--- a/k8s/bases/infrastructure/controllers/plugin-barman-cloud/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/plugin-barman-cloud/networkpolicy.yaml
@@ -39,3 +39,28 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+---
+# The CloudNativePG operator *initiates* the CNPG-I gRPC call to the plugin's
+# :9090 (the ingress allowed above), so under the same default-deny baseline it
+# also needs a matching *egress* allow to reach the plugin — the rule on
+# allow-plugin-barman-cloud only opens the plugin's receiving side. Without this
+# the operator's dial to the barman-cloud Service is dropped at egress and times
+# out, and every Cluster that enables the plugin reports ContinuousArchiving=False
+# / Ready=False ("wal archive plugin is not available: barman-cloud.cloudnative-pg.io").
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-to-plugin-barman-cloud
+  namespace: cnpg-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloudnative-pg
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: plugin-barman-cloud
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP


### PR DESCRIPTION
## Problem

[PR #2075](https://github.com/devantler-tech/platform/pull/2075) (and every other k8s-touching PR) was stuck in the merge queue. The merge-queue `deploy-prod` job runs `ksail workload reconcile`, which waits for the `flux-system/apps` Kustomization (`wait: true`) to become Ready — and it never did.

Root cause is **not** in PR #2075. It's a Cilium egress gap introduced with the barman-cloud plugin install (#2073):

- `cnpg-system` runs under a `default-deny` baseline.
- `allow-plugin-barman-cloud` (added by #2073) correctly opens the **plugin's ingress** on `:9090` from the operator.
- But the **operator's matching egress** to the plugin was never opened. `allow-cnpg`'s egress only permits `:8000`/`:5432` (Postgres status/SQL), not `:9090`.

So the CloudNativePG operator's CNPG-I gRPC dial to the `barman-cloud` Service was dropped at egress:

```
setPluginProtocol … "Error while connecting to plugin (logical)"
  error: while querying plugin identity: rpc error: code = Unavailable
  desc = … dial tcp 10.99.190.72:9090: i/o timeout
```

### Symptom chain

1. `#2074` migrated `umami-db` to the barman-cloud plugin (`spec.plugins`, `isWALArchiver: true`).
2. Operator can't reach the plugin → `umami-db`: `ContinuousArchiving=False` / `Ready=False` ("wal archive plugin is not available: barman-cloud.cloudnative-pg.io").
3. `umami-db` is in the `flux-system/apps` inventory; `apps` has `wait: true` → its health check times out.
4. `apps` never goes Ready → merge-queue `deploy-prod`'s `ksail workload reconcile` hangs → `CI - Required Checks` fails → **PR #2075 stuck**.

## Fix

Add the operator's egress side of the CNPG-I gRPC call: allow `cloudnative-pg` → `plugin-barman-cloud` on TCP `9090`. This is the mirror of the ingress rule `#2073` already added.

## Verification

Applied the identical policy to the live prod cluster as immediate incident remediation (prod's `umami-db` WAL archiving was broken and the queue was blocked). After applying it + restarting the operator to drop its stale pooled connection:

- operator `i/o timeout` errors stopped;
- `umami-db` advanced out of the plugin error: `… error while interacting with plugins` → `Waiting for the instances to become active` → primary restart to inject the WAL-archiver sidecar (now running 2/2 per instance pod);
- the `umami` tenant policy already permits the sidecar's R2 egress (`*.r2.cloudflarestorage.com:443`), so there's no second gap.

This PR makes that fix durable + version-controlled; Flux will adopt the identical live resource on reconcile (no churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
