### PR TITLE
fix(talos): drop grubUseUKICmdline:false once KSail folds extraKernelArgs into the schematic

### DIFF
--- a/talos/cluster/apparmor.yaml
+++ b/talos/cluster/apparmor.yaml
@@ -1,22 +1,14 @@
 machine:
   install:
+    # security=apparmor is baked into the Talos Image Factory schematic by KSail
+    # (>= the release carrying devantler-tech/ksail#5297): KSail reads this
+    # machine.install.extraKernelArgs, folds it into the schematic's
+    # customization.extraKernelArgs alongside the configured extensions, and then
+    # clears this (deprecated) field from the rendered config. The arg therefore
+    # rides the UKI's baked-in kernel cmdline, so install.grubUseUKICmdline must
+    # stay at its Talos >=1.12 default (true) — do NOT set it false here, or GRUB
+    # would build the cmdline host-side WITHOUT the UKI's security=apparmor.
+    # (This replaces the grubUseUKICmdline:false stopgap from #2099, which was only
+    # needed while the pre-#5297 KSail left extraKernelArgs in the rendered config.)
     extraKernelArgs:
       - security=apparmor
-    # MUST stay false while extraKernelArgs is set above.
-    #
-    # Talos >= 1.13.4 rejects a machine config that sets BOTH
-    # install.extraKernelArgs and install.grubUseUKICmdline=true:
-    #   "install.extraKernelArgs and install.grubUseUKICmdline can't be used together"
-    # and grubUseUKICmdline defaults to TRUE here — KSail generates this cluster's
-    # config with the Talos >=1.12 version contract, and that contract's default
-    # for grubUseUKICmdline is true (gated at >1.11). Without this explicit
-    # override the freshly-generated config carries extraKernelArgs + the
-    # defaulted grubUseUKICmdline:true, so the v1.13.4 installer fails validation
-    # mid-upgrade and `ksail cluster update` aborts on the first node.
-    #
-    # grubUseUKICmdline controls whether the legacy GRUB bootloader reuses the
-    # UKI's baked-in kernel cmdline instead of building one on the host. This
-    # cluster boots GRUB on Hetzner (no SecureBoot/UKI), so the cmdline MUST be
-    # built host-side to carry security=apparmor — which is exactly what
-    # grubUseUKICmdline:false selects.
-    grubUseUKICmdline: false


### PR DESCRIPTION
> ⛔ **GATED — DO NOT MERGE/DEPLOY until a KSail release carrying [devantler-tech/ksail#5297](https://github.com/devantler-tech/ksail/pull/5297) is out AND the `KSAIL_VERSION` pin (ci.yaml/cd.yaml) is bumped to it.** Deploying earlier re-breaks the cluster (see below).

## What this does

Removes the `install.grubUseUKICmdline: false` stopgap that [#2099](https://github.com/devantler-tech/platform/pull/2099) added to `talos/cluster/apparmor.yaml`, leaving just `machine.install.extraKernelArgs: [security=apparmor]`.

## Why it's needed (not just cleanup)

KSail [#5297](https://github.com/devantler-tech/ksail/pull/5297) changes how KSail handles `machine.install.extraKernelArgs`: it **folds** the args into the Image Factory schematic (`customization.extraKernelArgs`) and **clears** the deprecated field from the rendered config. The arg then rides the **UKI's baked-in kernel cmdline**.

With the arg in the UKI cmdline, `install.grubUseUKICmdline` must be at its `≥1.12` default (**true**) for GRUB to use it. The #2099 `grubUseUKICmdline: false` line tells GRUB to build the cmdline **host-side instead** — and since #5297 has cleared `machine.install.extraKernelArgs`, that host-side cmdline would **lack `security=apparmor`**. So leaving the stopgap in place after #5297 ships would silently **disable AppArmor**.

## ⛔ Sequencing — re-break risk

| State | apparmor.yaml | KSail | Result |
|---|---|---|---|
| Now (#2099 merged) | extraKernelArgs + `grubUseUKICmdline:false` | pre-#5297 (no fold) | ✅ apparmor host-side; upgrade OK |
| **This PR deployed too early** | extraKernelArgs only | pre-#5297 (no fold) | ❌ extraKernelArgs + default `grubUseUKICmdline:true` → **Talos ≥1.13.4 rejects** → upgrade aborts (the original bug) |
| This PR + KSAIL_VERSION≥#5297 | extraKernelArgs only | folds → schematic, clears field, `grubUseUKICmdline:true` | ✅ apparmor via UKI cmdline |

So this must land **atomically with / after** the `KSAIL_VERSION` bump to a #5297 release — ideally fold this one-line change into that bump PR. Until then it stays a draft.

## Background
Original incident + analysis in [#2099](https://github.com/devantler-tech/platform/pull/2099); the deprecated-field/`grubUseUKICmdline` conflict is [ksail#5295](https://github.com/devantler-tech/ksail/issues/5295), fixed by [ksail#5297](https://github.com/devantler-tech/ksail/pull/5297).

🤖 Generated with [Claude Code](https://claude.com/claude-code)