### PR TITLE
feat(autoscaler): enable native CapacityBuffer overprovisioning

### DIFF
--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -46,19 +46,17 @@ resources:
   # no real pods, so nothing sits Pending and it rides along here like any other
   # resource. Hetzner/prod-only (the autoscaler pools are Hetzner).
   #
-  # TEMPORARILY DISABLED (2026-06-16): the CapacityBuffer CRD
-  # (autoscaling.x-k8s.io/v1beta1) is installed by KSail only from a release that
-  # contains ksail#5277, but the pinned KSAIL_VERSION (7.58.3, ci.yaml/cd.yaml)
-  # predates it (5277 merged after the 7.58.3 release). So the CapacityBuffer CR
-  # fails server-side apply ("no matches for kind CapacityBuffer in version
-  # autoscaling.x-k8s.io/v1beta1"), which wedged the whole `infrastructure`
-  # Kustomization (and its `apps` dependent) — exactly the deploy-ordering gate
-  # that ksail.prod.yaml warns about. Re-enable this line once a KSail release
-  # with #5277 ships AND KSAIL_VERSION is bumped + deployed (so the CRD +
-  # controller exist before this CR reconciles). No over-provisioning headroom
-  # until then, which is acceptable — the old balloon-pod buffer was already
-  # removed in #2087.
-  # - overprovisioning/
+  # The CapacityBuffer CRD (autoscaling.x-k8s.io/v1beta1) + controller are
+  # installed by KSail only from a release that ships ksail#5277, first released
+  # in v7.59.0. The pinned KSAIL_VERSION is now 7.59.1 (ci.yaml/cd.yaml, bumped in
+  # #2097), so the gate is satisfied. Deploy ordering keeps the first apply safe:
+  # `ksail cluster update` (installs the CRD + controller) runs before `ksail
+  # workload reconcile` (applies this CR) in both cd.yaml and the ci.yaml
+  # merge-queue deploy, so the CRD always exists before Flux reconciles the
+  # CapacityBuffer — no "no matches for kind CapacityBuffer" wedge. (It was
+  # TEMPORARILY DISABLED 2026-06-16..#2097 while the pin still read 7.58.3, which
+  # predated #5277; the old balloon-pod buffer was already removed in #2087.)
+  - overprovisioning/
   #
   # NOTE: tenant-owned custom-domain TLS (the ascoachingogvaner.dk Certificate +
   # its simply.com DNS01 solver credential) is NOT a platform resource at all —


### PR DESCRIPTION
## What

Re-enable the native Cluster Autoscaler CapacityBuffer overprovisioning by uncommenting `- overprovisioning/` in the hetzner `infrastructure` kustomization. This delivers the `overprovisioning` namespace, the `PodTemplate`, and the `CapacityBuffer` CR that were added (disabled) in #2087 — restoring one warm spare node of scale-up headroom.

## Why

#2087 added the manifests and set `autoscaler.node.capacityBuffers: true` in `ksail.prod.yaml`, but left the resource commented out: the CapacityBuffer CRD + controller are installed by ksail only from a release shipping ksail#5277 — **first released in v7.59.0** — and the pinned `KSAIL_VERSION` was still 7.58.3. #2097 bumped the pin to **7.59.1** (≥ v7.59.0), so the gate is satisfied and this is the final step.

Verification that v7.59.1 ships #5277:
- ksail commit `e9d295db` = PR #5277 *"feat(autoscaler): add capacityBuffers knob for native CapacityBuffer overprovisioning"*, released in v7.59.0.
- `e9d295db` is an ancestor of tag `v7.59.1` (`gh api compare/e9d295db...v7.59.1` → `behind_by: 0`).
- The `autoscaler.node.capacityBuffers` config key and the installer wiring (both feature flags + RBAC + CRD via the chart's `extraObjects`) are present at v7.59.1.

## Reviewer notes

- **Deploy-ordering safe:** both `cd.yaml` and the `ci.yaml` merge-queue deploy run `ksail cluster update` (which installs the CRD + controller) **before** `ksail workload reconcile` (which applies the CR), so the CRD always exists before Flux reconciles the CapacityBuffer — no `no matches for kind CapacityBuffer` wedge.
- **No `wait: false` Kustomization / Kyverno exemption needed:** the native buffer reserves headroom as virtual, pod-less chunks (no real pods sit Pending), so it rides along in the `wait: true` infrastructure layer — unlike the old balloon ReplicaSet, whose expected-Pending pods forced a dedicated `wait: false` Kustomization and once held deploys red for ~30h.
- `ksail.prod.yaml` is **unchanged** — it already carried `capacityBuffers: true`, and it is a protected file.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/` builds and now includes the `CapacityBuffer` (`autoscaling.x-k8s.io/v1beta1`), `PodTemplate`, and `overprovisioning` namespace.
- `ksail workload validate` **and** `ksail --config ksail.prod.yaml workload validate` both pass — **314 files, exit 0** (the three overprovisioning files validate clean; no schema gap, no `skipKinds` required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
