### PR TITLE
fix(flagger): wire HA replica count to leaderElection.replicaCount

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -132,11 +132,12 @@ spec:
           #   * spire-server: HA needs a shared external datastore, not just
           #     replicas (its StatefulSet uses the built-in datastore) -- a
           #     deliberate single-node posture; revisit for HA separately.
-          # Left flagged ON PURPOSE (real signal, not exempted): flagger -- the
-          # comment above intends 3 for HA but it runs flagger_replicas:=1, a
-          # genuine HA gap to close by raising that var when memory allows; and
-          # the cert-manager simply-dns-webhook, part of the in-flight tenant-TLS
-          # rework.
+          # Left flagged ON PURPOSE (real signal, not exempted): the cert-manager
+          # simply-dns-webhook, part of the in-flight tenant-TLS rework. (flagger
+          # was previously flagged here too: flagger_replicas was set but wired to
+          # the chart's non-existent top-level replicaCount, so it silently ran 1;
+          # fixed by wiring it to leaderElection.replicaCount, so flagger now meets
+          # the floor and is no longer a real signal.)
           - resources:
               names:
                 - cluster-autoscaler-hetzner-cluster-autoscaler

--- a/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/flagger/helm-release.yaml
@@ -37,11 +37,19 @@ spec:
     meshProvider: gatewayapi:v1
 
     # HA: Flagger elects a single leader to drive canaries; the other replicas
-    # are warm standbys. leaderElection MUST be enabled before replicas > 1, or
-    # every replica double-drives each canary. require-replica-floor policy.
+    # are warm standbys. leaderElection.enabled MUST stay true before replicas >
+    # 1, or every replica double-drives each canary. require-replica-floor policy.
+    #
+    # The replica count MUST be set as leaderElection.replicaCount: this chart has
+    # NO top-level `replicaCount` (its values.yaml exposes the count only under
+    # leaderElection), so a top-level replicaCount is silently dropped by Helm and
+    # the Deployment renders replicas: 1. That is why flagger ran a single replica
+    # in prod despite flagger_replicas being "2" -- the HA gap require-replica-floor
+    # (#1882) kept flagging. Wiring flagger_replicas to leaderElection.replicaCount
+    # makes the value actually take effect.
     leaderElection:
       enabled: true
-    replicaCount: ${flagger_replicas:=1}
+      replicaCount: ${flagger_replicas:=1}
 
     # Reuse Coroot's bundled Prometheus (the metrics TSDB the coroot-operator
     # deploys, the same endpoint OpenCost queries). Coroot's eBPF node-agent

--- a/k8s/bases/infrastructure/controllers/flagger/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/flagger/pod-disruption-budget.yaml
@@ -7,9 +7,9 @@ spec:
   # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880).
   # The chart's own podDisruptionBudget value only offers minAvailable (the
   # shape validate-pdb-drain-safe flags), so the PDB is declared here instead.
-  # Flagger runs leader-elected (flagger_replicas: 3 in prod, warm standbys);
-  # bounding evictions to one pod at a time keeps a leader available while a
-  # canary analysis is in flight.
+  # Flagger runs leader-elected (flagger_replicas: 2 in prod, one leader + a warm
+  # standby); bounding evictions to one pod at a time keeps a leader available
+  # while a canary analysis is in flight.
   maxUnavailable: 1
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary

Flagger has been running a **single replica in prod** the whole time despite `flagger_replicas: "2"` being set in the prod cluster config — a silent HA single-point-of-failure that `require-replica-floor` (#1882) kept flagging.

### Root cause
The flagger chart (`1.43.0`) has **no top-level `replicaCount`** value. Its only replica knob is `leaderElection.replicaCount` (default `1`). The HelmRelease set:

```yaml
leaderElection:
  enabled: true
replicaCount: ${flagger_replicas:=1}   # ← silently ignored by the chart
```

Helm drops the unknown `replicaCount` key, so the Deployment always rendered `replicas: 1` — regardless of `flagger_replicas` being `"2"` (or, earlier, `"3"`). `leaderElection.enabled: true` was set, but with one pod a node drain can take the canary controller fully offline.

Proven with `helm template flagger/flagger --version 1.43.0`:

| values | rendered Deployment |
|---|---|
| `replicaCount=2` + `leaderElection.enabled=true` (old) | `replicas: 1` ❌ |
| `leaderElection.replicaCount=2` + `leaderElection.enabled=true` (new) | `replicas: 2` ✅ |

Live confirmation: the HelmRelease carried `replicaCount: 2` in `.spec.values` and reconcile succeeded (`flagger.v75`), yet the live Deployment was `spec.replicas: 1`.

### Fix
Wire `flagger_replicas` to `leaderElection.replicaCount` (where the chart actually reads it) and drop the dead top-level `replicaCount`. The per-cluster value is unchanged (`flagger_replicas`: `1` local default, `2` prod), so on the next reconcile prod flagger scales to 2 (one leader + a warm standby) and clears the policy violation.

Also synced two now-stale comments my fix invalidates (definition-of-done):
- the PDB comment said `flagger_replicas: 3 in prod` (it's `2`);
- `validate-replica-floor.yaml` listed flagger as an open "real signal" HA gap — now resolved (only `simply-dns-webhook` remains flagged there).

## Validation
- `kubectl kustomize k8s/clusters/{prod,local}/` ✅
- `kubectl kustomize k8s/bases/infrastructure/controllers/flagger/` ✅ (rendered HR now carries `leaderElection.replicaCount: ${flagger_replicas:=1}`)
- `ksail --config ksail.prod.yaml workload validate` ✅ (318 files)
- `kubectl apply --dry-run=client` on all 3 edited files ✅
- `helm template` behaviour proof above

Behaviour-preserving for local (default stays `1`); prod gains the second replica it was already configured (but failing) to run.

---

Found while investigating prod platform health (a sweep of Flux/Kyverno/pod state). Draft per repo convention — merging cuts a `fix` release and deploys to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)