### PR TITLE
fix(cnpg): exempt plugin-barman-cloud from the replica-floor policy

### DIFF
--- a/k8s/bases/infrastructure/controllers/plugin-barman-cloud/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/plugin-barman-cloud/helm-release.yaml
@@ -36,3 +36,15 @@ spec:
   # replica; raise replicaCount once the operator↔plugin path is verified if HA
   # is wanted (the operator retries, so a brief plugin restart only delays
   # backups, it does not drop the database).
+  values:
+    # Intentionally single-replica: this chart (0.7.0) exposes no leaderElection
+    # knob, so >1 replica would run two uncoordinated backup controllers. It is a
+    # controller off every request-serving path — a node drain only briefly
+    # interrupts backup reconciliation (the CNPG operator retries), never user
+    # traffic — so the require-replica-floor (#1882) HA floor of 2 is *wrong*
+    # here, exactly like the other single-by-design controllers it exempts
+    # (csi-snapshotter, longhorn-driver-deployer, …). Opt out with the policy's
+    # durable, self-documenting pod-template label rather than leaving a standing
+    # PolicyReport violation.
+    podLabels:
+      platform.devantler.tech/replica-floor: exempt


### PR DESCRIPTION
## Summary

`cnpg-system/plugin-barman-cloud` runs a single replica and is flagged by `require-replica-floor` (#1882, audit mode) on every background scan — a standing PolicyReport violation. This exempts it the documented way, because the floor is **wrong** for this workload, not merely unmet.

### Why exempt rather than scale to 2
- The chart (`plugin-barman-cloud` `0.7.0`) exposes **no leader-election knob** (verified via `helm show values`). A second replica would run **two uncoordinated backup controllers**, not an HA pair.
- The plugin is a CNPG backup controller, **off every request-serving path**. A node drain only briefly interrupts backup reconciliation — the CNPG operator retries, so backups are delayed, never dropped, and no user traffic is affected (the HelmRelease's own comment already documents this tolerance).

That is exactly the "single-by-design controller a floor is *wrong* for" category the policy **already** exempts (`csi-snapshotter`, `longhorn-driver-deployer`, the single-controller operators). `plugin-barman-cloud` is new (added in #2075/#2100, after that 2026-06-16 triage), so it uses the policy's documented escape hatch for "any new singleton": the durable, self-documenting `platform.devantler.tech/replica-floor: exempt` pod-template label, set chart-natively via `podLabels`.

### Fix
```yaml
values:
  podLabels:
    platform.devantler.tech/replica-floor: exempt
```
Reversible: if a future chart version adds leader election, drop the label and raise `replicaCount` for real HA.

## Validation
- `helm template … --set podLabels."platform\.devantler\.tech/replica-floor"=exempt` → label confirmed in the Deployment **pod template** (the path `require-replica-floor`'s precondition checks) ✅
- `kubectl kustomize k8s/clusters/{prod,local}/` ✅
- `kubectl kustomize k8s/bases/infrastructure/controllers/plugin-barman-cloud/` ✅
- `ksail --config ksail.prod.yaml workload validate` ✅ (318 files)
- `kubectl apply --dry-run=client` ✅

Behaviour-preserving (label-only; no replica/spec change).

---

Found during a prod platform health sweep (Flux/Kyverno/pod/Kubescape review). Companion to #2104 (flagger HA). Draft per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)