### PR TITLE
fix(kubescape): allow report.armo.cloud egress so posture scans persist

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
@@ -29,6 +29,13 @@ spec:
     # pod cannot exfiltrate to arbitrary external services:
     # - grype/toolbox-data.anchore.io — kubevuln's Grype vulnerability DB
     # - api.armosec.io                — Kubescape backend (version/artifacts)
+    # - report.armo.cloud            — posture/scan report ingestion. The
+    #   scanner POSTs each postureReport here as the final step of a config
+    #   scan; with this host missing the submit times out and the WHOLE scan
+    #   errors out ("failed to submit scan results … report.armo.cloud …
+    #   i/o timeout"), so NO config-scan results persist to the in-cluster
+    #   storage API and the cluster has a 0/blank compliance score. Same
+    #   trust domain as the already-allowed api.armosec.io.
     # - github.com + CDNs             — regolibrary / controls artifacts
     # If scan components log download failures, extend this list with the
     # missing host (failure mode is stale scan data, not an outage).
@@ -36,6 +43,7 @@ spec:
         - matchName: "grype.anchore.io"
         - matchName: "toolbox-data.anchore.io"
         - matchName: "api.armosec.io"
+        - matchName: "report.armo.cloud"
         - matchName: "github.com"
         - matchName: "api.github.com"
         - matchName: "objects.githubusercontent.com"


### PR DESCRIPTION
## Problem

Kubescape **configuration/posture scanning produces zero results** on prod — `workloadconfigurationscansummaries` / `configurationscansummaries` are empty in every namespace and the cluster compliance score is blank — even though the operator, scheduler and storage components are all healthy and `configurationScan` is enabled.

## Root cause (confirmed from scanner logs)

The scanner computes the posture locally (the log even prints `Overall compliance-score: 0`, `Failed: 8`) but its **final step POSTs the report to `report.armo.cloud`**, which is **not** in the `allow-kubescape` CiliumNetworkPolicy egress allow-list (only `api.armosec.io` is). The submit times out and the **whole scan is marked failed**, so results are never persisted to the in-cluster storage API:

```
{"level":"error","msg":"scanning failed",
 "error":"failed to submit scan results. reason: Post
  \"https://report.armo.cloud/k8s/v2/postureReport?...\":
  dial tcp 13.48.180.207:443: i/o timeout"}
```

Vulnerability (image) scanning is unaffected — it uses hosts already in the list.

## Fix

Add `report.armo.cloud` to the egress FQDN allow-list. It is the same ARMO trust domain as the already-allowed `api.armosec.io`, so it does **not** weaken the policy's anti-exfiltration model (FQDN-pinned, no `world:443`). This is precisely the maintenance the file documents: *"If scan components log download failures, extend this list with the missing host."*

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/` builds clean; `report.armo.cloud` renders into the policy, `api.armosec.io` retained.
- `ksail --config ksail.prod.yaml workload validate` → ✔ 318 files validated.

## Alternative considered

If sending posture data to the ARMO SaaS is **not** wanted, the alternative is to run Kubescape fully offline (disable cloud submission so results persist locally without the upload). I went with allowing the host because an ARMO account (`customerGUID`) is already configured and `api.armosec.io` is already permitted — i.e. ARMO integration is already in use. Happy to switch to the offline approach instead if you'd prefer no third-party submission.

> ⚠️ This won't reach prod until the CD pipeline is unblocked — it is currently failing on the unreachable `prod-control-plane-2` Talos API (separate report/PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)