### PR TITLE
fix(headlamp): allow release-assets.githubusercontent.com so plugins install

### DIFF
--- a/k8s/bases/apps/headlamp/networkpolicy.yaml
+++ b/k8s/bases/apps/headlamp/networkpolicy.yaml
@@ -23,6 +23,11 @@ spec:
     # from GitHub releases (helm-release.yaml). Pinned by FQDN instead of
     # world:443 so a compromised pod cannot exfiltrate to arbitrary
     # external services.
+    # github.com 302-redirects a release-asset download
+    # (github.com/<org>/<repo>/releases/download/...) to this release-asset
+    # CDN; without it every plugin archive fetch times out, the
+    # headlamp-plugin sidecar crashloops and the dashboard ships with no
+    # plugins. Same gap the kubescape policy already had to close.
     - toFQDNs:
         - matchName: "dex.${domain}"
         - matchName: "artifacthub.io"
@@ -30,6 +35,7 @@ spec:
         - matchName: "api.github.com"
         - matchName: "objects.githubusercontent.com"
         - matchName: "raw.githubusercontent.com"
+        - matchName: "release-assets.githubusercontent.com"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Problem

The `headlamp-plugin` sidecar **crashloops** (`BackOff restarting failed container headlamp-plugin`) — observed on prod and recurring across cold starts (headlamp is KEDA-scaled to zero, so it restarts on each access). The dashboard ends up with no plugins.

## Root cause (confirmed)

`pluginsManager` resolves plugin metadata on `artifacthub.io` then downloads each archive from a **GitHub release asset**. GitHub now **302-redirects** release-asset downloads (`github.com/<org>/<repo>/releases/download/...`) to **`release-assets.githubusercontent.com`**, which is **not** in the `allow-headlamp` CiliumNetworkPolicy egress list (it has `objects.githubusercontent.com` but not the release-asset CDN). The redirect target is blocked → the download hangs → the sidecar crashloops.

Verified the redirect directly:

```
$ curl -sI github.com/headlamp-k8s/plugins/releases/download/flux-0.6.0/headlamp-k8s-flux-0.6.0.tar.gz
302 -> https://release-assets.githubusercontent.com/github-production-release-asset/...
```

This is the **identical gap** the `allow-kubescape` policy already documents and closes for its regolibrary release-asset fetch.

## Fix

Add `release-assets.githubusercontent.com` to the egress FQDN allow-list — same GitHub trust domain as the already-allowed `*.githubusercontent.com` hosts, so the anti-exfiltration posture (FQDN-pinned, no `world:443`) is preserved.

## Validation

- `kubectl kustomize k8s/providers/hetzner/apps/` builds clean; `release-assets.githubusercontent.com` renders, `objects.githubusercontent.com` retained.
- `ksail --config ksail.prod.yaml workload validate` → ✔ 318 files validated.

> ⚠️ Won't reach prod until CD is unblocked (failing on the unreachable `prod-control-plane-2` Talos API — separate report/PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)