### PR TITLE
ci(cd): run Talos cluster-update last so a down node can't freeze delivery

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -121,12 +121,13 @@ jobs:
           echo "::error::Prod cluster (context admin@prod) is unreachable with the restored kubeconfig (last kubectl error: ${last_err}). KUBE_CONFIG (and likely TALOS_CONFIG) are probably stale after a cluster rebuild — refresh both and update the 'prod' environment secrets. See docs/dr/runbook.md → 'Refresh CI deploy credentials'."
           exit 1
 
-      - name: 🔄 Update cluster
-        run: ksail --config ksail.prod.yaml cluster update
-        env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-
+      # Publish the GitOps manifests (push → sign → attest → reconcile) BEFORE
+      # syncing Talos machine config (the "🔄 Update cluster" step now runs last).
+      # Manifest delivery never touches the nodes, so it must not be gated on
+      # every control-plane node being reachable: when one node's Talos API was
+      # down, `ksail cluster update` ran first, hard-failed the job, and froze
+      # ALL app/config delivery to an otherwise-healthy cluster (the apiserver
+      # and Flux were fine on the two surviving control-plane nodes).
       - name: 📦 Push manifests to GHCR
         run: ksail --config ksail.prod.yaml workload push
         env:
@@ -319,3 +320,16 @@ jobs:
           echo "::group::Recent events (warnings)"
           kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -50
           echo "::endgroup::"
+
+      - name: 🔄 Update cluster (Talos machine config)
+        # Runs LAST, after manifest delivery, so an unreachable control-plane
+        # node cannot block GitOps delivery (see the Push step's comment). Talos
+        # config sync still runs on every deploy and a genuine node-reachability
+        # problem still fails the deploy (red) — it just no longer takes the
+        # app/config pipeline down with it. Automatically skipped if an earlier
+        # delivery step already failed (no point syncing nodes for a broken
+        # release).
+        run: ksail --config ksail.prod.yaml cluster update
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}


### PR DESCRIPTION
## Problem (observed on prod today)

The `🚀 Deploy to Production` job runs steps sequentially in this order:

1. setup + `🩺 Verify prod cluster is reachable` (checks only the **K8s API**, which was up via CP-1/CP-3)
2. **`🔄 Update cluster`** → `ksail cluster update` (syncs Talos machine config to **all** control-plane nodes)
3. `📦 Push manifests to GHCR` → `ksail workload push`
4. cosign sign / SBOM / attest / `🔁 Trigger Flux reconciliation`

`prod-control-plane-2`'s Talos API (`:50000`) is down, so step 2 fails:

```
✗ talos.config: fetch running config: retries exhausted: ...
  dial tcp 178.105.202.211:50000: connect: connection refused
```

…and because it's step 2, **steps 3–4 never run**. The OCI manifest artifact is never republished, so prod is frozen on a stale artifact and **every merge to `main` stops reaching the cluster** — even though the apiserver and Flux are perfectly healthy on the two surviving control-plane nodes. The last 3 CD runs all failed this way.

## Fix

Reorder so GitOps delivery (**push → sign → attest → reconcile**) happens first and the Talos machine-config sync (`🔄 Update cluster`) runs **last**. Manifest publishing never touches the nodes, so it shouldn't be gated on every control-plane node being reachable.

- A genuine Talos/node problem **still fails the deploy** (the step still runs and still goes red) — it just no longer takes the app/config delivery pipeline down with it.
- The step is auto-skipped if an earlier delivery step failed (no point syncing nodes for a broken release).

## Trade-off (flagging for your call)

For the rare release that changes Talos machine config **and** ships a manifest depending on it, manifests now deliver slightly before the node config (Flux reconcile is async anyway). The far more common case — app/config-only releases — becomes resilient to a single unreachable node. The previous order fails-closed for *all* releases whenever any one node is unreachable, which is strictly worse for the common case.

An alternative is splitting into two independent jobs (`publish` + `talos-sync`); I went with the minimal in-job reorder since it solves the freeze with a small, reviewable diff. Happy to do the two-job split instead if you prefer.

## Validation

- YAML parses; step order verified (`Update cluster` now the final step, single occurrence).
- This change does not affect `ksail workload validate` (✔ 318 files).

> Note: the underlying outage — `prod-control-plane-2` Talos API down — still needs operator recovery (Hetzner power-cycle / Talos inspect). This PR stops that outage from also freezing GitOps delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)