### PR TITLE
fix(cd): add manual workflow_dispatch deploy trigger

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,9 +1,18 @@
 name: CD
 
 on:
+  # Release-tag deploys: semantic-release tags a version on every fix/feat/perf
+  # merge, which publishes + signs the manifests and reconciles Flux.
   push:
     tags:
       - 'v*'
+  # Manual deploy of the current default branch — the recovery/escape hatch for
+  # when the tag-driven path can't ship a known-good main: e.g. a CD-pipeline
+  # fix lands as a non-releasing commit (ci:/chore: cut no semantic-release tag,
+  # so the change sits in main undeployed), or an incident froze release deploys.
+  # Still gated by the `prod` environment approval and the shared prod-deploy
+  # concurrency group below; checks out and ships main HEAD.
+  workflow_dispatch: {}
 
 permissions: {}
 


### PR DESCRIPTION
## Problem

Prod GitOps delivery is **frozen** and there is **no way to ship a known-good `main`** short of recovering the down node:

1. `prod-control-plane-2`'s Talos API is unreachable, so the tag-driven CD deploy fails (this is what #2113 addresses).
2. The decouple fix **#2113 is merged to `main` but undeployed** — it landed as a `ci(cd):` commit, and semantic-release (default rules) **does not cut a release for `ci:`**, so no tag → no CD run → the reorder never took effect.
3. CD only triggers on `push: tags: v*`. With the auto-release path blocked, there is **no manual lever** to deploy current `main`.

Net effect: the whole merged backlog (the kubescape/headlamp egress fixes #2111/#2112, the flagger/barman replica-floor fixes, etc.) is sitting in `main` but **not on the cluster** — the deployed OCI artifact is still `fc6141d6` from 10:22 UTC.

## Fix

Add a `workflow_dispatch` trigger to CD so the current default branch can be deployed on demand — the standard recovery/escape hatch for a release-tag-driven pipeline. It stays gated by the `prod` environment approval and the shared `prod-deploy` concurrency group, and ships `main` HEAD.

## Why this also unblocks prod immediately

This commit is a **`fix:`**, so merging it cuts a release. That release's CD run checks out a `main` that now contains **#2113's reorder**, so it publishes → signs → reconciles **before** the Talos `cluster update` step — i.e. it ships the frozen backlog to prod **even though `prod-control-plane-2` is still down**. (The `Update cluster` step will still go red until the node is recovered — that remains a separate operator action.)

After this lands you can also just hit **Run workflow** on CD anytime to redeploy `main`.

## Validation

- `yamllint` clean; both triggers present (`push: tags` + `workflow_dispatch`).
- Pure trigger addition; no permission or step changes.

> Root cause still open separately: `prod-control-plane-2` Talos API down (needs Hetzner power-cycle / Talos console). etcd is 2/3 — quorum holds, zero fault tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)