### PR TITLE
fix(kubescape): run posture scanning offline so config-scan results persist

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -24,6 +24,19 @@ spec:
       continuousScan: enable
       vulnerabilityScan: enable
       runtimeDetection: enable
+      # Run posture/config scanning OFFLINE (air-gapped). This cluster has no
+      # ARMO SaaS account, but the chart defaults to submit-mode: the scanner
+      # POSTs each posture report to report.armo.cloud and treats the submit as
+      # a terminal step. With no account that submit fails ("400 missing account
+      # id"), which ABORTS the scan before results are written — so NO
+      # config-scan CRs (workloadconfigurationscansummaries /
+      # configurationscansummaries) ever persist and the cluster compliance
+      # score stays 0. Offline mode skips the cloud submit and persists results
+      # straight to the in-cluster storage component (storage:true,
+      # keepLocal:true are already set), restoring posture scanning + findings.
+      # Vulnerability scanning (kubevuln) is unaffected — it never gated on the
+      # cloud submit.
+      kubescapeOffline: enable
     hostScanner:
       enabled: true
     nodeAgent:

--- a/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/networkpolicy.yaml
@@ -28,14 +28,15 @@ spec:
     # External endpoints, pinned by FQDN instead of world:443 so a compromised
     # pod cannot exfiltrate to arbitrary external services:
     # - grype/toolbox-data.anchore.io — kubevuln's Grype vulnerability DB
-    # - api.armosec.io                — Kubescape backend (version/artifacts)
-    # - report.armo.cloud            — posture/scan report ingestion. The
-    #   scanner POSTs each postureReport here as the final step of a config
-    #   scan; with this host missing the submit times out and the WHOLE scan
-    #   errors out ("failed to submit scan results … report.armo.cloud …
-    #   i/o timeout"), so NO config-scan results persist to the in-cluster
-    #   storage API and the cluster has a 0/blank compliance score. Same
-    #   trust domain as the already-allowed api.armosec.io.
+    # - api.armosec.io                — Kubescape backend (version check only;
+    #   vestigial under offline mode, kept harmless — its failure mode is a
+    #   skipped version check, not an outage).
+    #   NOTE: report.armo.cloud (ARMO posture-report ingestion) is deliberately
+    #   NOT allowed — the operator runs OFFLINE (capabilities.kubescapeOffline:
+    #   enable, see helm-release.yaml), so config-scan results persist to the
+    #   in-cluster storage component instead of being POSTed to ARMO. There is
+    #   no ARMO account, so the submit only ever 400'd "missing account id" and
+    #   aborted the scan; offline mode removes that dependency entirely.
     # - github.com + CDNs             — regolibrary / controls artifacts
     # If scan components log download failures, extend this list with the
     # missing host (failure mode is stale scan data, not an outage).
@@ -43,7 +44,6 @@ spec:
         - matchName: "grype.anchore.io"
         - matchName: "toolbox-data.anchore.io"
         - matchName: "api.armosec.io"
-        - matchName: "report.armo.cloud"
         - matchName: "github.com"
         - matchName: "api.github.com"
         - matchName: "objects.githubusercontent.com"


### PR DESCRIPTION
## Problem

Kubescape **posture/configuration scanning still produces zero results** on prod — `workloadconfigurationscansummaries` / `configurationscansummaries` are empty and the cluster compliance score is **0** — even after the egress fix (#2111) that this supersedes.

## Root cause (confirmed from scanner logs)

#2111 correctly unblocked the `report.armo.cloud` connection (the i/o timeout is gone), but that only **revealed a second, pre-existing blocker**: the operator defaults to **ARMO-cloud submit mode**, and the scanner treats the cloud POST as a terminal step. This cluster has **no ARMO account**, so the submit now fails:

```
"scanning failed" ... "failed to submit scan results. reason:
 http-error: '400 Bad Request', reason: 'missing account id'"
```

That error **aborts the scan before results are written**, so no config-scan CRs ever persist to the in-cluster `storage` component — despite `storage:true` / `keepLocal:true` being set. (Vulnerability scanning via `kubevuln` is unaffected; it never gated on the submit.)

## Fix

Set **`capabilities.kubescapeOffline: enable`** — the chart's air-gapped/offline mode. The scanner skips the ARMO submit and persists posture results straight to the in-cluster storage component, restoring compliance scoring + per-workload findings. This matches the platform's self-hosted, no-third-party-egress posture (there is no ARMO account to submit to).

Also **remove `report.armo.cloud` from the `allow-kubescape` egress** — it was added in #2111 to make the submit work, but offline mode removes the submit entirely, so it's now dead config. Kept `api.armosec.io` (harmless vestigial version check); regolibrary controls still pull from GitHub.

## Validation

- Deployed chart **1.40.2 recognizes the capability** (live `ks-capabilities` shows `kubescapeOffline: disable` today).
- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/` builds clean: `kubescapeOffline: enable` renders, `report.armo.cloud` gone, regolibrary/anchore egress retained.
- `ksail --config ksail.prod.yaml workload validate` → ✔ 318 files.

After this deploys, posture results should populate (re-check `configurationscansummaries -A`); the per-workload HIGH/CRITICAL control findings can then be triaged for follow-up hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)