### PR TITLE
ci(deps): re-pin ksail-cluster action to its v7.61.0 tag commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           remove_folders: "/usr/share/swift /usr/share/miniconda /usr/share/az* /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli /usr/share/gradle"
 
       - name: 🧪 System Test
-        uses: devantler-tech/ksail/.github/actions/ksail-cluster@e9d295dbc161d38b8079bcd4fe113f74829b83ab # v7.59.0
+        uses: devantler-tech/ksail/.github/actions/ksail-cluster@ac3518f1e47d1e3ce38dfdf200dd58716e075c54 # v7.61.0
         with:
           distribution: Talos
           provider: Docker


### PR DESCRIPTION
## Problem

[#2107](https://github.com/devantler-tech/platform/pull/2107) fails the `zizmor` (GitHub Advanced Security) check with:

> `action's hash pin has mismatched or missing version comment: points to commit 0d0049356346`

This is **not** a one-off bad Dependabot PR — it's the symptom of an orphaned pin on `main`.

## Root cause

On `main`, the System Test step pins the ksail composite action at:

```yaml
uses: devantler-tech/ksail/.github/actions/ksail-cluster@e9d295dbc161d38b8079bcd4fe113f74829b83ab # v7.59.0
```

But `e9d295db` **is not the `v7.59.0` tag** — it's a never-tagged commit, 9 commits behind it. Timeline:

1. Dependabot [#2066](https://github.com/devantler-tech/platform/pull/2066) ("7.57.0 → 7.59.0") pinned `e9d295db` (committed `2026-06-16 07:58`) when `v7.59.0` briefly pointed there.
2. Upstream **`devantler-tech/ksail` re-cut the release**: the `v7.59.0` git tag was moved to `0d004935` (committed `2026-06-16 17:49`) and its **GitHub Release deleted** (releases now skip from `v7.58.3` straight to `v7.59.1`; `v7.59.0` returns 404).
3. The pinned SHA `e9d295db` now maps to **no tag**. Dependabot loses the version mapping and falls back to **following ksail's default-branch `HEAD` by raw SHA** — that's [#2107](https://github.com/devantler-tech/platform/pull/2107) (`e9d295db → b3d09cd`, ksail's `main` HEAD), keeping the stale `# v7.59.0` comment.
4. zizmor's `ref-version-mismatch` (and underlying `stale-action-refs`) audits flag the comment↔commit↔tag mismatch.

Renovate doesn't touch this line (`"github-actions": { "enabled": false }`); the action pin is owned exclusively by Dependabot, so re-anchoring it here is the correct lever.

## Fix

Re-pin to `v7.61.0`'s **actual tag commit** with a matching comment:

```yaml
uses: devantler-tech/ksail/.github/actions/ksail-cluster@ac3518f1e47d1e3ce38dfdf200dd58716e075c54 # v7.61.0
```

- ✅ Clears the zizmor `ref-version-mismatch` / `stale-action-refs` findings (SHA now matches the `v7.61.0` tag the comment names).
- ✅ Re-anchors Dependabot to normal **semver tag-tracking** (it bumps SHA + comment in lockstep again, as it did v7.24.0 → v7.27.2), so this can't silently drift into HEAD-following again.
- ✅ Brings the System Test action into lockstep with the CLI `KSAIL_VERSION` pin (already `7.61.0`).

**Supersedes [#2107](https://github.com/devantler-tech/platform/pull/2107)** — once this lands, the action is at the latest real tag and Dependabot's HEAD-following PR is obsolete.

## Validation

Reproduced and verified with the same audit CI runs, `zizmor 1.25.2`:

- **Before** (`e9d295db # v7.59.0`): `warning[ref-version-mismatch] ... points to commit 0d0049356346` at `ci.yaml:70:109` — exact CI failure. Plus `help[stale-action-refs]: commit hash does not point to a Git tag`.
- **After** (`ac3518f1 # v7.61.0`): both findings gone.

The CI System Test exercises this exact action version on this PR.