### PR TITLE
fix(simply-dns-webhook): run 2 replicas with a drain-safe PDB

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/helm-release.yaml
@@ -20,6 +20,15 @@ spec:
         name: simply-dns-webhook
   # https://github.com/RunnerM/simply-dns-webhook/blob/master/deploy/simply-dns-webhook/values.yaml
   values:
+    # Run 2 replicas (HA) so the drain-safe PDB (pod-disruption-budget.yaml)
+    # keeps the DNS01 solver available through a node drain, and to satisfy the
+    # validate-replica-floor policy (it was the one workload still flagged). The
+    # solver is a stateless Go webhook — cert-manager calls it via its Service
+    # during ACME DNS01 challenges — so extra replicas just load-balance, no
+    # coordination needed. Hardcoded (not the ${..._replicas} cluster-config
+    # pattern) because this controller is hetzner/prod-only with no other
+    # environment to tune it for.
+    replicaCount: 2
     # Don't override groupName: the chart's challenge-management ClusterRole
     # hardcodes this group, so a custom one breaks the solver's RBAC.
     groupName: com.github.runnerm.cert-manager-simply-webhook

--- a/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - networkpolicy.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/pod-disruption-budget.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook/pod-disruption-budget.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: simply-dns-webhook
+  namespace: cert-manager
+spec:
+  # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 keeps the node
+  # drainable at any replica count, unlike minAvailable: 1 which deadlocks a
+  # drain when only 1 replica is ready. The chart ships no PDB knob, so this is
+  # a standalone manifest (same approach as origin-ca-issuer). Pairs with
+  # replicaCount: 2 in helm-release.yaml: the second replica is a warm standby
+  # that keeps DNS01 challenge validation available while a node drains.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      # The runnerm/simply-dns-webhook chart labels its Deployment/pods with the
+      # legacy app + release keys (not app.kubernetes.io/*), so the PDB selector
+      # must match those.
+      app: simply-dns-webhook
+      release: simply-dns-webhook


### PR DESCRIPTION
## Problem

`cert-manager/simply-dns-webhook` runs a **single replica with no PodDisruptionBudget**, so it was the one workload still failing the `validate-replica-floor` Kyverno policy (firing a `PolicyViolation` warning event every ~30–60s on prod). The policy comment notes it was *"left flagged on purpose… part of the in-flight tenant-TLS rework"* — this resolves it properly rather than exempting it.

A single replica also means an ACME **DNS01 challenge can't be solved while its one node drains** (the webhook is down for the duration), which can stall certificate issuance/renewal during routine node maintenance.

## Fix

- **`replicaCount: 2`** in the HelmRelease — the chart's Deployment honours `.Values.replicaCount` (it was unset → defaulted to 1). The solver is a stateless Go webhook (cert-manager calls it via its `Service` during DNS01 challenges), so a second replica just load-balances; no coordination needed.
- **Drain-safe PDB** (`maxUnavailable: 1`) as a standalone manifest — the chart ships no PDB knob, so this follows the same pattern as `origin-ca-issuer`. Selector matches the chart's legacy `app` + `release` pod labels (same selector the existing `allow-simply-dns-webhook` CiliumNetworkPolicy uses).

Hardcoded `replicaCount: 2` rather than the `${..._replicas}` cluster-config var pattern because this controller is **hetzner/prod-only** (no other environment to tune it for); happy to switch to the var pattern if preferred.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/simply-dns-webhook` builds clean; renders the HelmRelease with `replicaCount: 2` and the PDB with the correct selector.
- After rollout: `validate-replica-floor` should stop flagging `simply-dns-webhook`, and the deployment runs 2/2 with a drain-safe PDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
