### PR TITLE
fix(flux): run controllers HA (active/standby) for node-failure resilience

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -38,18 +38,40 @@ spec:
           - op: add
             path: /spec/template/spec/containers/0/args/-
             value: --requeue-dependency=5s
-      # Spread the four Flux controllers across worker nodes. They are
-      # single-replica Deployments that all carry app.kubernetes.io/part-of=flux,
-      # so a per-controller topology spread keyed on that label distributes the
-      # set (skew <= 1) instead of letting the scheduler stack them on one node.
+      # Run the four Flux controllers active/standby (HA) for node-failure
+      # resilience. Each controller binary already runs with
+      # --enable-leader-election and holds a coordination.k8s.io Lease, so it is
+      # safe to run more than one replica: exactly one pod is the active leader
+      # and the other is a warm standby that acquires the Lease and resumes
+      # reconciliation within the lease TTL when the leader's node fails. The
+      # upstream Deployments ship replicas: 1, which is why Coroot flags each
+      # controller as "single instance - not resilient to node failure"; bumping
+      # to 2 clears that. Patched by label so the one rule covers
+      # source-/kustomize-/helm-/notification-controller (all carry
+      # app.kubernetes.io/part-of=flux). Paired with the topologySpread below so
+      # the two replicas land on different nodes — otherwise both could sit on
+      # the node that fails. flux-operator itself is left single-replica: its
+      # chart does not expose replicas/leaderElection (0.50.0), so it relies on
+      # reschedule, not hot standby; see flux-operator/helm-release.yaml.
+      - target:
+          kind: Deployment
+          labelSelector: app.kubernetes.io/part-of=flux
+        patch: |
+          - op: replace
+            path: /spec/replicas
+            value: 2
+      # Spread the four Flux controllers across worker nodes. They all carry
+      # app.kubernetes.io/part-of=flux, so a per-controller topology spread
+      # keyed on that label distributes the set (skew <= 1) — and, combined with
+      # the replicas: 2 patch above, keeps each controller's active and standby
+      # pods on different nodes instead of letting the scheduler stack them.
       # On 2026-05-28 kustomize-controller landed on prod-worker-2 when that
       # node's Cilium ClusterIP datapath degraded after an OOMKill; it then
       # crash-looped on "dial tcp 10.96.0.1:443: i/o timeout" and GitOps
       # reconciliation stalled — so the fix for the underlying OOM could not be
       # applied (a deadlock GitOps cannot self-heal from). Keeping the
       # controllers spread means a single bad worker cannot decapitate
-      # reconciliation. Soft (ScheduleAnyway) so it never blocks scheduling on
-      # the capacity-constrained 3-worker cluster.
+      # reconciliation. Soft (ScheduleAnyway) so it never blocks scheduling.
       - target:
           kind: Deployment
           labelSelector: app.kubernetes.io/part-of=flux


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Coroot flags the `flux-system` controllers — **source-controller, kustomize-controller, helm-controller, notification-controller** (and flux-operator) — as **"single instance - not resilient to node failure"**. The upstream Flux Deployments ship `replicas: 1`, so a worker-node failure that hosts a controller pod stalls that controller until the pod is rescheduled.

## Chosen HA mechanism: leader-elected hot standby (`replicas: 2`)

Flux HA is **not** a naïve `replicas: 2` on an arbitrary workload — the controllers are single-leader by design. But each Flux controller binary **already runs with `--enable-leader-election`** and holds a `coordination.k8s.io` Lease (verified against the upstream manager Deployments — e.g. [kustomize-controller `config/manager/deployment.yaml`](https://github.com/fluxcd/kustomize-controller/blob/main/config/manager/deployment.yaml): container `manager`, `--enable-leader-election`, `replicas: 1`; source-/helm-/notification-controller are identical). This is the documented Flux scaling model — see the Flux [horizontal scaling / sharding docs](https://fluxcd.io/flux/installation/configuration/sharding/) and the flux-operator [FluxInstance API](https://fluxcd.control-plane.io/operator/fluxinstance/).

So running **2 replicas** gives an **active leader + warm standby**: exactly one pod holds the Lease and reconciles; if the leader's node fails, the standby acquires the Lease and resumes within the lease TTL. This directly clears the Coroot "single instance" risk for all four controllers with minimal blast radius.

I considered **horizontal sharding** (`FluxInstance.spec.sharding`) — but that is the *throughput-scaling* path (it spreads tens-of-thousands of objects across extra controller deployments and requires labelling resources with a `sharding.fluxcd.io/key`), not the node-failure-resilience path, and would be a much larger, behaviour-changing epic. Leader-elected replicas is the correct, lowest-risk fix for *this* problem.

## Exactly what was patched

In `k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml`, added one patch to `FluxInstance.spec.kustomize.patches`:

```yaml
- target:
    kind: Deployment
    labelSelector: app.kubernetes.io/part-of=flux
  patch: |
    - op: replace
      path: /spec/replicas
      value: 2
```

- The `app.kubernetes.io/part-of=flux` selector means the single rule covers **source-controller, kustomize-controller, helm-controller, and notification-controller** — the four installed components (image-reflector/image-automation are not installed; tenants use native OCIRepository semver).
- The **existing `topologySpreadConstraints`** (already in the file) is what keeps each controller's two replicas on **different nodes** — otherwise both could land on the node that fails. Kept **soft (`ScheduleAnyway`)** on purpose: a hard constraint could leave the standby unschedulable during the very node outage we're hardening against. Updated the surrounding comments accordingly (the cluster is no longer the capacity-constrained 3-worker box the old comment described).

### What is NOT changed, and why

**flux-operator** is intentionally left **single-replica**. Its Helm chart (`0.50.0`) exposes **no** replica-count or leader-election toggle (only `web.serverReplicas` for the standalone web UI), and its own guidance points at single-replica installs (`strategy: Recreate`). Running it 2× **without** leader election would mean two operators reconciling in parallel — unsafe. It therefore relies on **rescheduling** on node failure, not hot standby. Making the operator itself HA needs upstream chart support (leader election) and is out of scope here — flagging it as the remaining gap.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/flux-instance` **renders clean** (exit 0, no warnings); the `replicas: 2` patch appears correctly inside the rendered `FluxInstance`.
- **Static validation only** — I cannot apply to the cluster. **This needs validation on a live Flux reconcile before promotion**: confirm the operator re-renders each controller Deployment to `replicas: 2`, both pods schedule on separate nodes, exactly one becomes Lease leader, and the Coroot "single instance" flag clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)