### PR TITLE
fix(keda): run http-add-on controller-manager and metrics-apiserver HA

### DIFF
--- a/k8s/bases/infrastructure/controllers/keda-http-add-on/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/keda-http-add-on/helm-release.yaml
@@ -30,6 +30,26 @@ spec:
     securityContext:
       runAsGroup: 1000
       privileged: false
+    operator:
+      # The http-add-on operator (Deployment keda-add-ons-http-controller-manager)
+      # reconciles HTTPScaledObjects. It runs controller-runtime leader election
+      # (the rendered Deployment passes `--leader-elect` and the chart grants
+      # coordination.k8s.io/leases RBAC), so 2 replicas are active/standby: only
+      # the leader reconciles, the second is a warm standby that takes over on a
+      # node failure/drain. Coroot flagged the single replica as "single instance
+      # - not resilient to node failure".
+      replicas: ${keda_http_operator_replicas:=1}
+      # Soft hostname spread so the standby lands on a different node than the
+      # leader (chart default is no spread). ScheduleAnyway keeps it a preference
+      # so single-node local/CI clusters still schedule.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: keda-http-add-on
+              app.kubernetes.io/component: operator
     scaler:
       replicas: ${keda_scaler_replicas:=1}
       # Soft hostname spread: the scaler's queue pinger polls every interceptor

--- a/k8s/bases/infrastructure/controllers/keda-http-add-on/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/keda-http-add-on/pod-disruption-budget.yaml
@@ -15,3 +15,22 @@ spec:
     matchLabels:
       app.kubernetes.io/component: scaler
       app.kubernetes.io/instance: keda-http-add-on
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keda-add-ons-http-controller-manager
+  namespace: keda
+spec:
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880).
+  # The chart ships a PDB for the interceptor (interceptor.pdb, enabled by
+  # default) but exposes no PDB knob for the operator/controller-manager, which
+  # is leader-elected (active/standby) and reconciles every HTTPScaledObject.
+  # Without a PDB a node drain could evict both replicas at once and stall HTTP
+  # app reconciliation. Selector mirrors the controller-manager Deployment's
+  # stable labels (component + instance).
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: operator
+      app.kubernetes.io/instance: keda-http-add-on

--- a/k8s/bases/infrastructure/controllers/keda/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/keda/helm-release.yaml
@@ -23,6 +23,17 @@ spec:
       install: true
     operator:
       replicaCount: ${keda_operator_replicas:=1}
+    metricsServer:
+      # The metrics-apiserver is a Kubernetes aggregated API server
+      # (group external.metrics.k8s.io, served behind an APIService) — stateless
+      # and load-balanced by the aggregation layer, so it does NOT use leader
+      # election: the operator drives scaling decisions, the metrics server only
+      # serves metric reads. The chart documents that extra replicas don't add
+      # throughput but DO reduce downtime through a node failure/drain
+      # (https://keda.sh/docs/latest/operate/cluster/#high-availability), so a
+      # second replica is a warm standby. Coroot flagged the single replica as
+      # "single instance - not resilient to node failure".
+      replicaCount: ${keda_metrics_server_replicas:=1}
     webhooks:
       replicaCount: ${keda_webhooks_replicas:=1}
     # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 never deadlocks a
@@ -36,3 +47,15 @@ spec:
         maxUnavailable: 1
       webhooks:
         maxUnavailable: 1
+    # Soft hostname spread so a second metrics-apiserver replica lands on a
+    # different node (the chart defaults to no spread, which packs both onto one
+    # node and defeats the HA intent). ScheduleAnyway keeps it a preference so
+    # single-node local/CI clusters still schedule.
+    topologySpreadConstraints:
+      metricsServer:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: keda-operator-metrics-apiserver

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -28,6 +28,13 @@ data:
   keda_webhooks_replicas: "2"
   keda_scaler_replicas: "2"
   keda_interceptor_min_replicas: "2"
+  # keda_metrics_server_replicas drives the KEDA metrics-apiserver (aggregated
+  # external.metrics.k8s.io API server — stateless, no leader election);
+  # keda_http_operator_replicas drives the http-add-on controller-manager
+  # (leader-elected, active/standby). Both were single-replica and flagged by
+  # Coroot as "single instance - not resilient to node failure".
+  keda_metrics_server_replicas: "2"
+  keda_http_operator_replicas: "2"
   # --- Leader-elected operators (2 replicas for HA; the require-replica-floor minimum) ---
   # One replica is active; the other is a warm standby that takes over on a node
   # failure/drain. velero stays 1 — its chart hardcodes replicas: 1 and it has


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Coroot flagged two single-replica KEDA control-plane components as **"single instance - not resilient to node failure"**:

1. **`keda-add-ons-http-controller-manager`** — the KEDA http-add-on operator (reconciles `HTTPScaledObject`s). Was `operator.replicas: 1`.
2. **`keda-operator-metrics-apiserver`** — the KEDA metrics-apiserver. Was `metricsServer.replicaCount: 1`.

A single replica means a node failure/drain (or a VPA `InPlaceOrRecreate` eviction) takes the component fully offline until it reschedules. The cluster is **not** resource-constrained, so both are scaled to 2 for HA — matching the existing replica-floor convention already applied to the keda operator, webhooks, HTTP scaler and interceptor.

## Verification that scaling is HA-safe (per component)

Both scales were verified safe *before* shipping — running 2 replicas of a controller that isn't leader-elected would mean two active controllers fighting, which is **not** done here:

- **`keda-add-ons-http-controller-manager` — leader-elected (active/standby).** `helm template keda-add-ons-http --version 0.14.1 --set operator.replicas=2` renders a Deployment whose container passes `--leader-elect`, and the chart grants `coordination.k8s.io` / `leases` RBAC. So with 2 replicas only the leader reconciles `HTTPScaledObject`s; the second is a warm standby that takes over on failure/drain. Safe.
- **`keda-operator-metrics-apiserver` — stateless aggregated API server.** It serves the `external.metrics.k8s.io` API behind an `APIService` (`group: external.metrics.k8s.io` in the rendered manifest) and is load-balanced by the Kubernetes aggregation layer — it does **not** drive scaling decisions (the operator does), so it needs no leader election. The chart's own values doc says extra replicas don't add throughput but **do reduce downtime** through a node failure ([KEDA HA docs](https://keda.sh/docs/latest/operate/cluster/#high-availability)). Safe.

Nothing was left at 1 replica — both components are leader-elected/stateless-HA-safe.

## What changed

Using the repo's `${keda_*_replicas:=N}` cluster-config var pattern (default 1 in the base HelmRelease; prod value `"2"`):

| Component | Replica var | HelmRelease value | PDB | topologySpread |
|---|---|---|---|---|
| http-add-on controller-manager | `keda_http_operator_replicas` | `operator.replicas` | new standalone `keda-add-ons-http-controller-manager` PDB (`maxUnavailable: 1`) | `operator.topologySpreadConstraints` (maxSkew 1, hostname, ScheduleAnyway) |
| metrics-apiserver | `keda_metrics_server_replicas` | `metricsServer.replicaCount` | chart's `podDisruptionBudget.metricServer` (already present) | `topologySpreadConstraints.metricsServer` (maxSkew 1, hostname, ScheduleAnyway) |

- The http-add-on chart exposes a PDB knob only for the interceptor, so the controller-manager gets a **standalone PDB** appended to the existing `pod-disruption-budget.yaml` (already wired into the component's `kustomization.yaml`), mirroring the existing external-scaler PDB.
- The keda chart already had `podDisruptionBudget.metricServer.maxUnavailable: 1`, so only the replica count + topology spread were added there.
- `whenUnsatisfiable: ScheduleAnyway` keeps the spread a *preference* so single-node local/CI clusters still schedule.

## Validation

`kubectl kustomize` passes (exit 0, no errors) on both changed base dirs:

- `k8s/bases/infrastructure/controllers/keda` → metrics-apiserver `replicaCount` placeholder + `metricsServer` topology spread render; `metricServer` PDB intact.
- `k8s/bases/infrastructure/controllers/keda-http-add-on` → operator `replicas` placeholder + operator topology spread render; **2** `PodDisruptionBudget`s (controller-manager + external-scaler).

Flux substitutes the `${...}` placeholders with the prod config-map values (`"2"`) at apply time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)