### PR TITLE
docs(kubescape): document why control-plane components stay single-replica

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -18,6 +18,31 @@ spec:
         name: kubescape
   # https://github.com/kubescape/helm-charts/blob/main/charts/kubescape-operator/values.yaml
   values:
+    # HA: the kubescape-operator chart is single-replica by design — Coroot
+    # flags operator/kubescape/kubevuln/storage as "single instance - not
+    # resilient to node failure", but the chart provides NO safe way to run
+    # them HA, so they are deliberately left at one replica (chart v1.40.2):
+    #
+    #   * operator, kubescape (scanner), storage — the Deployment templates
+    #     HARDCODE `replicas: 1` with no value to override it, and the chart
+    #     ships NO leader-election anywhere. Two operators/scanners would
+    #     double-trigger every scan (cf. the velero/VPA/flagger HA comments in
+    #     this tree: we only scale components that leader-elect). Making these
+    #     HA would require forking the chart — out of scope and unsafe.
+    #   * storage is additionally a singleton by ARCHITECTURE: it is an
+    #     aggregated APIServer backed by a ReadWriteOnce PVC
+    #     (kubescape-storage, persistence.size.backingStorage below) with a
+    #     `Recreate` rollout — a single-writer store, not a stateless replica
+    #     set. A second replica would fail to multi-attach the RWO volume.
+    #   * kubevuln is the ONLY component exposing `kubevuln.replicaCount`, but
+    #     its Deployment ships `strategy: type: Recreate` and mounts RWO PVCs
+    #     when grypeDb/tmpDir persistence is enabled — i.e. the chart itself
+    #     forbids concurrent replicas. With no leader election, two kubevuln
+    #     pods would duplicate every image scan. So it stays at 1 too.
+    #
+    # Upstream's guidance for larger clusters is to raise RESOURCES, not add
+    # replicas (helm-charts README). Revisit if the chart adds leader election
+    # / multi-replica support for any of these components.
     clusterName: ${cluster_name}
     capabilities:
       configurationScan: enable


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Context

Coroot flags the Kubescape control-plane Deployments — `operator`, `kubescape`
(scanner), `kubevuln`, `storage` — as **"single instance - not resilient to
node failure"** and asked us to make them HA where the chart supports it (the
cluster is not resource-constrained).

## Finding: the `kubescape-operator` chart (v1.40.2) does NOT support running any of these HA

I inspected the chart's actual Deployment templates and values, not just the
values file. The result is that **no flagged component is HA-capable**, so this
PR makes the honest change: it **documents the architectural reason in the
HelmRelease** (matching the existing velero/VPA/flagger HA-comment convention in
`k8s/bases/infrastructure/controllers/`) rather than shipping a scale that the
chart would silently ignore or that would actively break.

| Component | Decision | Reason (chart evidence) |
|---|---|---|
| `operator` | **left single** | `templates/operator/deployment.yaml` HARDCODES `replicas: 1`; no chart value exists to override it. No leader election anywhere in the chart → two operators would double-trigger every scan (it is the singleton scan dispatcher). |
| `kubescape` (scanner) | **left single** | `templates/kubescape/deployment.yaml` HARDCODES `replicas: 1`; no chart value; no leader election. |
| `storage` | **left single (architectural)** | `templates/storage/deployment.yaml` HARDCODES `replicas: 1` **and** it is an **aggregated APIServer** backed by a **ReadWriteOnce PVC** (`kubescape-storage`) with `strategy: Recreate` — a single-writer store. A 2nd replica can't multi-attach the RWO volume. This is the singleton-by-architecture component the task warned about. |
| `kubevuln` | **left single** | The **only** component exposing `kubevuln.replicaCount` — BUT its Deployment ships `strategy: type: Recreate` and mounts RWO PVCs when `grypeDbPersistence`/`tmpDirPersistence` are enabled, i.e. the chart explicitly forbids concurrent replicas. No leader election → two pods would duplicate every image scan. |
| `node-agent` | n/a | DaemonSet (one per node) — out of scope, already node-resilient. |

### Chart-values / template evidence
- Of all components, **only** `kubevuln/deployment.yaml` wires `replicas: {{ .Values.kubevuln.replicaCount }}` (default `1`). `operator`, `kubescape`, `storage`, and `synchronizer` all literally write `replicas: 1`.
- `grep` for leader election / lease / HA across the **entire** chart returns **nothing** — the chart has no active-active or active-passive coordination for any microservice.
- The chart ships **no** `PodDisruptionBudget`, `topologySpreadConstraints`, or `podAntiAffinity` values — it provides zero HA primitives.
- This matches upstream guidance: the [helm-charts README](https://github.com/kubescape/helm-charts/blob/main/charts/kubescape-operator/README.md) tells larger clusters to **raise resources**, not add replicas; the [operator docs](https://kubescape.io/docs/operator/) describe the operator as the singleton "command and control" of scans and storage results as ephemeral, regenerable in-cluster state.
- This repo's own HA pattern (see the `velero`/`vertical-pod-autoscaler`/`flagger` HelmReleases) is to scale **only** components that leader-elect, with an explicit "two X would double-evict/double-drive" warning — exactly the reasoning that rules these components out.

## Change
A comment-only block in `k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml` recording the above, so the next Coroot triage sees *why* these stay single and doesn't repeatedly re-flag / re-attempt a broken scale. No `replicaCount`, PDB, or spread is added because none would take effect safely.

## Note on the title
The originally-suggested title (`fix(kubescape): run HA-capable control-plane components with 2 replicas`) asserts a scale that the evidence shows is **not possible** for any component in this chart. Shipping that title with a doc-only diff would be misleading and — per this repo's "Conventional-Commit title drives the changelog" rule — a `fix:` for a comment-only change is wrong. Retitled to `docs(kubescape):` to match what actually changed.

## Validation
`kubectl kustomize k8s/bases/infrastructure/controllers/kubescape` builds successfully and renders **byte-identical** to before this change (verified with `diff` — comments don't render), so this is provably safe.

## Follow-up
Revisit if `kubescape-operator` ever adds leader election / multi-replica support for any of these components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)