### PR TITLE
fix(coroot): run ClickHouse + keeper (and HA-capable components) with redundancy

### DIFF
--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -48,19 +48,58 @@ spec:
   # Bundled Prometheus = the metrics TSDB. Kept as a real Prometheus (we do
   # NOT set storeMetricsInClickhouse) precisely so OpenCost can still query it
   # at http://coroot-prometheus.observability.svc.cluster.local:9090.
+  # SINGLE INSTANCE BY DESIGN: the operator's `spec.prometheus` exposes no
+  # `replicas` field (verified against coroot.com/v1), so the bundled Prometheus
+  # has no HA mode here. It recovers by rescheduling onto a healthy node with
+  # its (durable, hcloud-backed) PVC; the gap is the in-flight scrape window
+  # during reschedule. Running redundant metrics ingestion would mean an
+  # external/federated Prometheus, which is a separate architectural decision.
   prometheus:
     retention: 7d
     storage:
       size: 10Gi
 
-  # ClickHouse stores logs, traces and continuous profiles. A single
-  # shard/replica (+ one keeper for replication metadata) is plenty for a
-  # homelab and keeps the footprint small on a memory-constrained cluster.
+  # ClickHouse stores logs, traces and continuous profiles. Run it with
+  # redundancy so a single node loss doesn't take the telemetry store down or
+  # lose data (Coroot's own risk view flagged every component as "single
+  # instance / all instances on one node"):
+  #   - shards: 1 — one shard is enough data volume for this cluster; we want
+  #     replication, not horizontal partitioning, so the shard count stays 1.
+  #   - replicas: 2 — two replicas *within* the shard, so the data is mirrored
+  #     and survives losing the node hosting either replica (ReplicatedMergeTree
+  #     via Keeper). This is the replica/shard field the operator exposes
+  #     (`spec.clickhouse.replicas`).
+  #   - keeper.replicas: 3 — ClickHouse Keeper is a Raft cluster; it needs an
+  #     ODD quorum to tolerate a failure. 1 keeper is a SPOF and 2 is INVALID
+  #     (no majority on a split), so the minimum fault-tolerant size is 3
+  #     (tolerates 1 keeper down). Field: `spec.clickhouse.keeper.replicas`.
+  # Hard pod anti-affinity (one replica per node) makes the redundancy real —
+  # without it the operator can schedule both ClickHouse replicas, or a keeper
+  # majority, onto one node and a single node loss still takes quorum/data with
+  # it. All nodes are in one Hetzner zone (fsn1), so the spread key is the node
+  # hostname. The operator exposes only `affinity` (no topologySpreadConstraints
+  # field), so anti-affinity is the available placement knob.
   clickhouse:
     shards: 1
-    replicas: 1
+    replicas: 2
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/part-of: coroot
+                app.kubernetes.io/component: clickhouse
+            topologyKey: kubernetes.io/hostname
     keeper:
-      replicas: 1
+      replicas: 3
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: coroot
+                  app.kubernetes.io/component: clickhouse-keeper
+              topologyKey: kubernetes.io/hostname
     storage:
       size: 10Gi
   logsTTL: 3d
@@ -78,4 +117,22 @@ spec:
 
   # cluster-agent is left at its default (enabled) — it provides the
   # kube-state-metrics-equivalent cluster inventory, replacing the standalone
-  # kube-state-metrics from the prometheus stack.
+  # kube-state-metrics from the prometheus stack. SINGLE INSTANCE BY DESIGN:
+  # `spec.clusterAgent` exposes no `replicas` field (verified against
+  # coroot.com/v1) — it is a cluster-wide singleton collector (like
+  # kube-state-metrics, which also runs one replica), so a second copy would
+  # only duplicate the same scrape. It recovers by rescheduling onto a healthy
+  # node; the gap is the reschedule window, during which the node-agents (one
+  # per node, already tolerations-spread above) keep collecting per-node
+  # telemetry.
+  #
+  # The Coroot server StatefulSet (coroot-coroot) is also left SINGLE INSTANCE.
+  # `spec.replicas` does exist, but the CRD documents it as requiring
+  # `spec.postgres` ("Store configuration in a Postgres DB instead of SQLite
+  # (required if replicas > 1)") — the default SQLite store cannot back more
+  # than one replica. CloudNativePG IS available in-cluster, so multi-replica
+  # is achievable, but it is a separate change (provision a CNPG Cluster +
+  # credentials, point `spec.postgres` at it, migrate state) with its own
+  # storage/backup story — out of scope for this redundancy pass and tracked as
+  # a follow-up. Until then the server recovers by rescheduling onto a healthy
+  # node with its durable PVC.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Coroot's own **risk view** flagged every component of the observability stack as *"single instance / all instances on one node"*: `coroot-clickhouse` (DatabaseCluster), `coroot-clickhouse-keeper` (StatefulSet), `coroot-coroot` (StatefulSet), `coroot-prometheus` (Deployment), `coroot-cluster-agent` (Deployment). A single node loss could take the telemetry store down or **lose data**. The cluster (3 CP + 3 workers, not resource-constrained) has ample room to spread replicas.

This change makes the components the operator can run redundantly *actually* redundant, and documents in-file why the rest must stay single-instance — so the file no longer silently misrepresents the HA posture.

## Per-component HA decision (every field verified against the live `coroot.com/v1` CRD)

| Component | Change | CRD field used | Notes |
|---|---|---|---|
| **ClickHouse** | `replicas: 1 → 2` | `spec.clickhouse.replicas` | Two replicas *within* the single shard (ReplicatedMergeTree via Keeper) → data mirrored, survives losing either replica's node. `shards: 1` kept (we want replication, not partitioning). |
| **ClickHouse Keeper** | `replicas: 1 → 3` | `spec.clickhouse.keeper.replicas` | Raft quorum **must be ODD**: 1 = SPOF, **2 = invalid** (no majority on a split), **3** = minimum fault-tolerant (tolerates 1 keeper down). |
| **Pod placement** | hard `podAntiAffinity` on `kubernetes.io/hostname` for both ClickHouse and Keeper | `spec.clickhouse.affinity` / `spec.clickhouse.keeper.affinity` | Without it the operator could co-locate both ClickHouse replicas or a keeper majority on one node and a single node loss still takes data/quorum. The operator exposes **only `affinity`** — there is **no `topologySpreadConstraints` field** — so anti-affinity is the available knob. All nodes are in one Hetzner zone (`fsn1-dc14`), so hostname is the correct spread key. |
| **Bundled Prometheus** | left **single-instance** | — | `spec.prometheus` exposes **no `replicas` field** (verified). The bundled Prometheus has no HA mode; it recovers by rescheduling onto a healthy node with its durable (hcloud) PVC. Redundant ingest would require an external/federated Prometheus — a separate architectural decision. |
| **cluster-agent** | left **single-instance** | — | `spec.clusterAgent` exposes **no `replicas` field** (verified). It is a cluster-wide singleton collector (like kube-state-metrics, which also runs one replica); a second copy would only duplicate the scrape. Recovers by reschedule; node-agents (one per node) keep per-node telemetry flowing meanwhile. |
| **Coroot server** (`coroot-coroot`) | left **single-instance** (follow-up) | `spec.replicas` exists | The CRD documents `spec.replicas` as requiring `spec.postgres`: *"Store configuration in a Postgres DB instead of SQLite (required if replicas > 1)."* The default SQLite store cannot back multiple replicas. **CloudNativePG is available in-cluster**, so multi-replica is achievable, but it is a separate change (provision a CNPG `Cluster` + credentials, point `spec.postgres` at it, migrate state) with its own storage/backup story — out of scope here, called out as a follow-up. |

## CRD-field evidence

- `kubectl explain coroot.spec.clickhouse` → `replicas`, `shards`, `keeper`, `affinity` all present.
- `kubectl explain coroot.spec.clickhouse.keeper` → `replicas`, `affinity` present.
- `kubectl explain coroot.spec.prometheus` / `coroot.spec.clusterAgent` → **no `replicas`** (confirms single-instance).
- No `topologySpreadConstraints` on `spec` or `spec.clickhouse` (confirmed absent — anti-affinity used instead).
- **Server-side dry-run** of the rendered base CR against the live cluster's CRD:
  `kubectl apply -f <rendered> --dry-run=server` → `coroot.coroot.com/coroot configured (server dry run)` — **zero schema errors**, proving no invented fields.

## Storage impact (cluster is not resource-constrained)

More replicas ⇒ more PVCs. On the hetzner overlay (hcloud block storage):
- **ClickHouse 15Gi × 2 = 30Gi** (was 15Gi) — **+15Gi**
- **Keeper 2Gi × 3 = 6Gi** (was 2Gi) — **+4Gi**
- Net added durable storage in prod: **~+19Gi** of hcloud volumes. Prometheus (20Gi) and the Coroot server (2Gi) PVCs are unchanged.

## Sequencing note for the maintainer

Raising `clickhouse.replicas`/`shards` topology **re-provisions the ClickHouse cluster** (the operator rolls the `DatabaseCluster`/StatefulSets to add the replica + grow the keeper ensemble). Please **sequence this deliberately** (off-peak) — expect new PVCs to bind and a short rebalance/replication window as the second ClickHouse replica syncs and the keeper ensemble grows 1 → 3. Telemetry already on disk is preserved; only logs/traces/profiles ingested during the roll are at the usual reschedule-window risk.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/coroot` — builds, CR renders with all HA fields. ✅
- `kubectl kustomize k8s/providers/hetzner/infrastructure` — builds; the overlay's storage/resources patch composes cleanly with the base HA fields (replicas + anti-affinity preserved). ✅
- Server-side dry-run against the live CRD — passes, no invented fields. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)