### PR TITLE
fix(platform): spread co-located HA controllers across nodes

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -68,6 +68,17 @@ spec:
         enabled: true
         replicas: ${cilium_replicas:=2}
         rollOutPods: true
+        # Coroot flagged the 2-replica Hubble Relay as co-located on a single
+        # node (not resilient to node failure). Soft spread prefers separate
+        # nodes; ScheduleAnyway never blocks scheduling. The chart's relay
+        # Deployment selects on k8s-app: hubble-relay.
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                k8s-app: hubble-relay
         podDisruptionBudget:
           enabled: true
           # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 never

--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -93,6 +93,18 @@ spec:
       podDisruptionBudget:
         minAvailable: null
         maxUnavailable: 1
+      # Coroot flagged the 2-replica background controller as co-located on a
+      # single node (not resilient to node failure). Soft spread (same idiom as
+      # admissionController above) lands the replicas on different nodes when
+      # possible; ScheduleAnyway never blocks scheduling.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: background-controller
+              app.kubernetes.io/instance: kyverno
       podSecurityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -147,6 +159,17 @@ spec:
       podDisruptionBudget:
         minAvailable: null
         maxUnavailable: 1
+      # Coroot flagged the 2-replica reports controller as co-located on a
+      # single node. Soft spread (admissionController idiom) prefers a second
+      # node; ScheduleAnyway never blocks scheduling.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: reports-controller
+              app.kubernetes.io/instance: kyverno
       podSecurityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -157,6 +180,17 @@ spec:
       podDisruptionBudget:
         minAvailable: null
         maxUnavailable: 1
+      # Coroot flagged the 2-replica cleanup controller as co-located on a
+      # single node. Soft spread (admissionController idiom) prefers a second
+      # node; ScheduleAnyway never blocks scheduling.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: cleanup-controller
+              app.kubernetes.io/instance: kyverno
       podSecurityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -80,3 +80,54 @@ spec:
         # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 never
         # deadlocks a node drain regardless of replica count.
         maxUnavailable: 1
+  # Coroot flagged the 2-replica admission controller and updater as co-located
+  # on a single node (not resilient to node failure). The FairwindsOps vpa chart
+  # (v4.11.0) exposes NO topologySpreadConstraints / affinity values for these
+  # components, so the soft spread is injected with a post-render Kustomize patch
+  # on each Deployment (same mechanism flagger uses above). maxSkew: 1 +
+  # ScheduleAnyway prefers separate nodes without ever blocking scheduling. The
+  # recommender is left untouched here (not flagged by Coroot). Selectors come
+  # from the chart's Deployment .spec.selector.matchLabels.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: vertical-pod-autoscaler-vpa-admission-controller
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: vertical-pod-autoscaler-vpa-admission-controller
+              spec:
+                template:
+                  spec:
+                    topologySpreadConstraints:
+                      - maxSkew: 1
+                        topologyKey: kubernetes.io/hostname
+                        whenUnsatisfiable: ScheduleAnyway
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/component: admission-controller
+                            app.kubernetes.io/name: vpa
+                            app.kubernetes.io/instance: vertical-pod-autoscaler
+          - target:
+              kind: Deployment
+              name: vertical-pod-autoscaler-vpa-updater
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: vertical-pod-autoscaler-vpa-updater
+              spec:
+                template:
+                  spec:
+                    topologySpreadConstraints:
+                      - maxSkew: 1
+                        topologyKey: kubernetes.io/hostname
+                        whenUnsatisfiable: ScheduleAnyway
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/component: updater
+                            app.kubernetes.io/name: vpa
+                            app.kubernetes.io/instance: vertical-pod-autoscaler

--- a/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml
@@ -49,6 +49,18 @@ spec:
       # Leader-elected; 2 replicas for HA (the require-replica-floor minimum) -- one
       # active while a backup takes CSI snapshots, the rest warm standbys.
       replicaCount: ${snapshot_controller_replicas:=1}
+      # Coroot flagged the 2-replica snapshot-controller as co-located on a
+      # single node (not resilient to node failure). Soft spread prefers
+      # separate nodes; ScheduleAnyway never blocks scheduling. Selector matches
+      # the pod-disruption-budget patch in the hetzner overlay.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: snapshot-controller
+              app.kubernetes.io/instance: snapshot-controller
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Coroot flagged several control-plane controllers that already run **≥2 replicas** as **"all instances on one node — not resilient to node failure"** (the replicas are co-located on a single node, so one node loss takes the whole controller down).

This PR adds **soft** `topologySpreadConstraints` (`maxSkew: 1`, `topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`) so the replicas **prefer** landing on different nodes. Because it is `ScheduleAnyway`, it **never blocks scheduling** — it only influences placement when a second node is available.

**This is a pure spread change — no replica counts and no resource requests are touched, so there is no capacity/cost impact.**

## Workloads changed

| Workload | File | Mechanism | Pod selector |
|---|---|---|---|
| Kyverno `backgroundController` | `k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml` | chart `topologySpreadConstraints` | `component=background-controller, instance=kyverno` |
| Kyverno `reportsController` | ″ | chart `topologySpreadConstraints` | `component=reports-controller, instance=kyverno` |
| Kyverno `cleanupController` | ″ | chart `topologySpreadConstraints` | `component=cleanup-controller, instance=kyverno` |
| Cilium Hubble Relay | `k8s/bases/infrastructure/controllers/cilium/helm-release.yaml` | chart `hubble.relay.topologySpreadConstraints` | `k8s-app=hubble-relay` |
| snapshot-controller | `k8s/providers/hetzner/infrastructure/controllers/snapshot-controller/helm-release.yaml` | chart `controller.topologySpreadConstraints` | `name=snapshot-controller, instance=snapshot-controller` |
| VPA `admissionController` | `k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml` | **postRenderers** (see below) | `component=admission-controller, name=vpa, instance=vertical-pod-autoscaler` |
| VPA `updater` | ″ | **postRenderers** (see below) | `component=updater, name=vpa, instance=vertical-pod-autoscaler` |

The Kyverno change mirrors the **already-present `admissionController` topologySpread idiom** in the same file, applied to the three other ≥2-replica controllers.

## Chart that needed a different approach (postRenderer)

**vertical-pod-autoscaler** (FairwindsOps `vpa` chart v4.11.0) exposes **no** `topologySpreadConstraints` (nor `affinity`) values for its components — confirmed with `helm show values`. So for the two flagged components (`admissionController`, `updater`) the spread is injected with a **`postRenderers` Kustomize patch** on each rendered Deployment — the same mechanism the `flagger` HelmRelease already uses in this repo. The VPA **recommender** is intentionally left untouched (Coroot did not flag it).

## Validation

- Confirmed each chart actually supports the key set (and VPA's absence of it) via `helm show values` / `helm template` at the exact chart versions/URLs in each `helm-release.yaml`.
- Confirmed every `labelSelector` matches the chart's Deployment `.spec.selector.matchLabels`.
- `kubectl kustomize` builds clean for all four changed dirs **and** for the merged `k8s/providers/hetzner/infrastructure/controllers` overlay — verified the relay spread coexists with the hetzner WireGuard strictMode patch, Kyverno shows all 4 spread blocks, and the VPA postRenderer survives the merge.
- End-to-end simulated the VPA postRenderer (`helm template` → `kustomize`) and confirmed both Deployments get `topologySpreadConstraints` with correct selectors while the recommender stays unmodified.

All flagged ≥2-replica controllers in scope were spread; nothing was left unspread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)