### PR TITLE
fix(umami): spread Flagger primary replicas across nodes

### DIFF
--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -46,6 +46,26 @@ spec:
     # replicaCount intentionally omitted — replicas are owned by the KEDA
     # ScaledObject (scaled-object.yaml) through the Canary's autoscalerRef;
     # the primary scales 2-3 on request rate.
+    # Spread the replicas across nodes so a single node failure cannot take down
+    # the whole web tier (Coroot flagged umami-umami-primary as "all instances on
+    # one node — not resilient to node failure": KEDA runs the primary at 2-3
+    # replicas — scaled-object.yaml — but nothing pulled them apart). Set on the
+    # SOURCE pod template here because Flagger builds umami-umami-primary by
+    # COPYING this template, so the constraint propagates to the primary that
+    # actually serves traffic. ScheduleAnyway (not DoNotSchedule) keeps scheduling
+    # best-effort: on a small/cordoned cluster a replica still lands rather than
+    # going Pending. The labelSelector keys on app.kubernetes.io/instance=umami —
+    # NOT app.kubernetes.io/name — because Flagger's default --selector-labels
+    # rewrites app.kubernetes.io/name to "umami-umami-primary" on the primary
+    # while leaving instance=umami intact on the pods (same reason the PDB and the
+    # Homepage pod-selector key on instance — see canary.yaml / pod-disruption-budget.yaml).
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: umami
     serviceAccount:
       # Umami needs no Kubernetes API access.
       automountServiceAccountToken: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Coroot flags `umami:Deployment:umami-umami-primary` as **"all instances on one node — not resilient to node failure."** The primary runs **2-3 replicas** (the KEDA `ScaledObject` via the Canary's `autoscalerRef` — `minReplicaCount: 2`, `maxReplicaCount: 3`), so this is a genuine **co-located** case, not a single-instance one — the replicas exist but nothing pulls them onto different nodes. A single node failure can take the whole web tier down.

## Fix

Add `topologySpreadConstraints` to the umami **chart values** in `helm-release.yaml`:

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: ScheduleAnyway
    labelSelector:
      matchLabels:
        app.kubernetes.io/instance: umami
```

The HelmForge umami chart exposes a top-level `topologySpreadConstraints` knob that renders straight into the Deployment pod spec — no postRenderer needed.

### Why it's set on the source template (and propagates to the primary)

Flagger builds `umami-umami-primary` by **copying the source Deployment's pod template**. It does not let you edit the primary's pod spec directly, and it freezes/filters primary metadata at creation. So the constraint has to live on the **source** workload's pod template (the chart values), and Flagger then copies it into the primary that actually serves traffic.

### Why the labelSelector keys on `app.kubernetes.io/instance` (not `/name`)

This is the load-bearing detail. Flagger's default `--selector-labels` are `app, name, app.kubernetes.io/name`, so on the primary it **rewrites `app.kubernetes.io/name` → `umami-umami-primary`**, while leaving **`app.kubernetes.io/instance=umami` intact** on the running pods. A selector on `app.kubernetes.io/name` would therefore match nothing on the primary. Keying on `app.kubernetes.io/instance=umami` matches the primary pods — exactly the same reasoning the existing **PDB** (`pod-disruption-budget.yaml`) and the **Homepage pod-selector** (`canary.yaml`) already use.

### Why `ScheduleAnyway` (not `DoNotSchedule`)

Best-effort: on a small or cordoned cluster a replica still lands rather than going `Pending`. With the primary capped at 3 replicas and the platform's node pool, the soft constraint is enough to pull replicas apart in the normal case while staying drain/scale-safe.

## Validation

`kubectl kustomize k8s/bases/apps/umami` builds clean (exit 0), and the rendered HelmRelease carries the spread in `spec.values.topologySpreadConstraints`, so Flux applies it to the source Deployment and Flagger copies it onto `umami-umami-primary`.

> [!NOTE]
> umami is excluded from the docker/CI overlay, so this isn't exercised by the system test. The propagation onto the live `umami-umami-primary` should be confirmed in prod (`kubectl -n umami get deploy umami-umami-primary -o jsonpath='{.spec.template.spec.topologySpreadConstraints}'` after the next reconcile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)