### PR TITLE
docs(velero): correct single-replica rationale + HA upgrade path

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -84,18 +84,41 @@ spec:
       uploaderType: kopia
       features: ""
 
-    # Run Velero itself with HA primitives matching the rest of the
-    # operator tier (PR #2b). Server is leader-elected so 2 replicas =
-    # instant failover, not extra capacity.
+    # Velero runs a SINGLE replica — this is correct, not a gap, and is why
+    # Coroot's "single instance - not resilient to node failure" flag is a
+    # known false-positive for this workload (the velero namespace is also
+    # exempt from the require-replica-floor Kyverno policy for the same reason).
     #
-    # Intentionally no PodDisruptionBudget: velero uses leader election,
-    # so pod-level PDB adds no availability; with replicaCount=1 on prod
-    # (`velero_replicas=1`), a PDB with `minAvailable: 1` creates a
-    # classic deadlock where a rolling upgrade cannot evict the sole
-    # pod. `Recreate` strategy is a better fit: brief blip during an
-    # upgrade is acceptable for a backup controller and avoids requiring
-    # a surge pod that the CX23 prod nodes cannot host.
-    replicaCount: ${velero_replicas:=2}
+    # The Velero *server* has NO leader election and does NOT support running
+    # multiple active replicas: two servers would both run the controller loops
+    # and double-run / compete on the same backups & schedules. Upstream still
+    # treats the server as single-instance (vmware-tanzu/velero#2694). At the
+    # version this HelmRelease pins (chart 12.0.2 → Velero v1.18.1), the chart's
+    # deployment.yaml additionally HARDCODES `replicas: 1` and never reads
+    # `.Values.replicaCount`, so the count cannot be raised from values anyway —
+    # `helm template --set replicaCount=2` still renders `replicas: 1`. (An
+    # earlier comment here claimed the server was leader-elected; that was
+    # incorrect — corrected to match the accurate rationale already in
+    # k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml and the
+    # validate-replica-floor policy.)
+    #
+    # Resilience to node failure therefore comes from FAST RESCHEDULE, not a warm
+    # standby: on a node loss the Deployment's sole pod is recreated on a healthy
+    # node, and Velero resumes its controller loops from API/object-store state
+    # (in-flight backups are retried; nothing is lost). No PriorityClass is added
+    # — no other controller in this infrastructure tier uses one, so a lone
+    # velero-only PriorityClass would be inconsistent for marginal benefit.
+    #
+    # Upgrade path: if a future Velero release adds server leader election (and
+    # the chart exposes a real `replicaCount`), this can become true HA — scale
+    # to ${velero_replicas} with a `maxUnavailable: 1` PDB and keep the spread
+    # below. Until then `velero_replicas` stays 1 everywhere (the default here and
+    # the prod override) and the value is effectively cosmetic given the hardcode.
+    replicaCount: ${velero_replicas:=1}
+    # Harmless at 1 replica (single pod trivially satisfies maxSkew); retained so
+    # that if the chart ever honours replicaCount and the server gains leader
+    # election, scaling up already spreads pods across nodes (kept per the
+    # upgrade-path note above).
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -104,6 +127,11 @@ spec:
           matchLabels:
             app.kubernetes.io/name: velero
             app.kubernetes.io/instance: velero
+    # `Recreate` matches the chart default and is the right fit for a single
+    # backup controller: a brief blip during an upgrade is acceptable and it
+    # avoids needing a surge pod the CX23 prod nodes cannot host. (No PDB: with a
+    # single replica a `minAvailable: 1` PDB would deadlock pod eviction during a
+    # node drain.)
     strategy:
       type: Recreate
 


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Context

Coroot flags `velero:Deployment:velero` as **"single instance - not resilient to node failure"**. This investigates whether Velero can safely run HA at the version this repo pins, and corrects the repo's own (self-contradicting) documentation of *why* it runs one replica.

## Leader-election / HA finding for the pinned version (chart `12.0.2` → Velero **v1.18.1**)

| Question | Answer |
|---|---|
| Does the Velero **server** have leader election? | **No.** No `--leader-elect` / `--enable-leader-election` flag in the server container args. |
| Can it run 2+ active replicas safely? | **No.** Two servers both run the controller loops, so they double-run / compete on the same backups & schedules. Upstream still treats the server as single-instance (vmware-tanzu/velero#2694). |
| Did Velero >=1.14 add server leader election? | **No** — a hypothesis worth checking, but the v1.14.0 release notes contain no leader-election / HA / multi-replica content for the server. |
| Can the chart even raise the count? | **No.** Chart `12.0.2`'s `templates/deployment.yaml` **hardcodes `replicas: 1`** (line 23) and never references `.Values.replicaCount`. `helm template vmware-tanzu/velero --version 12.0.2 --set replicaCount=2` still renders `replicas: 1`. |

Verified locally by pulling the pinned chart and rendering it.

## Decision: do **not** scale — correct the docs (the real defect)

Scaling Velero is both **wrong** (competing backup controllers) and **impossible** here (chart hardcodes `replicas: 1`). The actual problem was that this repo **contradicted itself**:

- The base `helm-release.yaml` claimed *"Server is leader-elected so 2 replicas = instant failover"* and defaulted `replicaCount: ${velero_replicas:=2}` — a **dead value** (the chart ignores it) attached to a **factually wrong** comment.
- Meanwhile `k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml` (`velero_replicas: "1"`) and the `validate-replica-floor` Kyverno policy (velero namespace exempted) already state the **correct** rationale: *"no leader election, chart hardcodes replicas: 1"*.

This PR makes the base file tell the truth:

- Rewrites the comment block to the accurate single-replica rationale (no server leader election; chart hardcodes the count; upstream single-instance), so future agents/readers are not misled. Notes that the Coroot flag is a **known false-positive** for this workload.
- Makes the dead default honest: `replicaCount: ${velero_replicas:=2}` -> `${velero_replicas:=1}` (matches the prod override; cosmetic given the hardcode, but no longer implies an HA story that does not exist).
- **Resilience to node failure** = fast reschedule: on node loss the sole pod is recreated on a healthy node and Velero resumes its loops from API/object-store state (in-flight backups retried, nothing lost).
- Documents the **upgrade path**: if a future Velero release adds server leader election *and* the chart exposes a real `replicaCount`, scale to `${velero_replicas}` + a `maxUnavailable: 1` PDB and keep the topology spread (kept, harmless at 1).
- **No PriorityClass added** — no other controller in this infrastructure tier uses one, so a lone velero-only PriorityClass would be inconsistent for marginal benefit.
- `topologySpreadConstraints` and `strategy: Recreate` retained (harmless at 1 replica; `Recreate` matches the chart default and avoids a surge pod the CX23 nodes cannot host).

## No behavior change

The chart already rendered exactly one replica regardless of the var, so this changes comments + a cosmetic default only — no rendered-manifest change to the running Deployment.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/controllers/velero` builds (1 HelmRelease; `replicaCount: ${velero_replicas:=1}` rendered).
- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers` builds (velero `EnableCSI` + volume-policies patch still lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)