### PR TITLE
fix(external-dns): harden single-replica writer against node failure

### DIFF
--- a/k8s/providers/hetzner/infrastructure/external-dns/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/external-dns/helm-release.yaml
@@ -22,6 +22,13 @@ spec:
     sources:
       - gateway-httproute
     policy: sync
+    # TXT-registry ownership is what makes this single writer safe to reschedule:
+    # every managed record gets a paired "_externaldns." TXT carrying this
+    # txtOwnerId, so a pod that restarts on another node (node failure / drain)
+    # recognises the records it already owns and reconciles idempotently instead
+    # of re-creating or fighting them. This ownership fence is also why a second
+    # ACTIVE replica is unsafe (see priorityClassName note) — two instances would
+    # share one owner id and issue duplicate Cloudflare writes.
     registry: txt
     txtOwnerId: "${domain}"
     txtPrefix: "_externaldns."
@@ -36,6 +43,36 @@ spec:
           secretKeyRef:
             name: external-dns-cloudflare
             key: api-token
+    # Node-failure resilience for a DELIBERATELY single-replica writer.
+    #
+    # external-dns has NO leader election at the pinned app version (chart 1.21.1
+    # = external-dns v0.21.0). The "support multiple replicas with leader
+    # election" proposal (docs/proposal/001-leader-election.md) is status
+    # `not-planned` and the `--enable-leader-election` flag does not exist in the
+    # controller binary — the only concurrency control is `--once` (run-once).
+    # So running >1 ACTIVE replica is unsafe: every replica would write to
+    # Cloudflare under the same txtOwnerId, causing duplicate API calls,
+    # rate-limit churn, and records fighting each other. The validate-replica-floor
+    # policy exempts external-dns by name for exactly this reason.
+    #
+    # Therefore we do NOT run 2 always-active replicas. We instead minimise the
+    # node-failure blast radius of the single writer:
+    #   * priorityClassName: system-cluster-critical — external-dns programs the
+    #     cluster's public DNS (its peer infrastructure CoreDNS and the hcloud-csi
+    #     controller use the same class), so on a node loss the scheduler places
+    #     the replacement pod ahead of normal workloads, shrinking the window in
+    #     which DNS records drift from desired state.
+    #   * a drain-safe PDB (pod-disruption-budget.yaml, maxUnavailable: 1) so a
+    #     node drain cycles the single pod cleanly instead of being a surprise.
+    #   * TXT-registry ownership (above) so the rescheduled pod reclaims its
+    #     records idempotently.
+    #
+    # UPGRADE PATH to true active/standby HA: once external-dns ships leader
+    # election (the `--enable-leader-election` flag, currently `not-planned`),
+    # switch to replicas: 2 with leader election enabled (only the leader writes),
+    # a topologySpreadConstraints across nodes, and drop this single-replica note.
+    # Track the upstream proposal before bumping the replica count.
+    priorityClassName: system-cluster-critical
     deploymentStrategy:
       type: Recreate
     serviceMonitor:

--- a/k8s/providers/hetzner/infrastructure/external-dns/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/external-dns/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - networkpolicy.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/hetzner/infrastructure/external-dns/pod-disruption-budget.yaml
+++ b/k8s/providers/hetzner/infrastructure/external-dns/pod-disruption-budget.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880):
+  # it never deadlocks a node drain regardless of replica count. external-dns is
+  # a DELIBERATELY single-replica writer (no leader election at the pinned app
+  # version v0.21.0 — see helm-release.yaml; a 2nd ACTIVE replica would issue
+  # duplicate Cloudflare writes under one txtOwnerId), so this PDB does not add
+  # standby redundancy. Its job is to let a node drain evict and reschedule the
+  # single pod cleanly (the high priorityClassName makes that reschedule fast)
+  # rather than the drain stalling on an un-budgeted pod. Convert to a true HA
+  # budget once external-dns ships leader election and this runs replicas: 2.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+      app.kubernetes.io/instance: external-dns


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Coroot flags `external-dns:Deployment:external-dns` (the cluster external-dns, Cloudflare provider) as **"single instance - not resilient to node failure"**. The cluster is not resource-constrained, so the question is the *correct* HA shape — not whether we can afford replicas.

## Leader-election finding for the pinned version (researched, not guessed)

The pinned chart is `external-dns` **1.21.1**, whose `appVersion` is external-dns **v0.21.0** (both are the latest releases as of this PR).

**external-dns does NOT support leader election at this version — or at any version.** Evidence:
- The controller's flag registration (`pkg/apis/externaldns/types.go`) at **v0.21.0** *and* at `master` contains **no** leader-election flag. The only concurrency control is `--once` (run-once mode).
- The only occurrence of `enable-leader-election` anywhere in the external-dns repo (default branch) is in `docs/proposal/001-leader-election.md` — i.e. it is a **design proposal, not an implementation**.
- That proposal's status is **`not-planned`**.
- The chart 1.21.1 `values.yaml` exposes **no** `replicaCount` / `replicas` / `leaderElection` / `lease` key (it offers only `deploymentStrategy`), and **no** PDB template.

So `--enable-leader-election` / a single-active-writer multi-replica mode is **not available** here.

## Why a naive 2-replica config is the wrong fix (the hazard)

external-dns uses a **TXT-registry ownership** model: every managed record is paired with a `_externaldns.` TXT carrying a single `txtOwnerId` (`${domain}`). Two **active** replicas share that one owner id, so they would both reconcile the same records and issue **duplicate Cloudflare API writes** — causing rate-limit churn and records fighting each other (flapping). This is exactly why the repo's `validate-replica-floor` Kyverno policy **exempts external-dns by name** ("chart has no replicaCount; >1 replica = duplicate Cloudflare writes + throttling"). Without leader election there is no safe way to keep a second replica passive.

## Decision: minimise the node-failure blast radius of a deliberately-single writer

Per the honest fix for a single writer that cannot do active/standby HA at this version:

1. **`priorityClassName: system-cluster-critical`** on the Deployment. external-dns programs the cluster's public DNS; its infrastructure peers **CoreDNS** and the **hcloud-csi controller** use the same class. On a node loss the scheduler now places the replacement pod **ahead of normal workloads**, shrinking the window in which live DNS drifts from desired state. (This is the real node-failure-resilience lever for a single pod: fast reschedule.)
2. **Drain-safe `PodDisruptionBudget`** (`maxUnavailable: 1`, the platform-wide #1880 pattern) added as a separate manifest because the chart ships no PDB template. It lets a node **drain** evict and reschedule the single pod cleanly instead of stalling on an un-budgeted pod.
3. **Documented the TXT-registry ownership fence** that makes a reschedule safe (the rescheduled pod recognises the records it already owns and reconciles idempotently) — and **documented the upgrade path**: once external-dns ships leader election (`--enable-leader-election`, currently `not-planned`), switch to `replicas: 2` + leader election (only the leader writes) + a `topologySpreadConstraints`, and drop the single-replica note. Track the upstream proposal before bumping the replica count.

No duplicate-writes 2-replica config is shipped.

## Changes
- `k8s/providers/hetzner/infrastructure/external-dns/helm-release.yaml` — add `priorityClassName: system-cluster-critical`; document the no-leader-election finding, the duplicate-writes hazard, the TXT-ownership safety, and the upgrade path.
- `k8s/providers/hetzner/infrastructure/external-dns/pod-disruption-budget.yaml` — new drain-safe PDB (`maxUnavailable: 1`).
- `k8s/providers/hetzner/infrastructure/external-dns/kustomization.yaml` — register the PDB.

## Validation
`kubectl kustomize k8s/providers/hetzner/infrastructure/external-dns` builds cleanly (exit 0); the rendered HelmRelease carries `priorityClassName: system-cluster-critical` and the PDB renders with the correct `app.kubernetes.io/name|instance: external-dns` selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)