### PR TITLE
fix(dns): extend ndots:1 to all Flux controllers to cut NXDOMAIN floods

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -63,19 +63,31 @@ spec:
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/part-of: flux
-      # source-controller polls external registries (ghcr.io OCI artifacts +
-      # Helm repo indexes) on every interval; with the default ndots:5 each
-      # lookup walks the four-entry search path first, producing thousands of
-      # guaranteed-NXDOMAIN queries per hour against CoreDNS (Coroot flags this
-      # as a DNS warning on the app). ndots:1 makes any dotted name resolve
-      # absolute-first; the search path remains a fallback, and Flux's own
-      # in-cluster URLs are already trailing-dot FQDNs
-      # (source-controller.flux-system.svc.cluster.local.), so nothing relies
-      # on search-path expansion.
+      # The Flux controllers poll external endpoints on every interval —
+      # source-controller fetches ghcr.io OCI artifacts + Helm repo indexes,
+      # kustomize-controller and helm-controller pull OCI artifacts/charts from
+      # external registries, and notification-controller posts to external
+      # webhook receivers. With the default ndots:5 each external (dotted) name
+      # is tried against the four-entry cluster search path FIRST, producing
+      # thousands of guaranteed-NXDOMAIN queries per hour against CoreDNS
+      # (Coroot flags this as a DNS warning on these apps). ndots:1 makes any
+      # dotted name resolve absolute-first; the search path remains a fallback.
+      # This is safe for in-cluster controller-to-controller traffic because
+      # Flux addresses its own services by trailing-dot absolute FQDN
+      # (source-controller advertises itself via
+      # --storage-adv-addr=source-controller.flux-system.svc.cluster.local.),
+      # which bypasses search-path expansion at any ndots value — so nothing
+      # relies on it.
+      #
+      # Applied to the whole controller set via the shared
+      # app.kubernetes.io/part-of=flux label (same selector as the topology
+      # spread above) rather than per-controller, so every current and future
+      # Flux controller inherits it. The image-reflector/image-automation
+      # controllers are not installed (see header), so this covers the four
+      # listed components.
       - target:
           kind: Deployment
-          name: source-controller
-          namespace: flux-system
+          labelSelector: app.kubernetes.io/part-of=flux
         patch: |
           - op: add
             path: /spec/template/spec/dnsConfig


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — ndots:5 search-domain expansion

Coroot flags DNS errors (NXDOMAIN floods) on `source-controller`, `cilium`, and `coredns`. The root cause for the Flux apps is the Kubernetes default **`ndots:5`**: any hostname with fewer than 5 dots (i.e. essentially every external name — `ghcr.io`, `index.docker.io`, a webhook host) is first tried against the four-entry cluster search path (`<ns>.svc.cluster.local`, `svc.cluster.local`, `cluster.local`, the node domain). Each external lookup therefore generates several **guaranteed-NXDOMAIN** queries against CoreDNS before the absolute name is tried — thousands per hour given Flux's reconcile cadence.

`source-controller` was **already mitigated** with a `dnsConfig: {options: [{name: ndots, value: "1"}]}` patch in this same FluxInstance. This PR extends that exact root-cause fix to the rest of the affected workloads where it is correct and safe, and documents where it is **not** applicable.

## What changed

`k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml` — the existing per-controller `dnsConfig` patch (which targeted only `source-controller` by name) is **retargeted to the shared `app.kubernetes.io/part-of=flux` label selector** — the same selector the `topologySpreadConstraints` patch in this file already uses. One patch now applies `ndots:1` to the whole installed Flux controller set:

| Controller | External lookups it makes |
|---|---|
| source-controller | ghcr.io OCI artifacts, Helm repo indexes (was already patched individually) |
| kustomize-controller | OCI artifacts from external registries |
| helm-controller | OCI Helm charts + Helm repo indexes from external registries |
| notification-controller | external webhook receivers (git providers, chat, etc.) |

(image-reflector/image-automation controllers are not installed — see the FluxInstance header — so this is the full set.)

**Why it's safe for in-cluster traffic:** Flux addresses its own services by **trailing-dot absolute FQDN** — source-controller advertises itself via `--storage-adv-addr=source-controller.flux-system.svc.cluster.local.` and the other controllers fetch artifacts from that absolute name. A trailing-dot name is absolute and bypasses search-path expansion at *any* ndots value, so lowering ndots does not affect controller-to-controller resolution; only the external lookups change (and for the better).

## What was NOT changed, and why (cilium & coredns)

After investigation, the `cilium` and `coredns` DNS errors Coroot reports are **not fixable by an ndots/dnsConfig change** — they reflect networking model / client behavior, not a tunable misconfig on those components:

- **cilium — N/A.**
  - The **cilium-agent** DaemonSet runs **`hostNetwork: true`** (it manages host networking and reaches the API via `k8sServiceHost: localhost:7445` with `kubeProxyReplacement`). A hostNetwork pod resolves via the **node's** `/etc/resolv.conf` (a flat Talos/cloud config), **not** the cluster pod resolv.conf with `ndots:5`, so the search-path NXDOMAIN pattern does not apply to it.
  - The **cilium-operator** is an ordinary pod, but its DNS is dominated by **in-cluster** lookups (kube-apiserver, CiliumIdentities/endpoint watches), not external-hostname floods.
  - The **Cilium Helm chart (v1.19.4) exposes no `dnsConfig`/`podDnsConfig` value** for any component (verified against upstream `values.yaml`), so forcing ndots would require a Flux `postRenderers` patch on the HelmRelease — heavy machinery for a workload that isn't the source of the search-path floods. Not done.

- **coredns — N/A (it's the resolver, not a client).** CoreDNS *is* the cluster resolver, so the "DNS errors" attributed to it are the **upstream-forwarded NXDOMANs from noisy clients** (exactly the ndots:5 floods this PR reduces at the source), not a coredns misconfig. The prod Corefile already does the right thing — it caches denials (`cache 30`) and forwards to `/etc/resolv.conf`. The genuine remedy is **quieting the noisy clients**, which is precisely what this change does; there is no correct coredns-side config edit here.

The most-affected *external*-resolving non-Flux workloads (external-dns → Cloudflare API, simply-dns-webhook → api.simply.com, cert-manager → ACME CAs, hcloud-ccm/csi → Hetzner API, velero → R2) are all **HelmReleases whose charts expose no `dnsConfig` value** either, so each would need its own post-render patch. Those are deliberately left out of this focused PR; they can be a follow-up (per-HelmRelease postRenderer) if Coroot still flags them after the Flux fix lands.

## Validation

`kubectl kustomize` builds clean:
- `k8s/providers/hetzner/infrastructure/controllers/flux-instance/` ✅
- `k8s/providers/hetzner/infrastructure/controllers/` (parent) ✅

The rendered FluxInstance carries the new `dnsConfig` patch under `app.kubernetes.io/part-of=flux` alongside the existing topology-spread patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)