### PR TITLE
fix(platform): run leader-elected operators HA (ksail/tetragon/cert-approver)

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -124,11 +124,17 @@ spec:
           #     (longhorn-manager / the chart owns their replica count).
           #   * single-controller operators (leader election makes >1 a hot
           #     standby at best, all off the serving path): cluster-autoscaler,
-          #     ksail-operator, tetragon-operator,
           #     keda-add-ons-http-controller-manager.
+          #     (ksail-operator + tetragon-operator were promoted OUT of this
+          #     exemption -- they now run HA: 2 leader-elected replicas + a
+          #     drain-safe maxUnavailable: 1 PDB + topology spread, so they meet
+          #     the floor like the rest of the operator tier. Coroot had flagged
+          #     them "single instance - not resilient to node failure".)
           #   * single-by-design adapters/approvers: keda-operator-metrics-
-          #     apiserver (KEDA's standard 1-replica metrics adapter) and
-          #     kubelet-serving-cert-approver (off every serving path).
+          #     apiserver (KEDA's standard 1-replica metrics adapter).
+          #     (kubelet-serving-cert-approver was also promoted OUT -- switched
+          #     to upstream's ha-install.yaml: 2 replicas, --enable-leader-election
+          #     + leases RBAC + required hostname anti-affinity + a drain-safe PDB.)
           #   * spire-server: HA needs a shared external datastore, not just
           #     replicas (its StatefulSet uses the built-in datastore) -- a
           #     deliberate single-node posture; revisit for HA separately.
@@ -141,11 +147,8 @@ spec:
           - resources:
               names:
                 - cluster-autoscaler-hetzner-cluster-autoscaler
-                - ksail-operator
-                - tetragon-operator
                 - keda-add-ons-http-controller-manager
                 - keda-operator-metrics-apiserver
-                - kubelet-serving-cert-approver
                 - longhorn-driver-deployer
                 - csi-snapshotter
                 - spire-server

--- a/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/helm-release.yaml
@@ -32,6 +32,17 @@ spec:
     # default "<release>-ksail-operator").
     fullnameOverride: ksail-operator
     operator:
+      # Run HA matching the rest of the operator tier (Coroot flagged the sole
+      # replica "single instance - not resilient to node failure"). The chart
+      # ships operator.leaderElection: true by default, which renders
+      # `--leader-elect` on the manager container and a leader-election Lease, so
+      # 2 replicas = one active reconciler + a warm standby that takes over on a
+      # node drain/failure -- not double-reconciliation. Drain safety comes from
+      # the standalone maxUnavailable: 1 PDB (pod-disruption-budget.yaml) plus the
+      # topologySpreadConstraints injected via the post-renderer below (the chart
+      # exposes neither a PDB nor a topologySpread value). leaderElection stays on
+      # (chart default) -- do not disable it while replicas > 1.
+      replicas: ${ksail_operator_replicas:=2}
       # Image tag comes from the chart default (v<appVersion>, per ksail #5168,
       # first shipped in chart 7.41.2) -> ghcr.io/devantler-tech/ksail:v7.41.2,
       # which is cosign-signed (ksail #5165) so prod Talos image verification
@@ -93,6 +104,20 @@ spec:
                     securityContext:
                       runAsUser: 65532
                       runAsGroup: 65532
+                    # Spread the 2 HA replicas across nodes so a single node
+                    # failure cannot take out both. ScheduleAnyway (soft) so a
+                    # single-node local/CI cluster still schedules both pods --
+                    # matching the velero/reloader spread posture. The chart has
+                    # no topologySpread value, so it is injected here.
+                    topologySpreadConstraints:
+                      - maxSkew: 1
+                        topologyKey: kubernetes.io/hostname
+                        whenUnsatisfiable: ScheduleAnyway
+                        labelSelector:
+                          matchLabels:
+                            app.kubernetes.io/name: ksail-operator
+                            app.kubernetes.io/instance: ksail-operator
+                            app.kubernetes.io/component: operator
                     containers:
                       - name: operator
                         securityContext:

--- a/k8s/bases/infrastructure/controllers/ksail-operator/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - helm-release.yaml
   - httproute.yaml
   - networkpolicy.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/infrastructure/controllers/ksail-operator/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/ksail-operator/pod-disruption-budget.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ksail-operator
+  namespace: ksail-operator
+spec:
+  # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 keeps the node
+  # drainable at any replica count, unlike minAvailable: 1 which deadlocks a
+  # drain when only 1 replica is ready. The ksail-operator chart ships no PDB
+  # knob, so this is a standalone manifest (same approach as snapshot-controller
+  # / simply-dns-webhook). Pairs with operator.replicas: 2 in helm-release.yaml:
+  # the operator is leader-elected (operator.leaderElection: true), so the second
+  # replica is a warm standby that keeps reconciliation available while a node
+  # drains.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ksail-operator
+      app.kubernetes.io/instance: ksail-operator
+      app.kubernetes.io/component: operator

--- a/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/helm-release.yaml
@@ -92,6 +92,26 @@ spec:
         serviceMonitor:
           enabled: false
     tetragonOperator:
+      # Run the operator HA matching the rest of the operator tier (Coroot
+      # flagged the sole replica "single instance - not resilient to node
+      # failure"). The operator manages the TracingPolicy/PodInfo CRDs and is off
+      # every serving path, so the second replica is a warm standby for node
+      # drains/failures, not extra capacity.
+      #
+      # IMPORTANT: the operator does NOT leader-elect by default -- the chart
+      # only sets `leader-election: "true"` when failoverLease.enabled is true
+      # ("Tetragon operator running in HA mode requires the use of ResourceLock
+      # for Leader Election", which also adds the coordination.k8s.io/leases
+      # RBAC). Running replicas: 2 WITHOUT this would give two active operators
+      # (duplicate CRD reconcilers), so the two MUST move together.
+      replicas: ${tetragon_operator_replicas:=2}
+      failoverLease:
+        enabled: true
+      # The chart already ships a hostname podAntiAffinity (preferred) for the
+      # operator pods, so the 2 replicas spread across nodes without an extra
+      # topologySpread. Drain safety is added via the standalone
+      # pod-disruption-budget.yaml (maxUnavailable: 1) in this directory -- the
+      # chart exposes no PDB value.
       # Operator metrics (:2113); operator already ships resource requests
       # and a non-root securityContext by default.
       prometheus:

--- a/k8s/bases/infrastructure/controllers/tetragon/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/infrastructure/controllers/tetragon/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/tetragon/pod-disruption-budget.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: tetragon-operator
+  namespace: kube-system
+spec:
+  # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 keeps the node
+  # drainable at any replica count, unlike minAvailable: 1 which deadlocks a
+  # drain when only 1 replica is ready. The tetragon chart ships no PDB knob, so
+  # this is a standalone manifest. Pairs with tetragonOperator.replicas: 2 +
+  # failoverLease.enabled: true in helm-release.yaml: the operator is then
+  # leader-elected, so the second replica is a warm standby that keeps the
+  # CRD/controller reconcilers available while a node drains. The selector scopes
+  # to the operator pods only (app.kubernetes.io/name: tetragon-operator) -- NOT
+  # the per-node tetragon agent DaemonSet (app.kubernetes.io/name: tetragon),
+  # which is node-pinned and must not be covered by this PDB.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tetragon-operator
+      app.kubernetes.io/instance: tetragon

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -38,6 +38,13 @@ data:
   cilium_replicas: "2"
   velero_replicas: "1"
   cloudnative_pg_replicas: "2"
+  # ksail-operator: chart default operator.leaderElection: true (renders
+  # --leader-elect + a Lease), so the 2nd replica is a warm standby.
+  ksail_operator_replicas: "2"
+  # tetragon-operator: leader election is gated behind failoverLease.enabled
+  # (set true in the helm-release), so these two MUST stay aligned -- 2 replicas
+  # without the lease would run two active operators.
+  tetragon_operator_replicas: "2"
   # KEDA-managed apps: HelmRelease replicas are the initial value only;
   # KEDA HTTPScaledObject overrides at runtime. Setting the initial to 1
   # saves memory until the first KEDA reconciliation.

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
@@ -2,5 +2,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml
+  # HA variant (was standalone-install.yaml, replicas: 1). Coroot flagged the
+  # sole replica "single instance - not resilient to node failure". Upstream
+  # ships a dedicated ha-install.yaml that is the supported way to run this
+  # controller HA: it sets replicas: 2, adds `--enable-leader-election` to the
+  # `serve` container args, ships the coordination.k8s.io/leases Role+RoleBinding
+  # the leader-election lock needs, and a REQUIRED hostname podAntiAffinity so
+  # the 2 replicas land on different nodes. So 2 replicas = one active CSR
+  # approver + a warm standby that takes over on a node drain/failure, not two
+  # active approvers. The standalone PDB (pod-disruption-budget.yaml) makes the
+  # node drain-safe (maxUnavailable: 1). When bumping, re-pin both this URL and
+  # the PDB selector to the same upstream ref.
+  - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/ha-install.yaml
   - networkpolicy.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/pod-disruption-budget.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kubelet-serving-cert-approver
+  namespace: kubelet-serving-cert-approver
+spec:
+  # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 keeps the node
+  # drainable at any replica count, unlike minAvailable: 1 which deadlocks a
+  # drain when only 1 replica is ready. The upstream ha-install.yaml ships no
+  # PDB, so it is declared here. Pairs with the HA base (replicas: 2 +
+  # --enable-leader-election in kustomization.yaml): the approver is then
+  # leader-elected, so the second replica is a warm standby that keeps kubelet
+  # serving-cert CSR approval available while a node drains.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet-serving-cert-approver
+      app.kubernetes.io/instance: kubelet-serving-cert-approver


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

Coroot flagged three single-replica controllers as **"single instance - not resilient to node failure."** All three binaries support **leader election**, so this scales each to **2 replicas** (one active + one warm standby) with a **drain-safe `maxUnavailable: 1` PDB** and node spread — matching the established operator-tier HA posture (velero / reloader / kyverno). The cluster is not resource-constrained.

For each target I verified leader-election support **before** scaling (`helm show values` / `helm template` for charts; fetched the upstream manifest for the remote kustomize base).

## Per-operator decision + leader-election evidence

### 1. `ksail-operator` — SCALED to 2 ✅
- **Evidence:** the chart ships `operator.leaderElection: true` by **default**; `helm template ... --set operator.replicas=2` renders `replicas: 2` and **`--leader-elect`** on the manager container (+ a leader-election `Lease`).
- **Change:** `operator.replicas: ${ksail_operator_replicas:=2}`; standalone `maxUnavailable: 1` PDB (`pod-disruption-budget.yaml`); `topologySpreadConstraints` (hostname, `ScheduleAnyway`) injected via the **existing post-renderer** — the chart exposes neither a PDB nor a topologySpread value.

### 2. `tetragon-operator` — SCALED to 2 ✅ (with a required caveat)
- **Evidence:** by default the operator does **not** leader-elect — the chart only emits `leader-election: "true"` (and the `coordination.k8s.io/leases` RBAC) when **`failoverLease.enabled: true`** ("Tetragon operator running in HA mode requires the use of ResourceLock for Leader Election"). Confirmed via a `helm template` diff.
- **Change:** set **`failoverLease.enabled: true`** *together with* `replicas: ${tetragon_operator_replicas:=2}` — the two must move together, since 2 replicas without the lease = two **active** operators (duplicate CRD reconcilers). The chart already ships a hostname `podAntiAffinity` for the operator pods (spread covered); added a standalone PDB. Only the `tetragonOperator` sub-component is touched — the per-node **agent DaemonSet is untouched**, and the PDB selector scopes to `app.kubernetes.io/name: tetragon-operator` only.

### 3. `kubelet-serving-cert-approver` — SCALED to 2 ✅
- **Evidence:** this is a **remote kustomize base**, currently `standalone-install.yaml` (`replicas: 1`, args `serve`, **no** leader-election RBAC). Upstream ships a dedicated **`ha-install.yaml`** with `replicas: 2`, args **`serve --enable-leader-election`**, the `coordination.k8s.io/leases` `Role`+`RoleBinding`, and a **required** hostname `podAntiAffinity`.
- **Change:** switched the base URL `standalone-install.yaml` → `ha-install.yaml` and added a standalone PDB. `kubectl kustomize` renders all of it (replicas:2, `--enable-leader-election`, leases Role, required anti-affinity, PDB).

> None of the three were left single — all three are genuinely leader-elected.

## Other changes
- **Prod replica counts** added to `k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml` (`ksail_operator_replicas: "2"`, `tetragon_operator_replicas: "2"`; cert-approver's HA base hardcodes 2).
- **`validate-replica-floor` Kyverno policy:** promoted all three **out of the exemption list** (with updated rationale comments) — they now meet the 2-replica floor, so leaving them exempt would let the policy drift from reality.

## Validation — `kubectl kustomize` (all exit 0)
- `k8s/bases/infrastructure/controllers/ksail-operator/` — HelmRelease + PDB + `replicas: ${ksail_operator_replicas:=2}` + topologySpread present.
- `k8s/bases/infrastructure/controllers/tetragon/` — HelmRelease (`failoverLease.enabled: true` + replicas var) + PDB present.
- `k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/` — rendered `replicas: 2`, `--enable-leader-election`, leases `Role`, required anti-affinity, `maxUnavailable: 1` PDB.
- Full **hetzner** + **docker** controllers overlays and **base infrastructure** all build clean; docker's `disableWait` tetragon patch still applies cleanly over the new values.

## Trade-offs
- Per the established convention (velero/reloader), PDBs use **`maxUnavailable: 1`** (drain-safe at any replica count, including 1) rather than `minAvailable: 1` (which deadlocks a single-pod drain).
- Replica defaults use the repo's `${var:=2}` pattern, so local/CI also get 2 by default (consistent with the rest of the operator tier); prod is explicit in the cluster-config map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)