### PR TITLE
fix(kyverno): curb reports-controller memory growth via resource filters

### DIFF
--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -19,6 +19,52 @@ spec:
         name: kyverno
   # https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
   values:
+    # --- reports-controller memory growth (Coroot "memory leak") --------------
+    # The reports-controller's memory scales with the number of (Cluster)PolicyReports
+    # it holds and aggregates. The slow, unbounded growth Coroot flags is the
+    # background scanner emitting one report per live resource for EVERY resource
+    # in the cluster -- because the chart ships `--skipResourceFilters=true`
+    # (features.backgroundScan.skipResourceFilters), so background scan IGNORES
+    # config.resourceFilters and reports on everything, including extremely
+    # high-churn ephemeral objects (leader-election Leases renewing every few
+    # seconds across cilium/flux/kyverno/cert-manager/KEDA/flagger/cnpg/operators,
+    # plus the controller's own report kinds). See kyverno/kyverno#13335 / #11746.
+    #
+    # Fix (root cause, not a limit bump): make background scan HONOR the resource
+    # filters, then exclude the highest-churn kinds. This is safe for enforcement
+    # because skipResourceFilters only affects BACKGROUND SCAN reporting --
+    # ADMISSION-time validation (pod-security, etc.) is unaffected, and we do NOT
+    # filter Pod/Deployment/etc., so those still get background-scan reports.
+    #
+    # NOT a static memory limit: auto-vpa.yaml runs a VPA over this Deployment
+    # (controlledValues: RequestsAndLimits, InPlaceOrRecreate, maxAllowed 6Gi),
+    # so a hard limit here would fight VPA. Cutting report volume is the correct
+    # lever; if growth persists, raise the VPA maxAllowed, don't pin a limit.
+    features:
+      backgroundScan:
+        # Honor config.resourceFilters during background scans (chart default is
+        # true = filters skipped = report-per-resource for everything). With this
+        # false, the chart's default filters (Event, ReplicaSet, Node,
+        # EphemeralReport, kube-system/public/node-lease, ...) plus the additions
+        # below actually suppress background-scan reports for those kinds.
+        skipResourceFilters: false
+    config:
+      # Additive (chart `concat`s this onto its ~80-entry default resourceFilters
+      # -- nothing default is lost, and it stays correct across chart upgrades).
+      # Exclude high-churn kinds that have ZERO matching policy in this repo, so
+      # nothing is lost by skipping them in background scan:
+      resourceFiltersInclude:
+        # Leader-election leases churn every few seconds cluster-wide -- the
+        # dominant driver of the slow report growth.
+        - "[Lease,*,*]"
+        # The reports-controller's own output/intermediate report kinds: stop it
+        # background-scanning (and re-reacting to) the reports it writes.
+        - "[PolicyReport,*,*]"
+        - "[ClusterPolicyReport,*,*]"
+        - "[AdmissionReport,*,*]"
+        - "[ClusterAdmissionReport,*,*]"
+        - "[BackgroundScanReport,*,*]"
+        - "[ClusterBackgroundScanReport,*,*]"
     # Restricted PSS baseline: kyverno's mutation policies exclude the kyverno namespace,
     # so we must set pod-level seccompProfile + runAsNonRoot via chart values.
     admissionController:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Symptom

Coroot flags a slow, unbounded "memory leak" (gradual growth) on
`kyverno:Deployment:kyverno-reports-controller`. The cluster is **not**
resource-constrained, so this is report accumulation, not pressure.

## Root cause (the actual growth driver)

The reports-controller's memory scales with the number of
`(Cluster)PolicyReport`s it holds and aggregates. The growth comes from the
**background scanner**, and the reason it's unbounded is a chart default:

```
features.backgroundScan.skipResourceFilters: true   # chart default in kyverno 3.8.1 (app v1.18.1)
```

With `--skipResourceFilters=true`, **background scan ignores
`config.resourceFilters` and emits one PolicyReport per live resource for
EVERY resource in the cluster** — see kyverno/kyverno#13335 ("too many policy
reports get generated by background scans") and kyverno/kyverno#11746. On this
cluster the high-churn kinds that dominate that volume are:

- **`Lease` (coordination.k8s.io)** — leader-election leases renew **every few
  seconds** across cilium, flux, kyverno's own controllers, cert-manager, KEDA,
  flagger, cnpg and every operator. This is the **dominant** driver of the slow
  growth. `Lease` is **not** in the chart's default `resourceFilters` at all.
- The controller's **own report kinds** (PolicyReport / ClusterPolicyReport /
  AdmissionReport / …) — background-scanned and re-reacted to, compounding churn.
- (Ephemeral Pods from Flagger canaries / KEDA scale events / CronJobs add to it,
  but those are deliberately left reportable — see below.)

The chart's default `resourceFilters` *does* already exclude Event, ReplicaSet,
Node, EphemeralReport, kube-system/public/node-lease, etc. — but
`skipResourceFilters: true` means **none of those exclusions apply to background
scan**, which is exactly where the reports are generated.

## Fix (root cause, not a limit bump)

1. **`features.backgroundScan.skipResourceFilters: false`** — make background
   scan **honor** `config.resourceFilters`. The chart's existing default filters
   immediately start suppressing background-scan reports for their kinds.
2. **`config.resourceFiltersInclude`** (additive — the chart `concat`s this onto
   its ~80-entry default list, so **nothing default is lost** and it stays correct
   across chart upgrades) excluding the highest-churn kinds that have **zero**
   matching policy in this repo:
   - `[Lease,*,*]` (the dominant driver)
   - the controller's own report kinds: `PolicyReport`, `ClusterPolicyReport`,
     `AdmissionReport`, `ClusterAdmissionReport`, `BackgroundScanReport`,
     `ClusterBackgroundScanReport`.

### Why this is safe for enforcement
`skipResourceFilters` affects **background-scan reporting only — never
admission**. Admission-time validation (pod-security, disallow-latest-tag,
host-restrictions, image signatures, …) is completely untouched. And `Pod`,
`Deployment`, etc. are **deliberately not filtered**, so they still get
background-scan reports — only the high-churn, zero-policy kinds are dropped.

### Why not a static memory limit
`auto-vpa.yaml` runs a VPA over this Deployment (`controlledValues:
RequestsAndLimits`, `updateMode: InPlaceOrRecreate`, `maxAllowed: 6Gi`). A hard
`resources.limits.memory` here would **fight VPA** (the same RequestsAndLimits
ratio reasoning the coroot/clickhouse blocks already document). Cutting report
**volume** is the correct lever. If growth still persists after this lands, the
follow-up is to **raise the VPA `maxAllowed`**, not pin a limit.

## Validation

`kubectl kustomize k8s/bases/infrastructure/controllers/kyverno` builds clean
(exit 0); the new `features` / `config` values render into the HelmRelease.

## Rollout note (no restart needed)
Kyverno reloads `resourceFilters` live from its ConfigMap, and
`skipResourceFilters` is a controller flag the HelmRelease re-rolls. Background
scan reconciles on its interval (default 1h), after which stale reports for the
now-filtered kinds are pruned and the working set drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
