### PR TITLE
fix(flux): pin source-controller to a single replica

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/flux-instance/flux-instance.yaml
@@ -46,9 +46,11 @@ spec:
       # reconciliation within the lease TTL when the leader's node fails. The
       # upstream Deployments ship replicas: 1, which is why Coroot flags each
       # controller as "single instance - not resilient to node failure"; bumping
-      # to 2 clears that. Patched by label so the one rule covers
-      # source-/kustomize-/helm-/notification-controller (all carry
-      # app.kubernetes.io/part-of=flux). Paired with the topologySpread below so
+      # to 2 clears that for kustomize-/helm-/notification-controller. Patched by
+      # label (all carry app.kubernetes.io/part-of=flux); source-controller is
+      # then pinned BACK to 1 by the override patch immediately below — it is the
+      # one controller for which a warm standby does NOT work (see that comment
+      # for the readiness-probe reason). Paired with the topologySpread below so
       # the two replicas land on different nodes — otherwise both could sit on
       # the node that fails. flux-operator itself is left single-replica: its
       # chart does not expose replicas/leaderElection (0.50.0), so it relies on
@@ -60,6 +62,30 @@ spec:
           - op: replace
             path: /spec/replicas
             value: 2
+      # source-controller is the ONE Flux controller that cannot run the warm
+      # standby above — pin it back to a single replica. Unlike the other three,
+      # its readiness probe targets the artifact file server on :9090, and that
+      # server is a leader-election runnable: it only starts on the active leader
+      # (the standby blocks in "attempting to acquire leader lease"). So the
+      # standby pod's readiness probe gets connection-refused forever, the
+      # Deployment is stuck at 1/2, the FluxInstance reports
+      # "source-controller status: InProgress", and the infrastructure-controllers
+      # Kustomization health-check times out after 25m — which freezes ALL GitOps
+      # delivery (infrastructure + apps stop reconciling). The other three
+      # controllers expose /readyz on the always-on health-probe port, so their
+      # standbys reach 2/2 fine. source-controller keeps its node-failure
+      # resilience via reschedule + storage, the same way flux-operator does;
+      # Coroot will still flag it single-instance, which is inherent and accepted.
+      # This override MUST stay after the replicas:2 patch so it wins for
+      # source-controller while topologySpread + ndots still apply to it.
+      - target:
+          kind: Deployment
+          name: source-controller
+          namespace: flux-system
+        patch: |
+          - op: replace
+            path: /spec/replicas
+            value: 1
       # Spread the four Flux controllers across worker nodes. They all carry
       # app.kubernetes.io/part-of=flux, so a per-controller topology spread
       # keyed on that label distributes the set (skew <= 1) — and, combined with


### PR DESCRIPTION
## 🔴 CRITICAL — GitOps delivery is currently frozen on prod

**Impact:** `infrastructure-controllers` → `infrastructure` → `apps` Kustomizations are all stuck not-ready, so **no GitOps changes are reconciling on prod** (this includes the just-merged #2135 coroot HA work). Merging this PR self-heals the freeze.

## Root cause

The prod `FluxInstance` patch runs all four Flux controllers at `replicas: 2` (active/standby HA, by `app.kubernetes.io/part-of=flux` label):

```
helm-controller          2/2
kustomize-controller     2/2
notification-controller  2/2
source-controller        1/2   ❌
```

`source-controller` is the **one** controller for which a warm standby does **not** work. Its readiness probe targets the artifact **file server on `:9090`**, which is a leader-election runnable — it only starts on the active leader. The standby blocks in `"attempting to acquire leader lease..."` and never opens `:9090`:

```
Readiness probe failed: Get "http://10.244.21.105:9090/": connect: connection refused  (x574 over 90m)
```

So the Deployment is permanently `1/2` → `FluxInstance` reports `source-controller status: 'InProgress'` → the `infrastructure-controllers` Kustomization health-check **times out after 25m** (`HealthCheckFailed: timeout waiting for: [FluxInstance/flux-system/flux status: 'InProgress']`) → the whole dependency chain freezes.

The other three controllers expose `/readyz` on the always-on health-probe port, so their standbys reach `2/2` fine — which is why only source-controller breaks.

## Fix

Add an override patch (ordered **after** the `replicas: 2` label patch so it wins for source-controller while `topologySpread` + `ndots` still apply) pinning `source-controller` to **1 replica**. It keeps node-failure resilience via reschedule + storage, the same way `flux-operator` does. Coroot will still flag it single-instance — that is inherent to source-controller's node-local artifact store and is accepted.

## Validation

- `kubectl kustomize k8s/clusters/prod/` ✅ builds
- `kubectl kustomize k8s/clusters/local/` ✅ builds
- `kubectl kustomize .../controllers/flux-instance/` ✅ builds; patch order confirmed (`replicas: 2` then source-controller `replicas: 1`)
- `kubectl apply --dry-run=client` ✅ valid

## How it self-heals (frozen-state safe)

The `infrastructure-controllers` Kustomization still **applies** every reconcile (only its health-check step times out). Once this merges and CD pushes the OCI artifact, the working leader source-controller pulls it, the new `FluxInstance` is applied, flux-operator scales source-controller to 1 → Deployment `1/1` → `FluxInstance` Ready → health-check passes → `infrastructure` + `apps` resume. No manual intervention needed (a manual `kubectl scale`/`edit` would be reverted by flux-operator/the apply step anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)