### PR TITLE
fix(policy): exempt crossplane from the replica-floor floor

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -104,6 +104,20 @@ spec:
                 - external-dns
                 - origin-ca-issuer
                 - flagger-loadtester
+          # Crossplane core + RBAC manager: external-state reconcilers that
+          # converge GitHub org/repo state (see providers/hetzner/.../github/).
+          # controllers/crossplane/helm-release.yaml keeps them single-instance
+          # by design -- the same external-single-writer reasoning as external-dns
+          # above ("external-state reconcilers must run on exactly one always-on
+          # cluster"). Off every request-serving path: a node failure only delays
+          # GitHub-state reconciliation, which is eventually consistent, and
+          # single-replica is also deliberately memory-lean on this cluster.
+          # Promote to 2 leader-elected replicas (like ksail-/tetragon-operator)
+          # if HA is ever wanted, but the floor must not force it.
+          - resources:
+              names:
+                - crossplane
+                - crossplane-rbac-manager
           # Lean leader-election controllers off every serving path: exempt so
           # the resource-lean single-replica default is allowed (a SPOF here only
           # delays reconciliation/reporting, never user traffic). Prod bumps them


### PR DESCRIPTION
## Problem

`crossplane` and `crossplane-rbac-manager` (crossplane-system, both 1/1) are the **only** workloads currently emitting live `validate-replica-floor` PolicyViolation warning events on prod — dozens per hour:

```
Warning  PolicyViolation  Deployment crossplane-system/crossplane: [require-replica-floor] fail; runs 1 replica(s); the platform HA floor is 2 ...
Warning  PolicyViolation  Deployment crossplane-system/crossplane-rbac-manager: [require-replica-floor] fail; ...
```

They are conspicuously **absent from the policy's exempt list**, even though the crossplane HelmRelease keeps them single-instance *by design*:

> external-state reconcilers must run on exactly one always-on cluster, or two clusters would race to converge the same GitHub org (same reasoning as external-dns living in this overlay).

That is exactly the external-single-writer rationale the policy **already** uses to exempt `external-dns`. So these are false-positive audit noise, not a real HA gap — and (unlike most other current replica-floor report entries, which are stale residue that clears once GitOps catches up) this one keeps firing fresh events until the policy is fixed.

## Fix

Add `crossplane` + `crossplane-rbac-manager` to `validate-replica-floor`'s exempt `names` list, with a comment documenting the rationale and noting the HA-promotion alternative (2 leader-elected replicas, like `ksail-`/`tetragon-operator`) if the maintainer ever wants it. The policy is `Audit`-only, so this is behaviour-preserving — it only stops the spurious report/event.

## Validation

- `kubectl kustomize k8s/clusters/prod/` ✅ builds
- `kubectl kustomize k8s/clusters/local/` ✅ builds
- Confirmed live: only these two deployments are flagged by replica-floor (fresh events, last 90m); all other current report entries are stale (the live gen-12 policy already exempts them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)