### PR TITLE
fix(cnpg): pin plugin-barman-cloud to a single replica

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -152,6 +152,19 @@ spec:
                 - longhorn-driver-deployer
                 - csi-snapshotter
                 - spire-server
+          # plugin-barman-cloud (cnpg-system): the CNPG-I backup plugin hardcodes
+          # --leader-elect and opens its operator-facing gRPC on :9090 only on the
+          # active leader -- exactly what its tcp-socket :9090 readiness probe
+          # checks. A 2nd replica can never go ready (it blocks acquiring the
+          # lease), which sticks the Deployment at 1/2 and loops the HelmRelease
+          # upgrade health gate, so it is pinned to a single replica (see
+          # controllers/plugin-barman-cloud/helm-release.yaml) and the chart
+          # exposes no pod-label value to carry the exempt opt-out. A node failure
+          # only reschedules the one replica; CNPG retries the gRPC across the gap.
+          # Same leader-only-:9090 shape as Flux source-controller.
+          - resources:
+              names:
+                - plugin-barman-cloud
       preconditions:
         all:
           # Durable opt-out on the pod template (charts expose podLabels more

--- a/k8s/bases/infrastructure/controllers/plugin-barman-cloud/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/plugin-barman-cloud/helm-release.yaml
@@ -32,25 +32,29 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: cloudnative-pg
-  # HA with leader election — verified the operator↔plugin path. The plugin
-  # Deployment runs the CNPG-I controller with `--leader-elect` hardcoded ON in
-  # the chart (templates/deployment.yaml) and ships the matching leader-election
-  # RBAC (templates/additional-rbac/leader_election.yaml: a Role/RoleBinding for
-  # coordination.k8s.io leases), so a second replica is a *lease-coordinated warm
-  # standby*, not a second uncoordinated backup controller — exactly the cnpg
-  # operator's pattern in this same namespace. replicaCount: 2 + a maxUnavailable:
-  # 1 PDB (pod-disruption-budget.yaml) + hostname topology spread keep one replica
-  # serving the operator's gRPC through a node failure/drain, clearing the Coroot
-  # "single instance — not resilient to node failure" finding and meeting the
-  # require-replica-floor (#1882) floor of 2 (so the prior replica-floor: exempt
-  # opt-out is removed). The Deployment uses the Recreate strategy (the operator
-  # does not yet support RollingUpdate, per the chart) — that only serialises a
-  # rollout; node-failure resilience comes from the standby on the surviving node.
+  # Single replica — this chart CANNOT run a ready warm standby. It hardcodes
+  # `--leader-elect` ON, and the operator-facing gRPC listener on :9090 (which
+  # the readiness probe checks via tcp-socket :9090) is a leader-election
+  # runnable: it only starts on the active leader. A 2nd replica blocks in
+  # "Attempting to acquire leader lease..." and never opens :9090, so its
+  # readiness probe is refused forever — the Deployment sticks at 1/2 and
+  # helm-controller's upgrade health gate times out
+  # ("Deployment/.../plugin-barman-cloud status: 'InProgress'"), then rolls back,
+  # in a loop. (Same shape as Flux source-controller's leader-only :9090 file
+  # server — see controllers/flux-instance.) A warm standby is therefore
+  # impossible here; node-failure resilience comes from rescheduling the single
+  # replica, and CNPG retries the plugin gRPC across that brief gap. The chart
+  # exposes no pod-label value, so single-replica is exempted from the
+  # require-replica-floor (#1882) floor via the policy's exempt list (see
+  # cluster-policies/best-practices/validate-replica-floor.yaml), not a label.
+  # The maxUnavailable: 1 PDB keeps the node drainable at one replica.
   values:
-    # 2 replicas for HA (active + warm standby); prod tunes via cluster config,
-    # default 2 to satisfy the floor in every environment. See the chart values:
+    # 1 replica: the standby can never become ready (leader-gated :9090), so 2
+    # only breaks the HelmRelease. The override stays available for the day the
+    # upstream chart supports non-leader readiness (or leader-only Service
+    # routing); until then 1 is the only working value. Chart values:
     # https://github.com/cloudnative-pg/plugin-barman-cloud/blob/main/charts/plugin-barman-cloud/values.yaml
-    replicaCount: ${plugin_barman_cloud_replicas:=2}
+    replicaCount: ${plugin_barman_cloud_replicas:=1}
     # Spread the replicas across nodes so a single node loss can't take both.
     # ScheduleAnyway (soft): never block scheduling the standby if the cluster is
     # momentarily short a distinct node — availability over strict placement.

--- a/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
+++ b/k8s/clusters/prod/bootstrap/variables-cluster-config-map.yaml
@@ -45,11 +45,14 @@ data:
   cilium_replicas: "2"
   velero_replicas: "1"
   cloudnative_pg_replicas: "2"
-  # CNPG-I barman-cloud plugin: the CNPG-I controller runs `--leader-elect`
-  # (hardcoded by the chart), so the standby is lease-coordinated, not a second
-  # backup controller. WAL archive/restore I/O runs in per-instance sidecars, not
-  # here; this is the operator-facing gRPC controller.
-  plugin_barman_cloud_replicas: "2"
+  # CNPG-I barman-cloud plugin: pinned to 1 — the chart hardcodes `--leader-elect`
+  # and only the leader opens the operator-facing gRPC listener on :9090, which is
+  # what the tcp-socket :9090 readiness probe checks. A 2nd replica never becomes
+  # ready (stuck acquiring the lease), so the Deployment sticks at 1/2 and the
+  # HelmRelease upgrade health gate times out and rolls back in a loop. WAL
+  # archive/restore I/O runs in per-instance sidecars, not here. See the
+  # plugin-barman-cloud HelmRelease comment for the full rationale.
+  plugin_barman_cloud_replicas: "1"
   # ksail-operator: chart default operator.leaderElection: true (renders
   # --leader-elect + a Lease), so the 2nd replica is a warm standby.
   ksail_operator_replicas: "2"


### PR DESCRIPTION
## Problem

`cnpg-system/plugin-barman-cloud` (the CNPG-I backup plugin) is stuck and its HelmRelease is in a perpetual failed-upgrade → rollback loop on prod:

```
HelmRelease: Helm upgrade failed ... timeout waiting for: [Deployment/cnpg-system/plugin-barman-cloud status: 'InProgress']
Deployment plugin-barman-cloud   1/2   (ReplicaSet: 2 desired, 1 ready)
```

## Root cause — identical to the source-controller freeze

The plugin was set to `replicaCount: 2` for warm-standby HA. But the chart hardcodes `--leader-elect`, and the **operator-facing gRPC listener on `:9090` only starts on the active leader** — which is exactly what the readiness probe checks (`tcp-socket :9090`). The standby pod's logs stop at:

```
"Attempting to acquire leader lease..."
```

…and never reach `"Starting plugin listener" serverAddress :9090`. So the standby's readiness probe is refused forever, the Deployment can never reach `2/2`, and helm-controller's upgrade health gate times out and rolls back, looping. This is the **same leader-only-`:9090` shape** as Flux `source-controller`'s file server (see the companion PR for that).

The HA reasoning in the HelmRelease comment ("a second replica is a lease-coordinated warm standby") is the same mistaken assumption: leader election makes the *controller* a standby, but the readiness-gating gRPC port is leader-only, so the standby is never `Ready`.

## Fix

Pin to **1 replica** (base default `:=1` + prod `plugin_barman_cloud_replicas: "1"`). A ready warm standby is impossible with this chart; node-failure resilience comes from rescheduling the single replica, which CNPG tolerates by retrying the plugin gRPC across the brief gap (the WAL archive/restore I/O runs in per-instance sidecars, not here). Re-add the `require-replica-floor` exemption via the policy exempt list (the chart exposes no pod-label value to carry the label); the existing `maxUnavailable: 1` PDB keeps the node drainable. Comments on all three touch-points updated to document the real constraint.

If genuine HA is wanted later, it needs upstream chart support for non-leader readiness (or a leader-only Service selector) — pinning the override back up is then a one-line change.

## Validation

- `kubectl kustomize k8s/clusters/prod/` ✅ builds
- `kubectl kustomize k8s/clusters/local/` ✅ builds (local does not deploy this chart; prod-only)
- Standby failure mode confirmed live: pod blocked on lease acquisition, `:9090` never opened, `0/1`.

> Note: lightly overlaps `validate-replica-floor.yaml` with the crossplane-exemption PR (different list entries); whichever merges second is a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)