### PR TITLE
fix(policy): exempt crossplane-system namespace from the replica-floor floor

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -71,14 +71,25 @@ spec:
                   platform.devantler.tech/replica-floor: exempt
           # Namespaces whose workloads genuinely can't run 2: velero (no leader
           # election, chart hardcodes replicas: 1), flux controllers and coroot
-          # (observability), and kubescape (operator + scanner control-plane are
-          # single-replica by design; node-agent is a DaemonSet).
+          # (observability), kubescape (operator + scanner control-plane are
+          # single-replica by design; node-agent is a DaemonSet), and
+          # crossplane-system. The latter holds only Crossplane control-plane
+          # components -- core, rbac-manager and the provider pods (e.g.
+          # provider-upjet-github) -- all controller-managed external-state
+          # reconcilers that run a single replica by design (see
+          # controllers/crossplane/helm-release.yaml: "must run on exactly one
+          # always-on cluster", the same external-single-writer reasoning as
+          # external-dns). Exempt by NAMESPACE, not name, because Crossplane names
+          # each provider Deployment after its ProviderRevision hash
+          # (provider-upjet-github-<hash>), so a name match silently stops matching
+          # on every provider upgrade.
           - resources:
               namespaces:
                 - velero
                 - flux-system
                 - observability
                 - kubescape
+                - crossplane-system
           # KEDA scale-to-zero targets, Flagger canary primaries (*-primary) and
           # the scaled-to-0 canary sources -- their replica count is owned by a
           # controller, not declared statically (the Flagger primary runs the HA
@@ -104,20 +115,6 @@ spec:
                 - external-dns
                 - origin-ca-issuer
                 - flagger-loadtester
-          # Crossplane core + RBAC manager: external-state reconcilers that
-          # converge GitHub org/repo state (see providers/hetzner/.../github/).
-          # controllers/crossplane/helm-release.yaml keeps them single-instance
-          # by design -- the same external-single-writer reasoning as external-dns
-          # above ("external-state reconcilers must run on exactly one always-on
-          # cluster"). Off every request-serving path: a node failure only delays
-          # GitHub-state reconciliation, which is eventually consistent, and
-          # single-replica is also deliberately memory-lean on this cluster.
-          # Promote to 2 leader-elected replicas (like ksail-/tetragon-operator)
-          # if HA is ever wanted, but the floor must not force it.
-          - resources:
-              names:
-                - crossplane
-                - crossplane-rbac-manager
           # Lean leader-election controllers off every serving path: exempt so
           # the resource-lean single-replica default is allowed (a SPOF here only
           # delays reconciliation/reporting, never user traffic). Prod bumps them


### PR DESCRIPTION
## Problem

After #2141 (which exempted `crossplane` + `crossplane-rbac-manager` by name), the Crossplane **provider** Deployments are still flagged by `validate-replica-floor`. Live, the only fresh replica-floor PolicyViolation is:

```
Deployment crossplane-system/provider-upjet-github-04d509bb9f6f: [require-replica-floor] fail; runs 1 replica(s) ...
```

Crossplane names each provider Deployment after its **ProviderRevision hash** (`provider-upjet-github-<hash>`), so the name rotates on every provider upgrade — a name-based exemption is fragile and would silently stop matching.

## Fix

`crossplane-system` holds **only** Crossplane control-plane components (core, rbac-manager, and provider pods) — all controller-managed external-state reconcilers that run a single replica by design (the HelmRelease: *"must run on exactly one always-on cluster"*, the same external-single-writer rationale as `external-dns`). Exempt the whole **namespace** — the same approach already used for `velero` / `flux-system` / `observability` / `kubescape` — and drop the now-redundant `crossplane` + `crossplane-rbac-manager` name entries from #2141.

This is robust against provider name rotation and future providers. `validate-replica-floor` is `Audit`-only, so the change is behaviour-preserving — it only stops the spurious report/events.

## Validation

- `kubectl kustomize k8s/clusters/prod/` ✅ builds
- `kubectl kustomize k8s/clusters/local/` ✅ builds
- Confirmed live (post-unfreeze, settled): `provider-upjet-github-*` is the sole remaining replica-floor violator; `crossplane`/`crossplane-rbac-manager`/`plugin-barman-cloud` already stopped firing once #2141/#2142 deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)