### PR TITLE
feat(github): activate OrganizationRuleset MRD for declarative org rulesets

### DIFF
--- a/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
@@ -21,3 +21,7 @@ spec:
     - branchprotections.repo.github.m.upbound.io
     - repositoryrulesets.repo.github.m.upbound.io
     - issuelabels.repo.github.m.upbound.io
+    # Org-level rulesets (the ~19 UI-managed org rules that gate every repo) —
+    # adopted Observe-first in devantler-tech/.github deploy/. The tenant Role
+    # already covers the enterprise.github.m.upbound.io group.
+    - organizationrulesets.enterprise.github.m.upbound.io


### PR DESCRIPTION
## What

Activates the namespaced `organizationrulesets.enterprise.github.m.upbound.io` MRD in the Crossplane activation policy, so the `github-config` app can bring the org's ~19 UI-managed **org-level rulesets** under declarative management (adopted Observe-first in devantler-tech/.github `deploy/`).

The tenant Role already grants verbs on the `enterprise.github.m.upbound.io` group, and the provider App has `organization_administration: write`, so no other platform change is needed.

## Why

Org rulesets are the most impactful GitHub config still hand-managed in the UI (they gate every repo) — and the source of the earlier `code_quality`/`code_scanning` blanket-targeting pain that had to be fixed imperatively. Codifying them is the durable fix.

Once this reconciles on prod (CRD established), the org rulesets are adopted Observe-first (read-only) in a follow-up .github release — zero risk — then promoted selectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)