### PR TITLE
docs(agents): Update renamed skills repo reference

### DIFF
--- a/.agents/skills/ways-of-working/SKILL.md
+++ b/.agents/skills/ways-of-working/SKILL.md
@@ -4,7 +4,7 @@ license: Apache-2.0
 metadata:
     github-path: ways-of-working
     github-ref: refs/tags/v1.1.0
-    github-repo: https://github.com/devantler-tech/skills
+    github-repo: https://github.com/devantler-tech/agent-skills
     github-tree-sha: be7d95e52d933a19e9fbdba7d4989de0af8ad8cd
 name: ways-of-working
 ---


### PR DESCRIPTION
## What

The `devantler-tech/skills` repo was renamed to `devantler-tech/agent-skills` (and `devantler-tech/plugins` → `devantler-tech/agent-plugins`). This updates the stale reference to the old name in this repo.

## Changes

- `.agents/skills/ways-of-working/SKILL.md`: `github-repo` metadata `https://github.com/devantler-tech/skills` → `https://github.com/devantler-tech/agent-skills`.

## Notes

- An exhaustive grep (`devantler-tech/skills` / `devantler-tech/plugins`) found exactly one stale reference; no `devantler-tech/plugins` references exist in this repo.
- This SKILL.md is synced from the `agent-skills` repo; updating the stale copy here is still correct.
- Only a `.agents/` docs/agent file was changed — no `k8s/` manifests, `*.enc.yaml`, `ksail.prod.yaml`, or `.sops.yaml` were touched, so no kustomize validation was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)