### PR TITLE
fix(coroot): grow coroot-db volume to 10Gi + bound WAL to clear infra wedge

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
@@ -44,8 +44,26 @@ spec:
   # pod anti-affinity, keeping a primary+replica quorum even under maintenance.
   instances: 3
   storage:
-    size: 2Gi
+    # Bumped 2Gi -> 10Gi (2026-06-19). The 2Gi volumes filled with WAL during a
+    # Talos node roll: the primary retained WAL for the rolled replicas'
+    # replication slots while base data was only ~32Mi (pg_wal alone reached
+    # 1.4Gi), tripping CNPG's low-disk guard. Postgres then refused to start on
+    # all three instances ("Not enough disk space"), so the coroot-db Cluster
+    # never went Ready and the `infrastructure` Kustomization's health check
+    # timed out — wedging infrastructure -> apps platform-wide. 10Gi gives WAL
+    # ample headroom; the longhorn StorageClass has allowVolumeExpansion=true, so
+    # CNPG (1.29) resizes the existing PVCs in place — no recreation needed.
+    size: 10Gi
     storageClass: longhorn
+  postgresql:
+    parameters:
+      # Bound replication-slot WAL retention so a replica that is down during a
+      # node roll (Talos upgrade / autoscaler churn) can no longer retain WAL
+      # without limit and re-fill the data volume — the root cause of the wedge
+      # above. Beyond this, CNPG invalidates the lagging slot and re-syncs that
+      # replica from a base backup (cheap: the DB is ~32Mi). Set well above
+      # normal WAL for this low-write metadata DB, yet well below the 10Gi volume.
+      max_slot_wal_keep_size: "3GB"
   bootstrap:
     initdb:
       database: coroot


### PR DESCRIPTION
## Symptom: whole platform wedged
The `infrastructure` Flux Kustomization (`wait: true`) is stuck *"Reconciliation in progress"* — its health check repeatedly times out (20m) on `Cluster/observability/coroot-db` reporting `InProgress`. That blocks `apps` (*"dependency 'flux-system/infrastructure' is not ready"*) and everything downstream.

## Root cause: coroot-db ran out of disk
The `coroot-db` CNPG Cluster's **2Gi** instance volumes filled up:
- Actual DB is tiny (`base` ≈ **32Mi**), but `pg_wal` had grown to **1.4Gi**.
- During the in-progress Talos node roll, the primary retained WAL for the rolled replicas' **replication slots without bound** (no `max_slot_wal_keep_size`).
- CNPG tripped its low-disk guard — Cluster phase **`Not enough disk space`**, instance log *"Detected low-disk space condition"* — and refused to start Postgres on all 3 instances (2 in `CrashLoopBackOff`, 17–22 restarts), so the Cluster never reaches `Ready`.

## Fix
- **`storage.size` 2Gi → 10Gi.** `longhorn` has `allowVolumeExpansion=true` and CNPG 1.29 resizes the existing PVCs **online (no recreation)**, so the instances regain headroom, restart, and drain WAL via the (working) barman-cloud archiver.
- **Add `postgresql.parameters.max_slot_wal_keep_size: "3GB"`** so a replica that is down during a future node roll can't retain WAL without bound and re-fill the volume. Past the bound CNPG invalidates the lagging slot and re-syncs that replica from a base backup (cheap at ~32Mi). Well above normal WAL for this low-write metadata DB, well below the 10Gi volume.

## ⚠️ Immediate un-wedge (prod is down now)
This deploys via the normal prod CD path (merge-queue / tag). For instant relief before then, apply the same change live (CNPG expands the PVCs in place):
```
kubectl -n observability patch cluster.postgresql.cnpg.io coroot-db --type=merge \
  -p '{"spec":{"storage":{"size":"10Gi"},"postgresql":{"parameters":{"max_slot_wal_keep_size":"3GB"}}}}'
```
I did **not** run this — live prod mutation is left to the maintainer (I diagnosed on the `admin@prod` context read-only). Once `coroot-db` reports `Ready`, the `infrastructure` health check passes and `apps` unblocks.

## Validation
`ksail --config ksail.prod.yaml workload validate` → **348 files green**; `kubectl kustomize k8s/providers/hetzner/infrastructure/` builds.

## Separate follow-up (not this PR)
The `crossview` pod is independently blocked by a Kyverno `disallow-latest-tag` violation on its chart's initContainer (`:latest`). That's apps-layer and unrelated to this wedge — flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)