### PR TITLE
fix(cnpg): protect Postgres clusters from Flux force-recreate data loss

### DIFF
--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -13,6 +13,14 @@ kind: Cluster
 metadata:
   name: umami-db
   namespace: umami
+  annotations:
+    # Never let Flux delete+recreate this database: the apps Flux Kustomization
+    # runs force: true + prune: true, and the longhorn PVCs are reclaimPolicy=
+    # Delete, so a force-recreate would wipe the data (the failure that hit
+    # coroot-db on 2026-06-18). Flux can still update it; immutable changes must
+    # be made by an operator with a backup/restore plan.
+    kustomize.toolkit.fluxcd.io/force: disabled
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   # Run 3 instances (1 primary + 2 streaming replicas) for high availability.
   # A single-instance Cluster makes CNPG create a `<cluster>-primary`

--- a/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
@@ -19,6 +19,13 @@ spec:
         kind: Cluster
         metadata:
           name: wedding-db
+          annotations:
+            # Never let Flux delete+recreate this database (force-recreate +
+            # reclaimPolicy=Delete PVCs = data loss, the failure that hit
+            # coroot-db on 2026-06-18). Flux can still update it; immutable
+            # changes need a manual backup/restore by an operator.
+            kustomize.toolkit.fluxcd.io/force: disabled
+            kustomize.toolkit.fluxcd.io/prune: disabled
         spec:
           storage:
             storageClass: longhorn

--- a/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
@@ -30,6 +30,17 @@ kind: Cluster
 metadata:
   name: coroot-db
   namespace: observability
+  annotations:
+    # Never let Flux delete+recreate this database. The infrastructure Flux
+    # Kustomization runs force: true + prune: true, so an immutable-field change
+    # or a live/Git drift on this Cluster would otherwise make kustomize-
+    # controller recreate it — and with the longhorn PVCs on reclaimPolicy=
+    # Delete that wipes the data via a fresh initdb (this happened 2026-06-18).
+    # force: disabled makes Flux surface the apply error for an operator to
+    # resolve deliberately (with a backup/restore plan) instead of recreating;
+    # prune: disabled stops GC if the Cluster is ever dropped from a kustomization.
+    kustomize.toolkit.fluxcd.io/force: disabled
+    kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
   # Run 3 instances (1 primary + 2 streaming replicas) for high availability —
   # the SAME rationale as umami-db: a single-instance Cluster makes CNPG create a


### PR DESCRIPTION
## Why
On 2026-06-18 the `coroot-db` CNPG Cluster was **deleted and recreated** by the `infrastructure` Flux Kustomization while clearing the [coroot-db disk wedge](https://github.com/devantler-tech/platform/pull/2158): a live `storage` change drifted from Git, and because every Flux Kustomization in `k8s/clusters/base/` runs **`force: true` + `prune: true`**, kustomize-controller resolved the conflict by recreating the Cluster — which, with the `longhorn` PVCs on `reclaimPolicy: Delete`, **bootstrapped a fresh empty database (initdb) and wiped the data**.

That is a latent footgun for *every* CNPG database, not just coroot-db: any immutable-field change or drift can trigger the same destructive recreate.

## What
Annotate all three CNPG `Cluster` resources so Flux can still **update** them but can never **delete or recreate** them:

| annotation | effect |
|---|---|
| `kustomize.toolkit.fluxcd.io/force: disabled` | an immutable-field conflict / drift surfaces as an **apply error** for an operator to resolve deliberately (backup → restore), instead of a silent recreate |
| `kustomize.toolkit.fluxcd.io/prune: disabled` | never garbage-collected if the Cluster is ever dropped from a kustomization |

Both are [documented Flux per-resource overrides](https://fluxcd.io/flux/components/kustomize/kustomizations/) of the Kustomization-level `force`/`prune`, and mirror the repo's existing `force: enabled` opt-ins on the vault Jobs.

Covered clusters:
- `coroot-db` — `k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml`
- `umami-db` — `k8s/bases/apps/umami/postgres-cluster.yaml`
- `wedding-db` — via the tenant patch `k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml`

Structural/immutable changes to these databases are now a **deliberate operator action**, never an automated Flux recreate. (Trade-off: an immutable change will now make the Kustomization report not-ready until an operator handles it — fail-safe, alerting instead of destroying.)

## Validation
`ksail --config ksail.prod.yaml workload validate` → **348 files green**; `kubectl kustomize` of `clusters/local` + `providers/hetzner/infrastructure` build.

Follow-up to #2158 (which fixed the disk-fill root cause). Future consideration: dropping the Kustomization-level `force: true` in favour of per-resource `force: enabled` opt-ins would make the whole platform safe-by-default, but is a larger change deferred from this targeted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)