### PR TITLE
feat(github-config): activate team CRDs and grant team RBAC

### DIFF
--- a/k8s/bases/apps/github-config/rbac.yaml
+++ b/k8s/bases/apps/github-config/rbac.yaml
@@ -26,6 +26,7 @@ metadata:
 rules:
   - apiGroups:
       - repo.github.m.upbound.io
+      - team.github.m.upbound.io
       - actions.github.m.upbound.io
       - enterprise.github.m.upbound.io
       - github.m.upbound.io

--- a/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
@@ -25,3 +25,9 @@ spec:
     # adopted Observe-first in devantler-tech/.github deploy/. The tenant Role
     # already covers the enterprise.github.m.upbound.io group.
     - organizationrulesets.enterprise.github.m.upbound.io
+    # Team management — the maintainers team + its membership and team->repo
+    # access (declared in devantler-tech/.github deploy/teams/). Lets a team be
+    # the canonical CODEOWNERS owner across the suite.
+    - teams.team.github.m.upbound.io
+    - teammemberships.team.github.m.upbound.io
+    - teamrepositories.team.github.m.upbound.io


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Activates the GitHub **team** managed resources so the `github-config` tenant can declaratively manage the `@devantler-tech/maintainers` team — per the maintainer's direction (2026-06-19): *teams over individuals*, managed *declaratively* (not via `gh api`/UI).

## What

provider-upjet-github v0.19.1 uses SafeStart (MRDs install **Inactive**; only those named in the `ManagedResourceActivationPolicy` become CRDs), and the tenant SA's Role is scoped to the activated groups. To let `.github` `deploy/teams/` manage a team, two enablers are needed here:

1. **`managed-resource-activation-policy.yaml`** — activate the three namespaced team CRDs:
   `teams.team.github.m.upbound.io`, `teammemberships.team.github.m.upbound.io`, `teamrepositories.team.github.m.upbound.io`.
2. **`k8s/bases/apps/github-config/rbac.yaml`** — add `team.github.m.upbound.io` to the github-config Role's `apiGroups` (the SA already has the same verbs on `repo.`/`actions.`/`enterprise.`/`github.` groups).

## Companion PR + rollout order

The team manifests live in **devantler-tech/.github#50** (`deploy/teams/maintainers.yaml`). **Merge this PR first** — once it reconciles, the team CRDs are active and the SA can apply them; then releasing `.github` (`v*` tag → OCI) lands the manifests. The github-config Kustomization retries benignly until the CRDs exist, so order isn't strictly required, but platform-first avoids noisy retries.

## Notes

- No `Delete` is introduced anywhere; activation only makes the CRDs available.
- Additive change consistent with the documented "extend this list as more of the org's GitHub surface comes under management" guidance in the MRAP comment and `docs/github-management.md`.
