### PR TITLE
fix(coroot): pin server/agent images to explicit versions for CVE tracking

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -78,6 +78,18 @@
       "depNameTemplate": "kubernetes/kubernetes",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the pinned Coroot CE component images (server, node-agent, cluster-agent) in the Coroot CR. The coroot-operator's `Coroot` CRD nests each image reference under `image.name` (an ImageSpec object), NOT a bare `image:` string, so Renovate's built-in `kubernetes` manager does not detect it — and when the field is left unset the operator auto-resolves the highest semver tag from ghcr on every reconcile (floating, untrackable; the source of the stale base-image CVEs in platform#2149). This regex manager captures each `name: ghcr.io/coroot/<component>:<tag>` and tracks it via the docker datasource so the pins get the normal Renovate bump PRs (minor/patch automerge per the rules below).",
+      "managerFilePatterns": [
+        "/^k8s/bases/infrastructure/coroot/coroot\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "name:\\s*(?<depName>ghcr\\.io/coroot/[a-z-]+):(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
     }
   ],
   "minor": {

--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -30,14 +30,19 @@ spec:
   # auto-resolution (it early-returns on a non-empty `image.name`). NB the
   # ImageSpec has only a `name` field (full ref incl. tag) — there is NO separate
   # `tag`/`repository` subfield, and a bare string under `image:` is silently
-  # ignored; the value MUST be `image.name`. The three pins below are kept
+  # ignored; the value MUST be `image.name`. CRITICAL: Coroot publishes its
+  # container tags as BARE semver (`1.22.2`), NOT the `v`-prefixed GitHub
+  # *release* tag (`v1.22.2`); a `v`-prefixed ref 404s on ghcr → ErrImagePull →
+  # the operator's StatefulSet/DaemonSet rollout wedges and stalls the
+  # infrastructure Kustomization health check. Always pin the bare tag. The
+  # three pins below are kept
   # Renovate-trackable by a dedicated regex customManager in
   # `.github/renovate.json` (the built-in kubernetes manager only reads a bare
   # `image:` string, not this `image.name` mapping). There is no spec.version
   # field; the operator HelmRelease itself also stays Flux/Renovate-pinned.
   communityEdition:
     image:
-      name: ghcr.io/coroot/coroot:v1.22.2
+      name: ghcr.io/coroot/coroot:1.22.2
 
   # CE has no native OIDC/SSO (Enterprise only), so the UI is fronted by the
   # existing oauth2-proxy (Dex) via httproute.yaml — exactly how Prometheus /
@@ -133,7 +138,7 @@ spec:
   nodeAgent:
     # Pinned (see the COMPONENT IMAGE PINS note at the top of spec).
     image:
-      name: ghcr.io/coroot/coroot-node-agent:v1.33.3
+      name: ghcr.io/coroot/coroot-node-agent:1.33.3
     priorityClassName: platform-critical
     tolerations:
       - operator: Exists
@@ -155,4 +160,4 @@ spec:
   # COMPONENT IMAGE PINS note at the top of spec).
   clusterAgent:
     image:
-      name: ghcr.io/coroot/coroot-cluster-agent:v1.7.1
+      name: ghcr.io/coroot/coroot-cluster-agent:1.7.1

--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -19,9 +19,25 @@ metadata:
   name: coroot
   namespace: observability
 spec:
-  # NB: the Coroot app version is managed by the operator (pin via
-  # spec.communityEdition.image if ever needed) — there is no spec.version
-  # field. The operator HelmRelease itself stays Flux/Renovate-pinned.
+  # COMPONENT IMAGE PINS. The operator does NOT bake a fixed tag into its
+  # components: when an image is left unset it lists `ghcr.io/coroot/<component>`
+  # on every reconcile and picks the highest semver tag (falling back to
+  # `:latest` only if that listing fails), so the running coroot / node-agent /
+  # cluster-agent versions FLOAT — non-deterministic and impossible to track for
+  # CVEs, which is exactly how stale reachable base-image CVEs accrued (platform
+  # #2149: coroot images flagged on `:latest`). Pinning each component's `.name`
+  # to an explicit `registry/component:tag` ref short-circuits the operator's
+  # auto-resolution (it early-returns on a non-empty `image.name`). NB the
+  # ImageSpec has only a `name` field (full ref incl. tag) — there is NO separate
+  # `tag`/`repository` subfield, and a bare string under `image:` is silently
+  # ignored; the value MUST be `image.name`. The three pins below are kept
+  # Renovate-trackable by a dedicated regex customManager in
+  # `.github/renovate.json` (the built-in kubernetes manager only reads a bare
+  # `image:` string, not this `image.name` mapping). There is no spec.version
+  # field; the operator HelmRelease itself also stays Flux/Renovate-pinned.
+  communityEdition:
+    image:
+      name: ghcr.io/coroot/coroot:v1.22.2
 
   # CE has no native OIDC/SSO (Enterprise only), so the UI is fronted by the
   # existing oauth2-proxy (Dex) via httproute.yaml — exactly how Prometheus /
@@ -115,6 +131,9 @@ spec:
   # (the operator only exposes priorityClassName on the node-agent, not on the
   # bundled Prometheus/ClickHouse).
   nodeAgent:
+    # Pinned (see the COMPONENT IMAGE PINS note at the top of spec).
+    image:
+      name: ghcr.io/coroot/coroot-node-agent:v1.33.3
     priorityClassName: platform-critical
     tolerations:
       - operator: Exists
@@ -132,3 +151,8 @@ spec:
   # singleton, not something we can scale. A brief gap only delays inventory
   # refresh, not user-facing telemetry. The genuinely scalable pieces are the
   # server (replicas: 2, hetzner overlay), ClickHouse (2) and Keeper (3).
+  # It stays at its default (enabled); only the image is pinned here (see the
+  # COMPONENT IMAGE PINS note at the top of spec).
+  clusterAgent:
+    image:
+      name: ghcr.io/coroot/coroot-cluster-agent:v1.7.1


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Kubescape's reachable-CVE scan flags the coroot stack as running stale base images on a floating tag (platform #2149). Root cause: the **coroot-operator** (v1.9.5, chart `coroot-operator` 0.9.7) leaves the **coroot server / node-agent / cluster-agent** images *unset*, so on every reconcile it lists `ghcr.io/coroot/<component>` and resolves the **highest semver tag** (falling back to `:latest` if that listing fails). The running versions therefore **float** — non-deterministic, and impossible to track for CVEs (no version to bump, `disallow-latest-tag` can't help). This is exactly the gap #2149 calls out for `observability`.

## What

Pin the three component images to their current latest releases on the `Coroot` CR, and make them Renovate-trackable:

| Component | Pinned to |
|---|---|
| `ghcr.io/coroot/coroot` (server / CE) | `v1.22.2` |
| `ghcr.io/coroot/coroot-node-agent` | `v1.33.3` |
| `ghcr.io/coroot/coroot-cluster-agent` | `v1.7.1` |

- Set on `spec.communityEdition.image.name`, `spec.nodeAgent.image.name`, `spec.clusterAgent.image.name`. The operator's `ImageSpec` has only a **`name`** field (full `registry/component:tag` ref) — there is **no** separate `tag`/`repository` subfield, and a bare string under `image:` is silently ignored; pinning `.name` short-circuits the auto-resolution (the operator early-returns on a non-empty `image.name`).
- Added a regex **Renovate `customManager`** (`.github/renovate.json`) scoped to `coroot.yaml`. Renovate's built-in `kubernetes` manager only reads a bare `image:` string, not the `image.name` mapping the CRD uses, so without this the pins would go stale. The manager tracks each `name: ghcr.io/coroot/<component>:<tag>` via the docker datasource → normal bump PRs (minor/patch automerge per existing rules).

This pins to the **current latest** of each, so it's behaviour-preserving versus the operator's own "newest semver" resolution — it just freezes + tracks it instead of letting it drift.

## Validation

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — both build clean.
- `kubectl kustomize k8s/bases/infrastructure/coroot/` — builds; all three pins present in the output.
- `kubectl apply --dry-run=client -f .../coroot.yaml` — validates against the live `coroot.com/v1` CRD schema (`coroot.coroot.com/coroot configured (dry run)`), confirming the `image.name` placement is accepted.
- `.github/renovate.json` is valid JSON; the regex matches all three pins.

## Notes / scope

- Component versions are released independently (server v1.22.x, node-agent v1.33.x, cluster-agent v1.7.x) — there's no operator-dictated matched set; pinning each to its own latest is the operator's own per-app resolution model. Verified against `coroot-operator@v1.9.5` source (`api/v1/common.go` `ImageSpec`, `controller/versions.go`, `controller/registry.go`).
- Bases hold universal config (this pin applies to every cluster), so it lives in the base, consistent with the recent ClickHouse-HA edit to this same file.
- Remaining `#2149` scope (not in this PR): confirming Renovate coverage for the HelmRelease-pinned `dex`/`flagger-loadtester` images, and a documented stance on the CNPG Postgres base-image refresh cadence.

Part of #2149.
