### PR TITLE
fix(unifi): grant tf-runner Lease access for the OpenTofu k8s backend

### DIFF
--- a/k8s/providers/hetzner/apps/unifi/rbac.yaml
+++ b/k8s/providers/hetzner/apps/unifi/rbac.yaml
@@ -1,7 +1,8 @@
 ---
-# The runner persists OpenTofu state as a Secret in this namespace (the
-# controller's default Kubernetes backend) and reads the vars Secret, so the
-# tf-runner SA needs namespaced Secret access. Scoped to this namespace only.
+# The runner uses the controller's default Kubernetes backend, which persists
+# OpenTofu state as a Secret AND locks it with a coordination.k8s.io Lease
+# (`lock-tfstate-default-unifi`). It also reads the vars Secret. So the tf-runner
+# SA needs namespaced Secret + Lease access. Scoped to this namespace only.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -10,6 +11,9 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Problem (live on prod after v1.69.0)

The `unifi` tenant's `Terraform` CR failed `init`:

```
leases.coordination.k8s.io "lock-tfstate-default-unifi" is forbidden:
User "system:serviceaccount:unifi:tf-runner" cannot get resource "leases"
in API group "coordination.k8s.io" in the namespace "unifi"
```

tofu-controller's default **Kubernetes backend locks state with a `coordination.k8s.io` Lease**, but the `tf-runner` Role only granted `secrets`. So the CR stayed `Ready=False` and — being in the `wait:true` apps layer — held the apps Kustomization `NotReady` (which gates the prod merge queue).

Everything else worked first try: the tf-runner pod scheduled + started (restricted PSS OK), reached the controller over gRPC (SPIRE mutual-auth OK), and `tofu init` downloaded the provider.

## Fix

Add `leases` (same verbs as `secrets`) to the `tf-runner` Role.

## Verified live

Applied the equivalent as a temporary additive Role on prod → the Terraform CR went **`Ready=True` (`TerraformPlannedNoChanges`** — the observe-first no-op plan) and the **apps Kustomization returned to `Ready=True`**. This PR makes it permanent; the temp Role is removed once this reconciles.

Validated: `ksail workload validate --config ksail.prod.yaml` (357 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)