### PR TITLE
fix(coroot): auto-restart server when coroot-db Secret rotates

### DIFF
--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -19,6 +19,21 @@ metadata:
   name: coroot
   namespace: observability
 spec:
+  # Restart the Coroot server when its Postgres credential rotates. The server
+  # reads the coroot-db password from the CNPG-managed `coroot-db-app` Secret via
+  # a `secretKeyRef` env var (PG_PASSWORD) — env vars are resolved once at pod
+  # start and never refreshed. CNPG regenerates that Secret whenever the coroot-db
+  # cluster is (re)created (e.g. during node-churn recovery), so a long-running
+  # server keeps presenting the OLD password and falls into a "password
+  # authentication failed for user coroot" loop until it is manually restarted
+  # (observed 2026-06-19, observability blind for hours). Reloader (deployed
+  # cluster-wide, `--reload-strategy=annotations`) watches the named Secret and
+  # rolls the server's pods on change; the annotation goes on the pod template via
+  # podAnnotations, matching the platform's existing convention (auth-proxy,
+  # oauth2-proxy, coredns).
+  podAnnotations:
+    secret.reloader.stakater.com/reload: coroot-db-app
+
   # COMPONENT IMAGE PINS. The operator does NOT bake a fixed tag into its
   # components: when an image is left unset it lists `ghcr.io/coroot/<component>`
   # on every reconcile and picks the highest semver tag (falling back to


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
During a live prod-health investigation the Coroot server (`observability/coroot-coroot-0`) was stuck in a tight loop:

```
failed to get projects: pq: password authentication failed for user "coroot"
```

**Root cause:** the server reads the coroot-db password from the CNPG-managed `coroot-db-app` Secret via a `secretKeyRef` env var (`PG_PASSWORD`). Env vars are resolved **once at pod start and never refreshed**. The `coroot-db` CNPG cluster had been (re)created ~8h earlier, so CNPG regenerated `coroot-db-app` with a **new** password — but the 19h-old server pod kept presenting the **old** one. Observability was effectively blind (no projects/incidents/SLOs) for hours until the pod was manually restarted.

Verified live: the current Secret password authenticates fine (`AUTH_OK`), and the freshly-recreated replica picked it up automatically — only the long-lived pod was stale.

## What
Add a Reloader hook via the Coroot CR's `spec.podAnnotations`:

```yaml
spec:
  podAnnotations:
    secret.reloader.stakater.com/reload: coroot-db-app
```

Reloader is already deployed cluster-wide with `--reload-strategy=annotations`; this matches the platform's existing pod-template annotation convention (`auth-proxy`, `oauth2-proxy`, `coredns`). When `coroot-db-app` changes, Reloader rolls the server so it picks up the rotated credential automatically — no manual restart, no observability blackout.

## Scope / notes
- The CR's `podAnnotations` land on the operator-managed StatefulSet's pod template (verified in `kubectl kustomize` output).
- This addresses the **auth** recurrence only. A separate, deeper issue (coroot-db being re-`initdb`'d on recovery also resets coroot's project id, desyncing it from the ClickHouse telemetry store) is reported separately to the maintainer.
- `kubectl kustomize k8s/bases/infrastructure/coroot` builds clean.