### PR TITLE
fix(crossview): pin bundled Postgres image off the :latest tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,6 +90,17 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the bundled Postgres image tag pinned for the Crossview app's chart-bundled database (k8s/bases/apps/crossview/helm-release.yaml). The crossview chart defaults database.image.tag to `latest`; pinning it lives in the Flux HelmRelease's inline spec.values, which the built-in flux manager (chart version only) and the kubernetes/helm-values managers (values.yaml files only) never see — so a custom manager is the only way to keep the pin current. Matches the `# renovate:` comment and the tag line that follows it, resolving from the docker datasource (Docker Hub library/postgres).",
+      "managerFilePatterns": [
+        "/^k8s/bases/apps/crossview/helm-release\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+tag:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "versioningTemplate": "docker"
     }
   ],
   "minor": {

--- a/k8s/bases/apps/crossview/helm-release.yaml
+++ b/k8s/bases/apps/crossview/helm-release.yaml
@@ -32,6 +32,15 @@ spec:
     # restart is acceptable — and it avoids the autoscaler-node Longhorn
     # data-loss footgun that bites stateful prod volumes.
     database:
+      # Pin the chart's bundled Postgres image. The crossview chart defaults
+      # database.image.tag to `latest` (a disallow-latest-tag policy violation,
+      # and a reliability footgun: a pod restart can silently pull a new Postgres
+      # major). Pin to the current stable — what `latest` resolves to today — and
+      # let Renovate keep it current via the customManager scoped to this file in
+      # .github/renovate.json. (Same image drives the chart's wait-for-db init.)
+      image:
+        # renovate: datasource=docker depName=postgres
+        tag: "18.4"
       persistence:
         enabled: false
     # The chart's bundled Postgres refuses to initialize without


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Live prod scan found the crossview app running the bundled Postgres on a floating tag:

```
crossview-654fc77dff   init: wait-for-db        postgres:latest
crossview-postgres-…   main: postgres           postgres:latest
```

(the main app image `ghcr.io/crossplane-contrib/crossview:v4.4.0` is already pinned). `postgres:latest`:
- trips the `disallow-latest-tag` Kyverno policy (recurring `PolicyViolation` warning events), and
- is a **reliability footgun** — any pod restart can silently pull a new Postgres **major**, which can fail to start or break compatibility.

The crossview chart defaults `database.image.tag` to `latest`; it's overridable via the HelmRelease values.

## What
- Pin `database.image.tag: "18.4"` in the crossview HelmRelease. `18.4` is exactly what `latest` resolves to today (verified `postgres --version` in the running pod → `18.4`), so this is **behaviour-preserving**. The same `database.image` drives the `wait-for-db` initContainer, so both stop using `:latest`.
- Add a Renovate `customManager` (`.github/renovate.json`) scoped to `crossview/helm-release.yaml` so the pin stays current — the built-in `flux` manager only tracks the chart version, and `helm-values`/`kubernetes` only read `values.yaml` files, not a Flux HelmRelease's inline `spec.values`. Mirrors the existing inline-`# renovate:` customManager convention.

## Validation
- `kubectl kustomize k8s/bases/apps/crossview` builds clean (`database.image.tag: "18.4"`).
- `renovate.json` is valid JSON; the customManager regex matches the pinned line (`docker / postgres → 18.4`).
- DB is ephemeral (`database.persistence.enabled: false`), so no data-migration concern.