### PR TITLE
fix(cilium): pin datapath to private NICs so mutual-auth (TCP 4250) survives the Talos firewall

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/patches/helm-release-patch.yaml
@@ -67,3 +67,51 @@ spec:
           # cilium-health host probes survive the IPCache propagation window
           # during node churn. Pod-to-pod across the CIDR above stays fail-closed.
           allowRemoteNodeIdentities: true
+    # Pin the eBPF datapath to the PRIVATE-network NICs so every node uses its
+    # private IP (10.0.1.x) as its primary node address for agent-to-agent
+    # control traffic — specifically the SPIRE mutual-auth handshake (TCP 4250).
+    #
+    # Hetzner nodes are dual-homed: a public NIC carrying the default route
+    # (workers enp1s0 / control-planes eth0) and the private-network NIC
+    # (workers enp7s0 / control-planes eth1). With devices unset, Cilium probes
+    # and attaches to BOTH, then takes the default-route (public) NIC's IP as the
+    # node's PRIMARY address. cilium-health (4240) and the VXLAN/WireGuard tunnel
+    # ride the private "Direct Routing" NIC and work — but the mutual-auth control
+    # connection (cilium-agent -> peer cilium-agent on 4250) dials the peer's
+    # PRIMARY (public) IP. The Talos ingress firewall only admits 4240/4250/8472
+    # from the private node CIDR (10.0.0.0/16, see
+    # talos/workers/ingress-firewall.yaml), so the public-sourced 4250 handshake
+    # is dropped (`dial <public-ip>:4250: i/o timeout`) and Cilium black-holes every
+    # cross-node pod flow the hetzner require-mutual-auth policy marks
+    # `authentication.mode: required` once its auth-cache entry lapses. Observed
+    # live (2026-06-19): the Crossview dashboard was unreachable — authenticated
+    # oauth2-proxy/auth-proxy -> crossview:3001 SYNs returned `policy-verdict:
+    # none ... Policy denied DROPPED` (the spire AUTH TYPE on that policy entry
+    # never completed its handshake) — while older dashboards limped on still-
+    # cached auth entries. Failures spanned all three workers, dialing each
+    # other's public IPs on 4250.
+    #
+    # Listing the private NICs makes the private IP each node's primary address,
+    # so the 4250 handshake uses 10.0.1.x and the firewall admits it.
+    #
+    # Safe on this topology (all verified live, 2026-06-19):
+    #   - Ingress: the Hetzner LB reaches nodes on their PRIVATE IPs
+    #     (load-balancer.hetzner.cloud/use-private-ip: "true", see
+    #     ../../../gateway-patch.yaml) and clients hit the LB's public IP, not
+    #     node public IPs. The private NIC stays a Cilium device, so the LB's
+    #     NodePort BPF is unaffected; only unused public-NIC NodePort BPF is shed.
+    #   - Egress: pod -> internet masquerade is the device-AGNOSTIC iptables rule
+    #     (-s podCIDR ! -d podCIDR ! -o cilium_+ -j MASQUERADE), not scoped to
+    #     this devices list, so pods still SNAT out the public NIC. (Masquerading
+    #     is iptables here; bpf.masquerade is off.)
+    #   - cilium-health / VXLAN / WireGuard already used the private NIC.
+    #
+    # WARNING: hard-codes the private-NIC names. Today every worker is enp7s0 and
+    # every control-plane is eth1 (verified on all 6 nodes). An autoscaler worker
+    # brought up on a server type whose private NIC is named differently would
+    # lose Cilium networking until its name is added here — keep this in sync with
+    # the node pool's machine type.
+    #
+    # PROD/HETZNER ONLY: the docker/local provider is single-NIC, so device
+    # autodetection is correct there. This pin lives in the hetzner overlay.
+    devices: "enp7s0 eth1"


### PR DESCRIPTION
## Symptom

`https://crossview.platform.devantler.tech` is unreachable: SSO login completes, then the page never loads.

## Root cause (traced live on `admin@prod`)

Crossview's own stack is healthy — pod `Running`, `crossview-service:80 → :3001` endpoints good, ExternalSecret synced, and the unauthenticated SSO redirect chain is byte-for-byte identical to the working `observability`/coroot dashboard. The break is one layer down, in the cluster's zero-trust mTLS fabric.

Authenticated traffic from `auth-proxy` to `crossview:3001` is dropped by Cilium:

```
oauth2-proxy/auth-proxy(ID:26637) <> crossview/...:3001 (ID:41147)
  policy-verdict:none ... Policy denied DROPPED (TCP Flags: SYN)
```

The `allow-crossview` policy *does* allow `oauth2-proxy → 3001`, but the BPF entry carries `AUTH TYPE: spire` — mutual auth is required by the clusterwide `require-mutual-auth` policy (identical to coroot). The SPIRE handshake never completes, so every SYN is dropped → timeout → the page never loads after login.

The cilium-agent log shows why:

```
Failed to authenticate ... failed to dial 46.224.168.140:4250: i/o timeout
```

`46.224.168.140` is a worker's **public** IP. The dual-homed Hetzner nodes have a public default-route NIC (`enp1s0`/`eth0`) and a private NIC (`enp7s0`/`eth1`). With `devices` unset, Cilium attaches to both and takes the **public** NIC's IP as each node's primary address — so the agent-to-agent mutual-auth handshake (TCP 4250) dials peers' public IPs. But `talos/workers/ingress-firewall.yaml` only admits 4250 (and 4240/8472) from the private node CIDR `10.0.0.0/16`, so the public-sourced handshake is firewall-dropped.

`cilium-health` (4240) and the VXLAN/WireGuard tunnel happen to ride the private "Direct Routing" NIC, so they work — which masked the breakage until a brand-new app (Crossview) needed a fresh handshake. Older dashboards limp along on still-cached auth entries. Auth failures actually span all three workers.

## Fix

Pin Cilium `devices` to the **private** NICs so every node's primary IP — and thus the 4250 mutual-auth handshake — uses `10.0.1.x`, which the firewall already allows:

```yaml
spec:
  values:
    devices: "enp7s0 eth1"   # workers: enp7s0, control-planes: eth1
```

Verified on all 6 nodes: every worker's private NIC is `enp7s0`, every control-plane's is `eth1`.

## Why it's safe (all verified live)

- **Ingress** — the Hetzner LB reaches nodes on their **private** IPs (`load-balancer.hetzner.cloud/use-private-ip: "true"`) and clients hit the LB's public IP, not node public IPs. The private NIC stays a Cilium device, so the LB's NodePort BPF is unaffected; only unused public-NIC NodePort BPF is shed.
- **Egress** — pod→internet masquerade is the **device-agnostic** iptables rule (`-s podCIDR ! -d podCIDR ! -o cilium_+ -j MASQUERADE`), not scoped to `devices`, so pods still SNAT out the public NIC. (Masquerading is iptables here; `bpf.masquerade` is off.)
- **cilium-health / VXLAN / WireGuard** already used the private NIC — unchanged.

## Rollout & residual risk

- `rollOutCiliumPods: true` is already set, so the cilium-agent DaemonSet rolls one node at a time on reconcile. Agent restarts are datapath-non-disruptive (eBPF state persists).
- **After merge, validate:** cross-node pod connectivity + `cilium-dbg bpf auth list` showing `26637↔41147` established, then confirm `https://crossview.platform.devantler.tech` loads.
- ⚠️ This hard-codes the private-NIC names. An autoscaler worker brought up on a server type whose private NIC isn't `enp7s0` would lose Cilium networking until added here — keep the list in sync with the node pool's machine type.

Prod/Hetzner-only: the docker/local provider is single-NIC, so autodetection is correct there; this pin lives in the hetzner overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)