### PR TITLE
fix(cnpg): synchronous replication so an unclean failover self-heals

### DIFF
--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -43,6 +43,30 @@ spec:
   storage:
     size: 5Gi
     storageClass: longhorn
+  # Quorum-based SYNCHRONOUS replication so a failover can never strand the old
+  # primary. Background: on 2026-06-19 the longhorn instance-manager on a storage
+  # worker was replaced; the CNPG primaries pinned to that node lost their RWO
+  # volume and CNPG failed over (failoverDelay defaults to 0 = immediate). Under
+  # the default ASYNC replication the promoted standby can be behind the dead
+  # primary, so the old primary came back on a diverged timeline and CNPG's
+  # automatic pg_rewind rejoin failed for hours with "could not find common
+  # ancestor of the source and target cluster's timelines" — umami-db and
+  # wedding-db both sat at 2/3 and wedged the apps / wedding-app Flux health
+  # checks until an operator deleted the stranded PVC to force a re-bootstrap.
+  # With `number: 1` every commit is acknowledged only once at least one standby
+  # has the WAL, so whichever standby is promoted already holds every committed
+  # transaction — the timeline never forks behind the old primary and the rejoin
+  # self-heals with no manual step. `dataDurability: preferred` keeps the DB
+  # WRITABLE if BOTH standbys are ever unavailable (it transparently relaxes to
+  # async for that window) instead of blocking commits the way `required` would,
+  # so this hardens durability with no write-availability regression — a good fit
+  # for this low-write metadata DB where the extra in-cluster commit round-trip is
+  # negligible.
+  postgresql:
+    synchronous:
+      method: any
+      number: 1
+      dataDurability: preferred
   bootstrap:
     initdb:
       database: umami

--- a/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
+++ b/k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml
@@ -29,6 +29,22 @@ spec:
         spec:
           storage:
             storageClass: longhorn
+          # Quorum-based SYNCHRONOUS replication, same rationale as umami-db: a
+          # longhorn instance-manager restart that kills the primary must not be
+          # able to fork the timeline and strand the old primary on a pg_rewind
+          # "could not find common ancestor" loop (which wedged wedding-db at 2/3
+          # and failed the wedding-app health check on 2026-06-19, requiring a
+          # manual PVC re-bootstrap). Like storageClass above this is a
+          # platform-storage concern (it mitigates longhorn/instance-manager
+          # churn), so it is patched here rather than hardcoded in the
+          # environment-agnostic wedding-app source artifact. `dataDurability:
+          # preferred` relaxes to async if BOTH standbys are unavailable, so the
+          # DB stays writable instead of blocking commits.
+          postgresql:
+            synchronous:
+              method: any
+              number: 1
+              dataDurability: preferred
     - target:
         kind: HTTPRoute
         name: wedding-app

--- a/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
@@ -75,6 +75,17 @@ spec:
       # replica from a base backup (cheap: the DB is ~32Mi). Set well above
       # normal WAL for this low-write metadata DB, yet well below the 10Gi volume.
       max_slot_wal_keep_size: "3GB"
+    # Quorum-based SYNCHRONOUS replication — the SAME rationale as umami-db: it
+    # guarantees the promoted standby holds every committed transaction, so an
+    # unclean primary loss during a longhorn instance-manager restart / node roll
+    # can no longer fork the timeline and strand the old primary on a pg_rewind
+    # "could not find common ancestor" loop (observed cluster-wide 2026-06-19).
+    # `dataDurability: preferred` relaxes to async if BOTH standbys are down, so
+    # the HA Coroot server's metadata DB stays writable rather than blocking.
+    synchronous:
+      method: any
+      number: 1
+      dataDurability: preferred
   bootstrap:
     initdb:
       database: coroot


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What happened (prod incident, 2026-06-19)

A graceful **longhorn instance-manager replacement** on storage worker-3 (~19:42) knocked the CNPG **primaries** pinned to that node off their RWO volumes. With `failoverDelay: 0` CNPG failed over immediately, and under the **default async replication** the promoted standby was slightly behind the dead primary. The old primaries (`umami-db-4`, `wedding-db-1`) then came back on a **diverged timeline**, and CNPG's automatic `pg_rewind` rejoin looped for ~90 min on:

```
pg_rewind: error: could not find common ancestor of the source and target cluster's timelines
```

Both databases sat at **2/3 redundancy** and their `Cluster` status stayed `InProgress`, which **wedged the `flux-system/apps` and `wedding-app` Flux health checks** (no app could reconcile via GitOps). It only cleared after an operator deleted the stranded PVCs to force a `pg_basebackup` re-bootstrap.

`coroot-db` survived the same event only because its *replica* (not its primary) happened to be the instance on worker-3 — pure luck-of-the-draw, so every CNPG cluster is exposed.

## Fix — make failover self-healing instead of manual

Enable **quorum-based synchronous replication** on all three CNPG clusters:

```yaml
spec:
  postgresql:
    synchronous:
      method: any
      number: 1
      dataDurability: preferred
```

- `number: 1` (method `any`) → every commit is acknowledged only once **at least one standby holds the WAL**. The promoted standby therefore always has every committed transaction, the timeline **cannot fork behind the old primary**, and `pg_rewind` rejoins cleanly — **the cluster self-heals with no manual PVC deletion** (the user's explicit ask).
- `dataDurability: preferred` (CNPG ≥1.26) → if **both** standbys are ever unavailable, it transparently relaxes to async so the DB **stays writable** instead of blocking commits. Net: more durability, **no write-availability regression**. These are all low-write metadata DBs, so the extra in-cluster commit round-trip is negligible.

### Files
| Cluster | Where | Note |
|---|---|---|
| `umami-db` | `k8s/bases/apps/umami/postgres-cluster.yaml` | canonical comment |
| `coroot-db` | `k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml` | sibling of existing `postgresql.parameters` |
| `wedding-db` | `k8s/providers/hetzner/apps/wedding-app/patches/kustomization-patch.yaml` | tenant-owned Cluster; patched platform-side next to the existing `storageClass: longhorn` override (both are longhorn-storage concerns) |

## Validation

- `kubectl kustomize k8s/clusters/local` and `k8s/clusters/prod`: build OK
- `kubectl kustomize k8s/providers/hetzner/{apps,infrastructure}`: build OK; the `synchronous` block renders on the `umami-db` and `coroot-db` Clusters and inside the `wedding-app` Flux Kustomization patch
- The two stranded instances were already re-bootstrapped operationally during this investigation; both clusters are back to **3/3 healthy**. This PR prevents the manual step from being needed again.

### Alternative considered
`failoverDelay: <N>s` (ride out a brief instance-manager blip without promoting at all) is complementary but adds write-downtime on genuine failures and doesn't *guarantee* against divergence. Synchronous replication addresses the root cause directly, so it's the primary fix here; `failoverDelay` could be layered on later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
