### PR TITLE
fix(headlamp): allow egress to registry.npmjs.org so the plugin sidecar can bootstrap

### DIFF
--- a/k8s/bases/apps/headlamp/networkpolicy.yaml
+++ b/k8s/bases/apps/headlamp/networkpolicy.yaml
@@ -28,6 +28,11 @@ spec:
     # CDN; without it every plugin archive fetch times out, the
     # headlamp-plugin sidecar crashloops and the dashboard ships with no
     # plugins. Same gap the kubescape policy already had to close.
+    # registry.npmjs.org: the headlamp-plugin sidecar bootstraps each plugin
+    # with `npx @headlamp-k8s/pluginctl ...`, which downloads pluginctl (and its
+    # deps) from the npm registry. Missing it -> npm ETIMEDOUT -> the sidecar
+    # crashloops on every (re)start; regression from the world:443 -> FQDN
+    # lockdown (#2019).
     - toFQDNs:
         - matchName: "dex.${domain}"
         - matchName: "artifacthub.io"
@@ -36,6 +41,7 @@ spec:
         - matchName: "objects.githubusercontent.com"
         - matchName: "raw.githubusercontent.com"
         - matchName: "release-assets.githubusercontent.com"
+        - matchName: "registry.npmjs.org"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
> 🤖 Generated by Claude Code (live investigation of the prod platform)

## Problem

The `headlamp` pod's `headlamp-plugin` sidecar (`node:lts-alpine`) is in **CrashLoopBackOff**. Captured crash (previous-container logs):

```
npm error code ETIMEDOUT
npm error network request to https://registry.npmjs.org/@headlamp-k8s%2fpluginctl failed
```

## Root cause

The sidecar bootstraps each plugin with `npx --yes @headlamp-k8s/pluginctl@latest install ...`, which must download `pluginctl` (+deps) from **`registry.npmjs.org`**. That host is **not** in the Cilium egress `toFQDNs` allow-list, so Cilium's L7 DNS/FQDN policy drops the request → `npm ETIMEDOUT` → `npx` exits 1 → sidecar crashloops on every (re)start.

This is a **regression** from the `world:443` → explicit-FQDN egress lockdown (#2019): the cached plugins on the PVC predate the lockdown, so the dashboard still renders, but the sidecar can no longer re-run pluginctl, and the newly added `crossview-headlamp` plugin never installs.

## Fix

Add `registry.npmjs.org` to the `toFQDNs` list in `k8s/bases/apps/headlamp/networkpolicy.yaml` — the same one-line pattern as the earlier plugin-egress fix (#2112, which added the GitHub release-asset CDN). The networkpolicy is identical local+prod, so the base file is the correct place (consistent with #2112).

## Validation

`kubectl kustomize k8s/bases/apps/headlamp/` builds; `registry.npmjs.org` renders in the allow-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)