### PR TITLE
fix(policy): exempt crossview from the replica-floor HA check

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-replica-floor.yaml
@@ -176,6 +176,21 @@ spec:
           - resources:
               names:
                 - plugin-barman-cloud
+          # crossview (apps/crossview): a deliberately non-HA, SSO-fronted,
+          # read-only Crossplane resource dashboard. Its bundled Postgres
+          # (crossview-postgres) runs with persistence DISABLED -- a single
+          # ephemeral session/user store whose loss on restart the chart values
+          # explicitly accept -- so it genuinely cannot run 2, and the upstream
+          # crossview chart exposes no pod-label value to carry the exempt
+          # opt-out (same constraint as plugin-barman-cloud). The frontend shares
+          # that single ephemeral store, so a 2nd app replica adds no real HA
+          # while the DB stays a SPOF. Exempt both by name (both names stable;
+          # no ProviderRevision-style hash suffix). Promote to HA later only if
+          # the bundled Postgres is moved to a replicated store (e.g. CNPG).
+          - resources:
+              names:
+                - crossview
+                - crossview-postgres
       preconditions:
         all:
           # Durable opt-out on the pod template (charts expose podLabels more


### PR DESCRIPTION
> 🤖 Generated by Claude Code (live investigation of the prod platform)

## Problem

`validate-replica-floor` continuously emits `PolicyViolation` warnings for `crossview` and `crossview-postgres` (both run 1 replica), e.g.:

```
Deployment crossview/crossview-postgres: [require-replica-floor] fail;
runs 1 replica(s); the platform HA floor is 2 ...
```

These recurring warnings are noise and can trip the merge-queue event gate.

## Why exempt (not scale to 2)

crossview is a **deliberately non-HA**, SSO-fronted, read-only Crossplane resource dashboard:

- Its bundled Postgres (`crossview-postgres`) runs with `database.persistence.enabled: false` — a **single ephemeral** session/user store whose loss on restart the chart values comment explicitly accepts. A plain Postgres Deployment genuinely cannot run 2 replicas, and the upstream chart exposes no pod-label value to carry the `replica-floor: exempt` opt-out (same constraint already documented for `plugin-barman-cloud`).
- The frontend shares that single ephemeral store, so a 2nd app replica would add **no real availability** while the DB remains a SPOF.

So this matches the policy's existing **by-name exemption** pattern for genuine singletons rather than the opt-in-to-2 path used for HA-capable controllers.

## Fix

Add `crossview` and `crossview-postgres` to the `validate-replica-floor` exclude-by-name list (stable names, no ProviderRevision-style hash suffix), with a comment documenting the rationale and the path to real HA (move the bundled Postgres to a replicated store such as CNPG, as the other prod DBs use).

## Validation

`kubectl kustomize k8s/bases/infrastructure/cluster-policies/` builds; both names render in the policy's exclude list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)