### PR TITLE
fix(ci): pin ksail to v7.65.0 in system-test to avoid the 7.66.0 validate race

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,15 @@ jobs:
       - name: 🧪 System Test
         uses: devantler-tech/ksail/.github/actions/ksail-cluster@2961d7c1fea92dd2885037af82b818076afffb93 # v7.65.0
         with:
+          # Pin the ksail BINARY to match the action ref above. Without this the
+          # action installs `latest`, which is currently 7.66.0 -- and 7.66.0 has
+          # a non-deterministic race in `ksail workload validate`'s in-process
+          # parallel Helm rendering that corrupts the rendered output at a random
+          # point, failing with varying YAML parse errors ("mapping values are
+          # not allowed in this context", "could not find expected ':'") on a
+          # different kustomization each run. 7.65.0 validates deterministically
+          # (97/97). Drop this pin once a ksail release fixes the race.
+          ksail-version: "7.65.0"
           distribution: Talos
           provider: Docker
           init: "false"


### PR DESCRIPTION
> 🤖 Generated by Claude Code (unblocking #2180)

## Problem

The **System Test** (`ksail workload validate`) fails intermittently on k8s PRs — it blocked [#2180](https://github.com/devantler-tech/platform/pull/2180). The failure is a YAML parse error in the rendered manifests, but **the location and error type vary every run**:

| Run | Result |
|---|---|
| CI (#2180) | `line 73 / 91: mapping values are not allowed in this context` |
| local 7.66.0 run 1 | `line 225 / 245 / 306: could not find expected ':' / did not find expected key` |
| local 7.66.0 runs | failed 2, 2, then 1 kustomization(s) — count varies |

## Root cause

The `ksail-cluster` action on this step is pinned to **v7.65.0**, but it installs the ksail **binary** with its default `ksail-version: latest` — currently **7.66.0**. ksail 7.66.0 has a **non-deterministic race in `workload validate`'s in-process parallel Helm rendering**: it corrupts the rendered manifest stream at a random point, so validation fails on a random kustomization with a random YAML error each run. The varying line numbers/error types are the signature of the race (a real manifest defect fails at a *fixed* location).

Verified locally with the exact CI version:
- **ksail 7.65.0** → `✔ 97 kustomizations validated` deterministically (both `ksail.yaml` and `ksail.prod.yaml`, repeated).
- **ksail 7.66.0** → reproduces the failure; `kubectl kustomize` of the same overlays passes (so it's the helm-render path, not the manifests).

The affected overlays (`providers/{docker,hetzner}/infrastructure/controllers`) aren't even touched by #2180 — confirming it's the tool, not the change.

## Fix

Pin the installed binary to **`ksail-version: "7.65.0"`**, matching the action ref already pinned on this step. Deterministic, and reversible — drop the pin once a ksail release fixes the race.

## Follow-up (separate, in the ksail repo)

The underlying bug is in **ksail** itself (`devantler-tech/ksail`): `workload validate` should serialize or isolate per-kustomization Helm rendering so concurrent renders can't corrupt each other's output. Worth a dedicated issue/fix there; this PR is just the platform-side unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)