### PR TITLE
feat(kro): install kube-resource-orchestrator controller

### DIFF
--- a/k8s/bases/infrastructure/controllers/kro/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kro/helm-release.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kro
+  namespace: kro-system
+  labels:
+    # The chart ships the ResourceGraphDefinition CRD; let Flux manage its
+    # lifecycle (install/upgrade crds: CreateReplace below).
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  interval: 10m0s
+  timeout: 10m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: kro
+      version: 0.9.2
+      sourceRef:
+        kind: HelmRepository
+        name: kro
+  # https://kro.run -- KRO (kube-resource-orchestrator) lets the platform define
+  # higher-level "archetype" APIs as ResourceGraphDefinitions (RGDs) that expand
+  # into a graph of standard Kubernetes resources. This release installs the
+  # CONTROLLER + RGD CRD ONLY; the Tenant (#1932) and WebApp (#1933) archetype
+  # RGDs land later in the `infrastructure` layer, which `dependsOn`
+  # `infrastructure-controllers` -- a CR of an RGD-defined kind cannot share a
+  # Flux Kustomization with the controller that installs its CRD (same
+  # server-side-dry-run deadlock the Coroot CR documents).
+  #
+  # KRO is pre-1.0 (v1alpha1 API); pinned to an exact patch and health-gated by
+  # the `wait: true` infrastructure-controllers Kustomization.
+  values:
+    # Clean resource names (kro instead of <release>-kro).
+    fullnameOverride: kro
+    rbac:
+      # Least-privilege RBAC. `aggregation` grants KRO only the minimal
+      # permissions to manage its OWN resources (RGDs + the instance CRDs it
+      # generates) and aggregates any ClusterRole labelled
+      # `rbac.kro.run/aggregate-to-controller: "true"`. The chart default
+      # `unrestricted` is a cluster-admin wildcard, which clashes with the
+      # platform's least-privilege posture (cf. ksail-operator clusterAdmin:
+      # false). Each archetype RGD PR (#1932 Tenant / #1933 WebApp) ships an
+      # aggregated ClusterRole granting exactly the verbs for the child kinds it
+      # manages -- until then KRO holds no standing access to arbitrary
+      # resources, which is the correct posture for a controller-only install.
+      mode: aggregation
+    deployment:
+      # Run HA matching the rest of the operator tier (Coroot flags a sole
+      # replica "single instance - not resilient to node failure"). The chart
+      # enables leader election by default (config.enableLeaderElection: true),
+      # so 2 replicas = one active reconciler + a warm standby that takes over
+      # on a node drain/failure -- not double-reconciliation. Drain safety comes
+      # from the standalone maxUnavailable: 1 PDB (pod-disruption-budget.yaml).
+      replicaCount: 2
+      # Spread the 2 HA replicas across nodes so a single node failure cannot
+      # take out both. ScheduleAnyway (soft) so a single-node local/CI cluster
+      # still schedules both pods -- matching the velero/ksail-operator posture.
+      # The chart exposes this as a value, so no post-renderer is needed (the
+      # chart's securityContext is already restricted-compliant -- see
+      # namespace.yaml).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: kro
+              app.kubernetes.io/instance: kro
+    config:
+      # GitOps owns CRD lifecycle (Flux, via crds: CreateReplace above) -- never
+      # let the controller delete a CRD out from under Git. (Chart default is
+      # already false; pinned explicitly so the intent survives a chart bump.)
+      allowCRDDeletion: false

--- a/k8s/bases/infrastructure/controllers/kro/helm-repository.yaml
+++ b/k8s/bases/infrastructure/controllers/kro/helm-repository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kro
+  namespace: kro-system
+spec:
+  type: oci
+  # KRO publishes its chart as an OCI artifact to the Kubernetes community
+  # registry (`oci://registry.k8s.io/kro/charts/kro`), so the source URL is the
+  # repository PREFIX and the chart name is appended via HelmRelease.chart.spec
+  # -- mirroring the flux-operator pattern (oci://<registry>/<prefix> + chart).
+  url: oci://registry.k8s.io/kro/charts

--- a/k8s/bases/infrastructure/controllers/kro/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kro/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - helm-release.yaml
+  - networkpolicy.yaml
+  - pod-disruption-budget.yaml

--- a/k8s/bases/infrastructure/controllers/kro/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/kro/namespace.yaml
@@ -1,0 +1,18 @@
+# Native PSA enforce=restricted is safe here (unlike keda / ksail-operator).
+#
+# The KRO chart ships a COMPLETE restricted-compliant securityContext out of the
+# box -- pod-level seccompProfile: RuntimeDefault and a container securityContext
+# with a NUMERIC runAsUser: 1000, runAsNonRoot: true, allowPrivilegeEscalation:
+# false and capabilities.drop: [ALL]. So kube-apiserver's PSA validator admits
+# the pod natively on cold bootstrap, before Kyverno's add-security-context
+# mutating webhook runs -- there is no partial-context gap to paper over. The
+# numeric runAsUser also avoids the "image has non-numeric user, cannot verify"
+# kubelet failure (cf. ksail-operator). The Kyverno validate-pod-security
+# ClusterPolicy (Enforce) remains a backstop at the webhook layer.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kro-system
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/k8s/bases/infrastructure/controllers/kro/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/kro/networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kro
+  namespace: kro-system
+spec:
+  endpointSelector: {}
+  ingress:
+    # Intra-namespace (the two HA replicas; leader-election peers).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kro-system
+  egress:
+    # Intra-namespace.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kro-system
+    # Kube API. KRO reconciles ResourceGraphDefinitions and creates/updates the
+    # child resources they expand into entirely through the apiserver, and
+    # writes its leader-election Lease there. KRO needs NO world/external egress:
+    # it never pulls charts or images itself -- the resources it creates (e.g.
+    # HelmReleases) are reconciled by their own controllers, which hold their own
+    # egress.
+    - toEntities:
+        - kube-apiserver
+    # DNS resolution.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/k8s/bases/infrastructure/controllers/kro/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/kro/pod-disruption-budget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kro
+  namespace: kro-system
+spec:
+  # Drain-safe PDB (#1880/#1882): maxUnavailable: 1 keeps the node drainable at
+  # any replica count, unlike minAvailable: 1 which deadlocks a drain when only
+  # 1 replica is ready. The KRO chart ships no PDB knob, so this is a standalone
+  # manifest (same approach as ksail-operator / snapshot-controller). Pairs with
+  # deployment.replicaCount: 2 in helm-release.yaml -- KRO is leader-elected, so
+  # the standby keeps reconciliation available while a node drains.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kro
+      app.kubernetes.io/instance: kro

--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - flagger/
   - flux-operator/
   - keda/
+  - kro/
   - ksail-operator/
   - kubescape/
   - kyverno/


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Installs **KRO** ([kube-resource-orchestrator](https://kro.run), `kro.run/v1alpha1`) as a base infrastructure controller — the prerequisite for the platform's archetype APIs. This PR ships the **controller + its `ResourceGraphDefinition` CRD only**; the actual archetype RGDs land in follow-up PRs.

Part of **#1932** (Tenant archetype) and **#1933** (WebApp archetype) — both decided to use KRO (maintainer ruling: "Custom Resource approach, more cloud-native"; Crossplane is reserved for external APIs, KRO is the in-cluster composition engine).

## Files (`k8s/bases/infrastructure/controllers/kro/`)

| File | Purpose |
|---|---|
| `helm-repository.yaml` | Flux OCI `HelmRepository` → `oci://registry.k8s.io/kro/charts` (mirrors flux-operator) |
| `helm-release.yaml` | `HelmRelease` chart `kro` **pinned `0.9.2`** (latest; v1alpha1 API) |
| `namespace.yaml` | `kro-system` with native PSA `enforce: restricted` |
| `networkpolicy.yaml` | `CiliumNetworkPolicy` — intra-ns + kube-apiserver + DNS egress |
| `pod-disruption-budget.yaml` | Drain-safe `maxUnavailable: 1` |
| `kustomization.yaml` | Subdir aggregate; wired into the base controllers list (alphabetical, between `keda/` and `ksail-operator/`) |

Placed at **Layer 2** (`infrastructure-controllers`); the Tenant/WebApp RGDs and any RGD-defined CRs belong at **Layer 3** (`infrastructure`, which `dependsOn` controllers) — the same server-side-dry-run deadlock the Coroot CR documents.

## Key decisions & trade-offs

- **Least-privilege RBAC (`rbac.mode: aggregation`, not the chart-default `unrestricted`).** `unrestricted` is a cluster-admin wildcard, which clashes with the platform's posture (cf. `ksail-operator` `clusterAdmin: false`). `aggregation` gives KRO only the perms to manage its own RGDs/instances plus any ClusterRole labelled `rbac.kro.run/aggregate-to-controller: "true"`. **Follow-up requirement:** each archetype RGD PR (#1932/#1933) must ship an aggregated ClusterRole granting exactly the verbs for the child kinds it manages — until then KRO holds no standing access to arbitrary resources, which is correct for a controller-only install.
- **HA (2 replicas).** The chart enables leader election by default (`config.enableLeaderElection: true`), so 2 replicas = one active reconciler + a warm standby on node drain/failure (not double-reconcile), preempting Coroot's "single instance — not resilient" flag. Soft `ScheduleAnyway` topology spread keeps single-node local/CI clusters schedulable.
- **Native PSA `restricted` on the namespace.** Unlike keda/ksail-operator, KRO's chart ships a complete restricted securityContext with a **numeric** `runAsUser: 1000`, so kube-apiserver admits it on cold bootstrap before Kyverno mutates — no partial-context gap, no "non-numeric user" kubelet failure.
- **No world egress.** KRO only talks to the apiserver (creates child resources + writes its leader-election Lease); it never pulls charts/images itself.
- **Flux owns CRDs** (`crds: CreateReplace` + `helm.toolkit.fluxcd.io/crds: enabled`); `config.allowCRDDeletion: false` so the controller never deletes a CRD out from under Git.

## Validation (no cluster started)

- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` — both build ✅
- `kubectl kustomize` of both provider controller overlays (`docker`, `hetzner`) — build clean, KRO present ✅
- Base controllers aggregate renders all 5 KRO resources ✅
- `helm template … --version 0.9.2` with the exact values block — accepted: ServiceAccount + 2 ClusterRoles (aggregation), Deployment `replicas: 2` + `--leader-elect` + topology spread ✅
- `kubectl apply --dry-run=client` on namespace + PDB ✅; chart ships `resourcegraphdefinitions.kro.run` CRD ✅

The Talos+Docker system test runs in CI on this PR.
