### PR TITLE
feat(crossview): authenticate via SSO trusted-header instead of native login

### DIFF
--- a/k8s/bases/apps/crossview/helm-release.yaml
+++ b/k8s/bases/apps/crossview/helm-release.yaml
@@ -75,3 +75,42 @@ spec:
           # plugin embeds in its "Open Crossview" iframe (resolved from the
           # crossview-ingress Ingress).
           origin: https://crossview.${domain}
+        # Authenticate via the platform SSO chain instead of Crossview's built-in
+        # username/password DB. Crossview already sits behind oauth2-proxy (Dex ->
+        # GitHub): httproute.yaml routes crossview.${domain} -> oauth2-proxy ->
+        # auth-proxy -> crossview-service:3001, and oauth2-proxy injects (and
+        # OVERWRITES — pass_user_headers, on by default) the authenticated identity
+        # as X-Forwarded-Email on the upstream request. AUTH_MODE=header makes
+        # Crossview trust that header — crossview-go-server/api/middlewares/
+        # header_auth.go reads it and 401s if it is absent — and auto-provision the
+        # user, so there is no second login prompt and the chart-default
+        # admin/password in the crossview-secrets Secret stops being an access path.
+        #
+        # Not spoofable from outside the cluster: oauth2-proxy sets X-Forwarded-Email
+        # from the validated Dex session (replacing any client-sent value) and
+        # redirects unauthenticated requests before they reach the upstream, and
+        # auth-proxy only accepts ingress from oauth2-proxy. The crossview
+        # NetworkPolicy additionally admits host/remote-node on :3001, but that path
+        # carries no header, so (a) kubelet probes hit the PUBLIC /api/health
+        # (registered with no auth middleware — health stays green in header mode)
+        # and (b) a direct pod port-forward just 401s; forging the header there
+        # already requires in-cluster port-forward access, far above read-only view.
+        #
+        # New users land as `viewer` — read-only, matching Crossview's role here
+        # (raise defaultRole to `admin` to let the SSO user manage Crossview itself;
+        # the SSO gate already restricts to the devantler-tech/platform GitHub team).
+        # createUsers + defaultRole are pinned, not cosmetic: the bundled Postgres is
+        # ephemeral (persistence disabled), so the user is re-created on every pod
+        # restart — a chart default-flip must not silently break login or escalate
+        # the granted role.
+        #
+        # Trade-off: the Headlamp DESKTOP "Open Crossview" port-forward now 401s (no
+        # oauth2-proxy in that path); the web crossview.${domain} iframe path
+        # (supported since #2188) is unaffected. If a real login 401s because
+        # X-Forwarded-Email is empty for an account, switch trustedHeader to
+        # X-Forwarded-Preferred-Username (the GitHub login).
+        auth:
+          mode: header
+          trustedHeader: X-Forwarded-Email
+          createUsers: true
+          defaultRole: viewer


### PR DESCRIPTION
## What

Switch Crossview from its built-in username/password login to the platform's existing SSO chain (oauth2-proxy → Dex → GitHub) via Crossview's trusted-header auth mode (`AUTH_MODE=header`).

- **Before:** `crossview.${domain}` passed oauth2-proxy SSO and *then* showed Crossview's own `admin`/`password` form (chart default in `crossview-secrets`) — a second login with a weak default credential.
- **After:** the identity oauth2-proxy already injects (`X-Forwarded-Email`) logs the user straight into Crossview as a read-only `viewer`. No second login; the default admin/password is no longer an access path.

This supersedes the originally-discussed OpenBao/ESO push-secret for the admin password — with header auth there is no native password to manage.

## Why it's safe
- `X-Forwarded-Email` is **set and overwritten** by oauth2-proxy from the validated Dex session (`pass_user_headers`, default on), and unauthenticated requests are redirected before reaching the upstream — not spoofable from outside the cluster.
- The external route to `crossview:3001` is `oauth2-proxy → auth-proxy` only (NetworkPolicy; auth-proxy accepts ingress solely from oauth2-proxy).
- The NetworkPolicy's `host`/`remote-node` allowance carries no header, so kubelet probes hit the **public** `/api/health` (no auth middleware — stays green in `header` mode) and a direct pod port-forward just 401s.

## Trade-off
The Headlamp **desktop** "Open Crossview" port-forward now 401s (no oauth2-proxy in that path); the **web** `crossview.${domain}` iframe path (supported since #2188) is unaffected.

## Validation
- `kubectl kustomize k8s/bases/apps/crossview` + `k8s/providers/hetzner/apps` build clean.
- `ksail --config ksail.prod.yaml workload validate` → **344 files validated**, exit 0.
- Source-verified against crossview v4.4.0: the `AUTH_MODE` Go switch matches `"header"`; `header_auth.go` 401s on an empty header; `/api/health` has no auth middleware.

## Verify after merge
Open `https://crossview.platform.devantler.tech` (or Headlamp web → "Open Crossview"): you should land in Crossview directly via GitHub SSO, no password prompt. If it 401s (empty `X-Forwarded-Email` for the account), flip `trustedHeader` to `X-Forwarded-Preferred-Username` (the GitHub login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)