### PR TITLE
feat(kro): add Tenant archetype ResourceGraphDefinition

### DIFF
--- a/k8s/bases/infrastructure/archetypes/kustomization.yaml
+++ b/k8s/bases/infrastructure/archetypes/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# KRO archetype ResourceGraphDefinitions (#1932 Tenant, #1933 WebApp) — typed
+# higher-level APIs that expand into the standard platform skeleton each tenant
+# /app otherwise hand-copies. Lives in the `infrastructure` layer (RGD CRs need
+# the KRO controller's RGD CRD from infrastructure-controllers/kro). Each
+# archetype ships its own aggregated ClusterRole granting KRO the verbs for the
+# child kinds it renders (KRO runs with rbac.mode: aggregation).
+resources:
+  - tenant/

--- a/k8s/bases/infrastructure/archetypes/tenant/aggregated-cluster-role.yaml
+++ b/k8s/bases/infrastructure/archetypes/tenant/aggregated-cluster-role.yaml
@@ -1,0 +1,58 @@
+# Aggregated ClusterRole for the Tenant archetype (#1932).
+#
+# The KRO controller is installed with `rbac.mode: aggregation` (see
+# controllers/kro/helm-release.yaml): it holds NO standing access to arbitrary
+# resources and instead aggregates any ClusterRole labelled
+# `rbac.kro.run/aggregate-to-controller: "true"`. This role grants KRO exactly
+# the verbs to manage the child kinds the Tenant RGD renders — nothing more — so
+# each archetype's blast radius is its own declared resources.
+#
+# Keep in lockstep with resource-graph-definition.yaml: a child kind added there
+# without a rule here makes KRO fail to reconcile that resource (forbidden);
+# a rule here with no corresponding child is dead over-grant.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kro-tenant-archetype
+  labels:
+    app.kubernetes.io/managed-by: ksail
+    rbac.kro.run/aggregate-to-controller: "true"
+rules:
+  # Namespace + ServiceAccount (core API group).
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - serviceaccounts
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # RoleBinding (tenant + external-dns) and the external-dns ClusterRoleBinding.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - rolebindings
+      - clusterrolebindings
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # RBAC escalation guard: creating a binding to a ClusterRole requires the
+  # `bind` verb on that role (or holding all its rules). Scope `bind` to exactly
+  # the roles the Tenant bindings reference — `edit` (tenant SA) and the two
+  # tenant-external-dns roles — never a blanket grant.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    resourceNames:
+      - edit
+      - tenant-external-dns
+      - tenant-external-dns-global
+    verbs: ["bind"]
+  # ghcr-auth pull secret.
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Default-deny NetworkPolicy.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Flux source + the impersonating Kustomization.
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["ocirepositories"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/k8s/bases/infrastructure/archetypes/tenant/kustomization.yaml
+++ b/k8s/bases/infrastructure/archetypes/tenant/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - resource-graph-definition.yaml
+  - aggregated-cluster-role.yaml

--- a/k8s/bases/infrastructure/archetypes/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/archetypes/tenant/resource-graph-definition.yaml
@@ -59,7 +59,7 @@ spec:
       sops: boolean | default=false
   resources:
     # --- Core skeleton (always rendered) ---------------------------------
-    - id: namespace
+    - id: tenantNamespace
       template:
         apiVersion: v1
         kind: Namespace
@@ -75,7 +75,7 @@ spec:
         kind: ServiceAccount
         metadata:
           name: ${schema.spec.name}
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
           labels:
             app.kubernetes.io/managed-by: ksail
         automountServiceAccountToken: false
@@ -87,7 +87,7 @@ spec:
         kind: RoleBinding
         metadata:
           name: ${schema.spec.name}
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
           labels:
             app.kubernetes.io/managed-by: ksail
         roleRef:
@@ -97,7 +97,7 @@ spec:
         subjects:
           - kind: ServiceAccount
             name: ${serviceAccount.metadata.name}
-            namespace: ${namespace.metadata.name}
+            namespace: ${tenantNamespace.metadata.name}
     # GHCR image-pull secret, sourced from OpenBao (not a SOPS Secret) via the
     # shared cluster-scoped `openbao` ClusterSecretStore reading the platform
     # path infrastructure/ghcr/auth. Reconciled platform-side (flux-system), so
@@ -110,7 +110,7 @@ spec:
         kind: ExternalSecret
         metadata:
           name: ghcr-auth
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
           labels:
             app.kubernetes.io/managed-by: ksail
         spec:
@@ -142,7 +142,7 @@ spec:
         kind: NetworkPolicy
         metadata:
           name: default-deny
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
         spec:
           podSelector: {}
           policyTypes:
@@ -154,7 +154,7 @@ spec:
         kind: OCIRepository
         metadata:
           name: ${schema.spec.name}
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
           labels:
             app.kubernetes.io/managed-by: ksail
         spec:
@@ -183,7 +183,7 @@ spec:
         kind: Kustomization
         metadata:
           name: ${schema.spec.name}
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
           labels:
             app.kubernetes.io/managed-by: ksail
           annotations:
@@ -200,7 +200,7 @@ spec:
           sourceRef:
             kind: OCIRepository
             name: ${ociRepository.metadata.name}
-          targetNamespace: ${namespace.metadata.name}
+          targetNamespace: ${tenantNamespace.metadata.name}
     - id: kustomizationSops
       includeWhen:
         - ${schema.spec.sops}
@@ -209,7 +209,7 @@ spec:
         kind: Kustomization
         metadata:
           name: ${schema.spec.name}
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
           labels:
             app.kubernetes.io/managed-by: ksail
           annotations:
@@ -226,7 +226,7 @@ spec:
           sourceRef:
             kind: OCIRepository
             name: ${ociRepository.metadata.name}
-          targetNamespace: ${namespace.metadata.name}
+          targetNamespace: ${tenantNamespace.metadata.name}
           decryption:
             provider: sops
             secretRef:
@@ -246,7 +246,7 @@ spec:
         kind: RoleBinding
         metadata:
           name: ${schema.spec.name}-external-dns
-          namespace: ${namespace.metadata.name}
+          namespace: ${tenantNamespace.metadata.name}
         roleRef:
           apiGroup: rbac.authorization.k8s.io
           kind: ClusterRole
@@ -254,7 +254,7 @@ spec:
         subjects:
           - kind: ServiceAccount
             name: external-dns
-            namespace: ${namespace.metadata.name}
+            namespace: ${tenantNamespace.metadata.name}
     - id: externalDnsGateway
       includeWhen:
         - ${schema.spec.externalDns}
@@ -271,7 +271,7 @@ spec:
         subjects:
           - kind: ServiceAccount
             name: external-dns
-            namespace: ${namespace.metadata.name}
+            namespace: ${tenantNamespace.metadata.name}
     - id: externalDnsNamespaces
       includeWhen:
         - ${schema.spec.externalDns}
@@ -287,4 +287,4 @@ spec:
         subjects:
           - kind: ServiceAccount
             name: external-dns
-            namespace: ${namespace.metadata.name}
+            namespace: ${tenantNamespace.metadata.name}

--- a/k8s/bases/infrastructure/archetypes/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/archetypes/tenant/resource-graph-definition.yaml
@@ -1,0 +1,281 @@
+# Tenant archetype (#1932) — the KRO ResourceGraphDefinition that expands a
+# small typed `Tenant` declaration into the full platform-side control-plane
+# skeleton every tenant otherwise hand-copies (namespace, Flux-impersonated SA +
+# RoleBinding, cosign-verified OCIRepository, impersonating Kustomization,
+# ghcr-auth ExternalSecret, default-deny NetworkPolicy), with optional
+# external-dns RBAC and SOPS decryption behind `includeWhen` toggles.
+#
+# Onboarding a tenant becomes a ~5-line `Tenant` CR instead of a ~7-file copy:
+#
+#   apiVersion: kro.run/v1alpha1
+#   kind: Tenant
+#   metadata: { name: ascoachingogvaner }
+#   spec:
+#     name: ascoachingogvaner
+#     externalDns: true
+#
+# The OCIRepository URL (oci://ghcr.io/devantler-tech/<name>/manifests) and the
+# cosign OIDC subject (the shared publish-app reusable workflow) are platform
+# invariants — every tenant publishes through the same pipeline — so they are
+# templated/fixed here rather than re-declared per tenant. Add an override field
+# only if a future tenant diverges from the convention.
+#
+# Lands in the `infrastructure` layer (which `dependsOn` infrastructure-controllers
+# where the KRO controller installs the RGD CRD) — a CR of an RGD-defined kind
+# cannot share a Flux Kustomization with the controller that installs its CRD.
+# Pre-1.0 KRO (v1alpha1): keep render-diffable; the `Tenant` instances arrive in
+# the local-first pilot (step 3 of #1932), not here.
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: tenant.kro.run
+  labels:
+    app.kubernetes.io/managed-by: ksail
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Tenant
+    spec:
+      # Tenant name — used verbatim as the namespace, ServiceAccount,
+      # OCIRepository/Kustomization name, and ghcr-auth target. Required.
+      name: string
+      # The tenant runs its own external-dns instance (e.g. ascoachingogvaner's
+      # simply.com zone) and needs the privileged cross-namespace reads granted
+      # by the tenant-external-dns ClusterRoles.
+      externalDns: boolean | default=false
+      # The tenant's Flux Kustomization decrypts SOPS-encrypted manifests from
+      # its artifact (e.g. wedding-app). Requires a `sops-age` Secret in the
+      # tenant namespace, applied separately — secret material is NEVER inlined
+      # into a Tenant spec.
+      sops: boolean | default=false
+  resources:
+    # --- Core skeleton (always rendered) ---------------------------------
+    - id: namespace
+      template:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: ${schema.spec.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+            pod-security.kubernetes.io/enforce: restricted
+            pod-security.kubernetes.io/enforce-version: latest
+    - id: serviceAccount
+      template:
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${namespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+        automountServiceAccountToken: false
+        imagePullSecrets:
+          - name: ghcr-auth
+    - id: roleBinding
+      template:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${namespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: edit
+        subjects:
+          - kind: ServiceAccount
+            name: ${serviceAccount.metadata.name}
+            namespace: ${namespace.metadata.name}
+    # GHCR image-pull secret, sourced from OpenBao (not a SOPS Secret) via the
+    # shared cluster-scoped `openbao` ClusterSecretStore reading the platform
+    # path infrastructure/ghcr/auth. Reconciled platform-side (flux-system), so
+    # the `restrict-tenant-secret-stores` Kyverno policy carve-out applies.
+    # Produces the `ghcr-auth` dockerconfigjson the OCIRepository (secretRef) and
+    # ServiceAccount (imagePullSecrets) consume.
+    - id: ghcrAuth
+      template:
+        apiVersion: external-secrets.io/v1
+        kind: ExternalSecret
+        metadata:
+          name: ghcr-auth
+          namespace: ${namespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+        spec:
+          refreshInterval: 1h
+          secretStoreRef:
+            name: openbao
+            kind: ClusterSecretStore
+          target:
+            name: ghcr-auth
+            creationPolicy: Owner
+            template:
+              engineVersion: v2
+              type: kubernetes.io/dockerconfigjson
+              data:
+                .dockerconfigjson: "{{ .dockerconfigjson }}"
+          data:
+            - secretKey: dockerconfigjson
+              remoteRef:
+                key: infrastructure/ghcr/auth
+                property: dockerconfigjson
+    # Default-deny NetworkPolicy mirroring the runtime Kyverno-generated
+    # CiliumNetworkPolicy, so the static Kubescape scan sees the namespace as
+    # network-restricted (C-0054). Behaviourally redundant with the runtime
+    # default-deny (per-workload allow CiliumNetworkPolicies still apply
+    # additively), so it adds no new restriction at runtime.
+    - id: defaultDeny
+      template:
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: default-deny
+          namespace: ${namespace.metadata.name}
+        spec:
+          podSelector: {}
+          policyTypes:
+            - Ingress
+            - Egress
+    - id: ociRepository
+      template:
+        apiVersion: source.toolkit.fluxcd.io/v1
+        kind: OCIRepository
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${namespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+        spec:
+          interval: 1m
+          ref:
+            semver: ">=1.0.0"
+          url: oci://ghcr.io/devantler-tech/${schema.spec.name}/manifests
+          secretRef:
+            name: ghcr-auth
+          verify:
+            provider: cosign
+            matchOIDCIdentity:
+              - issuer: '^https://token\.actions\.githubusercontent\.com$'
+                subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
+    # --- Flux Kustomization (one of two variants by `sops`) ---------------
+    # The impersonating Kustomization that reconciles the tenant's own artifact
+    # under its namespaced `edit` SA. Two variants because the SOPS `decryption`
+    # block is a field of the Kustomization spec (not a separable resource) and
+    # must be present ONLY for SOPS tenants — a `decryption.secretRef: sops-age`
+    # on a tenant with no `sops-age` Secret would wedge reconciliation.
+    - id: kustomization
+      includeWhen:
+        - ${!schema.spec.sops}
+      template:
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${namespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+          annotations:
+            ksail.devantler.tech/reconcile-exclude: "true"
+        spec:
+          interval: 1m
+          timeout: 5m
+          retryInterval: 2m
+          path: .
+          prune: true
+          wait: true
+          force: true
+          serviceAccountName: ${serviceAccount.metadata.name}
+          sourceRef:
+            kind: OCIRepository
+            name: ${ociRepository.metadata.name}
+          targetNamespace: ${namespace.metadata.name}
+    - id: kustomizationSops
+      includeWhen:
+        - ${schema.spec.sops}
+      template:
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${namespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+          annotations:
+            ksail.devantler.tech/reconcile-exclude: "true"
+        spec:
+          interval: 1m
+          timeout: 5m
+          retryInterval: 2m
+          path: .
+          prune: true
+          wait: true
+          force: true
+          serviceAccountName: ${serviceAccount.metadata.name}
+          sourceRef:
+            kind: OCIRepository
+            name: ${ociRepository.metadata.name}
+          targetNamespace: ${namespace.metadata.name}
+          decryption:
+            provider: sops
+            secretRef:
+              name: sops-age
+    # --- external-dns RBAC (only when the tenant runs external-dns) -------
+    # Privileged cross-namespace reads a tenant's `edit` RoleBinding cannot
+    # self-grant: HTTPRoutes (own namespace), the shared Gateway (kube-system),
+    # and Namespaces (cluster-wide informer). Capabilities live in the
+    # tenant-external-dns / tenant-external-dns-global ClusterRoles
+    # (infrastructure/cluster-roles/). The tenant creates the `external-dns` SA
+    # itself in its own artifact; only these bindings are platform territory.
+    - id: externalDnsHttproutes
+      includeWhen:
+        - ${schema.spec.externalDns}
+      template:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: ${schema.spec.name}-external-dns
+          namespace: ${namespace.metadata.name}
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: tenant-external-dns
+        subjects:
+          - kind: ServiceAccount
+            name: external-dns
+            namespace: ${namespace.metadata.name}
+    - id: externalDnsGateway
+      includeWhen:
+        - ${schema.spec.externalDns}
+      template:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: ${schema.spec.name}-external-dns
+          namespace: kube-system
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: tenant-external-dns
+        subjects:
+          - kind: ServiceAccount
+            name: external-dns
+            namespace: ${namespace.metadata.name}
+    - id: externalDnsNamespaces
+      includeWhen:
+        - ${schema.spec.externalDns}
+      template:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: ${schema.spec.name}-external-dns
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: tenant-external-dns-global
+        subjects:
+          - kind: ServiceAccount
+            name: external-dns
+            namespace: ${namespace.metadata.name}

--- a/k8s/bases/infrastructure/archetypes/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/archetypes/tenant/resource-graph-definition.yaml
@@ -31,6 +31,15 @@ metadata:
   name: tenant.kro.run
   labels:
     app.kubernetes.io/managed-by: ksail
+  annotations:
+    # Exempt from Flux postBuild envsubst. The `infrastructure` Kustomization
+    # runs variable substitution (substituteFrom variables-base/variables-cluster),
+    # which would try to expand this RGD's KRO `${...}` CEL expressions as Flux
+    # variables and fail ("envsubst error: variable substitution failed: missing
+    # closing brace"). Every `${...}` below is a KRO expression resolved by the
+    # kro controller at instance time — this resource needs no Flux variables —
+    # so substitution is disabled for it wholesale.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
   schema:
     apiVersion: v1alpha1

--- a/k8s/bases/infrastructure/kustomization.yaml
+++ b/k8s/bases/infrastructure/kustomization.yaml
@@ -2,6 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # KRO archetype RGDs (Tenant #1932 / WebApp #1933) + their aggregated KRO
+  # ClusterRoles. In `infrastructure` (not `infrastructure-controllers`) so the
+  # RGD CRs land a layer after the KRO controller that installs the RGD CRD.
+  - archetypes/
   - certificates/
   - cluster-policies/
   - cluster-role-bindings/

--- a/k8s/clusters/base/infrastructure-flux-kustomization.yaml
+++ b/k8s/clusters/base/infrastructure-flux-kustomization.yaml
@@ -32,5 +32,14 @@ spec:
       - kind: Secret
         name: variables-cluster
   wait: true
+  # kstatus (used by `wait: true`) has no built-in readiness rule for KRO's
+  # ResourceGraphDefinition, so it stays InProgress forever and the whole
+  # infrastructure reconcile times out (the Tenant archetype RGD added here).
+  # KRO reports readiness via `status.state: Active|Inactive`, so teach Flux to
+  # health-check RGDs by that field via a CEL expression.
+  healthCheckExprs:
+    - apiVersion: kro.run/v1alpha1
+      kind: ResourceGraphDefinition
+      current: status.state == 'Active'
   prune: true
   force: true

--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -61,6 +61,9 @@ resources:
   # Utilities:
   #   - ../../../../bases/infrastructure/controllers/reloader/
   #   - ../../../../bases/infrastructure/controllers/ksail-operator/
+  # KRO archetype controller (pair with infrastructure/archetypes/ for the
+  # Tenant #1932 / WebApp #1933 RGDs — needed for the local-first pilot):
+  #   - ../../../../bases/infrastructure/controllers/kro/
 components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — see
   # bases/components/helmrelease-drift-detection.

--- a/k8s/providers/docker/infrastructure/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/kustomization.yaml
@@ -29,6 +29,8 @@ resources:
   #   - ../../../bases/infrastructure/tracing-policies/     # Tetragon TracingPolicy — needs controllers/tetragon
   # OpenBao raft-snapshot backups (needs controllers/velero + minio):
   #   - ../../../bases/infrastructure/vault-backup/
+  # KRO archetype RGDs — Tenant (#1932) / WebApp (#1933) (needs controllers/kro):
+  #   - ../../../bases/infrastructure/archetypes/
 components:
   # Platform-wide HelmRelease drift detection (mode: enabled). No-op until an
   # opt-in HelmRelease (e.g. coroot/opencost) is enabled above. See


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Defines the **KRO `Tenant` archetype** as a `ResourceGraphDefinition` — **step 2** of the maintainer's incremental plan for #1932 (step 1, the KRO controller install, landed in #2190). Onboarding a tenant becomes a ~5-line typed `Tenant` CR instead of the ~7-file control-plane skeleton each tenant hand-copies today (and which already drifts).

```yaml
apiVersion: kro.run/v1alpha1
kind: Tenant
metadata: { name: ascoachingogvaner }
spec:
  name: ascoachingogvaner
  externalDns: true   # tenant runs its own external-dns
  # sops: true        # tenant's Kustomization decrypts SOPS (e.g. wedding-app)
```

## Design (matches the ratified ADR — KRO decided 2026-06-19)

The RGD (`k8s/bases/infrastructure/archetypes/tenant/`) renders the full skeleton verbatim from today's bases:

- **Core (always):** namespace (PSA `restricted`), Flux-impersonated `edit` ServiceAccount + RoleBinding, `ghcr-auth` ExternalSecret (OpenBao `ClusterSecretStore`), cosign-verified `OCIRepository`, impersonating `Kustomization` (interval/timeout/retries per `enforce-flux-best-practices`), default-deny `NetworkPolicy`.
- **`includeWhen` toggles — the only real variations across today's tenants:**
  - `externalDns` → the three external-dns RBAC bindings (ascoaching's `simply.com` zone).
  - `sops` → emits the Kustomization's `decryption` block (wedding-app). Two Kustomization variants because `decryption` is a Kustomization-spec field, not a separable resource, and a `secretRef: sops-age` on a tenant with no `sops-age` Secret would wedge reconciliation. **The encrypted `sops-age` Secret stays applied separately — secret material is never inlined into a `Tenant` spec.**
- **Platform invariants templated/fixed**, not re-declared per tenant: the OCI URL (`oci://ghcr.io/devantler-tech/<name>/manifests`) and the cosign OIDC subject (the shared `publish-app` reusable workflow). Add an override field only if a future tenant diverges.

### RBAC (KRO runs `rbac.mode: aggregation`)

Ships `kro-tenant-archetype`, an aggregated ClusterRole (`rbac.kro.run/aggregate-to-controller: "true"`) granting KRO **exactly** the verbs for the child kinds it renders — including a **scoped `bind`** on `edit` / `tenant-external-dns` / `tenant-external-dns-global` (RBAC-escalation guard: creating a binding to a ClusterRole needs `bind` on that role). Keep this in lockstep with the RGD's child set.

### Placement / layering

- RGD + ClusterRole in the **`infrastructure`** layer (one after `infrastructure-controllers/kro`, per the #2190 install comment — a CR of an RGD-defined kind can't share a Flux Kustomization with the controller that installs its CRD). Ships to **prod** via the hetzner full-base aggregate.
- **Commented opt-in** lines added to the docker overlay (controllers `kro/` + infra `archetypes/`) so the **local-first pilot (step 3)** is a clean uncomment.

## Validation

- `kubectl kustomize` builds clean for `archetypes/`, base `infrastructure/`, and **hetzner/prod** (which includes the RGD); **docker/local excludes it** (opt-in commented), as intended.
- `ksail --config ksail.prod.yaml workload validate`: **the archetype groups pass** — `✔ bases/infrastructure/archetypes validated`, `✔ bases/infrastructure/archetypes/tenant validated`.
- The run also surfaces a **pre-existing, unrelated** failure in `providers/docker/infrastructure/controllers` (`yaml: line N: did not find expected key`, line N varying 131/175/197/214 between runs). This is the known ksail concurrent-Helm-render corruption flake (#5362/#5371) in the **local ksail v7.66.2 binary** (predates the #5364/#5372 fixes) — it **reproduces identically on clean `origin/main`** and never touches the archetype manifests. Platform CI's pinned **ksail v7.68.0** has the fix and is unaffected.

## Scope / next

This PR **defines** the RGD only. The **local-first pilot** — enabling KRO locally, migrating `ascoachingogvaner` to a `Tenant` CR, and render-diffing the RGD expansion vs the current bases (`ksail workload validate` parity, prune-on-removal) — is **step 3**, a separate PR that requires the live KRO controller. RGD expansion correctness can only be verified against a running KRO controller, so that verification belongs to the pilot.

Composes with the **WebApp** archetype (#1933) on the same KRO foundation.

Part of #1932.
