### PR TITLE
fix(cluster-policies): exempt velero from generated ResourceQuota

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -66,6 +66,27 @@ patches:
                   # requests.memory quota. Longhorn sizing is operator-/VPA-owned
                   # (manager, csi, ui carry VPAs), not quota-bounded.
                   - longhorn-system
+                  # Velero backup data plane. Velero runs a kopia
+                  # repository-maintenance Job per backup repo (one per backed-up
+                  # namespace, ~15), keeps the last few, and recreates them every
+                  # maintenance cycle -- a constant churn of short-lived pods. The
+                  # Kubernetes ResourceQuota controller LEAKS requests.memory usage
+                  # under that churn (kubernetes#118946): completed pods are dropped
+                  # from accounting unreliably, so status.used.requests.memory drifts
+                  # upward unbounded -- observed 16300Mi "used" against this 16Gi cap
+                  # while only ~430Mi of pods were actually non-terminal. Once the
+                  # phantom usage reaches the cap the quota admission webhook rejects
+                  # every new maintenance/backup pod ("exceeded quota:
+                  # default-resourcequota, requested: requests.memory=128Mi"), which
+                  # silently halts repository maintenance and kopia/restic backups --
+                  # a data-protection outage with no failing Deployment to alert on.
+                  # Velero's real footprint is the node-agent DaemonSet (one per
+                  # node) plus these ephemeral Jobs, not steady-state tenant
+                  # workloads, so a static per-namespace memory quota is the wrong
+                  # tool and actively harmful here. Exempt it like the other
+                  # platform-owned namespaces; the LimitRange (rule 1) still applies,
+                  # so backup pods keep sane default requests/limits.
+                  - velero
       - op: add
         path: /spec/rules/0/generate/generateExisting
         value: true


### PR DESCRIPTION
> 🤖 Generated by Claude Code (on-request prod investigation)

## Impact (what's actually broken)

**The prod `velero-daily-full` backup has PartiallyFailed or Failed every day for 6+ days** (2026-06-16 → 06-21) — a silent data-protection degradation:

```
velero-daily-full-20260617...   Failed
velero-daily-full-20260618...   PartiallyFailed (4 errors)
velero-daily-full-20260619...   PartiallyFailed (10)
velero-daily-full-20260620...   PartiallyFailed (19)
velero-daily-full-20260621...   PartiallyFailed (10)
```

Today's run completed 14 PodVolumeBackups + 2 DataUploads, then the remaining ~8 DataUploads failed (`timeout on preparing data upload` / `Pod is in abnormal state [Failed]`). That "first few succeed, rest fail" pattern is the fingerprint of a **namespace quota filling mid-run**: the DataUpload exposer pods run in the `velero` namespace and are rejected once the quota is exhausted.

Alertmanager also fires `velero / FailedCreate` for the kopia repository-maintenance Jobs (confirmed live, 20:59Z):
```
pods "cert-manager-default-kopia-maintain-job-...": is forbidden:
exceeded quota: default-resourcequota, requested: requests.memory=128Mi,
used: requests.memory=16300Mi, limited: requests.memory=16Gi
```

## Root cause

The `velero` namespace's `default-resourcequota` (generated by the `add-ns-quota` Kyverno policy, `requests.memory: 16Gi`) reports `used.requests.memory=16300Mi` — but a live snapshot shows only **4 Running + 45 Succeeded** pods (~430Mi actually non-terminal). The `used` value is **phantom/leaked accounting**.

Velero runs a **kopia repository-maintenance Job per backup repo** (~15) and **DataUpload exposer pods** per CSI volume, recreated continuously — a constant churn of short-lived pods. The Kubernetes ResourceQuota controller is known to **leak `requests.memory` usage under high pod churn** ([kubernetes#118946](https://github.com/kubernetes/kubernetes/issues/118946)): completed pods are dropped from accounting unreliably, so `status.used` drifts upward unbounded until it hits the cap and the admission webhook rejects every new pod — maintenance Jobs *and* backup DataUpload pods alike.

(Note: backups 06-09→06-13 failed for a *different*, now-resolved reason — the workers were 8GB and at ~98% memory; they've since been upgraded to 16GB and now sit at 70-78%. The current failures are purely the quota.)

## Fix

Exempt the `velero` namespace from the `add-ns-quota` **ResourceQuota** rule (rule 0), exactly as `observability` and `longhorn-system` already are. Velero is platform-owned backup infrastructure whose footprint is the `node-agent` DaemonSet (one per node) plus ephemeral Jobs/exposer pods — not steady-state tenant workloads — so a static per-namespace memory quota is the wrong tool and actively harmful.

- The **LimitRange** (rule 1) still applies, so backup pods keep sane default requests/limits.
- With `synchronize: true`, Kyverno **removes the now-orphaned leaked quota object** from the `velero` namespace, clearing the stuck `used` value. (Fallback if it lingers: a one-time `kubectl delete resourcequota -n velero default-resourcequota` — Kyverno won't recreate it now that velero is excluded.)

## Validation

- `kubectl kustomize k8s/bases/infrastructure/cluster-policies/` builds clean; rendered `add-ns-quota` confirmed:
  - rule 0 (ResourceQuota) exclude → `…observability, longhorn-system, velero` ✅
  - rule 1 (LimitRange) exclude → unchanged (no `velero`) ✅
- `kubectl kustomize k8s/clusters/prod/` and `.../local/` build clean.

(Per repo guidance + known ksail 7.66.x `workload validate` flakiness, `kubectl kustomize` is the authoritative deterministic check.)