### PR TITLE
feat(crossview): authenticate via native Dex OIDC, drop oauth2-proxy gating

### DIFF
--- a/k8s/bases/apps/crossview/external-secret.yaml
+++ b/k8s/bases/apps/crossview/external-secret.yaml
@@ -1,15 +1,32 @@
-# crossview-credentials: the bundled Postgres password (db-password) and the
-# app's session signing key (session-secret), read from OpenBao via External
-# Secrets and consumed by the HelmRelease through secretKeyRef (POSTGRES_PASSWORD
-# / DB_PASS / SESSION_SECRET). Both values are generated once and seeded into
-# OpenBao by the ESO Password generators + PushSecrets in
-# infrastructure/vault-seed (remoteKeys apps/crossview/db + apps/crossview/app),
-# so no manual seeding and no committed credential is required — the same
-# generate-once-then-mirror pattern umami uses for its app secret. Stable values
-# keep Postgres data readable and login sessions valid across chart upgrades and
-# pod restarts. Read access is granted by the app-crossview-readonly policy on
-# the shared `external-secrets` ClusterSecretStore role (see
-# infrastructure/vault-config/job.yaml).
+# crossview-credentials: every secret Crossview needs, materialized from OpenBao
+# by External Secrets and consumed by the HelmRelease through secretKeyRef
+# (POSTGRES_PASSWORD / DB_PASS, SESSION_SECRET, ADMIN_PASSWORD, OIDC_CLIENT_SECRET):
+#
+#   - db-password        the bundled Postgres password (apps/crossview/db)
+#   - session-secret     the app's session-cookie signing key (apps/crossview/app)
+#   - admin-password     the break-glass native `admin` login password
+#                        (apps/crossview/admin) — replaces the chart's well-known
+#                        admin/password default; the boot-time admin user
+#                        (createAdmin, session mode) is seeded from it
+#   - oidc-client-secret the SHARED Dex confidential-client secret
+#                        (infrastructure/oidc/dex, property client-secret) — the
+#                        same value oauth2-proxy / headlamp / actual-budget read,
+#                        seeded into OpenBao from the SOPS bootstrap secret by the
+#                        seed-dex-client-secret PushSecret. Crossview authenticates
+#                        to Dex as the `public-client` (see helm-release.yaml), so
+#                        it reuses this secret rather than minting a new one.
+#
+# db-password / session-secret / admin-password are generated once and seeded into
+# OpenBao by the ESO Password generators + PushSecrets in infrastructure/vault-seed
+# (remoteKeys apps/crossview/{db,app,admin}) — the same generate-once-then-mirror
+# pattern umami uses — so nothing is committed to this public repo. Stable values
+# keep Postgres data readable, login sessions valid, and the admin login working
+# across chart upgrades and pod restarts.
+#
+# All four paths are read through the shared `external-secrets` ClusterSecretStore
+# role, which already bundles app-crossview-readonly (apps/crossview/*) AND
+# infra-oidc-readonly (infrastructure/oidc/*) — see infrastructure/vault-config/job.yaml
+# — so no policy change is needed to read the Dex client secret here.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -32,3 +49,11 @@ spec:
       remoteRef:
         key: apps/crossview/app
         property: session-secret
+    - secretKey: admin-password
+      remoteRef:
+        key: apps/crossview/admin
+        property: admin-password
+    - secretKey: oidc-client-secret
+      remoteRef:
+        key: infrastructure/oidc/dex
+        property: client-secret

--- a/k8s/bases/apps/crossview/helm-release.yaml
+++ b/k8s/bases/apps/crossview/helm-release.yaml
@@ -127,13 +127,17 @@ spec:
       #     server-side calls from the Crossview pod, which cannot resolve
       #     dex.${domain} on the local/docker cluster and should not hairpin the
       #     LoadBalancer in prod.
-      # Crossview's SSO service (services/sso_service.go) tries OIDC discovery
-      # FIRST and only falls back to these explicit URLs when discovery fails — so
-      # `issuer` is intentionally left at the chart's bogus localhost default:
-      # the discovery GET to http://localhost:8080/... is refused instantly
-      # in-cluster, discovery fails closed, and the split URLs below are used
-      # verbatim on every cluster. (Crossview validates the user via the userinfo
-      # endpoint, not the id_token, so no JWKS/issuer match is required.)
+      # WORKAROUND (upstream gap): Crossview's SSO code (services/sso_service.go)
+      # runs OIDC discovery whenever `issuer` is non-empty and lets a successful
+      # discovery OVERRIDE the explicit endpoints below — and the chart's configmap
+      # forces a non-empty issuer (it `default`s an unset value to a localhost URL).
+      # There is no skip-discovery / explicit-endpoint-precedence knob, so to keep
+      # the split we rely on the chart's localhost default being unreachable
+      # in-cluster: the discovery GET is refused instantly, discovery fails closed,
+      # and the split URLs below are used verbatim on every cluster. Revisit if the
+      # chart gains a discovery toggle or if discovery ever becomes fatal (it would
+      # crash-loop the pod). Crossview validates the user via the userinfo endpoint,
+      # not the id_token, so no JWKS/issuer match is required.
       #
       # SECURITY NOTE: removing oauth2-proxy drops its allowed_groups gate
       # (devantler-tech:platform team). Crossview does not gate on OIDC groups, so
@@ -149,4 +153,3 @@ spec:
           tokenURL: http://dex.dex.svc.cluster.local:5556/token
           userInfoURL: http://dex.dex.svc.cluster.local:5556/userinfo
           callbackURL: https://crossview.${domain}/api/auth/oidc/callback
-          scope: openid profile email

--- a/k8s/bases/apps/crossview/helm-release.yaml
+++ b/k8s/bases/apps/crossview/helm-release.yaml
@@ -26,6 +26,15 @@ spec:
       createNamespace: false
     app:
       replicas: ${crossview_replicas:=1}
+      extraEnv:
+        # Crossview keys several behaviours off NODE_ENV (lib/env.go ->
+        # Environment): with it set to `production` the session-cookie middleware
+        # marks the cookie Secure (api/middlewares/session.go), CORS debug logging
+        # is off, and gin runs in release mode. Crossview is always served over
+        # HTTPS (crossview.${domain}), local included, so a Secure cookie is safe
+        # in every environment.
+        - name: NODE_ENV
+          value: "production"
     # The chart bundles a Postgres for session/user state. Run it ephemeral (no
     # PVC) instead of provisioning a Longhorn volume: Crossview is an
     # SSO-fronted, read-only dashboard, so losing session/user rows on a pod
@@ -43,19 +52,28 @@ spec:
         tag: "18.4"
       persistence:
         enabled: false
-    # The chart's bundled Postgres refuses to initialize without
-    # POSTGRES_PASSWORD, and the app signs sessions with SESSION_SECRET. Both
-    # default to empty strings in the chart, so the chart omitted the env vars
-    # entirely — leaving Postgres in CrashLoopBackOff ("superuser password is
-    # not specified"), the app stuck in Init, and the HelmRelease install
-    # hanging (which froze the whole `apps` Kustomization). Source both from the
-    # crossview-credentials Secret (external-secret.yaml) via secretKeyRef. That
-    # Secret is materialized from OpenBao by External Secrets — the values are
-    # generated once and seeded into OpenBao by the ESO Password generators +
-    # PushSecrets in infrastructure/vault-seed (apps/crossview/db,
-    # apps/crossview/app), exactly like umami's app secret — so nothing is
-    # committed to this public repo. Stable values keep Postgres data readable
-    # and login sessions valid across chart upgrades / pod restarts.
+    # Every Crossview secret is sourced from the crossview-credentials Secret
+    # (external-secret.yaml) via secretKeyRef. That Secret is materialized from
+    # OpenBao by External Secrets — the values are generated once and seeded by
+    # the ESO Password generators + PushSecrets in infrastructure/vault-seed
+    # (apps/crossview/{db,app,admin}), and oidc-client-secret is the shared Dex
+    # client secret read from infrastructure/oidc/dex — so nothing is committed
+    # to this public repo.
+    #
+    #   dbPassword       the chart's bundled Postgres refuses to initialize
+    #                    without POSTGRES_PASSWORD (it CrashLoopBackOffs with
+    #                    "superuser password is not specified", stalling the app
+    #                    in Init and hanging the whole `apps` Kustomization).
+    #   sessionSecret    signs the session cookie set after OIDC / admin login;
+    #                    a stable value keeps logins valid across pod restarts.
+    #   adminPassword    the break-glass native `admin` login (createAdmin runs
+    #                    at boot in session mode). Overriding it here means the
+    #                    chart no longer emits the well-known admin/password
+    #                    default into the crossview-secrets Secret — that Secret
+    #                    now carries only the non-secret admin USERNAME.
+    #   OIDCClientSecret the Dex confidential-client secret for the OIDC login
+    #                    (config.sso.oidc below); Crossview presents it as the
+    #                    shared `public-client`.
     secrets:
       dbPassword:
         secretKeyRef:
@@ -65,52 +83,70 @@ spec:
         secretKeyRef:
           name: crossview-credentials
           key: session-secret
+      adminPassword:
+        secretKeyRef:
+          name: crossview-credentials
+          key: admin-password
+      OIDCClientSecret:
+        secretKeyRef:
+          name: crossview-credentials
+          key: oidc-client-secret
     config:
       server:
         cors:
-          # The public URL Crossview is served at (crossview.${domain}, behind
-          # oauth2-proxy SSO — see httproute.yaml). It is the post-SSO-login
-          # redirect target (must be the public URL, or users bounce to localhost
-          # after authenticating) AND the URL the Headlamp crossview-headlamp
-          # plugin embeds in its "Open Crossview" iframe (resolved from the
-          # crossview-ingress Ingress).
+          # The public URL Crossview is served at (crossview.${domain}). It is the
+          # post-login redirect target (must be the public URL, or users bounce to
+          # localhost after authenticating) AND the URL the Headlamp
+          # crossview-headlamp plugin embeds in its "Open Crossview" iframe
+          # (resolved from the crossview-ingress Ingress).
           origin: https://crossview.${domain}
-        # Authenticate via the platform SSO chain instead of Crossview's built-in
-        # username/password DB. Crossview already sits behind oauth2-proxy (Dex ->
-        # GitHub): httproute.yaml routes crossview.${domain} -> oauth2-proxy ->
-        # auth-proxy -> crossview-service:3001, and oauth2-proxy injects (and
-        # OVERWRITES — pass_user_headers, on by default) the authenticated identity
-        # as X-Forwarded-Email on the upstream request. AUTH_MODE=header makes
-        # Crossview trust that header — crossview-go-server/api/middlewares/
-        # header_auth.go reads it and 401s if it is absent — and auto-provision the
-        # user, so there is no second login prompt and the chart-default
-        # admin/password in the crossview-secrets Secret stops being an access path.
-        #
-        # Not spoofable from outside the cluster: oauth2-proxy sets X-Forwarded-Email
-        # from the validated Dex session (replacing any client-sent value) and
-        # redirects unauthenticated requests before they reach the upstream, and
-        # auth-proxy only accepts ingress from oauth2-proxy. The crossview
-        # NetworkPolicy additionally admits host/remote-node on :3001, but that path
-        # carries no header, so (a) kubelet probes hit the PUBLIC /api/health
-        # (registered with no auth middleware — health stays green in header mode)
-        # and (b) a direct pod port-forward just 401s; forging the header there
-        # already requires in-cluster port-forward access, far above read-only view.
-        #
-        # New users land as `viewer` — read-only, matching Crossview's role here
-        # (raise defaultRole to `admin` to let the SSO user manage Crossview itself;
-        # the SSO gate already restricts to the devantler-tech/platform GitHub team).
-        # createUsers + defaultRole are pinned, not cosmetic: the bundled Postgres is
-        # ephemeral (persistence disabled), so the user is re-created on every pod
-        # restart — a chart default-flip must not silently break login or escalate
-        # the granted role.
-        #
-        # Trade-off: the Headlamp DESKTOP "Open Crossview" port-forward now 401s (no
-        # oauth2-proxy in that path); the web crossview.${domain} iframe path
-        # (supported since #2188) is unaffected. If a real login 401s because
-        # X-Forwarded-Email is empty for an account, switch trustedHeader to
-        # X-Forwarded-Preferred-Username (the GitHub login).
+        # Crossview does its OWN authentication now — there is no oauth2-proxy in
+        # front of it (httproute.yaml routes crossview.${domain} straight to
+        # crossview-service). Mode `session` is mandatory for the OIDC flow below:
+        # the SessionAuthMiddleware gates the /api/kubernetes/* data routes on a
+        # signed session cookie, the cookie store is ONLY wired up when
+        # AUTH_MODE=session (api/middlewares/session.go), and the boot-time admin
+        # user is seeded only in session mode (createAdmin, commands/serve.go). The
+        # public /api/auth/* + /api/health routes stay unauthenticated so login and
+        # kubelet probes work.
         auth:
-          mode: header
-          trustedHeader: X-Forwarded-Email
-          createUsers: true
-          defaultRole: viewer
+          mode: session
+      # Native OIDC against Dex — the platform's single OIDC IdP (Dex -> GitHub).
+      # Crossview's Login page shows a "Sign in with OIDC" button when this is
+      # enabled (src/presentation/pages/Login.jsx); clicking it runs
+      # /api/auth/oidc -> Dex -> GitHub -> /api/auth/oidc/callback, which sets the
+      # session cookie. Crossview reuses the shared confidential `public-client`
+      # (clientId below + OIDCClientSecret from infrastructure/oidc/dex), exactly
+      # like oauth2-proxy / headlamp; its callback is registered on that client in
+      # controllers/dex/helm-release.yaml.
+      #
+      # Split-horizon endpoints, mirroring oauth2-proxy (skip_oidc_discovery):
+      #   - authorizationURL is the PUBLIC Dex URL — the browser is redirected
+      #     there and resolves it via /etc/hosts (local) or public DNS (prod).
+      #   - tokenURL / userInfoURL are the IN-CLUSTER Dex Service — these are
+      #     server-side calls from the Crossview pod, which cannot resolve
+      #     dex.${domain} on the local/docker cluster and should not hairpin the
+      #     LoadBalancer in prod.
+      # Crossview's SSO service (services/sso_service.go) tries OIDC discovery
+      # FIRST and only falls back to these explicit URLs when discovery fails — so
+      # `issuer` is intentionally left at the chart's bogus localhost default:
+      # the discovery GET to http://localhost:8080/... is refused instantly
+      # in-cluster, discovery fails closed, and the split URLs below are used
+      # verbatim on every cluster. (Crossview validates the user via the userinfo
+      # endpoint, not the id_token, so no JWKS/issuer match is required.)
+      #
+      # SECURITY NOTE: removing oauth2-proxy drops its allowed_groups gate
+      # (devantler-tech:platform team). Crossview does not gate on OIDC groups, so
+      # the effective gate widens to any devantler-tech ORG member that Dex
+      # authenticates (its github connector is org-scoped). They land as a
+      # non-admin `user` on a read-only dashboard (the first login is the
+      # break-glass `admin` seeded at boot, so SSO users are never `admin`).
+      sso:
+        oidc:
+          enabled: true
+          clientId: public-client
+          authorizationURL: https://dex.${domain}/auth
+          tokenURL: http://dex.dex.svc.cluster.local:5556/token
+          userInfoURL: http://dex.dex.svc.cluster.local:5556/userinfo
+          callbackURL: https://crossview.${domain}/api/auth/oidc/callback
+          scope: openid profile email

--- a/k8s/bases/apps/crossview/httproute.yaml
+++ b/k8s/bases/apps/crossview/httproute.yaml
@@ -1,11 +1,16 @@
-# SSO-fronted route for Crossview at crossview.${domain}. Its primary purpose is
-# to give the Headlamp crossview-headlamp plugin a browser-reachable URL to embed
-# in its "Open Crossview" iframe: the plugin reads the crossview-ingress Ingress
-# (ingress.yaml), resolves https://crossview.${domain}, and frames it. Direct
-# navigation to the host works too — always behind oauth2-proxy/Dex SSO, since
-# Crossview exposes infrastructure state and must never be reachable
-# unauthenticated. No homepage tile by design: Crossview is surfaced through
-# Headlamp, not the homepage (the consolidation intent of #2156).
+# Route for Crossview at crossview.${domain}. Two purposes: a browser-reachable
+# host for direct navigation, and the URL the Headlamp crossview-headlamp plugin
+# embeds in its "Open Crossview" iframe (the plugin reads the crossview-ingress
+# Ingress (ingress.yaml), resolves https://crossview.${domain}, and frames it).
+# No homepage tile by design: Crossview is surfaced through Headlamp, not the
+# homepage (the consolidation intent of #2156).
+#
+# Crossview authenticates itself via native Dex OIDC (helm-release.yaml), so this
+# route goes STRAIGHT to crossview-service — there is no oauth2-proxy hop. The app
+# gates its data routes (session middleware) and redirects unauthenticated users
+# to its own /login, so the host is never an unauthenticated window into cluster
+# state. The backendRef is same-namespace (crossview -> crossview-service), so no
+# ReferenceGrant is needed.
 #
 # Prod/hetzner only in practice: this lives in bases/apps/crossview, but apps are
 # opt-in on the local docker overlay, so the route renders only where Crossview
@@ -23,16 +28,7 @@ spec:
   hostnames:
     - crossview.${domain}
   rules:
-    # Front with oauth2-proxy (Dex SSO) like the other infra dashboards
-    # (homepage/coroot/opencost/longhorn). oauth2-proxy's static upstream is the
-    # auth-proxy Traefik instance, which host-fans-out crossview.${domain} to
-    # crossview-service:80 (see controllers/auth-proxy/config-map.yaml).
     - filters:
-        - type: RequestHeaderModifier
-          requestHeaderModifier:
-            set:
-              - name: X-Auth-Request-Redirect
-                value: https://crossview.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
@@ -49,9 +45,8 @@ spec:
                 value: "frame-ancestors 'self' https://headlamp.${domain}"
             remove:
               # Belt-and-braces for older browsers that honor X-Frame-Options over
-              # CSP: strip any DENY/SAMEORIGIN the app or oauth2-proxy emit.
+              # CSP: strip any DENY/SAMEORIGIN the app emits.
               - X-Frame-Options
       backendRefs:
-        - name: oauth2-proxy
-          namespace: oauth2-proxy
+        - name: crossview-service
           port: 80

--- a/k8s/bases/apps/crossview/networkpolicy.yaml
+++ b/k8s/bases/apps/crossview/networkpolicy.yaml
@@ -6,16 +6,15 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    # Authenticated traffic from oauth2-proxy/auth-proxy: gateway -> oauth2-proxy
-    # (Dex SSO) -> auth-proxy (Traefik host fan-out) -> crossview app on 3001.
-    # This is the public route (crossview.${domain}, httproute.yaml) that also
-    # backs the Headlamp crossview-headlamp plugin's "Open Crossview" iframe.
-    # auth-proxy runs in the oauth2-proxy namespace, so this one selector covers
-    # both hops. In prod the cluster-wide require-mutual-auth policy additionally
-    # requires a SPIRE handshake on this pod-to-pod ingress (both ends have SVIDs).
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+    # Public route traffic from the Cilium Gateway (crossview.${domain},
+    # httproute.yaml), which also backs the Headlamp crossview-headlamp plugin's
+    # "Open Crossview" iframe. There is no oauth2-proxy hop anymore — the gateway
+    # dials the crossview pod directly, arriving with the reserved `ingress`
+    # identity (Cilium's L7 proxy). Like the gateway -> oauth2-proxy hop, this is
+    # NOT a SPIRE workload, so the cluster-wide require-mutual-auth policy does not
+    # apply and authentication.mode must NOT be set here.
+    - fromEntities:
+        - ingress
       toPorts:
         - ports:
             - port: "3001"
@@ -24,7 +23,8 @@ spec:
     # the Headlamp DESKTOP app: that final hop is dialed by the kubelet on the
     # pod's node, so it arrives with the "host" identity (no SVID) and is exempt
     # from the SPIRE mutual-auth requirement — authentication.mode must NOT be set
-    # here.
+    # here. (Desktop port-forward reaches Crossview's own /login; without a Dex
+    # session it cannot read cluster data, same as web.)
     - fromEntities:
         - host
         - remote-node
@@ -41,6 +41,18 @@ spec:
     # resources, and providers.
     - toEntities:
         - kube-apiserver
+    # Dex OIDC server-side calls: the authorization-code -> token exchange and the
+    # userinfo lookup (config.sso.oidc tokenURL / userInfoURL in helm-release.yaml)
+    # go to the IN-CLUSTER Dex Service on :5556, which the pod can always resolve —
+    # unlike the public dex.${domain} URL, which the browser (not this pod) hits
+    # for the authorization redirect. Mirrors the oauth2-proxy egress.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: dex
+      toPorts:
+        - ports:
+            - port: "5556"
+              protocol: TCP
     # Intra-namespace: app -> bundled Postgres (5432).
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -42,12 +42,6 @@ data:
           rule: "Host(`longhorn.${domain}`)"
           entryPoints: ["web"]
           service: longhorn
-        # Hetzner-only (Crossplane dashboard): inert on local/CI where no
-        # HTTPRoute sends crossview.${domain} to oauth2-proxy.
-        crossview:
-          rule: "Host(`crossview.${domain}`)"
-          entryPoints: ["web"]
-          service: crossview
       services:
         homepage:
           loadBalancer:
@@ -71,7 +65,3 @@ data:
           loadBalancer:
             servers:
               - url: "http://longhorn-frontend.longhorn-system.svc.cluster.local:80"
-        crossview:
-          loadBalancer:
-            servers:
-              - url: "http://crossview-service.crossview.svc.cluster.local:80"

--- a/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     # Disable Coroot's latency SLO for this proxy (availability SLO stays).
     # auth-proxy is a low-traffic (~600 requests/day) Host fan-out in front of
-    # several heavy dashboards (Coroot, OpenCost, Hubble, Longhorn, Crossview);
+    # several heavy dashboards (Coroot, OpenCost, Hubble, Longhorn);
     # a few slow first-render responses are enough to blow a 99%-under-500ms SLO
     # at that volume, making it a permanent false-critical. Warm-path health is
     # still covered by the availability SLO here and by the per-app SLOs behind

--- a/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
@@ -62,18 +62,6 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
-    # Crossview upstream (Crossplane resource dashboard). The crossview-service
-    # (port 80) forwards to the crossview pod on container port 3001, and Cilium
-    # enforces egress on that backend pod port. Like the other dashboards it
-    # exposes infrastructure state, so it is only reachable post-SSO via
-    # auth-proxy. Inert on local/CI where the crossview namespace is absent.
-    - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: crossview
-      toPorts:
-        - ports:
-            - port: "3001"
-              protocol: TCP
     # DNS resolution
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -73,6 +73,10 @@ spec:
             - "https://budget.${domain}/oidc/callback"
             - "https://vault.${domain}/ui/vault/auth/oidc/oidc/callback"
             - "https://ksail.${domain}/api/v1/auth/callback"
+            # crossview authenticates natively against Dex as this shared
+            # confidential client (k8s/bases/apps/crossview/helm-release.yaml,
+            # config.sso.oidc); its callback path is /api/auth/oidc/callback.
+            - "https://crossview.${domain}/api/auth/oidc/callback"
           trustedPeers:
             - kubectl
         - name: kubectl

--- a/k8s/bases/infrastructure/controllers/dex/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/networkpolicy.yaml
@@ -22,6 +22,18 @@ spec:
         - ports:
             - port: "5556"
               protocol: TCP
+    # OIDC token + userinfo exchange from the Crossview backend. Crossview does
+    # native OIDC against Dex (apps/crossview/helm-release.yaml, config.sso.oidc)
+    # and dials the in-cluster Dex Service directly on :5556, so Dex sees the
+    # crossview pod identity here — matching crossview's egress allow. Inert on
+    # local/CI where the crossview namespace is absent (crossview is prod-only).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: crossview
+      toPorts:
+        - ports:
+            - port: "5556"
+              protocol: TCP
     # gRPC from oauth2-proxy
     - fromEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -103,7 +103,7 @@ spec:
         # upstream_timeout — max time to await upstream response headers
         # (default 30s). Kept generous (90s) so a slow first render from one of
         # the heavy dashboards behind auth-proxy (Coroot, OpenCost, Hubble,
-        # Longhorn, Crossview) doesn't surface as a 504. Kept under Cloudflare's
+        # Longhorn) doesn't surface as a 504. Kept under Cloudflare's
         # ~100s edge timeout so oauth2-proxy answers first.
         upstream_timeout = "90s"
         # Button-less flow: with skip_provider_button + Dex skipApprovalScreen

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
@@ -24,12 +24,6 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: longhorn-system
-    # Hetzner-only: the Crossview dashboard HTTPRoute (crossview ns) backends to
-    # the oauth2-proxy Service for SSO. Inert on local/CI where crossview has no
-    # HTTPRoute.
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      namespace: crossview
   to:
     - group: ""
       kind: Service

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -591,10 +591,13 @@ spec:
               }
               POLICY
 
-              # crossview reads its bundled-Postgres password + app session
-              # secret from OpenBao via the shared `external-secrets`
-              # ClusterSecretStore role (apps/crossview/{db,app}); the values are
-              # generated and seeded by infrastructure/vault-seed.
+              # crossview reads its bundled-Postgres password, app session secret,
+              # and break-glass admin password from OpenBao via the shared
+              # `external-secrets` ClusterSecretStore role (apps/crossview/{db,app,
+              # admin}); the values are generated and seeded by
+              # infrastructure/vault-seed. (Its OIDC client secret is read from the
+              # shared infrastructure/oidc/dex path via infra-oidc-readonly, also on
+              # that role — no crossview-specific grant needed.)
               bao policy write app-crossview-readonly - <<'POLICY'
               path "secret/data/apps/crossview/*" {
                 capabilities = ["read"]

--- a/k8s/bases/infrastructure/vault-seed/generators.yaml
+++ b/k8s/bases/infrastructure/vault-seed/generators.yaml
@@ -126,3 +126,18 @@ spec:
   symbols: 0
   noUpper: false
   allowRepeat: true
+---
+# crossview's break-glass native `admin` login password (ADMIN_PASSWORD),
+# replacing the chart's well-known admin/password default. symbols:0 keeps it
+# safe to pass as an env var without escaping.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: crossview-admin-password
+  namespace: openbao
+spec:
+  length: 32
+  digits: 8
+  symbols: 0
+  noUpper: false
+  allowRepeat: true

--- a/k8s/bases/infrastructure/vault-seed/push-generated-secrets.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-generated-secrets.yaml
@@ -394,3 +394,43 @@ spec:
         remoteRef:
           remoteKey: apps/crossview/app
           property: session-secret
+---
+# crossview break-glass `admin` login password — generate once, cache, mirror to
+# OpenBao. Read back via crossview-credentials (apps/crossview/admin) and seeded
+# into the boot-time admin user (createAdmin, session mode).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: generated-crossview-admin-password
+  namespace: openbao
+spec:
+  refreshInterval: "0"
+  target:
+    name: generated-crossview-admin-password
+    creationPolicy: Owner
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: crossview-admin-password
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: push-crossview-admin-password
+  namespace: openbao
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - name: openbao
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: generated-crossview-admin-password
+  data:
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: apps/crossview/admin
+          property: admin-password


### PR DESCRIPTION
## Problem

Crossview's native login was unusable — even the username/password from the
chart-created `crossview-secrets` Secret returned **"Login failed: Invalid
credentials"**. The chart ships a well-known `admin`/`password` default, and in
the prior header-auth setup the session middleware (which native login needs) is
disabled, so the form never authenticates.

## What this does

Switches Crossview to authenticate itself via **native OIDC against Dex** and
**removes the oauth2-proxy gate** in front of it, with every secret sourced from
**OpenBao via External Secrets** (generated + mirrored by PushSecrets — no
committed credentials).

### Auth
- `config.sso.oidc.enabled: true`, reusing the shared confidential
  **`public-client`** (same client oauth2-proxy / headlamp / actual-budget use).
  The Login page now shows a **"Sign in with OIDC"** button → Dex → GitHub → back.
- `auth.mode: session` — mandatory: the session middleware gates the
  `/api/kubernetes/*` data routes, the cookie store is only wired in session
  mode, and the break-glass `admin` user is seeded at boot only in session mode.
- **Split-horizon endpoints** mirroring oauth2-proxy: the browser hits the
  **public** `dex.${domain}/auth`; the pod's server-side **token + userinfo**
  calls go to the **in-cluster** Dex Service (`dex.dex.svc.cluster.local:5556`).
  `issuer` is intentionally left at the chart's localhost default so Crossview's
  discovery-first SSO code fails closed (connection-refused) and uses the
  explicit split URLs — identical behavior on local and prod, no LB hairpin.
- `NODE_ENV=production` → Secure session cookie, release-mode logging.

### Secrets (PushSecret + OpenBao + External Secrets)
- `crossview-credentials` now carries four keys: `db-password`, `session-secret`
  (existing), **`admin-password`** (new — generated, mirrored to
  `apps/crossview/admin`, replaces the chart's `admin/password` default) and
  **`oidc-client-secret`** (new — the shared Dex client secret already seeded at
  `infrastructure/oidc/dex`). All via `secretKeyRef`.
- No OpenBao policy change needed — the shared `external-secrets` ClusterSecretStore
  role already bundles read on both `apps/crossview/*` and `infrastructure/oidc/*`.

### Routing / wiring
- `httproute` → straight to `crossview-service` (no oauth2-proxy hop; same-namespace
  backend, so no ReferenceGrant).
- `networkpolicy` → ingress from the gateway (`ingress` entity) on `:3001`; egress
  to the in-cluster Dex Service on `:5556`.
- `dex` → crossview callback registered on `public-client`.
- `auth-proxy` config-map/networkpolicy + `oauth2-proxy` reference-grant → drop the
  now-dead crossview fan-out and grant.

## ⚠️ Security trade-off

Removing oauth2-proxy drops its `allowed_groups = ["devantler-tech:platform"]`
gate. Crossview does **not** gate on OIDC group claims, so the effective access
gate **widens from the `platform` team to any `devantler-tech` org member** that
Dex authenticates (its GitHub connector is org-scoped). Such users land as a
read-only `user` (the first/boot login is the break-glass `admin`, so SSO users
are never `admin`). If team-level gating must be preserved, keep oauth2-proxy in
front instead — happy to switch the approach.

## Validation

- `ksail --config ksail.prod.yaml workload validate` → **exit 0** (95
  kustomizations, 357 files; renders Crossview, which is prod-only).
- `kubectl kustomize` for both cluster overlays + all six provider trees → builds.
- `helm template crossview` with these exact values → renders the expected
  ConfigMap / Deployment env / Secret wiring.
- The local-overlay `ksail workload validate` hit the known flaky 7.66.x
  parallel-render race once (`yaml: line N`); `kubectl kustomize` is authoritative
  and the comprehensive prod run passed.

> Live login can only be confirmed after merge (Flux deploys to prod). This PR is
> a **draft** — nothing deploys until it's promoted to ready and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
