### PR TITLE
fix(coroot): retry pricing API calls through the mutual-auth connection race

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/custom-cloud-pricing-cronjob.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/custom-cloud-pricing-cronjob.yaml
@@ -110,6 +110,19 @@ spec:
                 - |
                   set -u
                   BASE="http://coroot-coroot.observability.svc.cluster.local:8080"
+                  # This cluster enforces Cilium mutual authentication
+                  # (CiliumClusterwideNetworkPolicy require-mutual-auth, mode:
+                  # required). The FIRST packet from this short-lived pod to coroot
+                  # is dropped while the SPIRE handshake is established, so a single
+                  # un-retried in-cluster call intermittently fails (curl exit /
+                  # HTTP 000). The project-discovery loop below already absorbs that
+                  # for /api/user, but the pricing GET + POST ran exactly once and so
+                  # flapped: a dropped GET skips the "already correct" short-circuit
+                  # and triggers a needless POST, which the same race then fails ->
+                  # the run errors even though pricing is already correct. Retry
+                  # transient connection/setup errors so a single tick converges
+                  # (still idempotent; the schedule remains the outer retry loop).
+                  RETRY="--retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused"
 
                   # Resolve the operator-created 'platform' project id (a random
                   # NanoId, so match by name). Retry while Coroot / the project
@@ -132,7 +145,7 @@ spec:
                   # Skip if Hetzner pricing is already applied (Coroot reports
                   # default:true while still on the GCP-C4 fallback). The numeric
                   # compare keeps the loop declarative: any drift re-POSTs.
-                  cur="$(curl -sf --max-time 10 "$BASE/api/project/$pid/custom_cloud_pricing" 2>/dev/null || true)"
+                  cur="$(curl -sf --max-time 10 $RETRY "$BASE/api/project/$pid/custom_cloud_pricing" 2>/dev/null || true)"
                   isdefault="$(printf '%s' "$cur" | grep -c '"default":true' 2>/dev/null || true)"
                   curcpu="$(printf '%s' "$cur" | sed -n 's/.*"per_cpu_core":\([0-9.eE+-]*\).*/\1/p')"
                   curmem="$(printf '%s' "$cur" | sed -n 's/.*"per_memory_gb":\([0-9.eE+-]*\).*/\1/p')"
@@ -145,7 +158,7 @@ spec:
 
                   # anonymous == Admin in-cluster (oauth2-proxy fronts only the
                   # external route), so no credential is needed.
-                  resp="$(curl -s -w '\n%{http_code}' --max-time 10 \
+                  resp="$(curl -s -w '\n%{http_code}' --max-time 10 $RETRY \
                     -X POST "$BASE/api/project/$pid/custom_cloud_pricing" \
                     -H 'content-type: application/json' \
                     -d "{\"per_cpu_core\":$PER_CPU_CORE,\"per_memory_gb\":$PER_MEMORY_GB}")"


### PR DESCRIPTION
## Problem

On **prod**, the `coroot-custom-cloud-pricing` CronJob (observability) fails ~**75% of runs** (`ERROR: set custom cloud pricing failed (HTTP 000)`), leaving an `Error` pod every 30 min:

```
coroot-custom-cloud-pricing-29701740   Error       11h
coroot-custom-cloud-pricing-29702250   Error       170m
coroot-custom-cloud-pricing-29702340   Error       80m
coroot-custom-cloud-pricing-29702400   Completed   20m
```

Yet the pricing **is** correctly applied and stable — querying Coroot directly returns the Hetzner values, not the GCP fallback:

```json
{"default":false,"per_cpu_core":0.0012933,"per_memory_gb":0.0006466}
```

So the failures are **false alarms**: the job is functionally fine but spams `Error` pods that mask real problems.

## Root cause

The cluster enforces **Cilium mutual authentication** (`CiliumClusterwideNetworkPolicy/require-mutual-auth`, `mode: required`). The **first packet** from a short-lived pod to a new destination is dropped while the SPIRE handshake completes; a one-shot call with no retry intermittently fails (curl exit / `HTTP 000`). Both target replicas (`coroot-coroot-0/1`) are stable with 0 restarts, ruling out target downtime.

The script's project-discovery loop already absorbs this for `/api/user`, but the **pricing-check GET** and the **POST** ran exactly once each. A dropped GET returns empty → the `"already correct"` short-circuit is skipped → a needless POST is attempted → the same race fails it → the run errors.

## Fix

Add `curl --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused` to the two previously un-retried in-cluster calls so a single tick converges. The change is:

- **Idempotent** — re-asserting the same pricing is a no-op (the GET short-circuits once it succeeds).
- **Design-preserving** — `backoffLimit: 0` and the `*/30` schedule-as-outer-retry are unchanged (per the file's documented design); this only makes each *run* resilient to the sub-second auth race. Worst-case added latency stays well under `activeDeadlineSeconds: 420`.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure` builds clean.
- `sh -n` on the rendered container script passes (the unquoted `$RETRY` word-splits into flags in busybox sh).

## Notes

Same root cause affects `umami-provision-tenants` (`fetch failed` at `ensureTeam`); hardened in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)