### PR TITLE
fix(kro): grant the Tenant controller watch on the tenants instance kind

### DIFF
--- a/k8s/bases/infrastructure/archetypes/tenant/aggregated-cluster-role.yaml
+++ b/k8s/bases/infrastructure/archetypes/tenant/aggregated-cluster-role.yaml
@@ -7,9 +7,17 @@
 # the verbs to manage the child kinds the Tenant RGD renders — nothing more — so
 # each archetype's blast radius is its own declared resources.
 #
-# Keep in lockstep with resource-graph-definition.yaml: a child kind added there
-# without a rule here makes KRO fail to reconcile that resource (forbidden);
-# a rule here with no corresponding child is dead over-grant.
+# Two distinct grants live here:
+#   1. The instance kind ITSELF (`tenants`) — KRO's dynamic micro-controller
+#      opens an informer on the kind, so it needs get/list/watch on it (and
+#      update/patch to write status back). Aggregation mode does NOT grant this
+#      automatically; without it the controller fails to start ("cache sync
+#      timeout for kro.run, Resource=tenants") and the RGD stays Inactive.
+#   2. The child kinds the RGD renders — so KRO can create/manage them.
+# Keep BOTH in lockstep with resource-graph-definition.yaml: a child kind added
+# there without a rule here makes KRO fail to reconcile that resource (forbidden);
+# a rule here with no corresponding child is dead over-grant. Every future
+# archetype (e.g. the #1933 WebApp RGD) needs its own instance-kind self-watch.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,6 +26,14 @@ metadata:
     app.kubernetes.io/managed-by: ksail
     rbac.kro.run/aggregate-to-controller: "true"
 rules:
+  # The instance kind itself: KRO's per-RGD micro-controller watches `tenants`
+  # (informer cache sync) and patches their status. Required for the RGD to
+  # reach state: Active — see header note (1).
+  - apiGroups: ["kro.run"]
+    resources:
+      - tenants
+      - tenants/status
+    verbs: ["get", "list", "watch", "update", "patch"]
   # Namespace + ServiceAccount (core API group).
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

After #1932's Tenant RGD (#2197) merged, `rgd/tenant.kro.run` came up **`state: Inactive`** with:

```
ControllerReady=False  FailedToStart
  add parent handler kro.run/v1alpha1, Resource=tenants: cache sync timeout for kro.run/v1alpha1, Resource=tenants
```

`GraphAccepted=True` / `KindReady=True` — the schema is fine. The failure is that KRO's **dynamic per-RGD micro-controller for `tenants` can't sync its informer**, because the controller SA has no `list/watch` on the instance kind (verified live):

```
kubectl auth can-i watch tenants.kro.run --as=system:serviceaccount:kro-system:kro  → no
kubectl auth can-i list  tenants.kro.run --as=system:serviceaccount:kro-system:kro  → no
```

`rbac.mode: aggregation` grants KRO only what the aggregated archetype roles declare. `kro-tenant-archetype` declared verbs on the Tenant's **child** kinds (namespaces, serviceaccounts, rolebindings, externalsecrets, networkpolicies, ocirepositories, kustomizations) but **never a rule for `tenants` itself** — and `kro:controller:static` only watches `resourcegraphdefinitions`/`graphrevisions`. So nothing lets the controller watch the new instance kind → informer cache-sync timeout → RGD stuck `Inactive`.

This matters operationally: the `healthCheckExprs` RGD gate (also added in #2197) makes the `infrastructure` Kustomization **wait** for the RGD to reach Active, so a stuck RGD blocks `infrastructure` → `apps` → the merge queue. Tracked live on #2208.

## Fix

Add the missing **instance-kind self-watch** to the `kro-tenant-archetype` aggregated ClusterRole: `get/list/watch/update/patch` on `tenants` (+ `tenants/status`, so the controller can write reconciled status back). Header comment updated to document that aggregation mode does **not** grant the instance-kind watch automatically — so every future archetype (the **#1933 WebApp RGD** especially) must ship its own self-watch rule.

## Validation

- Pure additive RBAC rule; `kubectl apply --dry-run=client` parses clean.
- The equivalent grant was applied live as a temporary standalone ClusterRole to unwedge the queue (see #2208); this PR folds it into the archetype role so the temp role can be deleted.

## Note on merge ordering

The queue is recovering from the #2208 incident. If the temporary unblock ClusterRole from #2208 is already applied, this is a no-op convergence; once merged, delete `kro-tenant-instance-watch`. `Refs #1932`.
