### PR TITLE
chore(security-exceptions): cover newly-added namespaces in SA-token and health-probe exceptions

### DIFF
--- a/k8s/bases/infrastructure/security-exceptions/health-probes.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/health-probes.yaml
@@ -48,3 +48,11 @@ spec:
             - dex
             - oauth2-proxy
             - homepage
+            # Controller namespaces added since this list was last updated whose
+            # workloads genuinely lack probe endpoints (verified failing C-0018 /
+            # C-0056 in the cluster Kubescape operator): the external-secrets
+            # operator/webhook/cert-controller and the Crossplane control-plane
+            # (core, rbac-manager, provider pods). crossview / ksail-operator /
+            # flagger DO configure probes, so they are deliberately NOT listed.
+            - external-secrets
+            - crossplane-system

--- a/k8s/bases/infrastructure/security-exceptions/service-account-tokens.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/service-account-tokens.yaml
@@ -60,3 +60,16 @@ spec:
             - homepage
             - headlamp
             - oauth2-proxy
+            # Controllers / middleware and dashboards added since this list was
+            # last updated, same accepted pattern as the entries above (verified
+            # failing C-0261 / C-0207 / C-0255 in the cluster Kubescape operator):
+            # external-secrets (the operator that syncs OpenBao -> Secrets, so it
+            # genuinely needs secret access), crossplane & ksail-operator
+            # (cluster-state reconcilers), flagger (progressive-delivery
+            # controller), and crossview (read-only Crossplane dashboard, like
+            # headlamp). RBAC still scopes what each SA can do.
+            - external-secrets
+            - crossplane-system
+            - ksail-operator
+            - flagger-system
+            - crossview


### PR DESCRIPTION
## Problem

Five namespaces added to the cluster since the `ClusterSecurityException` lists were last updated are absent from them, so the in-cluster **Kubescape operator** flags accepted-by-design findings on platform controllers as if they were gaps:

`external-secrets`, `crossplane-system`, `crossview`, `ksail-operator`, `flagger-system`

This is dashboard noise of the same kind the exceptions directory exists to suppress — `external-secrets` (the operator that literally syncs OpenBao → Secrets) being unexcepted is an obvious omission.

## Evidence

Verified against the **live Kubescape operator** (per-object GET — the LIST response strips `controls`):

| Namespace | `service-account-tokens` (C-0261/0207/0012/0255) | `health-probes` (C-0018/0056) |
|---|---|---|
| external-secrets | ✓ C-0255, C-0261 | ✓ C-0018, C-0056 |
| crossplane-system | ✓ C-0012, C-0255, C-0261 | ✓ C-0018, C-0056 |
| crossview | ✓ C-0207, C-0261 | — (has probes) |
| ksail-operator | ✓ C-0207, C-0261 | — (has probes) |
| flagger-system | ✓ C-0261 | — (has probes) |

## Change

- **`service-account-tokens.yaml`** — add all five (every one is a controller/dashboard that mounts SA tokens / accesses secrets, same accepted pattern as the ~24 existing entries; RBAC still scopes each SA).
- **`health-probes.yaml`** — add **only** `external-secrets` and `crossplane-system` (the two that actually fail the probe controls; the other three configure probes, so they are deliberately left out rather than blanket-added).
- **`controller-rbac.yaml`** — **no change**: none of the five fail its currently-excepted controls.

## Scope / impact

- **Dashboard hygiene only.** The `ksail workload scan` CI gate ignores `ClusterSecurityException` CRs ([ksail#5369](https://github.com/devantler-tech/ksail/issues/5369)), so this does **not** move the NSA compliance score or change runtime posture.
- Builds clean: `kubectl kustomize k8s/bases/infrastructure/security-exceptions` and `k8s/providers/hetzner/infrastructure`.

## Follow-up (not in this PR — deliberate)

All five (and, per a separate sweep, the existing GitOps/operator controllers generally) also fail **C-0267** (workload with cluster-takeover roles) and **C-0272** (administrative roles) — newer Kubescape controls not yet excepted *anywhere*. Adding `C-0267`/`C-0272` to `controller-rbac.yaml` would clear them, but that changes coverage for **every** controller namespace (broader blast radius) and is a deliberate platform-wide risk-acceptance call, so it is intentionally left for a separate decision rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)