### PR TITLE
fix(kro): grant the tenant archetype controller RBAC on its own parent CR

### DIFF
--- a/k8s/bases/infrastructure/archetypes/tenant/aggregated-cluster-role.yaml
+++ b/k8s/bases/infrastructure/archetypes/tenant/aggregated-cluster-role.yaml
@@ -18,6 +18,21 @@ metadata:
     app.kubernetes.io/managed-by: ksail
     rbac.kro.run/aggregate-to-controller: "true"
 rules:
+  # The parent Tenant CR itself. KRO renders the child kinds below, but its
+  # dynamic controller must first watch/list the instances of the kind this RGD
+  # generates -- and in rbac.mode: aggregation KRO holds NO standing access even
+  # to the CRD it just created from the RGD. Without this rule the controller
+  # fails to start ("cannot list resource tenants in API group kro.run" -> cache
+  # sync timeout -> ControllerReady=False / RGD Inactive), which wedges the
+  # infrastructure Kustomization health check and blocks the apps layer behind it.
+  # get/list/watch to observe instances; update/patch (+ status/finalizers) to
+  # write reconcile status and manage the lifecycle finalizer.
+  - apiGroups: ["kro.run"]
+    resources: ["tenants"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["kro.run"]
+    resources: ["tenants/status", "tenants/finalizers"]
+    verbs: ["get", "update", "patch"]
   # Namespace + ServiceAccount (core API group).
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
## Problem (active prod blocker)

The KRO `tenant.kro.run` ResourceGraphDefinition added in #2197 is stuck **`Inactive` / `ControllerReady=False`** on prod:

```
ControllerReady: False | FailedToStart |
  cache sync timeout for kro.run/v1alpha1, Resource=tenants
```

kro controller log:

```
watch error: tenants.kro.run is forbidden: User
"system:serviceaccount:kro-system:kro" cannot list resource "tenants"
in API group "kro.run" at the cluster scope
```

Because the `infrastructure` Flux Kustomization waits on this RGD's health, it stays `Reconciliation in progress`, and the `apps` layer behind it is blocked:

```
kustomization/apps  False  dependency 'flux-system/infrastructure' is not ready
```

(All other infra resources applied cleanly — `server-side apply completed`, everything `unchanged` except the new `ResourceGraphDefinition/tenant.kro.run` + `ClusterRole/kro-tenant-archetype`.)

## Root cause

KRO runs in `rbac.mode: aggregation` — it holds **no** standing access and aggregates ClusterRoles labelled `rbac.kro.run/aggregate-to-controller: "true"`. The `kro-tenant-archetype` role grants every **child** kind the Tenant RGD renders (namespaces, serviceaccounts, rolebindings, externalsecrets, networkpolicies, ocirepositories, kustomizations) — but **omits the parent `tenants.kro.run` kind itself**, which KRO's dynamic controller must `list`/`watch` to reconcile instances of the CRD it generated.

Confirmed live:

```
$ kubectl auth can-i list tenants.kro.run --as=system:serviceaccount:kro-system:kro
no
$ kubectl auth can-i list namespaces      --as=system:serviceaccount:kro-system:kro
yes        # aggregation works — only the parent kind is missing
```

## Fix

Add the parent CR to the aggregated role:

```yaml
- apiGroups: ["kro.run"]
  resources: ["tenants"]
  verbs: ["get", "list", "watch", "update", "patch"]
- apiGroups: ["kro.run"]
  resources: ["tenants/status", "tenants/finalizers"]
  verbs: ["get", "update", "patch"]
```

`get/list/watch` clears the `cannot list tenants` error; `update/patch` + `status`/`finalizers` let the controller write reconcile status and manage the lifecycle finalizer. Same archetype-self-contained blast-radius model as the existing child rules (per the file's own "keep in lockstep" note — the parent kind was the one resource missed).

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure` and `.../docker/infrastructure` both build; the role renders with the `kro.run` / `tenants` / `tenants/status` rules.
- `kubectl apply --dry-run=client` on the file is valid.
- Once merged + reconciled, the `tenant` RGD should go `Active`/`Ready`, unblocking `infrastructure` → `apps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)