### PR TITLE
fix(heartbeat): stop cluster-heartbeat flapping into DeadlineExceeded

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/cluster-heartbeat-cronjob.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cluster-heartbeat-cronjob.yaml
@@ -42,7 +42,14 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 30
+      # Headroom for a slow tick: pod scheduling + Cilium's L7 DNS proxy
+      # resolving the external host + curl's own --retry budget (below) can
+      # exceed a tight 30s, which marks the Job Failed (reason: DeadlineExceeded)
+      # even though `|| true` swallowed curl's exit code -- a false failure event.
+      # 120s sits well above the worst case (4 attempts x --max-time 10 + delays)
+      # and far below the */5 schedule, so a genuinely-down cluster still stops
+      # pinging within one period.
+      activeDeadlineSeconds: 120
       template:
         metadata:
           labels:
@@ -65,6 +72,7 @@ spec:
                 - -c
                 - >-
                   curl -sf --max-time 10
+                  --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused
                   "${alertmanager_heartbeat_url:=https://example.invalid/no-heartbeat-configured}"
                   || true
               securityContext:


### PR DESCRIPTION
## Problem

The `cluster-heartbeat` CronJob (the cluster dead-man's switch) occasionally fails with `reason: DeadlineExceeded`, firing a Kubernetes-events alert even though the heartbeat ping itself is fine.

## Root cause

The script ends in `|| true` — which guards **curl's exit code** but cannot guard the **Job-level `activeDeadlineSeconds: 30`**. A slow tick (pod scheduling + Cilium's L7 DNS proxy resolving the external host + external egress latency) runs past 30s, and Kubernetes marks the Job `Failed/DeadlineExceeded`. The target is external (`hc-ping.com` via the `toFQDNs` allow-list), so this is DNS-proxy/egress latency, not the mutual-auth race.

## Fix

- `activeDeadlineSeconds: 30 → 120` — well above the worst-case retry budget (4 × `--max-time 10` + delays), far below the `*/5` schedule, so a genuinely-down cluster still stops pinging within one period.
- Add `curl --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused` so a transient external hiccup recovers within the run.

**Dead-man semantics unchanged**: `|| true` stays; the alarm signal remains the *absence* of pings observed externally, never the Job's exit code.

## Validation

`kubectl kustomize k8s/providers/hetzner/infrastructure` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)