### PR TITLE
fix(vpa): add leader-election RBAC for the recommender and updater

### DIFF
--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - networkpolicy.yaml
+  - leader-election-rbac.yaml

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/leader-election-rbac.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/leader-election-rbac.yaml
@@ -1,0 +1,47 @@
+# Leader-election RBAC for the VPA recommender and updater.
+#
+# helm-release.yaml runs both at the prod 2-replica HA floor with
+# `extraArgs.leader-elect: true` (active/standby, so duplicate recommenders
+# don't race and duplicate updaters don't double-evict). The Fairwinds chart
+# wires a coordination.k8s.io/leases grant only for the admission-controller
+# (the recommender/updater default to a single replica with no leader election),
+# so enabling leader-elect via extraArgs WITHOUT this Role leaves both
+# controllers unable to create/renew their lock Lease:
+#
+#   leaderelection.go: "Error retrieving lease lock" / "Error initially creating
+#   lease lock" err="leases.coordination.k8s.io \"vpa-recommender-lease\" is
+#   forbidden: User \"system:serviceaccount:vertical-pod-autoscaler:
+#   vertical-pod-autoscaler-vpa-recommender\" cannot ... at the cluster scope"
+#
+# logged every few seconds on all four pods -- a constant error stream (Coroot
+# "Log errors") and, worse, leader election never completes so the HA standby
+# can't actually coordinate. Namespaced (the client-go lock Lease lives in each
+# controller's own namespace) and scoped to leases only -- least privilege for
+# acquiring/renewing the lock. The admission-controller already has its own
+# chart-provided lease grant, so it is intentionally not bound here.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vpa-leader-election
+  namespace: vertical-pod-autoscaler
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vpa-leader-election
+  namespace: vertical-pod-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vpa-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: vertical-pod-autoscaler-vpa-recommender
+    namespace: vertical-pod-autoscaler
+  - kind: ServiceAccount
+    name: vertical-pod-autoscaler-vpa-updater
+    namespace: vertical-pod-autoscaler


### PR DESCRIPTION
## Problem

The VPA recommender and updater log a leader-election RBAC error **every few seconds on all four pods** (~40 lines/min — a chronic Coroot "Log errors" source):

```
E leaderelection.go:452 "Error retrieving lease lock"
  err="leases.coordination.k8s.io \"vpa-recommender-lease\" is forbidden:
  User \"system:serviceaccount:vertical-pod-autoscaler:vertical-pod-autoscaler-vpa-recommender\" ..."
E leaderelection.go:456 "Error initially creating lease lock"
  err="leases.coordination.k8s.io is forbidden: User \"...vpa-updater\" ..."
```

Worse than the noise: leader election **never completes**, so the HA standby can't actually coordinate.

## Root cause

`helm-release.yaml` runs both controllers at the prod 2-replica HA floor with `extraArgs.leader-elect: true`, but the Fairwinds chart wires a `coordination.k8s.io/leases` grant only for the **admission-controller** (the recommender/updater default to a single replica with no leader election). Enabling `--leader-elect` via `extraArgs` without the matching RBAC leaves both SAs unable to create/renew their lock Lease.

Confirmed live:
```
$ kubectl auth can-i create leases.coordination.k8s.io \
    --as=system:serviceaccount:vertical-pod-autoscaler:vertical-pod-autoscaler-vpa-recommender
no
```
(The admission-controller's ClusterRole *does* have leases RBAC, which is why only recommender/updater error.)

## Fix

Add a namespaced `Role` + `RoleBinding` granting the recommender and updater SAs `leases` access — least privilege (their own namespace, `leases` only). The admission-controller keeps its existing chart-provided grant and is intentionally not bound.

## Validation

- `kubectl apply --dry-run=client` valid.
- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers` builds clean; the Role/RoleBinding render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)