### PR TITLE
build(deps): pin kubelet-serving-cert-approver to a release tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -68,6 +68,20 @@
     },
     {
       "customType": "regex",
+      "description": "Track the kubelet-serving-cert-approver version pinned in the prod controller's kustomize remote resource URL. The project ships NO Helm chart (only raw deploy/*-install.yaml manifests), so it is installed as a kustomize remote resource pinned to a release tag rather than the moving `main` branch — but the version then lives inside a raw.githubusercontent.com URL that no built-in manager (flux/kubernetes/docker) sees. This regex manager resolves it from the authoritative alex1989hu/kubelet-serving-cert-approver GitHub releases; the `v` literal sits outside the capture group and extractVersionTemplate strips the leading `v` from the `vX.Y.Z` release tags, so the resolved version matches the captured X.Y.Z while the URL keeps its `v` prefix. On a bump, re-check the standalone PDB selector still matches the upstream labels (see the kustomization comment).",
+      "managerFilePatterns": [
+        "/^k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "kubelet-serving-cert-approver/v(?<currentValue>[0-9.]+)/deploy/"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "alex1989hu/kubelet-serving-cert-approver",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
       "description": "Track the Kubernetes version pinned for the prod cluster in ksail.prod.yaml (kubernetesVersion), resolved from the authoritative kubernetes/kubernetes GitHub releases. This pin is the version's ONLY home in the repo, so Renovate edits ksail.prod.yaml to bump it. KSail/Talos own this pin and the docker system-test runs off ksail.yaml (which has no kubernetesVersion), so the built-in kubernetes/flux managers — scoped to k8s/** — never see it; a custom manager is the only way to track it. The v regex literal sits outside the capture group and extractVersionTemplate strips the leading v from the vX.Y.Z release tags, so the resolved version matches the captured X.Y.Z while the file keeps its v prefix. Renovate opens the PR automatically — the same flow as every other dependency, with no Dependency Dashboard approval gate. It is NOT automerged (see the matching packageRule): CI never validates this prod pin, and a Kubernetes minor/major can exceed the pinned Talos version's supported Kubernetes ceiling, so each bump is reviewed and promoted in lockstep with Talos.",
       "managerFilePatterns": [
         "/^ksail\\.prod\\.ya?ml$/"

--- a/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kubelet-serving-cert-approver/kustomization.yaml
@@ -11,8 +11,13 @@ resources:
   # the 2 replicas land on different nodes. So 2 replicas = one active CSR
   # approver + a warm standby that takes over on a node drain/failure, not two
   # active approvers. The standalone PDB (pod-disruption-budget.yaml) makes the
-  # node drain-safe (maxUnavailable: 1). When bumping, re-pin both this URL and
-  # the PDB selector to the same upstream ref.
-  - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/ha-install.yaml
+  # node drain-safe (maxUnavailable: 1).
+  #
+  # Pinned to a release tag (not the moving `main` branch) for reproducibility:
+  # Renovate bumps the version in this URL automatically via the github-releases
+  # custom manager in .github/renovate.json (the project ships no Helm chart, only
+  # these raw install manifests, so a kustomize remote resource is the install
+  # path). On a bump, re-check the PDB selector still matches the upstream labels.
+  - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/v0.11.0/deploy/ha-install.yaml
   - networkpolicy.yaml
   - pod-disruption-budget.yaml


### PR DESCRIPTION
## What

The `kubelet-serving-cert-approver` controller (prod/hetzner only) was installed via a kustomize **remote resource pinned to the moving `main` branch**:

```
- https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/ha-install.yaml
```

This is not reproducible (an upstream push to `main` lands in prod unreviewed) and is the one component not tracked by Renovate.

## Why not a HelmRelease

The original review framing was "convert to a HelmRelease for consistency", but verification shows **the project ships no Helm chart at all** — only raw `deploy/*-install.yaml` manifests (no `Chart.yaml`, no gh-pages helm repo). So a kustomize remote resource is the correct install path; the fix is to pin it.

## Change

- Pin the remote resource to the **`v0.11.0`** release tag (latest).
- Add a **`github-releases` Renovate custom manager** in `.github/renovate.json`, mirroring the existing Talos / Kubernetes managers (`extractVersionTemplate` strips the leading `v`), so version bumps arrive as normal reviewed PRs.
- Update the kustomization comment to reflect the pin + Renovate tracking.

The HA variant is unchanged (`ha-install.yaml`: replicas 2, `--enable-leader-election`, leases RBAC, podAntiAffinity).

## Validation

- `kubectl kustomize` of the cert-approver kustomization builds against the tagged URL (12 resources; leader-election / replicas 2 / podAntiAffinity present in the render).
- `.github/renovate.json` is valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)