### PR TITLE
fix(oauth2-proxy): per-request CSRF cookie so homepage loads on first visit

### DIFF
--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -96,6 +96,21 @@ spec:
         cookie_secure = true
         cookie_httponly = true
         cookie_samesite = "lax"
+        # Per-request CSRF cookies. The platform front page (homepage, served at
+        # the apex ${domain}) fires several unauthenticated requests at once on a
+        # cold visit -- the HTML document plus the /favicon.ico and
+        # /apple-touch-icon*.png the browser probes -- and each independently
+        # triggers an OAuth login. With the default single shared CSRF cookie
+        # (_oauth2_proxy_csrf) the last flow to start overwrites the document
+        # flow's cookie, so when the document's /oauth2/callback returns its
+        # nonce is gone and oauth2-proxy rejects it with "CSRF token mismatch"
+        # (HTTP 403): the dashboard fails to load on the first visit and only a
+        # reload -- assets now cached, no competing flow -- succeeds. Naming the
+        # CSRF cookie per request (the state nonce is embedded in the cookie name)
+        # lets the concurrent flows coexist, so the document flow's callback
+        # always finds its own token. Fixes "homepage often doesn't start on
+        # first visit".
+        cookie_csrf_per_request = true
         cookie_domains=[".${domain}"]
         whitelist_domains = ["${domain}", ".${domain}"]
         redirect_url = "https://oauth2-proxy.${domain}/oauth2/callback"


### PR DESCRIPTION
## Symptom

Homepage (the platform front page at the apex `${domain}`) **often does not start on first visit** — it fails to load the first time, and a reload fixes it.

## Root cause

Not the homepage app itself — its pods are healthy and serve fine (HTTP 200/304) once authenticated. The failure is in the **oauth2-proxy SSO handshake** that fronts the dashboard.

A cold visit to the apex fires **several unauthenticated requests at once**: the HTML document **plus** the `/favicon.ico` and `/apple-touch-icon*.png` the browser probes. Each independently triggers an OAuth login flow. With the default **single shared** CSRF cookie (`_oauth2_proxy_csrf`), the last flow to start **overwrites** the document flow's CSRF cookie. When the document flow's `/oauth2/callback` returns, its nonce is gone, so oauth2-proxy rejects it:

```
GET /oauth2/callback?...state=...platform.devantler.tech/   → 403  (1.045s)
[AuthFailure] Invalid authentication via OAuth2: CSRF token mismatch, potential attack
```

The one flow that *does* succeed in that visit carries a different nonce and a redirect target of `/` (a sub-resource flow), so the browser lands on the oauth2-proxy host root (observed `404`s) instead of the dashboard. Net effect: the homepage doesn't load on the first visit. On reload the assets are cached (no competing flow), so the document flow's callback finds its own cookie and succeeds.

This matches the report exactly:
- **"first visit"** — only while unauthenticated (no session cookie yet);
- **"often"** — race-dependent on which callback returns against the shared cookie;
- **works on retry** — cached assets / no competing flow.

## Fix

Enable `cookie_csrf_per_request = true`. Each concurrent login flow then gets its own uniquely-named CSRF cookie (the state nonce is embedded in the cookie name), so the flows stop clobbering each other and every callback finds its matching token. This is oauth2-proxy's purpose-built remedy for multi-request landing pages; no security regression (it is strictly more robust against CSRF cookie fixation). The cookie applies cluster-wide, so it fixes the apex on both local and prod.

## Validation

- `kubectl kustomize k8s/bases/infrastructure/controllers/oauth2-proxy/` builds; the setting renders in the right place in the HelmRelease `configFile`.
- `ksail workload validate` — **✔ 359 files** (local) and **✔ 359 files** (prod), exit 0.

## Note (not changed here, to keep this focused)

oauth2-proxy also logs `request host "platform.devantler.tech" did not match any of the specific cookie domains of ".platform.devantler.tech"` on every apex request — the leading-dot `cookie_domains` doesn't suffix-match the apex. It's benign (the session cookie still works via the fallback) and unrelated to the CSRF failure, but `cookie_domains = ["${domain}"]` (no leading dot) would remove the noise. Left out to keep the blast radius minimal (changing it forces a one-time re-auth across all SSO-fronted apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)