### PR TITLE
feat(kro): add WebApp archetype ResourceGraphDefinition

### DIFF
--- a/k8s/bases/infrastructure/resource-graph-definitions/kustomization.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/kustomization.yaml
@@ -9,3 +9,4 @@ kind: Kustomization
 # child kinds it renders (KRO runs with rbac.mode: aggregation).
 resources:
   - tenant/
+  - webapp/

--- a/k8s/bases/infrastructure/resource-graph-definitions/webapp/aggregated-cluster-role.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/webapp/aggregated-cluster-role.yaml
@@ -1,0 +1,52 @@
+# Aggregated ClusterRole for the WebApp RGD (#1933).
+#
+# The KRO controller is installed with `rbac.mode: aggregation` (see
+# controllers/kro/helm-release.yaml): it holds NO standing access to arbitrary
+# resources and instead aggregates any ClusterRole labelled
+# `rbac.kro.run/aggregate-to-controller: "true"`. This role grants KRO exactly
+# the verbs to manage the child kinds the WebApp RGD renders — nothing more — so
+# each RGD's blast radius is its own declared resources.
+#
+# Two distinct grants live here (the same two the Tenant RGD documents):
+#   1. The instance kind ITSELF (`webapps`) — KRO's dynamic micro-controller
+#      opens an informer on the kind, so it needs get/list/watch on it (and
+#      update/patch to write status back). Aggregation mode does NOT grant this
+#      automatically; without it the controller fails to start ("cache sync
+#      timeout for kro.run, Resource=webapps") and the RGD stays Inactive — the
+#      exact failure #2212 fixed for the Tenant RGD. Every RGD needs its own
+#      instance-kind self-watch from the start.
+#   2. The child kinds the RGD renders (Deployment, Service, HTTPRoute) — so KRO
+#      can create/manage them.
+# Keep BOTH in lockstep with resource-graph-definition.yaml: a child kind added
+# there without a rule here makes KRO fail to reconcile that resource (forbidden);
+# a rule here with no corresponding child is dead over-grant. No `bind` verb is
+# needed (the WebApp RGD renders no RoleBindings, unlike the Tenant RGD).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kro-webapp-rgd
+  labels:
+    app.kubernetes.io/managed-by: ksail
+    rbac.kro.run/aggregate-to-controller: "true"
+rules:
+  # The instance kind itself: KRO's per-RGD micro-controller watches `webapps`
+  # (informer cache sync) and patches their status. Required for the RGD to reach
+  # state: Active — see header note (1). Dropping it re-wedges the infrastructure
+  # Kustomization (the #2212 failure mode), so keep it through any future refactor.
+  - apiGroups: ["kro.run"]
+    resources:
+      - webapps
+      - webapps/status
+    verbs: ["get", "list", "watch", "update", "patch"]
+  # The workload Deployment.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # The ClusterIP Service.
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # The Gateway-API HTTPRoute (attaches to the central platform Gateway).
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/k8s/bases/infrastructure/resource-graph-definitions/webapp/kustomization.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/webapp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - resource-graph-definition.yaml
+  - aggregated-cluster-role.yaml

--- a/k8s/bases/infrastructure/resource-graph-definitions/webapp/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/webapp/resource-graph-definition.yaml
@@ -1,0 +1,213 @@
+# WebApp RGD (#1933) — the KRO ResourceGraphDefinition that expands a small typed
+# `WebApp` declaration into the standard containerized-web-app workload skeleton
+# (Deployment + Service + Gateway-API HTTPRoute) every tenant web app
+# (`ascoachingogvaner`, `wedding-app`) otherwise hand-copies into its OCI artifact.
+#
+# Sibling to the Tenant RGD: a *Tenant* sets up the namespace/isolation/sync
+# (tenant/resource-graph-definition.yaml); a *WebApp* defines the application that
+# runs INSIDE that tenant namespace. A WebApp instance therefore does NOT create
+# its namespace — it renders into the namespace named by `spec.name`, which the
+# Tenant archetype already provisioned. The convention is app == namespace
+# (ascoachingogvaner / wedding-app are both); add a `namespace` override field
+# only if a future app diverges (the same "template the invariant, add an override
+# when it breaks" rule the Tenant RGD follows for the OCIRepository URL).
+#
+# Onboarding a web app becomes a ~7-line `WebApp` CR instead of a 3-file
+# Deployment/Service/HTTPRoute copy:
+#
+#   apiVersion: kro.run/v1alpha1
+#   kind: WebApp
+#   metadata: { name: wedding-app, namespace: wedding-app }
+#   spec:
+#     name: wedding-app
+#     image: ghcr.io/devantler-tech/wedding-app:latest
+#     host: wedding.platform.lan
+#     port: 3000
+#     probePath: /login
+#
+# SCOPE (V1 — a deliberately render-diffable first cut mirroring the Tenant RGD's
+# conservative start): the common workload SKELETON only. App-specific extensions —
+# secret-backed env (ESO/SOPS-sourced k8s Secrets consumed via secretKeyRef), KEDA
+# HTTP scale-to-zero, the www→apex 301 redirect + per-tenant public-domain SNI
+# listeners, OIDC/auth — stay in the tenant artifact for now and land here
+# incrementally as the pilot migration needs them (tracked in the #1933 follow-up).
+# The skeleton IS the boilerplate the readability win targets (#1933: "no more
+# Kustomize overlay/component stacking").
+#
+# Lands in the `infrastructure` layer alongside the Tenant RGD (a CR of an
+# RGD-defined kind cannot share a Flux Kustomization with the controller that
+# installs its CRD). Pre-1.0 KRO (v1alpha1): only scalar schema fields with
+# defaults (the proven Tenant-RGD subset, which reconciled live); `WebApp`
+# instances arrive with the pilot migration, not here.
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: webapp.kro.run
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  annotations:
+    # Exempt from Flux postBuild envsubst — see the Tenant RGD for the full
+    # rationale. Every `${...}` below is a KRO CEL expression resolved by the kro
+    # controller at instance time, not a Flux variable; the `infrastructure`
+    # Kustomization's substituteFrom would otherwise fail trying to expand them
+    # ("envsubst error: variable substitution failed: missing closing brace").
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: WebApp
+    spec:
+      # App name — used verbatim as the Deployment/Service/HTTPRoute name AND as
+      # the target namespace (the tenant namespace the Tenant archetype created).
+      # Required.
+      name: string
+      # Container image (with tag/digest). Required.
+      image: string
+      # Public hostname the HTTPRoute answers for (e.g. wedding.platform.lan).
+      # Attaches to the shared wildcard `https` listener on the central gateway.
+      # Required.
+      host: string
+      # Container port (and Service targetPort). The Service always fronts it on
+      # port 80. Default 8080 (ascoachingogvaner); wedding-app overrides to 3000.
+      port: integer | default=8080
+      # Desired replicas. Default 2 (HA across nodes via the topology spread
+      # below), matching both pilots.
+      replicas: integer | default=2
+      # HTTP path for the liveness/readiness probes. Default "/"
+      # (ascoachingogvaner); wedding-app overrides to "/login".
+      probePath: string | default="/"
+      # Pod resource requests/limits. Defaults match ascoachingogvaner's tiny
+      # static-site footprint; override per app (wedding-app runs larger).
+      cpuRequest: string | default="10m"
+      memoryRequest: string | default="16Mi"
+      cpuLimit: string | default="100m"
+      memoryLimit: string | default="64Mi"
+  resources:
+    - id: deployment
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${schema.spec.name}
+          labels:
+            app.kubernetes.io/name: ${schema.spec.name}
+            app.kubernetes.io/managed-by: ksail
+            # Both pilots opt out of the replica-floor policy and self-manage
+            # replicas (default 2). Kept for behaviour-preserving parity; revisit
+            # if a WebApp should instead inherit the platform replica floor.
+            platform.devantler.tech/replica-floor: exempt
+        spec:
+          replicas: ${schema.spec.replicas}
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: ${schema.spec.name}
+          strategy:
+            type: RollingUpdate
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 0
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: ${schema.spec.name}
+                app.kubernetes.io/managed-by: ksail
+            spec:
+              # restricted-PSA-compliant: the tenant namespace enforces
+              # `pod-security.kubernetes.io/enforce: restricted`, so the pod ships
+              # a compliant security context (Kyverno mutate is additive and
+              # idempotent over these — it sets the same values, no conflict).
+              # Matches both pilots (non-root uid/gid 1000).
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              # Spread replicas across nodes (soft) so a single node failure can't
+              # take out the whole app; ScheduleAnyway keeps single-node local/CI
+              # clusters schedulable — matches both pilots + the operator tier.
+              topologySpreadConstraints:
+                - maxSkew: 1
+                  topologyKey: kubernetes.io/hostname
+                  whenUnsatisfiable: ScheduleAnyway
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: ${schema.spec.name}
+              containers:
+                - name: ${schema.spec.name}
+                  image: ${schema.spec.image}
+                  ports:
+                    - containerPort: ${schema.spec.port}
+                      protocol: TCP
+                  livenessProbe:
+                    httpGet:
+                      path: ${schema.spec.probePath}
+                      port: ${schema.spec.port}
+                    initialDelaySeconds: 5
+                    periodSeconds: 10
+                  readinessProbe:
+                    httpGet:
+                      path: ${schema.spec.probePath}
+                      port: ${schema.spec.port}
+                    initialDelaySeconds: 3
+                    periodSeconds: 5
+                  resources:
+                    requests:
+                      cpu: ${schema.spec.cpuRequest}
+                      memory: ${schema.spec.memoryRequest}
+                    limits:
+                      cpu: ${schema.spec.cpuLimit}
+                      memory: ${schema.spec.memoryLimit}
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: false
+                    capabilities:
+                      drop:
+                        - ALL
+                    seccompProfile:
+                      type: RuntimeDefault
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${schema.spec.name}
+          labels:
+            app.kubernetes.io/name: ${schema.spec.name}
+            app.kubernetes.io/managed-by: ksail
+        spec:
+          type: ClusterIP
+          selector:
+            app.kubernetes.io/name: ${schema.spec.name}
+          ports:
+            - name: http
+              port: 80
+              targetPort: ${schema.spec.port}
+              protocol: TCP
+    - id: httpRoute
+      template:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${schema.spec.name}
+          labels:
+            app.kubernetes.io/name: ${schema.spec.name}
+            app.kubernetes.io/managed-by: ksail
+        spec:
+          parentRefs:
+            # The central Cilium Gateway in kube-system — reference it, never
+            # recreate it. The shared wildcard `https` listener terminates TLS;
+            # per-tenant public-domain SNI listeners (e.g. ascoachingogvaner.dk)
+            # remain app-specific gateway patches outside this archetype.
+            - name: platform
+              namespace: kube-system
+              sectionName: https
+          hostnames:
+            - ${schema.spec.host}
+          rules:
+            - backendRefs:
+                - name: ${service.metadata.name}
+                  port: 80


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

Adds the **WebApp** KRO `ResourceGraphDefinition` — the sibling archetype to the merged Tenant RGD (#2197/#2212) — that expands a small typed `WebApp` declaration into the standard containerized-web-app workload skeleton (Deployment + Service + Gateway-API HTTPRoute) every tenant web app (`ascoachingogvaner`, `wedding-app`) otherwise hand-copies into its OCI artifact.

Onboarding a web app becomes a ~7-line CR instead of a 3-file copy:

```yaml
apiVersion: kro.run/v1alpha1
kind: WebApp
metadata: { name: wedding-app, namespace: wedding-app }
spec:
  name: wedding-app
  image: ghcr.io/devantler-tech/wedding-app:latest
  host: wedding.platform.lan
  port: 3000
  probePath: /login
```

Part of #1933.

## Decision (acceptance criterion 1)

**KRO**, reusing the Tenant-archetype decision (maintainer-ruled, comments on #1932/#1933 — "Custom Resource approach, more cloud-native"; Helm ruled out). Placement is **platform-published** (the issue's default): the platform owns the RGD, tenants own the values. The KRO foundation this builds on is fully merged — controller install #2190, Tenant RGD #2197, instance-kind self-watch RBAC #2212.

## What it ships

- `resource-graph-definitions/webapp/resource-graph-definition.yaml` — the `webapp.kro.run` RGD. Renders, into the tenant namespace named by `spec.name` (app == namespace, the established convention; the WebApp does **not** create the namespace — the Tenant archetype does):
  - **Deployment** — restricted-PSA-compliant securityContext (non-root uid/gid 1000, seccomp RuntimeDefault, drop ALL, no-priv-esc), topology spread across nodes (soft), RollingUpdate, probes, resources, and the `platform.devantler.tech/replica-floor: exempt` label both pilots carry. Kyverno mutate is additive/idempotent over these (sets the same values) — no fight.
  - **Service** — ClusterIP, port 80 → `targetPort: spec.port`.
  - **HTTPRoute** — attaches to the central Cilium `Gateway` `platform`/`kube-system`, shared wildcard `https` listener (referenced, never recreated).
- `resource-graph-definitions/webapp/aggregated-cluster-role.yaml` — the `kro-webapp-rgd` aggregated ClusterRole (KRO runs `rbac.mode: aggregation`), granting exactly the verbs for the rendered child kinds **plus the `webapps` instance-kind self-watch from the start** (`get/list/watch/update/patch` on `webapps` + `webapps/status`) — without it the RGD would come up `Inactive` with a `cache sync timeout for …Resource=webapps`, the exact failure #2212 fixed for the Tenant RGD.
- `kustomize.toolkit.fluxcd.io/substitute: disabled` on the RGD from the start — its `${...}` are KRO CEL expressions, not Flux variables; without this the `infrastructure` Kustomization's postBuild envsubst fails on them (the same fix the Tenant RGD documents).
- Wires `webapp/` into `resource-graph-definitions/kustomization.yaml` (which already named #1933 in its header). Flux readiness is already covered: the generic `healthCheckExprs` for `kro.run/v1alpha1` ResourceGraphDefinition (`status.state == 'Active'`) applies to all RGD GVKs — no change needed.

## Scope (V1 — a deliberately render-diffable first cut, mirroring the Tenant RGD)

V1 is the common workload **skeleton** with scalar schema fields only (the proven Tenant-RGD subset that reconciled live; KRO is pre-1.0 `v1alpha1`). App-specific extensions stay in the tenant artifact and land here incrementally as the pilot migration needs them — see follow-ups. The skeleton **is** the boilerplate the readability win targets (#1933: "no more Kustomize overlay/component stacking").

## Validation

`ksail workload validate` (the exact CI static check, both overlays, in-process Helm render): **passes with this change — `bases/infrastructure/resource-graph-definitions/webapp validated ✔`, 0 errors** on a clean run.

⚠️ **Pre-existing, unrelated flake observed:** the `infrastructure/controllers` validation group fails **nondeterministically** (~50% of runs) with a YAML parse error at varying line/message (`line 154: did not find expected key` / `line 173: could not find expected ':'` / `line 145: mapping values are not allowed`) in **both** providers — including `docker`, where resource-graph-definitions is commented out and this PR's content is **not built at all**. I reproduced it on a **clean `main` checkout without this PR** (1/3 runs failed identically), so it is independent of this change (almost certainly nondeterministic in-process Helm rendering of a controllers-group HelmRelease). Flagged separately for the maintainer; it can intermittently red this PR's CI through no fault of the diff — a re-run greens it.

## Acceptance criteria

- [x] Decision recorded (KRO, reusing the Tenant decision; placement platform-published).
- [ ] One app migrated as a pilot — **follow-up** (the workload lives in the tenant's own OCI artifact repo, a separate PR; exactly how the Tenant RGD deferred its instances to the local-first pilot step). `wedding-app` is the cleaner pilot (single HTTPRoute on the `https` listener, no public-domain SNI).
- [x] A new web app becomes a small declaration (the `WebApp` CR above).
- [x] No added Kustomize overlay/component stacking.

## Follow-ups (to file / track under #1933)

1. **Pilot migration** — replace `wedding-app`'s raw Deployment/Service/HTTPRoute in its artifact with a `WebApp` CR; render-diff for parity; enable `resource-graph-definitions/` in the docker overlay for local validation.
2. **Deferred schema fields, added as the pilot needs them:** secret-backed env (ESO/SOPS-sourced k8s Secrets via `secretKeyRef`) + plain env; KEDA HTTP scale-to-zero (the 5-point interceptor recipe — no interceptor infra exists yet); the www→apex 301 redirect + per-tenant public-domain SNI listeners (ascoaching); OIDC/auth.

## Notes / maintainer calls

- The `replica-floor: exempt` label is kept for behaviour-preserving parity with both pilots; revisit whether a WebApp should instead inherit the platform replica floor.
- `WebApp` name == tenant namespace is templated as the invariant; add a `namespace` override field only if a future app diverges (same rule the Tenant RGD applies to the OCIRepository URL).
