### PR TITLE
fix(longhorn): raise engineReplicaTimeout to 30s for mutual-auth handshake latency

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -68,6 +68,24 @@ spec:
       # against it). Longhorn briefly attaches the volume in maintenance mode,
       # rebuilds, and detaches again.
       offlineReplicaRebuilding: true
+      # Engine->replica gRPC timeout. Raised from the 8s chart default to the
+      # 30s maximum because this cluster enforces Cilium SPIRE mutual
+      # authentication (the require-mutual-auth CiliumClusterwideNetworkPolicy,
+      # mode: required) on all intra-cluster traffic. When an engine<->replica
+      # auth-cache entry is cold -- after a cilium/spire-agent roll wipes every
+      # node's cache, or once an idle entry expires -- Cilium drops the first
+      # packet(s) while the SPIRE handshake completes, and the TCP
+      # retransmit-during-handshake delay intermittently exceeds the 8s default.
+      # The engine then declares an otherwise-healthy replica `in error` ->
+      # Faulted -> rebuild -> recover (~40-80s), so longhorn-manager spams
+      # Faulted / FailedRebuilding / FailedSnapshotPurge events (and matching
+      # log errors) every hour even though every volume is healthy at every
+      # point-in-time check. 30s absorbs the handshake latency WITHOUT weakening
+      # mutual auth (WireGuard still encrypts the wire and the SPIRE identity
+      # gate is unchanged) -- the long-lived-data-plane equivalent of the in-run
+      # curl retries the coroot-pricing / umami-provision CronJobs already use
+      # for the same first-packet-drop race. Longhorn caps this setting at 30s.
+      engineReplicaTimeout: "30"
 
     persistence:
       # Longhorn is the default StorageClass (replaces hcloud for new PVCs).


### PR DESCRIPTION
## Problem

The cluster sends a steady stream of hourly Coroot/Slack alerts from Longhorn — `Faulted`, `FailedRebuilding`, `FailedSnapshotPurge`, `FailedStartingSnapshotPurge`, plus `longhorn-manager` / `instance-manager-*` log errors — yet every volume reports **healthy at every point-in-time check**. The volumes are *churning*: replicas fault → rebuild → recover in ~40–80s loops.

## Root cause (not alert noise — a real, recurring fault)

Verified via `longhorn-manager` logs:
```
failed to get engine client proxy: ... rpc error: code = Unavailable
  ... dial tcp 10.244.x.x:8501: i/o timeout      # instance-manager proxy gRPC
FailedSnapshotPurge: ... dial tcp 10.244.x.x:11411: i/o timeout   # replica data port
```
The instance-manager pods are perfectly healthy (0 restarts, no disk/CPU/OOM pressure) — only the *path* to them intermittently fails. That path is gated by the enforced **`require-mutual-auth`** CiliumClusterwideNetworkPolicy (`authentication.mode: required`). When an engine↔replica auth-cache entry is cold (after a cilium/spire-agent roll wipes every node's cache, or once an idle entry expires on the `mesh-auth-gc-interval`), Cilium **drops the first packet(s)** while the SPIRE handshake completes. The TCP retransmit-during-handshake delay intermittently exceeds Longhorn's **8s** `engine-replica-timeout` (the chart default), so the engine declares an otherwise-healthy replica `in error` → Faulted → rebuild.

This is the same first-packet-drop race already documented for short-lived Jobs (coroot-pricing / umami-provision got in-run `curl` retries) — here it hits a long-lived, tight-timeout data plane.

## Fix

Raise `engineReplicaTimeout` from the 8s default to the **30s maximum** (`defaultSettings`, hetzner overlay) so a cold-cache handshake no longer faults a replica.

- **Not an exemption / workaround.** Mutual auth stays fully enforced for all Longhorn traffic; WireGuard still encrypts the wire and the SPIRE identity gate is unchanged. This simply calibrates Longhorn's gRPC timeout for the platform's authenticated network (the 8s default assumes no handshake latency) — the data-plane analogue of the existing curl-retry fix.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/controllers/longhorn/` renders `engineReplicaTimeout: "30"`.
- `ksail --config ksail.prod.yaml workload validate` → **✔ 358 files validated** (exit 0).
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.

> Generated during an interactive investigation of the prod alert flood. Draft for maintainer review before rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)