### PR TITLE
fix(unifi): persist the tf-runner pod to stop recurring "restarted" alerts

### DIFF
--- a/k8s/providers/hetzner/apps/unifi/terraform.yaml
+++ b/k8s/providers/hetzner/apps/unifi/terraform.yaml
@@ -22,6 +22,14 @@ spec:
   varsFrom:
     - kind: Secret
       name: unifi-credentials
+  # Keep the plan-runner pod alive between reconciles instead of recreating it
+  # every `interval`. With the controller default (true) the observe-first,
+  # plan-only loop creates + deletes the `unifi-tf-runner` pod every 15m, which
+  # Coroot reports as recurring "application restarted N times" alerts even
+  # though nothing is wrong (the Terraform stays Ready / no-drift — the runner
+  # is just being recycled, not crashing). A single persistent runner removes
+  # that churn at the cost of one small pod holding the read-only UniFi API key.
+  alwaysCleanupRunnerPod: false
   # Restricted-PSS-compliant runner. NB (live-validate): the upstream tf-runner
   # image may default to a root user; if it cannot satisfy restricted PSS, the
   # platform Kyverno mutate policies should supply the container securityContext


### PR DESCRIPTION
## Problem

Coroot/Alertmanager fire recurring `Instance restarts - unifi/unifi-tf-runner application restarted N times` alerts — even though the unifi Terraform is `Ready` with no drift.

## Root cause (not a crash — runner recycling)

The unifi `Terraform` CR runs **observe-first / plan-only** (`approvePlan: ""`) on a **15m** interval. It doesn't set `alwaysCleanupRunnerPod`, so it inherits the controller default (**`true`**) — tofu-controller **creates and deletes** the `unifi-tf-runner` pod on every reconcile. Confirmed from events (`Created` → `Killing` every ~15m). Because the pod has a stable name, Coroot reads each recreation as a restart.

## Fix

Set `alwaysCleanupRunnerPod: false` so a single runner pod persists across the 15m plan cycles. The Terraform behaviour is unchanged (still plan-only/observe-first); the only difference is one small persistent runner pod (holding the read-only UniFi API key) instead of one created+destroyed every 15 minutes. This removes the restart churn at its source rather than muting the alert.

## Validation

- `kubectl kustomize k8s/providers/hetzner/apps/unifi/` renders `alwaysCleanupRunnerPod: false`.
- `ksail --config ksail.prod.yaml workload validate` → **✔ 358 files validated**.
- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build.

> Part of an investigation into the cluster's hourly Slack alert flood. Draft for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)