### PR TITLE
fix(openbao): make vault-snapshot-init one-shot to stop hourly RWO FailedMount

### DIFF
--- a/k8s/bases/infrastructure/vault-backup/init-job.yaml
+++ b/k8s/bases/infrastructure/vault-backup/init-job.yaml
@@ -29,7 +29,18 @@ metadata:
     # Jobs are immutable; let Flux delete-and-recreate on spec change.
     kustomize.toolkit.fluxcd.io/force: enabled
 spec:
-  ttlSecondsAfterFinished: 600
+  # No ttlSecondsAfterFinished (intentional). This is a one-shot "snapshot at
+  # deploy/change time" Job (see header) -- it must run ONCE per vault-backup
+  # change, NOT hourly. A finite TTL deletes the completed Job, so every
+  # `infrastructure` reconcile re-created it (via the force annotation) ~hourly;
+  # it then mounted the single-attach RWO vault-snapshots PVC *concurrently with
+  # the also-hourly vault-config Job*. The two pods land on different nodes, so
+  # the hcloud volume cannot reattach in time and both spam `FailedMount`
+  # (exit 255 / "Resource busy") every hour. Persisting the completed Job means
+  # only the force-recreation on a real spec change re-runs it; vault-config
+  # then runs alone against a detached volume and attaches cleanly. (vault-config
+  # keeps its TTL + hourly re-run on purpose -- its config steps retry for
+  # late-arriving deps; only this one-shot snapshot Job was re-running needlessly.)
   backoffLimit: 30
   activeDeadlineSeconds: 3600
   template:


### PR DESCRIPTION
## Problem

Recurring hourly `openbao/vault-config` and `openbao/vault-snapshot-init` `FailedMount` (+ `BackOff`) alerts:
```
MountVolume.SetUp failed for volume "pvc-4a2f858e…" : rpc error: code = Internal
  desc = failed to publish volume: mount failed: exit status 255 … Resource busy
```

## Root cause

`vault-snapshot-init` is documented as a **one-shot "snapshot at deploy/change time"** Job, but `ttlSecondsAfterFinished: 600` deletes it after each run, so every `infrastructure` reconcile re-creates it (via `kustomize.toolkit.fluxcd.io/force`) **~hourly**. It then mounts the **single-attach RWO** `vault-snapshots` PVC **concurrently with the also-hourly `vault-config` Job** (verified: both Job pods are created on the same reconcile). The two pods land on different nodes, so the hcloud block volume can't detach/reattach in time → both pods `FailedMount` until the handoff completes, every hour.

When only one consumer runs (the volume is detached between runs), the attach is clean — so the fix is to stop the needless hourly **concurrency**.

## Fix

Remove `ttlSecondsAfterFinished` from `vault-snapshot-init` so the completed Job **persists** and is only re-run by `force` on a real spec change — matching its documented one-shot purpose. `vault-config` then runs alone each hour against a detached volume and attaches cleanly.

- `vault-config` is intentionally left unchanged (it keeps its TTL + hourly re-run because its config steps retry for late-arriving dependencies).
- Trade-off: the completed `vault-snapshot-init` Job now lingers until the next vault-backup change (and a `force` recreation on a change can orphan its prior pod — cosmetic, no alert). This is the lesser evil vs. the hourly `FailedMount` flood, and matches the "one-shot" intent.

## Residual (flagged, not fixed here)

The daily `vault-snapshot` CronJob (03:30 UTC) can still occasionally coincide with a `vault-config` run. Fully eliminating that would require `vault-config`'s DR auto-restore to read the latest snapshot from the **R2 mirror** instead of mounting the RWO PVC — a change to the incident-tuned recovery path, so I left it for separate review.

## Validation

- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build; rendered `vault-snapshot-init` no longer has `ttlSecondsAfterFinished` (and `vault-config` still does).

> Part of an investigation into the prod hourly alert flood. Draft for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)