### PR TITLE
fix(github-config): wait: false so external GitHub failures don't degrade apps health

### DIFF
--- a/k8s/bases/apps/github-config/sync.yaml
+++ b/k8s/bases/apps/github-config/sync.yaml
@@ -47,7 +47,21 @@ spec:
   retryInterval: 2m
   path: .
   prune: true
-  wait: true
+  # wait: false (NOT true like other apps). This Kustomization applies external
+  # GitHub state as Crossplane managed resources, whose readiness depends on the
+  # GitHub API + App credentials -- OUTSIDE the platform's control. With
+  # wait: true, Flux gates this Kustomization's health on that external
+  # reconciliation, and because this Kustomization is itself health-checked by
+  # the parent `apps` Flux Kustomization, any GitHub-side failure cascades into
+  # the WHOLE apps layer's GitOps health. That is currently happening: the
+  # maintainers-team resources fail forever (teamId references the team by name
+  # not id -> strconv.ParseInt error; the App lacks org-owner perms -> 403 -- a
+  # devantler-tech/.github + GitHub-App problem, tracked in #2235), so wait: true
+  # times out at 5m and flaps `apps` into HealthCheckFailed. The apply still
+  # runs and apply errors are still surfaced; only the readiness WAIT is dropped,
+  # so a broken EXTERNAL resource is tracked via its Crossplane status / alerts
+  # instead of degrading unrelated in-cluster apps' GitOps health.
+  wait: false
   force: true
   # Runs as the app SA: the GitHub managed resources are applied with only the
   # namespace-scoped authority in rbac.yaml. This Kustomization is itself applied


### PR DESCRIPTION
## Problem

The `apps` and `github-config` Flux Kustomizations intermittently flap into `HealthCheckFailed` / `Unknown (Reconciliation in progress)` — real GitOps health degradation on the prod cluster.

## Root cause

`github-config` applies **external GitHub state** as Crossplane managed resources (Team / TeamRepository / TeamMembership, from the `devantler-tech/.github` OCI artifact). Their readiness depends on the **GitHub API + App credentials**, outside the platform's control. With **`wait: true`**, Flux gates this Kustomization's health on that external reconciliation — and because the parent `apps` Kustomization health-checks this one, a GitHub-side failure **cascades into the whole apps layer's GitOps health**.

It's happening now (see #2235): the `maintainers`-team resources never reconcile —
```
CannotObserveExternalResource ... strconv.ParseInt: parsing "maintainers": invalid syntax  (teamId is a name, not an id)
CannotCreateExternalResource  ... 403 You must be an organization owner or team maintainer  (App lacks org perms)
```
— so `wait: true` times out at 5m and flaps `apps`/`github-config` unhealthy.

## Fix

Set **`wait: false`** on the `github-config` Kustomization to decouple external-dependency reconciliation from in-cluster GitOps health. The apply still runs and apply errors are still surfaced — only the readiness *wait* is dropped, so a broken external resource is tracked via its Crossplane status / alerts (#2235) instead of degrading unrelated in-cluster apps.

- **Failure isolation, not masking.** github-config is the only app whose health depends on external-API reconciliation; every other app's health is internal (pods). Coupling the platform's GitOps health to GitHub-side state conflates two domains.
- **Does not fix the root cause** (#2235, external) — it stops the blast radius from including the whole apps layer.
- `github-config` is a leaf (nothing in-cluster depends on the GitHub state reconciling), so dropping the wait has no dependents.

## Validation

- `kubectl kustomize k8s/clusters/prod/` and `k8s/clusters/local/` both build; the rendered `github-config` Kustomization now has `wait: false`.

> Found during a fresh sweep of the prod platform. Draft for maintainer review (it's a judgment call on coupling external-dependency health to GitOps health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)