### PR TITLE
fix(openbao): vault-config restores from R2 mirror, not the RWO PVC

### DIFF
--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -86,16 +86,88 @@ spec:
           secret:
             secretName: vault-config-oidc
             optional: true
-        # Raft snapshots written by the vault-snapshot CronJob (vault-backup/),
-        # mounted read-only as the vault-init container's automated restore
-        # source. RWO is fine: the CronJob only holds the volume for seconds
-        # around 03:30 UTC, so attach conflicts with this Job are practically
-        # impossible.
+        # Local scratch for the newest raft snapshot, populated by the
+        # fetch-snapshot initContainer from the OFF-CLUSTER mirror (Cloudflare R2
+        # in prod, in-cluster MinIO locally) -- NOT the single-attach RWO
+        # vault-snapshots PVC. Mounting that PVC here made vault-config attach the
+        # hcloud volume on every hourly run and collide with the vault-snapshot
+        # CronJob / vault-snapshot-init (both also mount it) -> hourly FailedMount
+        # (exit 255 / "Resource busy"). R2 is also the copy that SURVIVES a
+        # disaster that loses the local PVC, so it is the correct restore source.
         - name: snapshots
-          persistentVolumeClaim:
-            claimName: vault-snapshots
-            readOnly: true
+          emptyDir: {}
+        # R2 credentials synced by ESO (vault-backup/external-secret.yaml).
+        # Optional: on a fresh cluster the fetch container skips with a log line
+        # until the sync lands; auto-restore degrades gracefully (see vault-init).
+        - name: r2-credentials
+          secret:
+            secretName: vault-snapshot-r2
+            optional: true
+        - name: mc-config
+          emptyDir: {}
       initContainers:
+        # --- 0. Fetch newest snapshot from the off-cluster mirror (best-effort) ---
+        # Pulls ONLY the newest raft snapshot from R2/MinIO into the shared
+        # `snapshots` emptyDir so the vault-init container's DR auto-restore can
+        # read it WITHOUT mounting the RWO vault-snapshots PVC. Best-effort by
+        # design: in steady state (vault already initialized) vault-init never
+        # reads /snapshots, and on a real DR an empty /snapshots makes vault-init
+        # abort with its existing "no snapshot available" guidance -- so a missing
+        # Secret or an R2 hiccup must NEVER fail this Job.
+        - name: fetch-snapshot
+          image: quay.io/minio/mc:RELEASE.2025-04-08T15-39-49Z@sha256:7e3efb09c22c0882fbf341b9d99f61f94ae6c4c20a06f2f1a2b20ea8993d8952
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: MC_CONFIG_DIR
+              value: /tmp/.mc
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              # kubescape C-0270; generous for the mc download.
+              cpu: 250m
+              memory: 128Mi
+          volumeMounts:
+            - name: snapshots
+              mountPath: /snapshots
+            - name: r2-credentials
+              mountPath: /r2
+              readOnly: true
+            - name: mc-config
+              mountPath: /tmp/.mc
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              if [ ! -f /r2/access_key_id ]; then
+                echo "vault-snapshot-r2 Secret not synced yet -- skipping snapshot"
+                echo "fetch. Auto-restore aborts cleanly if a DR is in progress."
+                exit 0
+              fi
+              # ${r2_endpoint}/${r2_bucket} are Flux post-build substitutions
+              # (Cloudflare R2 in prod, in-cluster MinIO locally) -- the same vars
+              # the vault-snapshot CronJob/init-job use to MIRROR; here we READ.
+              mc alias set backup "${r2_endpoint}" \
+                "$(cat /r2/access_key_id)" "$(cat /r2/secret_access_key)" || exit 0
+              # Newest by name (openbao-YYYYMMDD-HHMMSS.snap sorts chronologically).
+              LATEST=$(mc ls "backup/${r2_bucket}/openbao-snapshots/" 2>/dev/null \
+                | awk '{print $NF}' | grep '\.snap$' | sort | tail -n1)
+              if [ -z "$LATEST" ]; then
+                echo "No snapshot in the mirror yet -- nothing to fetch."
+                exit 0
+              fi
+              echo "Fetching newest snapshot $LATEST from the off-cluster mirror..."
+              mc cp "backup/${r2_bucket}/openbao-snapshots/$LATEST" "/snapshots/$LATEST" || true
+              ls -l /snapshots/ || true
         # --- 1. Auto-init + unseal ---
         - name: vault-init
           image: quay.io/openbao/openbao:2.5.3@sha256:fdc6da21ca6963560c32336fd7feb9cf2d5e52668f1a1647205a4b41171f0806

--- a/k8s/bases/infrastructure/vault-config/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/vault-config/networkpolicy.yaml
@@ -20,7 +20,8 @@ spec:
     # Kube API for Kubernetes auth configuration
     - toEntities:
         - kube-apiserver
-    # DNS resolution
+    # DNS resolution. rules.dns makes Cilium snoop the responses so it can
+    # populate the toFQDNs IP set for the off-cluster mirror egress below.
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: kube-system
@@ -30,4 +31,26 @@ spec:
             - port: "53"
               protocol: UDP
             - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    # Off-cluster snapshot mirror for the fetch-snapshot initContainer's DR
+    # auto-restore (Cloudflare R2 in prod). Scoped by FQDN to R2's domain ONLY --
+    # deliberately NOT `toEntities: world` -- so this root-token-holding Job can
+    # reach the backup target and nothing else on the internet. (Reaching another
+    # R2 account is moot: it only holds OUR account's read credentials.)
+    - toFQDNs:
+        - matchPattern: "*.r2.cloudflarestorage.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # In-cluster MinIO mirror target for local/CI (the same restore source).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: minio
+      toPorts:
+        - ports:
+            - port: "9000"
               protocol: TCP


### PR DESCRIPTION
## Problem

vault-config's DR auto-restore mounted the **single-attach RWO** `vault-snapshots` PVC (read-only), so it attached the hcloud volume on **every hourly run** and collided with the `vault-snapshot` CronJob / `vault-snapshot-init` (which also mount it) → hourly `FailedMount` (`exit status 255` / `Resource busy`).

## Fix

Replace the PVC mount with an `emptyDir` populated by a new **best-effort `fetch-snapshot` initContainer** that pulls only the newest raft snapshot from the **off-cluster mirror** (Cloudflare R2 in prod, in-cluster MinIO locally — the same target the snapshot jobs write to). vault-init's DR auto-restore logic is **unchanged** — it still reads the newest `/snapshots/openbao-*.snap`.

- **R2 is the more correct restore source.** It survives a disaster that loses the local PVC (the exact scenario DR exists for); the PVC was only a local convenience.
- **Best-effort, never fails the Job.** A missing `vault-snapshot-r2` Secret or an R2 hiccup → the initContainer exits 0. Steady state never reads `/snapshots`; a real DR with an empty `/snapshots` aborts cleanly with vault-init's existing "no snapshot available" guidance.

## Security — scoped egress, NOT `toEntities: world`

This is the reason the residual was left unfixed earlier. Reading from R2 needs egress from the **root-token-holding** vault-config Job, and `toEntities: world` would be an unacceptable exfiltration surface. Instead, `allow-vault-config` now uses a **Cilium `toFQDNs` rule scoped to `*.r2.cloudflarestorage.com`** (+ `rules.dns` so Cilium snoops DNS to populate the FQDN IP set), so the Job can reach the backup target **and nothing else on the internet**. (Reaching another R2 account is moot — it only holds our account's read credentials.) Local/CI keeps the in-cluster MinIO endpoint.

## Relationship to #2238

Complementary: [#2238](https://github.com/devantler-tech/platform/pull/2238) makes `vault-snapshot-init` one-shot; this removes vault-config as a PVC consumer. Together they leave the **daily CronJob as the only regular consumer** of the RWO volume → it always attaches a detached volume cleanly. Either PR alone substantially reduces the FailedMount; both fully eliminate it.

## Validation

- `kubectl kustomize k8s/clusters/prod/` + `k8s/clusters/local/` build; vault-config job has **0** `vault-snapshots` PVC refs; the `toFQDNs` rule + `fetch-snapshot` initContainer render.
- `ksail --config ksail.prod.yaml workload validate` → `✔ bases/infrastructure/vault-config validated` (CiliumNetworkPolicy `toFQDNs` schema OK).

> Draft for maintainer review — it touches the incident-tuned OpenBao DR auto-restore path (snapshot source PVC → R2). The restore semantics are preserved; only the snapshot's origin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)