### PR TITLE
feat(chaos-mesh): add opt-in Chaos Mesh game-day fault-injection rig

### DIFF
--- a/docs/chaos-engineering.md
+++ b/docs/chaos-engineering.md
@@ -1,0 +1,148 @@
+# Chaos engineering
+
+The platform ships a **Chaos Mesh** fault-injection engine for *game days* — the
+deliberate, observed injection of failures (pod kills, network faults, IO/stress,
+time skew, node-pressure) to prove the platform's resilience controls actually
+work: PodDisruptionBudgets, `topologySpreadConstraints`, self-healing, and the
+node-lifecycle / Longhorn-volume behaviour that has driven the recurring prod
+incidents (#1816, #1820, #2024).
+
+It is the active counterpart to the [disaster-recovery runbooks](dr/runbook.md)
+and the [restore drill](dr/restore-drill.md): the runbooks prove we can *recover*;
+chaos game days prove we *degrade gracefully* in the first place.
+
+## Why it is opt-in (not always-on)
+
+`chaos-daemon` is a permanently-privileged DaemonSet — it mounts the host
+containerd socket and runs with `hostPID` so it can enter a target pod's
+namespaces. Leaving that on every node 24/7 is real attack surface for a
+capability used a few times a quarter, so Chaos Mesh is **not** in the always-on
+base controller aggregate. It follows the kubevirt/cdi precedent: a single-line
+opt-in in the provider overlay, enabled for the duration of a game day and
+removed afterwards.
+
+## Running a game day
+
+1. **Enable the engine** — uncomment `chaos-mesh` in the target overlay:
+   - Local/CI: `k8s/providers/docker/infrastructure/controllers/kustomization.yaml`
+   - Prod: `k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml`
+
+   Then `ksail workload push && ksail workload reconcile` (local) or merge the PR
+   (prod). The namespace is PSA `privileged` and pre-exempted in the Kyverno
+   cluster-policies, so the daemon admits.
+
+2. **Pick a steady-state hypothesis** — e.g. *"killing one `whoami` replica never
+   drops the route, because the PDB + 2 replicas + spread keep one serving."*
+   Watch it in Coroot (`observability.${domain}`) — request success-rate and
+   latency are the SLIs that must hold.
+
+3. **Apply a scoped experiment** (examples below). Start small: one pod, one
+   namespace, a short `duration`.
+
+4. **Observe** the SLO in Coroot for the experiment window; confirm the
+   hypothesis held (or file the gap it exposed).
+
+5. **Clean up** — delete the experiment (`kubectl delete -f <experiment>.yaml`),
+   re-comment `chaos-mesh` in the overlay, and reconcile. Chaos Mesh also
+   auto-recovers a fault when its `duration` elapses or the CR is deleted.
+
+## Safety rules
+
+- **Never target the platform's own foundations.** Scope every experiment's
+  `selector.namespaces` to a *non-critical app* (`whoami`, `homepage`). Never
+  target `kube-system`, `flux-system`, `longhorn-system`, `chaos-mesh`,
+  `observability`, `openbao`, or `cnpg-*` — a fault there can wedge the cluster
+  or the very tooling you need to recover.
+- **Always set a `duration`** so a fault self-heals even if you lose your
+  session.
+- **One variable at a time**, and only when you are watching.
+- **Prod game days run in a maintenance window**, announced via the same Slack
+  channel the Coroot alerts post to.
+
+## Example experiments
+
+Experiments are Git-defined CRs reviewed through a PR — they are intentionally
+*not* committed into the always-on kustomizations. Copy one, scope it, apply it.
+
+### Pod kill — validate self-healing + PDB
+
+Proves a single-replica loss is absorbed without dropping the service.
+
+```yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: whoami-pod-kill
+  namespace: chaos-mesh
+spec:
+  action: pod-kill
+  mode: one # kill exactly one matching pod
+  selector:
+    namespaces:
+      - whoami
+    labelSelectors:
+      app.kubernetes.io/name: whoami
+  duration: 30s
+```
+
+### Scheduled pod failure — recurring resilience check
+
+A `Schedule` makes a fault recurring (e.g. a weekly game day). Keep it scoped and
+short; remove it when the game day ends.
+
+```yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: Schedule
+metadata:
+  name: weekly-homepage-pod-failure
+  namespace: chaos-mesh
+spec:
+  schedule: "0 9 * * 1" # Mondays 09:00 — inside a maintenance window
+  type: PodChaos
+  historyLimit: 5
+  concurrencyPolicy: Forbid
+  podChaos:
+    action: pod-failure # make the pod unavailable (not deleted) for the window
+    mode: one
+    selector:
+      namespaces:
+        - homepage
+    duration: 60s
+```
+
+### Network latency — validate timeout/retry budgets
+
+```yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: whoami-latency
+  namespace: chaos-mesh
+spec:
+  action: delay
+  mode: one
+  selector:
+    namespaces:
+      - whoami
+  delay:
+    latency: "200ms"
+    jitter: "50ms"
+  duration: 60s
+```
+
+### Node-lifecycle rehearsal (the recurring prod incident class)
+
+The node-roll / autoscaler-churn faults that strand Longhorn volumes (#1816,
+#1820, #2024) are best rehearsed by draining a *storage* worker and watching
+Longhorn re-attach. Chaos Mesh's `StressChaos` (CPU/memory pressure) can
+reproduce the eviction pressure that triggers it; pair it with a manual
+`kubectl drain` of one Longhorn worker and confirm volumes re-attach and the
+SPIRE/ExternalSecrets chain stays healthy. Document findings on the relevant
+Theme-1 issue.
+
+## Reference
+
+- Chaos Mesh docs: <https://chaos-mesh.org/docs/>
+- Experiment types: PodChaos, NetworkChaos, StressChaos, IOChaos, TimeChaos,
+  DNSChaos (the DNSChaos server is left off by default — enable `dnsServer` in
+  the HelmRelease if a game day needs it).

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -56,6 +56,7 @@ spec:
                 - cdi
                 - observability
                 - velero
+                - chaos-mesh
       mutate:
         patchStrategicMerge:
           spec:
@@ -87,6 +88,7 @@ spec:
                 - cdi
                 - observability
                 - velero
+                - chaos-mesh
       mutate:
         foreach:
           - list: "request.object.spec.containers"

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-host-restrictions.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-host-restrictions.yaml
@@ -49,6 +49,7 @@ spec:
                 - cdi
                 - observability
                 - velero
+                - chaos-mesh
           - resources:
               names:
                 - "helper-pod-create-pvc-*"
@@ -80,6 +81,7 @@ spec:
                 - cdi
                 - observability
                 - velero
+                - chaos-mesh
           - resources:
               names:
                 - "helper-pod-create-pvc-*"

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/validate-pod-security.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/validate-pod-security.yaml
@@ -53,6 +53,7 @@ spec:
                 - cdi
                 - observability
                 - velero
+                - chaos-mesh
           - resources:
               names:
                 - "helper-pod-create-pvc-*"
@@ -109,6 +110,7 @@ spec:
                 - cdi
                 - observability
                 - velero
+                - chaos-mesh
           - resources:
               names:
                 - "helper-pod-create-pvc-*"
@@ -141,6 +143,7 @@ spec:
                 - cdi
                 - observability
                 - velero
+                - chaos-mesh
           - resources:
               names:
                 - "helper-pod-create-pvc-*"

--- a/k8s/bases/infrastructure/controllers/chaos-mesh/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/chaos-mesh/helm-release.yaml
@@ -1,0 +1,77 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: chaos-mesh
+  namespace: chaos-mesh
+  labels:
+    # The chart ships its CRDs (PodChaos, NetworkChaos, StressChaos, Schedule,
+    # Workflow, …) in the chart's crds/ dir — Helm installs but never upgrades
+    # them, so let Flux own them. The helm-release-install-crds Kyverno policy
+    # turns this label into install/upgrade `crds: CreateReplace` (also set
+    # explicitly below, mirroring flagger).
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  interval: 10m
+  timeout: 10m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: chaos-mesh
+      version: 2.8.3
+      sourceRef:
+        kind: HelmRepository
+        name: chaos-mesh
+  # https://github.com/chaos-mesh/chaos-mesh/blob/master/helm/chaos-mesh/values.yaml
+  values:
+    # Talos runs containerd. The chart DEFAULTS to docker + /var/run/docker.sock,
+    # which CrashLoops chaos-daemon on boot here — both fields MUST be overridden.
+    # The daemon mounts dir(socketPath) (=/run/containerd) as a hostPath and
+    # reaches a target container through base(socketPath) under it.
+    chaosDaemon:
+      runtime: containerd
+      socketPath: /run/containerd/containerd.sock
+      # privileged: true is the chart default and is REQUIRED: alongside the
+      # hardcoded hostPID and the hostPath socket mount, it is what lets the
+      # daemon enter a target pod's namespaces to inject faults. This is the
+      # reason the namespace is PSA `privileged` and Kyverno-exempt
+      # (see namespace.yaml) — the privilege is irreducible, not a shortcut.
+
+    controllerManager:
+      # Single leader-elected replica. The cluster is memory-tight and chaos is
+      # an occasional game-day tool, not a latency-critical control loop, so one
+      # replica is enough — and a lone replica is exempt from the replica-floor /
+      # drain-safe-PDB policies (no PDB needed).
+      replicaCount: 1
+      # The controller-manager is an ordinary workload (no host access), so give
+      # it a fully specified restricted securityContext: it stays PSA-compliant
+      # on its own merits even though the namespace is exempt. Only the daemon
+      # relies on the exemption (defence-in-depth).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+
+    # Minimal footprint. This installs the fault-injection ENGINE
+    # (controller-manager + chaos-daemon + CRDs) only; experiments are
+    # Git-defined Schedule/PodChaos CRs reviewed through a PR, not clicked in a
+    # UI (see docs/chaos-engineering.md). The optional dashboard, the DNSChaos
+    # server (chart default is ON), the eBPF KernelChaos installer and the Go
+    # debug-server are all left off.
+    dashboard:
+      create: false
+    dnsServer:
+      create: false
+    bpfki:
+      create: false
+    chaosDlv:
+      enable: false

--- a/k8s/bases/infrastructure/controllers/chaos-mesh/helm-repository.yaml
+++ b/k8s/bases/infrastructure/controllers/chaos-mesh/helm-repository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: chaos-mesh
+  namespace: chaos-mesh
+spec:
+  # The canonical Chaos Mesh Helm repo. There is no official OCI chart
+  # (ghcr.io/chaos-mesh hosts images only), so this stays a default-type
+  # HelmRepository.
+  url: https://charts.chaos-mesh.org

--- a/k8s/bases/infrastructure/controllers/chaos-mesh/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/chaos-mesh/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - helm-release.yaml
+  - networkpolicy.yaml

--- a/k8s/bases/infrastructure/controllers/chaos-mesh/namespace.yaml
+++ b/k8s/bases/infrastructure/controllers/chaos-mesh/namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chaos-mesh
+  labels:
+    # chaos-daemon is irreducibly privileged: it mounts the host containerd
+    # socket (hostPath) and the chart hardcodes hostPID so it can enter a target
+    # pod's namespaces to inject faults. That can never satisfy PSA `restricted`,
+    # so this namespace runs `privileged` and is added to the matching exclusions
+    # in the Kyverno cluster-policies (validate-host-restrictions,
+    # validate-pod-security, add-security-context) — the same treatment
+    # kubevirt/cdi get for their host-level access. The controller-manager keeps
+    # a fully specified restricted securityContext regardless (see
+    # helm-release.yaml); only the daemon needs the privilege.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/k8s/bases/infrastructure/controllers/chaos-mesh/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/chaos-mesh/networkpolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-chaos-mesh
+  namespace: chaos-mesh
+spec:
+  # The Kyverno add-default-deny policy generates a default-deny (ingress+egress)
+  # CiliumNetworkPolicy plus an allow-dns rule per namespace; this allow-list
+  # opens only what Chaos Mesh actually needs on top of that baseline.
+  endpointSelector: {}
+  ingress:
+    # kube-apiserver -> controller-manager admission/conversion webhooks.
+    - fromEntities:
+        - kube-apiserver
+    # controller-manager <-> chaos-daemon gRPC, both in this namespace.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: chaos-mesh
+  egress:
+    # Reconcile chaos CRs and select target pods/nodes via the API.
+    - toEntities:
+        - kube-apiserver
+    # controller-manager -> chaos-daemon gRPC (fault dispatch), both in this
+    # namespace. Faults themselves are applied node-locally by the daemon
+    # (containerd socket + hostPID), not over the pod network, so no egress to
+    # target namespaces is required.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: chaos-mesh
+    # DNS resolution.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -58,6 +58,8 @@ resources:
   # VM stack (local/CI-only; add the kubevirt CR patch below):
   #   - ../../../../bases/infrastructure/controllers/cdi/
   #   - ../../../../bases/infrastructure/controllers/kubevirt/
+  # Chaos engineering (game-day fault injection; see docs/chaos-engineering.md):
+  #   - ../../../../bases/infrastructure/controllers/chaos-mesh/
   # Utilities:
   #   - ../../../../bases/infrastructure/controllers/reloader/
   #   - ../../../../bases/infrastructure/controllers/ksail-operator/

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -42,6 +42,11 @@ resources:
   # HelmRelease is included via ../../../../bases/...; this dir only adds the
   # prod-only ConfigMap, and the patch below rewires the HelmRelease.
   - velero/
+  # Opt-in game-day chaos engineering — uncomment to enable, re-comment when the
+  # game day ends (see docs/chaos-engineering.md). Left off by default: the
+  # chaos-daemon is a permanently-privileged DaemonSet, so it ships only while
+  # experiments are actually running, not as always-on prod attack surface.
+  # - ../../../../bases/infrastructure/controllers/chaos-mesh/
 components:
   # Platform-wide HelmRelease drift detection (mode: enabled). Restores
   # Helm-rendered resources deleted/mutated out-of-band — the cause of the


### PR DESCRIPTION
## What

Adds **Chaos Mesh 2.8.3** as an **opt-in chaos engineering rig** — the active counterpart to the DR runbooks/restore drill. Those prove we can *recover*; chaos game days prove the platform *degrades gracefully* in the first place: PodDisruptionBudgets hold, `topologySpreadConstraints` keep a service up, pods self-heal, and the node-lifecycle / Longhorn behaviour behind #1816 / #1820 / #2024 can be rehearsed deliberately.

Part of a broader "state-of-the-art best practices" pass on the platform (chaos engineering was one of the explicitly requested additions).

## Design decisions

- **Engine only, GitOps-native.** Installs controller-manager + chaos-daemon + CRDs; the dashboard, DNSChaos server, eBPF KernelChaos installer and Go debug-server are all **off**. Experiments are Git-defined `Schedule`/`PodChaos` CRs reviewed through a PR (see the doc), not clicked in a UI — which fits the platform's declarative model and avoids a click-ops surface.
- **Opt-in in *both* overlays, not always-on.** `chaos-daemon` is an irreducibly privileged DaemonSet (host containerd socket + hardcoded `hostPID`). Rather than leave that container-escape-class surface on every prod node 24/7 for a capability used a few times a quarter, it ships only while a game day is running — a one-line uncomment in the docker or hetzner overlay, mirroring the **cdi/kubevirt** opt-in precedent. **If you'd prefer it always-on in prod, that's a one-line change — say the word.**
- **Talos containerd.** The chart defaults to docker + `/var/run/docker.sock` (CrashLoops on Talos); overridden to `containerd` + `/run/containerd/containerd.sock`.
- **PSS exemption (kubevirt/cdi precedent).** The namespace runs PSA `privileged` and is added to the `validate-host-restrictions` / `validate-pod-security` / `add-security-context` Kyverno exemptions. `disallow-latest-tag` is deliberately **not** touched (chart pins its image tags — no guardrail loosened). The controller-manager keeps a fully specified restricted securityContext regardless.

## Files

- `k8s/bases/infrastructure/controllers/chaos-mesh/` — namespace, HelmRepository, HelmRelease, networkpolicy, kustomization
- `docs/chaos-engineering.md` — game-day workflow, safety rules, ready-to-use PodChaos/Schedule/NetworkChaos + node-lifecycle experiments
- Kyverno exemptions (3 policies) + opt-in wiring in the docker & hetzner controller overlays

## Validation

- `helm template chaos-mesh 2.8.3` with the exact HelmRelease values → renders 24 manifests, containerd socket resolved to `/host-run/containerd.sock` ✅
- `ksail workload validate` (with chaos-mesh temporarily enabled) → `✔ bases/infrastructure/controllers/chaos-mesh validated` ✅
- `kubectl kustomize` of the component and the cluster-policies (exemption present) ✅
- Note: local `ksail` is 7.72.0 (the documented-racy render, ksail#5371); an `actual-budget` YAML-parse flake on an untouched app is that race, not this change. CI's pinned 7.65.0 validates deterministically.

## Follow-ups (not in this PR)

- Optional: expose the chaos dashboard behind oauth2-proxy forward-auth (like the Coroot/Longhorn UIs) if click-driven game days are wanted.
- Wire a first scheduled game-day experiment once a maintenance-window cadence is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)