### PR TITLE
fix(coroot): allow egress to coroot.github.io so the cost rollup populates (#2148)

### DIFF
--- a/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
@@ -74,14 +74,24 @@ spec:
         - remote-node
     # External HTTPS, pinned by FQDN instead of world:443 so a compromised
     # pod cannot exfiltrate telemetry to arbitrary external services:
-    # - hooks.slack.com — Coroot incident notifications (Slack webhook)
-    # - hc-ping.com     — the cluster-heartbeat CronJob's dead-man ping
-    #                     (${alertmanager_heartbeat_url})
-    # - coroot.com      — Coroot version checks / usage statistics
+    # - hooks.slack.com  — Coroot incident notifications (Slack webhook)
+    # - hc-ping.com      — the cluster-heartbeat CronJob's dead-man ping
+    #                      (${alertmanager_heartbeat_url})
+    # - coroot.com       — Coroot version checks / usage statistics
+    # - coroot.github.io — the cloud-pricing data dump
+    #                      (coroot.github.io/cloud-pricing/data/cloud-pricing.json.gz).
+    #                      Coroot's cost engine loads this dump into its in-memory
+    #                      pricing model on startup; if it can't reach the host the
+    #                      model stays nil and GetNodePrice returns nil for EVERY
+    #                      node — so even a correctly-applied Custom Cloud Pricing
+    #                      (the coroot-custom-cloud-pricing CronJob, prod) yields an
+    #                      empty cost rollup with custom_pricing:false (#2148). This
+    #                      is a DIFFERENT host from coroot.com above.
     - toFQDNs:
         - matchName: "hooks.slack.com"
         - matchName: "hc-ping.com"
         - matchName: "coroot.com"
+        - matchName: "coroot.github.io"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## What

Fixes **#2148** — Coroot's cost view shows `custom_pricing: false` with null `costs.nodes` / `costs.applications` on prod, even though the `coroot-custom-cloud-pricing` CronJob applies the correct Hetzner CX33 rates and returns HTTP 200.

## Root cause (sourced from coroot v1.22.2)

The issue hypothesised that bare Hetzner nodes lack the instance-type metadata Coroot needs. That turns out to be **wrong** — and the real cause is cleaner:

- Coroot's cost engine loads a **pricing model dump** from `https://coroot.github.io/cloud-pricing/data/cloud-pricing.json.gz` on startup. If `mgr.model == nil` (dump never loaded), `GetNodePrice` returns `nil` for **every** node up front (`cloud-pricing/manager.go:69-71`) — *before* the custom-pricing branch — so the rollup is empty and `custom_pricing` stays false.
- Custom Cloud Pricing alone **is** sufficient for Hetzner: the node-agent reports `provider="Hetzner"`, which lowercases to `hetzner` and takes the `default` branch of `GetNodePrice`, computing price from `per_cpu_core`/`per_memory_gb` with `Custom: true` — **no instance type required** (`manager.go:79-94`).
- This platform runs **default-deny egress**. The Coroot pod's allow-list pinned `hooks.slack.com`, `hc-ping.com`, and `coroot.com` — but **not `coroot.github.io`** (a distinct host). So the dump download was silently blocked, the model stayed nil, and the otherwise-correct CronJob rates never attributed.

## Fix

Add `coroot.github.io` to the Coroot egress FQDN allow-list (one line + comment). Once the dump loads, the existing CronJob's CX33-derived rates populate per-node/per-app cost — no other change needed. The OpenCost cost view (separately and accurately priced from the same CX33 source) is unaffected.

> Note: `coroot.github.io` also hosts the Coroot *Helm repo*, but that's pulled by flux-system's source-controller — a different pod/egress from the Coroot workload, which genuinely needed its own allow.

## Validation

- `kubectl kustomize` of the Coroot component builds; `coroot.github.io` present in the rendered `CiliumNetworkPolicy` egress ✅
- Behavioural confirmation is live-cluster (the rollup populating) — the code path above is the high-confidence cause; if the rollup is *still* null after this lands, the only remaining cause per the source is missing `node_cpu_cores`/`node_memory_total_bytes` for a node, which would be a genuine upstream bug to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)