### PR TITLE
docs: document Organization → Members App permission for github-config teams

### DIFF
--- a/docs/github-management.md
+++ b/docs/github-management.md
@@ -56,8 +56,14 @@ Velero), so the manually-set values are durable without a GitOps source of truth
 1. Create a **GitHub App** on the devantler-tech org (Settings → Developer
    settings → GitHub Apps): permissions *Repository: Administration
    (read/write), Contents (read)* and *Organization: Administration
-   (read/write)* to start — widen as more resource kinds come under
-   management. Install it on **all repositories** of the org. No webhook.
+   (read/write), Members (read/write)* to start — widen as more resource
+   kinds come under management. **Organization → Members (read/write) is
+   required for the `maintainers`-team resources**: `Team` observe needs
+   `read`, and `TeamMembership`/`TeamRepository` create needs `write` —
+   without it they stay stuck on `CannotObserveExternalResource` /
+   `403 must be an organization owner or team maintainer` and flap the
+   `github-config` Flux health check. Install it on **all repositories**
+   of the org. No webhook.
 2. **Overwrite the placeholders in OpenBao** with the App's real values — the
    keys already exist (seeded by the vault-config Job), so just set them, e.g.:
    ```sh


### PR DESCRIPTION
## What

Adds **Organization → Members (read/write)** to the `provider-upjet-github` GitHub App permission list in [`docs/github-management.md`](docs/github-management.md) "Credential setup", with a note on exactly why it's needed.

## Why

The setup doc listed only *Repository: Administration/Contents* and *Organization: Administration* — it never mentioned **Members**. That omission is the root cause of [#2235](https://github.com/devantler-tech/platform/issues/2235): the App was created without it (`members: none`, vs `members: read` on every other org App), so the `maintainers`-team managed resources can't reconcile:

- `Team` **observe** needs `members: read` → without it: `CannotObserveExternalResource` (the dominant hourly alert source).
- `TeamMembership` / `TeamRepository` **create** needs `members: write` → without it: `403 must be an organization owner or team maintainer`.

With `wait: true` on the `github-config` Kustomization these never-ready MRs also flap the `github-config` (and parent `apps`) Flux health checks.

## Scope

Docs-only — **does not by itself fix #2235** (the live fix is granting the App that permission on the org install, which has no `gh`/API path). This records the requirement so a future App setup includes it and the gap can't silently recur. The `.github` team manifests are already correct (numeric `teamId` / `teamIdRef`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)