### PR TITLE
feat(alerting): re-instate FluxKustomizationNotReady alert via notification-controller

### DIFF
--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -70,12 +70,22 @@ stays quiet by design, exactly as the old Alertmanager did.
 
 ### Changed from the old stack
 
-- **Custom PromQL platform alerts are gone.** The old
+- **Custom PromQL platform alerts: partially re-instated.** The old
   `alerts/platform-critical.yaml` (Velero/CNPG backup, cert expiry,
   `FluxKustomizationNotReady`, autoscaler) had no 1:1 in Coroot's SLO/inspection
   model and was dropped. Node/pod/OOM/disk/crashloop health is covered by
-  Coroot's auto-inspections; the backup/cert/Flux checks can be re-expressed
-  later as Coroot `alertingRules` if needed.
+  Coroot's auto-inspections. The **`FluxKustomizationNotReady`** check is now
+  back — re-expressed the Flux-native way rather than as a Coroot rule: a
+  notification-controller `Provider` + `Alert`
+  (`providers/hetzner/infrastructure/flux-notifications/`) posts every
+  Kustomization reconciliation error to the same Slack webhook, event-driven and
+  with no polling pod for the kubescape scan to flag. The four top-level
+  Kustomizations (`bootstrap → infrastructure-controllers → infrastructure →
+  apps`) wait on their children, so a failed controller / app / HelmRelease
+  surfaces here as its parent going NotReady. The remaining **backup-success**
+  and **cert-expiry** checks are not Flux resources, so they need a scan-safe
+  synthetic check (e.g. per-CronJob dead-man pings like the heartbeat below, tied
+  to the silent vault snapshot in #1970) and are still TODO.
 - **kube-apiserver audit-log retention is gone.** Coroot's node-agent ingests
   container logs/traces, not host audit-log files, so the previous
   alloy-audit → Loki pipeline was removed.

--- a/k8s/providers/hetzner/infrastructure/flux-notifications/alert.yaml
+++ b/k8s/providers/hetzner/infrastructure/flux-notifications/alert.yaml
@@ -1,0 +1,29 @@
+# Re-instates the FluxKustomizationNotReady safety-net alert that was dropped in
+# the Coroot migration (docs/dr/alerting.md "Changed from the old stack"): Coroot
+# auto-inspects node/pod/OOM/disk/crashloop health, but it does NOT know when a
+# Flux *reconciliation* is stuck or failing — a build error, a failed
+# server-side apply, an unresolved dependency, or a child resource that never
+# goes Ready under a wait:true Kustomization.
+#
+# Watching every Kustomization at error severity catches the whole class: the
+# four top-level health gates (bootstrap → infrastructure-controllers →
+# infrastructure → apps) wait on their children, so a failed controller / app /
+# HelmRelease surfaces as its parent Kustomization going NotReady → an error
+# event here → Slack. Event-driven (no polling pod, so nothing for the kubescape
+# scan to flag) and posting to the same channel as the Coroot alerts.
+#
+# notification-controller dedupes + rate-limits, so a persistently-failing
+# Kustomization pages once, not every reconcile.
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: platform-reconciliation
+  namespace: flux-system
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: error
+  eventSources:
+    - kind: Kustomization
+      name: "*"
+  summary: "Flux reconciliation error — prod platform"

--- a/k8s/providers/hetzner/infrastructure/flux-notifications/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/flux-notifications/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - slack-secret.yaml
+  - provider.yaml
+  - alert.yaml

--- a/k8s/providers/hetzner/infrastructure/flux-notifications/provider.yaml
+++ b/k8s/providers/hetzner/infrastructure/flux-notifications/provider.yaml
@@ -1,0 +1,12 @@
+# Routes Flux notification-controller events to Slack via the incoming-webhook
+# Secret. notification-controller is enabled in the FluxInstance (see
+# controllers/flux-instance) and runs HA (2 replicas).
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  type: slack
+  secretRef:
+    name: slack-webhook

--- a/k8s/providers/hetzner/infrastructure/flux-notifications/slack-secret.yaml
+++ b/k8s/providers/hetzner/infrastructure/flux-notifications/slack-secret.yaml
@@ -1,0 +1,14 @@
+# Slack incoming-webhook for the Flux notification-controller Provider. It is the
+# SAME webhook the Coroot integration posts to (${alertmanager_webhook_url},
+# injected by Flux from the per-cluster variables-cluster Secret) — so Flux
+# reconciliation alerts land in the same channel as Coroot's incident/SLO alerts,
+# no new secret to provision. The inline default keeps `ksail workload validate`
+# (which has no SOPS access) building and leaves local/CI inert.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: slack-webhook
+  namespace: flux-system
+type: Opaque
+stringData:
+  address: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -43,6 +43,13 @@ resources:
   - coroot/db-scheduled-backup.yaml
   - coroot/networkpolicy.yaml
   - coroot/pod-disruption-budget.yaml
+  # Prod-only safety-net alerting: a Flux notification-controller Provider + Alert
+  # that posts Kustomization reconciliation errors to the SAME Slack webhook the
+  # Coroot integration uses (${alertmanager_webhook_url}). Re-instates the
+  # FluxKustomizationNotReady alert dropped in the Coroot migration (see
+  # docs/dr/alerting.md) — event-driven, so nothing for the kubescape scan to
+  # flag. Prod-only, where that webhook is configured.
+  - flux-notifications/
   # Longhorn CSI VolumeSnapshotClass for Velero CSI backups. Kept in this
   # `infrastructure` layer (not `infrastructure/controllers/`) so the
   # snapshot.storage.k8s.io CRDs shipped by the snapshot-controller HelmRelease


### PR DESCRIPTION
## What

Re-instates the platform-health alerting that was dropped in the Coroot migration ([docs/dr/alerting.md](https://github.com/devantler-tech/platform/blob/main/docs/dr/alerting.md) "Changed from the old stack"). Coroot auto-inspects node/pod/OOM/disk/crashloop health, but it does **not** know when a Flux *reconciliation* is stuck or failing — a build error, a failed apply, an unresolved dependency, or a child resource that never goes Ready under a `wait:true` Kustomization. So today, **delivery itself can be broken and nothing pages you** — the gap I flagged in the platform review.

## How

`notification-controller` is already enabled (and HA) in the FluxInstance, so this is the Flux-native, **scan-safe** fix:

- A `Provider` (type `slack`) + an `Alert` watching **every `Kustomization` at error severity**, posting to the **same `${alertmanager_webhook_url}` Slack webhook** the Coroot integration already uses — one channel for all platform alerts.
- The four top-level health gates (`bootstrap → infrastructure-controllers → infrastructure → apps`) wait on their children, so a failed controller / app / HelmRelease surfaces here as its parent Kustomization going `NotReady` → an error event → Slack. notification-controller dedupes + rate-limits, so a persistent failure pages once.

### Why notification-controller and not a kubectl CronJob

A polling health-checker would have to mount a broad SA token to read resource statuses — a **kubescape NSA `C-0034` finding** that risks dropping the CI compliance-scan score below its (tight) threshold. The event-driven Provider/Alert has **no pod at all**, so it's strictly better here: real-time *and* zero scan impact.

## Scope (honest)

This covers the **`FluxKustomizationNotReady`** half of the dropped alerts — the broadest and highest-value one. **Backup-success (Velero/CNPG) and cert-expiry are not Flux resources**, so notification-controller can't cover them. They need a separate scan-safe synthetic check (e.g. per-CronJob dead-man pings like the existing heartbeat, which also closes the silent vault-snapshot in #1970). That's documented as the remaining TODO in `docs/dr/alerting.md` and is worth its own focused PR rather than bolting a scan-breaking pod on here.

## Files

- `providers/hetzner/infrastructure/flux-notifications/` — Secret + Provider + Alert (prod-only, where the webhook lives; inline default keeps validate/local inert)
- wired into the hetzner infrastructure overlay; `docs/dr/alerting.md` updated

## Validation

- `kubectl kustomize` builds the component (Secret + Provider + Alert) and the full hetzner infrastructure overlay (139 resources) ✅
- Behavioural confirmation (a real error event reaching Slack) is live-cluster; the wiring matches the Flux v1beta3 Alert/Provider API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)