### PR TITLE
docs(github-management): document the required Organization Members App permission

### DIFF
--- a/docs/github-management.md
+++ b/docs/github-management.md
@@ -54,10 +54,24 @@ Velero), so the manually-set values are durable without a GitOps source of truth
 ## Credential setup (one-time, maintainer)
 
 1. Create a **GitHub App** on the devantler-tech org (Settings → Developer
-   settings → GitHub Apps): permissions *Repository: Administration
-   (read/write), Contents (read)* and *Organization: Administration
-   (read/write)* to start — widen as more resource kinds come under
-   management. Install it on **all repositories** of the org. No webhook.
+   settings → GitHub Apps) with these permissions, then install it on **all
+   repositories** of the org (no webhook):
+   - *Repository → Administration (read/write)* — repositories, rulesets and
+     team↔repo access; plus *Repository → Contents (read)*.
+   - *Organization → Administration (read/write)* — org-level rulesets.
+   - *Organization → Members (read/write)* — **required for the `maintainers`
+     `Team`, `TeamMembership` and `TeamRepository` resources, and easy to miss
+     (`Administration` is NOT enough).** Without `Members`, the provider can't
+     even *read* a team (observe fails `external resource does not exist`, even
+     though the team exists) and team *writes* fail `403 You must be an
+     organization owner or team maintainer` — so team management silently breaks
+     while the repo/ruleset/label resources keep working. Widen further as more
+     resource kinds come under management.
+
+   When you **add** a permission to an *existing* App, you must also **approve
+   the new permission on the org installation** (Org settings → Installed GitHub
+   Apps → the App → review the request) — the installation keeps the old
+   permission set until you do, so the resources stay broken until approved.
 2. **Overwrite the placeholders in OpenBao** with the App's real values — the
    keys already exist (seeded by the vault-config Job), so just set them, e.g.:
    ```sh


### PR DESCRIPTION
## Why

The GitHub App setup step in `docs/github-management.md` listed *Repository: Administration/Contents* and *Organization: Administration* — but **not Organization: Members**. That's exactly the permission whose absence silently breaks the `maintainers` team management (#2235): the `provider-upjet-github` App had `members: none`, so it couldn't **read** the team (observe → `external resource does not exist`) or **write** membership/team-repo access (`403 You must be an organization owner or team maintainer`), while repo/ruleset/label resources kept working.

## Change

- Add **Organization → Members (read/write)** to the documented App permissions, with the failure-mode it causes if missed (`Administration` is not enough).
- Note that **adding** a permission to an *existing* App requires **approving the new permission on the org installation** before it takes effect — otherwise the resources stay broken even after editing the App.

Docs-only. No manifest change.

> Follow-up to the #2235 investigation (root cause = the App's missing Members permission, not a manifest or in-cluster issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)