### PR TITLE
feat: activate RepositoryPermissions MRD for actions SHA-pinning policy

### DIFF
--- a/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
@@ -31,3 +31,11 @@ spec:
     - teams.team.github.m.upbound.io
     - teammemberships.team.github.m.upbound.io
     - teamrepositories.team.github.m.upbound.io
+    # Actions repository permissions — the per-repo "Require actions to be pinned
+    # to a full-length commit SHA" policy (sha_pinning_required), declared in
+    # devantler-tech/.github deploy/actions-permissions/ for every managed repo
+    # except `actions`. The tenant Role already covers the
+    # actions.github.m.upbound.io group. REQUIRES a provider-upjet-github release
+    # embedding terraform-provider-github >= 6.11.0 (where sha_pinning_required
+    # landed) — absent in the currently-deployed v0.19.1 (TF 6.6.0).
+    - repositorypermissions.actions.github.m.upbound.io


### PR DESCRIPTION
> **Draft — gated on [crossplane-contrib/provider-upjet-github#288](https://github.com/crossplane-contrib/provider-upjet-github/pull/288).** Do not promote/merge until a provider release embedding terraform-provider-github ≥ 6.11.0 is pinned in `provider.yaml`.

## What

Activates `repositorypermissions.actions.github.m.upbound.io` in the
`github-config` `ManagedResourceActivationPolicy`, so the org's per-repo
**Require actions to be pinned to a full-length commit SHA** policy
(`sha_pinning_required`) can be reconciled declaratively.

## Why

`provider-upjet-github` declares SafeStart — its Actions managed resources ship
**Inactive**; only those named in the MRAP become CRDs. The companion
`devantler-tech/.github` change (`deploy/actions-permissions/`) declares a
`RepositoryPermissions` per managed repo asserting `shaPinningRequired: true`;
those need this MRD active to reconcile.

The `github-config` tenant Role already grants the `actions.github.m.upbound.io`
API group, so **no RBAC change is needed**.

## Gating

`sha_pinning_required` is absent from the deployed provider **v0.19.1** (pins
terraform-provider-github 6.6.0); it landed in the TF provider in v6.11.0 and is
unavailable until a provider release embedding ≥ 6.11.0 is pinned here. Tracked
by crossplane-contrib/provider-upjet-github#288.

## Validation

`kubectl kustomize k8s/providers/hetzner/infrastructure/crossplane` builds; the
MRAP `activate` list now includes `repositorypermissions.actions.github.m.upbound.io`.

## Companion

devantler-tech/.github#67 — `deploy/actions-permissions/` (the `RepositoryPermissions` resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
