### PR TITLE
feat(homepage): surface Backstage under a first "Internal Developer Platform" group

### DIFF
--- a/k8s/bases/apps/backstage/httproute.yaml
+++ b/k8s/bases/apps/backstage/httproute.yaml
@@ -8,7 +8,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Backstage
     gethomepage.dev/description: Internal developer portal — software catalog.
-    gethomepage.dev/group: Platform
+    gethomepage.dev/group: Internal Developer Platform
     gethomepage.dev/icon: backstage.png
     gethomepage.dev/href: https://backstage.${domain}
 spec:

--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -61,6 +61,11 @@ data:
     # the HTTPRoutes under k8s/bases/apps/** and k8s/**/infrastructure/** (incl.
     # provider overlays, e.g. Longhorn on Hetzner) and the service entries below.
     layout:
+      # First on the page: the Internal Developer Platform (Backstage and any
+      # future self-service portals). Keep this entry first so the IDP is the
+      # landing focus.
+      Internal Developer Platform:
+        icon: mdi-developer-board
       Kubernetes:
         icon: si-talos-#FF7300
       Observability:


### PR DESCRIPTION
## What

Follow-up to #2246 (merged). The Backstage tile shipped in the generic **Platform** homepage group; this moves it into a dedicated **Internal Developer Platform** group and makes that group the **first** entry in the homepage layout, so the IDP is the landing focus of the dashboard.

- `backstage/httproute.yaml` — `gethomepage.dev/group` → `Internal Developer Platform`
- `homepage/config-map.yaml` — add the group as the **first** `layout:` entry (icon `mdi-developer-board`). Layout order controls render order, and this keeps the layout in sync with the group annotation per the config's own convention note.

## Validation

- `kubectl kustomize k8s/bases/apps/` builds ✅
- Rendered Backstage HTTPRoute group is `Internal Developer Platform` ✅
- Rendered homepage layout lists `Internal Developer Platform` ahead of `Kubernetes` (the previous first group) ✅

> Icon note: used `mdi-developer-board` (section-level, future-proof for more self-service tools). Swap to `si-backstage` if you'd prefer the Backstage logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)