### PR TITLE
fix(policies): split add-ns-quota so the ResourceQuota rule stops erroring on quota-exempt namespaces

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-default-limitrange.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-default-limitrange.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-default-limitrange
+  annotations:
+    policies.kyverno.io/title: Add Default LimitRange
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/subject: LimitRange
+    policies.kyverno.io/description: >-
+      Generates the default-limitrange LimitRange (per-container request/limit
+      defaults) in every tenant namespace. Split out of add-ns-quota -- which now
+      generates only the ResourceQuota -- so the two no longer share one policy.
+      Kyverno evaluates EVERY rule of a policy against any trigger that matches ANY
+      rule (a single shared UpdateRequest per trigger), so while the ResourceQuota
+      and LimitRange rules lived together with different exclude scopes, the
+      ResourceQuota rule fired against observability and velero (which it excludes
+      but the LimitRange rule did not) and emitted "generate-resourcequota error:
+      policy does not apply to resource" PolicyError events on every background
+      reconcile. As two independent single-rule policies that cross-rule mismatch
+      cannot occur: each namespace either matches a policy (and is generated for)
+      or does not (and produces no UpdateRequest).
+spec:
+  # Required for generateExisting + synchronize to reconcile pre-existing
+  # namespaces and keep the generated LimitRange in sync.
+  background: true
+  rules:
+    - name: generate-limitrange
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      exclude:
+        any:
+          - resources:
+              names:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - flux-system
+                # Longhorn instance-managers must run WITHOUT the default memory
+                # limit: during a volume rebuild they burst past the default
+                # (512Mi), get OOMKilled, and longhorn-manager recreates the IM
+                # pod -- faulting every replica engine on the node and cascading
+                # into CNPG failover (observed 2026-06-20). observability and
+                # velero are intentionally NOT excluded here -- they are exempt
+                # from the ResourceQuota (see add-ns-quota) but still need sane
+                # default requests/limits.
+                - longhorn-system
+      preconditions:
+        all:
+          # Skip a terminating namespace: it rejects a new LimitRange with
+          # "namespace is being terminated", which Kyverno surfaces as a
+          # PolicyError Warning event. Mirrors add-ns-quota.
+          - key: "{{ request.object.metadata.deletionTimestamp || '' }}"
+            operator: Equals
+            value: ""
+      generate:
+        apiVersion: v1
+        kind: LimitRange
+        name: default-limitrange
+        namespace: "{{request.object.metadata.name}}"
+        synchronize: true
+        generateExisting: true
+        data:
+          spec:
+            limits:
+              - default:
+                  cpu: 500m
+                  memory: 512Mi
+                defaultRequest:
+                  # CPU floor matches VPA minAllowed (auto-vpa.yaml); idle
+                  # controllers default lower until VPA right-sizes them.
+                  cpu: 15m
+                  memory: 128Mi
+                type: Container

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   # Custom policies (no upstream equivalent)
   - best-practices/add-default-deny.yaml
+  - best-practices/add-default-limitrange.yaml
   - best-practices/add-resource-defaults.yaml
   - best-practices/add-security-context.yaml
   - best-practices/auto-vpa.yaml
@@ -50,7 +51,8 @@ patches:
                   # stalls the coroot-operator and the infrastructure-controllers
                   # Flux Kustomization cluster-wide. Exempt it like the other
                   # platform-owned namespaces; its sizing is VPA-owned, not
-                  # quota-bounded. The LimitRange (rule 1) still applies.
+                  # quota-bounded. It still gets the default LimitRange from the
+                  # add-default-limitrange policy.
                   - observability
                   # Longhorn storage data plane. longhorn-manager creates the
                   # instance-manager pods WITHOUT a memory limit by design: during
@@ -60,11 +62,13 @@ patches:
                   # engine on that node (DetachedUnexpectedly), cascading into
                   # CNPG primary failover and Postgres timeline divergence
                   # cluster-wide (observed 2026-06-20). It is excluded from BOTH
-                  # rules: rule 1 drops the OOM-inducing limit, and this rule
-                  # (ResourceQuota) must drop too -- otherwise pods that no longer
-                  # receive the LimitRange-supplied requests get rejected by the
-                  # requests.memory quota. Longhorn sizing is operator-/VPA-owned
-                  # (manager, csi, ui carry VPAs), not quota-bounded.
+                  # the ResourceQuota (here) and the LimitRange
+                  # (add-default-limitrange drops the OOM-inducing limit by
+                  # excluding it too); this rule must drop it as well -- otherwise
+                  # pods that no longer receive LimitRange-supplied requests get
+                  # rejected by the requests.memory quota. Longhorn sizing is
+                  # operator-/VPA-owned (manager, csi, ui carry VPAs), not
+                  # quota-bounded.
                   - longhorn-system
                   # Velero backup data plane. Velero runs a kopia
                   # repository-maintenance Job per backup repo (one per backed-up
@@ -84,8 +88,8 @@ patches:
                   # node) plus these ephemeral Jobs, not steady-state tenant
                   # workloads, so a static per-namespace memory quota is the wrong
                   # tool and actively harmful here. Exempt it like the other
-                  # platform-owned namespaces; the LimitRange (rule 1) still applies,
-                  # so backup pods keep sane default requests/limits.
+                  # platform-owned namespaces; it still gets the default LimitRange
+                  # from add-default-limitrange, so backup pods keep sane defaults.
                   - velero
       - op: add
         path: /spec/rules/0/generate/generateExisting
@@ -104,49 +108,25 @@ patches:
           # resources; limits are burst ceilings VPA now owns per pod.
           requests.cpu: "8"
           requests.memory: 16Gi
-      - op: add
-        path: /spec/rules/1/exclude
-        value:
-          any:
-            - resources:
-                names:
-                  - kube-system
-                  - kube-public
-                  - kube-node-lease
-                  - flux-system
-                  # See rule 0: Longhorn instance-managers must run without the
-                  # default memory limit -- an OOM during a rebuild recreates the
-                  # IM pod and faults every volume on the node, taking the storage
-                  # data plane (and every CNPG database on it) down.
-                  - longhorn-system
-      - op: add
-        path: /spec/rules/1/generate/generateExisting
-        value: true
-      - op: replace
-        path: /spec/rules/1/generate/data/spec/limits/0/default
-        value:
-          cpu: 500m
-          memory: 512Mi
-      - op: replace
-        path: /spec/rules/1/generate/data/spec/limits/0/defaultRequest
-        value:
-          # CPU floor lowered 50m->15m to match VPA minAllowed (auto-vpa.yaml);
-          # idle controllers default lower until VPA right-sizes them.
-          cpu: 15m
-          memory: 128Mi
+      # Remove the upstream sample's LimitRange rule. It is re-homed in the
+      # standalone add-default-limitrange policy so the ResourceQuota and the
+      # LimitRange never share one policy: Kyverno evaluates EVERY rule of a
+      # policy against any trigger matching ANY rule (one shared UpdateRequest),
+      # so while the LimitRange rule (which does not exclude observability/velero)
+      # lived here next to this ResourceQuota rule (which does), this rule fired
+      # against those two namespaces and emitted "generate-resourcequota error:
+      # policy does not apply to resource" PolicyError events every reconcile.
+      # Removing a generate rule leaves its already-generated LimitRanges in
+      # place (stale, not deleted -- verified via the validate-policy webhook),
+      # so add-default-limitrange adopts them with no gap.
+      - op: remove
+        path: /spec/rules/1
       # Skip namespaces that are being deleted. A terminating namespace (e.g.
       # cdi/kubevirt after the prod disable) rejects new ResourceQuota/LimitRange
       # with "forbidden: namespace is being terminated", which Kyverno surfaces
       # as PolicyError Warning events that trip the merge-queue event gate.
       - op: add
         path: /spec/rules/0/preconditions
-        value:
-          all:
-            - key: "{{ request.object.metadata.deletionTimestamp || '' }}"
-              operator: Equals
-              value: ""
-      - op: add
-        path: /spec/rules/1/preconditions
         value:
           all:
             - key: "{{ request.object.metadata.deletionTimestamp || '' }}"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live on prod)

`clusterpolicy/add-ns-quota` emits a recurring burst of `PolicyError` Warning events every background reconcile (≈10 events/hour, at :10):

```
policy add-ns-quota/generate-resourcequota error: policy does not apply to resource
```

The event's `related` object pins it to exactly two namespaces — `Namespace/observability` and `Namespace/velero` (5 events each). The policy is otherwise functional (31 ResourceQuotas + LimitRanges generated correctly), but the maintainer's own comment notes these PolicyError Warnings can trip the merge-queue event gate.

## Root cause

`add-ns-quota` generated **both** a ResourceQuota (rule 0) and a LimitRange (rule 1) from one policy, with **asymmetric exclude scopes**:

| rule | excludes |
|---|---|
| `generate-resourcequota` | kube-system, kube-public, kube-node-lease, flux-system, **observability**, longhorn-system, **velero** |
| `generate-limitrange` | kube-system, kube-public, kube-node-lease, flux-system, longhorn-system |

Kyverno evaluates **every rule of a policy** against any trigger that matches **any** rule (one shared `UpdateRequest` per trigger). `observability` and `velero` match only the LimitRange rule, so an UpdateRequest is created for them — and the ResourceQuota rule is then evaluated against them too, finds them excluded, and raises *"policy does not apply to resource."* Every other excluded namespace is excluded from **both** rules, so no UpdateRequest exists for them and they produce no error. That's why only these two namespaces are affected — they are intentionally quota-exempt but still get a LimitRange.

## Fix — one generated resource per single-rule policy

So no namespace can ever match one rule but not another:

- **`add-ns-quota`** keeps only the `generate-resourcequota` rule (unchanged) — name still accurate, ResourceQuota generation untouched.
- The LimitRange rule moves verbatim into a new **`add-default-limitrange`** ClusterPolicy (same match, same `longhorn-system`-only exclude, same `generateExisting`/`synchronize`/precondition, same `default`/`defaultRequest` values).

`observability`/`velero` now match `add-default-limitrange` (single rule → generates their LimitRange) and don't match `add-ns-quota` (single rule → no evaluation, no error).

## Why this is safe to roll out (validated against the live cluster)

A generate rule's `match`/`exclude` is **immutable** once the policy exists — Kyverno's `validate-policy` webhook rejects in-place scope edits (*"changes of immutable fields of a rule spec in a generate rule is disallowed"*). I verified every step with **server-side dry-run** against prod:

- ✅ Removing the LimitRange rule from `add-ns-quota` is accepted, and the webhook reports *"no synchronization will be performed to the old target resource … stale targets"* — i.e. the already-generated LimitRanges are **left in place, not deleted**.
- ✅ The new `add-default-limitrange` policy is accepted; with `generateExisting` it adopts those persisting LimitRanges.

So **no LimitRange is ever absent** during the transition (which would otherwise risk the requests.memory-quota rejection cascade the comments document), and no ResourceQuota churns either (rule 0 is untouched). The generated specs are byte-identical.

## Validation

- `kubectl kustomize` of the cluster-policies base (21 policies) and `k8s/providers/hetzner/infrastructure` (254 resources) build clean.
- Server-side dry-run (Kyverno webhook) accepts both the reduced `add-ns-quota` and the new `add-default-limitrange`.
- Rendered LimitRange `default`/`defaultRequest` values match the original rule 1 exactly.

Draft per the engineering contract — ready for promotion; comments on the rule-0 exclude that referenced "rule 1 / the LimitRange" are updated to point at the new policy.