### PR TITLE
fix(kubescape): pin node-agent v0.3.142 to fix the concurrent-map-writes crash

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -65,6 +65,19 @@ spec:
     hostScanner:
       enabled: true
     nodeAgent:
+      image:
+        # Chart 1.40.2 pins node-agent v0.3.119, whose vendored inspektor-gadget
+        # has a data race in GadgetPubSub.Publish -- under container churn the
+        # DaemonSet dies with "fatal error: concurrent map writes" (observed
+        # crashlooping every prod node, 15/8/3 restarts, during the 06-20..06-23
+        # load). node-agent v0.3.128 fixed it by bumping the inspektor-gadget pin
+        # (kubescape/node-agent#825); this pin also carries the later v0.3.132
+        # (eBPF deadlock + OOM under load) and v0.3.136 (send-on-closed-channel
+        # panic on SIGTERM/rolling restart) crash fixes. The chart's node-agent
+        # default still lags the node-agent release train (kubevuln is already at
+        # v0.3.142 in the same chart), so override it here; drop this once the
+        # chart default catches up past v0.3.128.
+        tag: v0.3.142
       config:
         hostSensor:
           enabled: true


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live on prod)

The kubescape `node-agent` DaemonSet was crashlooping on every prod node (15 / 8 / 3 restarts) with a Go runtime fatal error:

```
fatal error: concurrent map writes

goroutine ... [running]:
... github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection.(*GadgetPubSub).Publish ...
```

The crashes clustered in the **06-20…06-23** window (the Longhorn/CNPG storage incident's high pod churn) and have paused since, but the bug is latent and re-fires under container churn.

## Root cause

A **data race** in the inspektor-gadget library the node-agent vendors: `GadgetPubSub.Publish` writes a map concurrently without synchronization, and Go aborts the process when it detects it. It is **not** a platform misconfiguration — it's upstream code.

The kubescape-operator chart (`1.40.2`, already the **latest** chart) still pins **node-agent `v0.3.119`** (2026-05-19), which predates the fix. The node-agent ships on its own release train ahead of the chart.

## Fix

node-agent **`v0.3.128`** fixed the race by updating its inspektor-gadget pin (release notes: *"Closes kubescape/node-agent#825 … the concurrent map writes fix"*). Override `nodeAgent.image.tag` to the current release **`v0.3.142`**, which carries that fix **plus** subsequent crash fixes the prior version lacks:

| node-agent | fix |
|---|---|
| `v0.3.128` | inspektor-gadget **concurrent map writes** (the observed crash) |
| `v0.3.132` | eBPF agent **deadlock + OOM** under high load |
| `v0.3.136` | **send-on-closed-channel panic** on SIGTERM / rolling restart |

```yaml
nodeAgent:
  image:
    tag: v0.3.142
```

This is a forward override of just the node-agent image (the chart's default lags — `kubevuln` is already at `v0.3.142` in the same chart). Drop it once the chart's node-agent default catches up past `v0.3.128`.

## Validation

- `helm template … --set nodeAgent.image.tag=v0.3.142` renders the node-agent DaemonSet at `quay.io/kubescape/node-agent:v0.3.142` (vs `v0.3.119` baseline) — override path confirmed.
- `kubectl kustomize` of the kubescape overlay builds.

## Notes / for review

- **Minimal alternative:** if you'd rather minimize version skew from the chart's tested `v0.3.119`, **`v0.3.128`** is the smallest pin that fixes the observed crash (well-soaked, ~4 weeks). `v0.3.142` is chosen here to also get the deadlock/OOM and teardown-panic fixes, since the node-agent is a per-node security component that had been crash-prone — but it's a recent release, so adjust the tag if you prefer more soak.
- Other kubescape components are untouched.

Draft per the engineering contract — ready for promotion.