### PR TITLE
fix(backstage): wire backstage into the oauth2-proxy SSO auth path

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
@@ -19,6 +19,14 @@ spec:
             - port: "8080"
               protocol: TCP
   egress:
+    # Backstage upstream (developer portal; Service backstage :7007).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: backstage
+      toPorts:
+        - ports:
+            - port: "7007"
+              protocol: TCP
     # Homepage upstream
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
@@ -8,6 +8,9 @@ spec:
   from:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
+      namespace: backstage
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
       namespace: homepage
     - group: gateway.networking.k8s.io
       kind: HTTPRoute


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
`backstage.platform.devantler.tech` returned a **bodyless HTTP 500** even though the backend pod was healthy (1/1 Ready) and the #2253 config fix had deployed. Pod-healthy ≠ URL-reachable: the external path (Gateway → oauth2-proxy → auth-proxy/Traefik → backend) was broken in two places.

## Root cause (two missing shared-side allowlist entries)
backstage was onboarded into the shared SSO auth path but two entries on the **oauth2-proxy side** were never added — every other SSO app (homepage, coroot, opencost, longhorn, hubble-ui) has both:

1. **ReferenceGrant** `allow-oauth2-proxy-backends` (ns `oauth2-proxy`) did not list `backstage` in `from`, so the backstage HTTPRoute's cross-namespace `backendRef` to the `oauth2-proxy` Service was rejected — `ResolvedRefs=False :: RefNotPermitted` → the Cilium Gateway returned **500**.
2. **CiliumNetworkPolicy** `allow-auth-proxy` (ns `oauth2-proxy`) egress allowlist did not include `backstage:7007`, so after auth the Traefik auth-proxy → backstage backend connection was dropped by default-deny (**timeout**).

The Traefik router/service for backstage (`auth-proxy` `dynamic.yaml`), the backstage-side ingress netpol (`allow-backstage`), the HTTPRoute, and the backend were all already present — these two shared-side entries were the only gap.

## Fix
- Add `backstage` to the ReferenceGrant `from` list.
- Add a `backstage:7007` egress rule to the `allow-auth-proxy` CiliumNetworkPolicy.

Both are additive `allow` entries mirroring the existing apps; inert on local/CI where the `backstage` namespace is absent (same pattern as the Hetzner-only longhorn entries).

## Validation
- `kubectl apply --server-side --dry-run=server` of both manifests against `admin@prod`: accepted.
- Applied live to `admin@prod` to confirm end-to-end: HTTPRoute → `ResolvedRefs=True`; public URL now returns **302 → Dex SSO login** (and on to GitHub OAuth) instead of 500.
- The pre-existing `ksail workload validate` noise (`/login/openid` minLength + a non-deterministic `infrastructure/controllers` build error at varying line numbers) is present on the baseline too — unrelated to this change.

Closes the backstage external-access gap left after #2253 fixed the backend config.
