### PR TITLE
fix(backstage): enable guest sign-in so the UI works behind SSO

### DIFF
--- a/k8s/bases/apps/backstage/helm-release.yaml
+++ b/k8s/bases/apps/backstage/helm-release.yaml
@@ -84,6 +84,20 @@ spec:
             pluginDivisionMode: schema
             connection:
               database: backstage
+        # Guest sign-in. The upstream demo image runs with NODE_ENV=production,
+        # where Backstage's guest provider refuses to mint a token unless this is
+        # set — without it the sign-in page's guest "Enter" 403s ("the guest
+        # provider cannot be used outside of a development environment …"), and
+        # every subsequent frontend API call is then 401, so the UI throws errors
+        # on every action. Access is already gated by the oauth2-proxy / Dex
+        # (GitHub) SSO forward-auth in front of the HTTPRoute, so a guest identity
+        # INSIDE Backstage is the intended model for this scaffold; swapping in a
+        # custom-built image with a real sign-in resolver is the productionisation
+        # step (see docs/backstage.md).
+        auth:
+          providers:
+            guest:
+              dangerouslyAllowOutsideDevelopment: true
 
       # Single pod: Backstage runs plugin DB migrations on startup, so two
       # concurrent pods can race them. maxSurge:0 retires the old pod before the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem
After the URL became reachable (auth-proxy `ReferenceGrant` + egress fix, #2262), the Backstage UI still **threw errors on every action** and **guest sign-in failed**.

## Root cause
The upstream **demo image runs with `NODE_ENV=production`**, where Backstage's guest auth provider refuses to mint a token unless explicitly allowed:

```
POST /api/auth/guest/refresh -> 403
"The guest provider cannot be used outside of a development environment
 unless 'auth.providers.guest.dangerouslyAllowOutsideDevelopment' is enabled"
```

With no guest token, the frontend's authenticated API calls (`/api/catalog/entities`, `entity-facets`, …) were all **401** — so the UI errored on every action. The two symptoms were one root cause.

## Fix
Set `auth.providers.guest.dangerouslyAllowOutsideDevelopment: true` in the generated `appConfig`.

Backstage sits behind the **oauth2-proxy / Dex (GitHub) SSO forward-auth**, so only authenticated org members ever reach it — a guest identity *inside* Backstage is the intended model for this demo scaffold (a custom-built image with a real sign-in resolver is the productionisation step, per the existing `docs/backstage.md` note in the manifest).

## Validation
Verified live against `admin@prod` (HelmRelease patched + reconciled, pod rolled out):
- `POST /api/auth/guest/refresh` → **200** with identity `user:development/guest` (was 403).
- `GET /api/catalog/entities` → **200**, `GET /api/catalog/entity-facets` → **200** with the guest token (were 401).

The catalog is empty (the demo image doesn't ship the `examples/*.yaml` referenced by the bundled `catalog.locations`) — benign, not an error; out of scope for this fix.

Follow-up to #2253 (backend config) and #2262 (network path) — this is the app-auth layer that makes the UI actually usable.
