### PR TITLE
ci: validate with --skip-helm-render to dodge ksail#5362 render flake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,14 +60,17 @@ jobs:
 
       - name: ⚙️ Setup KSail
         # Renovate-managed (datasource github-releases; grouped 'ksail' with the
-        # deploy-prod / dr-rebuild pins). Previously frozen at 7.65.0 to dodge the
-        # non-deterministic in-process Helm render 7.66.x introduced — `ksail
-        # workload validate` (varying YAML parse errors) and `ksail workload scan`
-        # (swinging compliance score) flaked run-to-run. That race is resolved
-        # upstream (devantler-tech/ksail#5371, closed COMPLETED), so the pin is
-        # lifted back onto the latest release.
-        # TRIPWIRE: if validate or scan starts swinging run-to-run again, re-pin
-        # to a known-good version (drop the renovate comment) and reopen #5371.
+        # deploy-prod / dr-rebuild pins). NOTE: the in-process Helm render added
+        # in 7.66.x (#5344) is non-deterministic — concurrent renders share
+        # process-global Helm caches and corrupt the rendered stream, so `ksail
+        # workload validate` fails with a *different* random YAML parse error
+        # run-to-run (ksail#5362). #5362's CLOSED fix (#5364/#5366) is INCOMPLETE:
+        # 7.77/7.78 still flake; only <=7.65 (pre-in-process-render) is clean.
+        # Rather than re-pin back 13 versions we stay current and pass
+        # --skip-helm-render to the validate step below (deterministic; same
+        # coverage as the old 7.65.0 pin). `scan` stays on the rendered path
+        # (score-gated with margin). TRIPWIRE: drop --skip-helm-render once #5362
+        # is genuinely fixed upstream; if scan starts swinging, re-pin to 7.65.0.
         shell: bash
         env:
           # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
@@ -82,9 +85,17 @@ jobs:
         # Schema-aware kubeconform validation with Flux variable substitution,
         # building both cluster overlays. Fully static: no cluster, no SOPS key
         # (Secrets are skipped), no network (offline schema cache).
+        #
+        # --skip-helm-render: INTERIM workaround for the still-open ksail#5362 —
+        # the default in-process Helm render is non-deterministic (concurrent
+        # renders share process-global Helm caches and corrupt the output, failing
+        # a random kustomization with a random YAML parse error each run). Skipping
+        # it validates HelmRelease CRs as-is (same coverage as the old 7.65.0 pin)
+        # and is deterministic. REMOVE once #5362 is genuinely fixed upstream to
+        # restore rendered-chart validation. See the Setup KSail note above.
         run: |
-          ksail workload validate
-          ksail --config ksail.prod.yaml workload validate
+          ksail workload validate --skip-helm-render
+          ksail --config ksail.prod.yaml workload validate --skip-helm-render
 
       - name: 🔎 Scan manifests (Kubescape NSA) — hard gate
         # Static NSA-CISA security scan, gated on the compliance score: the job


### PR DESCRIPTION
Makes `🧪 Validate Manifests` deterministic by passing `--skip-helm-render`, working around the still-open [ksail#5362](https://github.com/devantler-tech/ksail/issues/5362). **Unblocks [#2268](https://github.com/devantler-tech/platform/pull/2268) (crossview standalone) and every other platform PR.**

## Root cause

ksail's in-process Helm render (added v7.66.0, [#5344](https://github.com/devantler-tech/ksail/pull/5344)) is **non-deterministic**: `validate` renders kustomizations concurrently (`validationConcurrency=5`) and concurrent `helm.TemplateChart` calls share **process-global Helm on-disk caches** → the rendered stream gets corrupted → a *different* kustomization fails with a *different* YAML parse error every run (always in the HelmRelease-dense `*/controllers` group).

The CI pin was lifted 7.65.0 → latest in #2265 believing #5371 fixed this — but that closed the *scan* score-swing; the *validate* corruption is **#5362**, whose closed fix (#5364/#5366 "serialize") is **incomplete**.

Determinism matrix (prod overlay, identical tree each run):

| ksail | mode | result |
|---|---|---|
| 7.65.0 | default (no in-process render) | **3/3 clean** |
| 7.72.0 | default render | 2/4 ❌ |
| 7.77.0 (current CI pin) | default render | ~1/5 ❌ |
| 7.78.0 (latest) | default render | 1/4 ❌ |
| 7.77.0 | **`--skip-helm-render`** | **3/3 clean** |
| 7.77.0 | `GOMAXPROCS=1` | 1/4 ❌ |

## Fix

Pass `--skip-helm-render` to both `validate` invocations (deterministic; validates HelmRelease CRs as-is — the **same coverage as the old 7.65.0 pin**, which predated in-process render anyway), instead of re-pinning back 13 versions and losing other fixes. Also corrects the stale Setup KSail comment that claimed the race was resolved upstream.

`scan` is left on the rendered path (it's score-gated with margin, and its threshold is calibrated against the rendered output).

## Caveat (self-CI)

GitHub runs `pull_request` workflows from the **base** branch, so *this* PR's own `Validate Manifests` check still uses the old (flaky) command and may go red on the #5362 flake — merge on the diff (or re-run). Once merged, `main`'s validate is deterministic and crossview #2268 can be re-run green.

## Follow-up

Reopening #5362 upstream with this repro, and attempting the real fix (isolate each render worker's Helm caches) so `--skip-helm-render` can later be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
