### PR TITLE
fix(oauth2-proxy): gate on the existing maintainers team, not platform

### DIFF
--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -78,14 +78,18 @@ spec:
         oidc_jwks_url = "http://dex.dex.svc.cluster.local:5556/keys"
         # Request the groups scope so Dex returns the user's GitHub teams as
         # group claims (its github connector uses teamNameField: slug), then
-        # gate on the 'platform' team -- preserving the stricter team
+        # gate on the 'maintainers' team -- preserving the stricter team
         # restriction the github provider enforced. NOTE: OIDC mode has no
         # per-user bypass (the old github_users escape hatch is gone), so the
-        # authenticating user MUST be a member of devantler-tech/platform.
+        # authenticating user MUST be a member of devantler-tech/maintainers.
+        # This must match an EXISTING GitHub team: devantler-tech has a single
+        # team, 'maintainers' (the old 'platform' team was consolidated into
+        # it), and Dex returns groups=[devantler-tech:maintainers]; gating on a
+        # non-existent 'platform' team rejects every login as "unauthorized".
         # Drop allowed_groups for an org-only gate (Dex's connector already
         # restricts to the devantler-tech org).
         scope = "openid email profile groups"
-        allowed_groups = ["devantler-tech:platform"]
+        allowed_groups = ["devantler-tech:maintainers"]
         # email_domains = ["*"] is intentional: GitHub (via Dex) does not
         # always return a public email, and the real gate is now
         # allowed_groups -- so don't additionally gate on the email domain.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Symptom

Logging in to https://platform.devantler.tech returns **403 Forbidden after the Dex "Grant Access" consent screen** — for the maintainer's own account, repeatedly. (Reported live ~11:25–11:35 CEST / 09:25–09:35 UTC, 2026-06-25.)

## Root cause

oauth2-proxy's authorization gate references a GitHub team that **no longer exists**:

```
allowed_groups = ["devantler-tech:platform"]
```

The `devantler-tech` org was consolidated to a **single `maintainers` team** — there is no `platform` team anymore. Dex's github connector returns the user's actual team, so every login carries `groups=[devantler-tech:maintainers]`. Since `email_domains = ["*"]` passes everyone, `allowed_groups` is the only gate — and it can **never** match `maintainers` against `platform`, so oauth2-proxy rejects the session after code redemption with `Invalid authentication via OAuth2: unauthorized` → **403**.

It's a hard lockout for fresh logins (any prior success was a still-valid session cookie that has since expired).

## Evidence (live, `admin@prod`)

- **Dex** (every attempt): `msg="login successful" connector_id=github email=ned@devantler.tech groups=[devantler-tech:maintainers]`
- **oauth2-proxy** (last 6h, ned@devantler.tech): **8× `[AuthFailure] Invalid authentication via OAuth2: unauthorized` → 403, 0× AuthSuccess**
- **GitHub**: `gh api orgs/devantler-tech/teams` → only `maintainers`; `teams/platform/memberships/devantler` → **404**; `teams/maintainers/memberships/devantler` → `active / maintainer`

## Fix

Point `allowed_groups` at the team that actually exists — `devantler-tech:maintainers` — preserving the intended team-gated (not org-wide) posture. Comments updated to match and to document the must-match-an-existing-team constraint so this can't silently regress again.

## Validation

- YAML parses (`yq`).
- One-line behavioural change inside the existing config block; no routing/cookie/scope changes.
- After deploy, a fresh login as a `maintainers` member should reach the dashboards (oauth2-proxy logs `AuthSuccess` instead of `unauthorized`).

## Note — separate, lesser issue (not fixed here)

The same window also shows intermittent `CSRF cookie ... was not found` 403s at the callback (stale per-request `_csrf` cookies from concurrent apex-page flows lingering while the current flow's cookie is absent). That is an earlier-stage, self-clearing papercut distinct from this deterministic group-gate lockout; happy to dig into it separately if it keeps biting.