### PR TITLE
docs(crossplane): correct stale org-ruleset adoption comment

### DIFF
--- a/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy.yaml
@@ -21,9 +21,14 @@ spec:
     - branchprotections.repo.github.m.upbound.io
     - repositoryrulesets.repo.github.m.upbound.io
     - issuelabels.repo.github.m.upbound.io
-    # Org-level rulesets (the ~19 UI-managed org rules that gate every repo) —
-    # adopted Observe-first in devantler-tech/.github deploy/. The tenant Role
-    # already covers the enterprise.github.m.upbound.io group.
+    # Org-level rulesets. Of the org's 20 org rules, the 10 provider-upjet-github
+    # can express are adopted Observe-first in devantler-tech/.github
+    # deploy/rulesets/ (+ a net-new tag-protection ruleset); the other 10
+    # (repository_property conditions, code_quality/copilot_code_review rules,
+    # repository-target rulesets) plus push rulesets and the new Actions
+    # workflow-execution-protections aren't expressible by the provider and stay
+    # UI-managed (tracked in devantler-tech/.github#69). The tenant Role already
+    # covers the enterprise.github.m.upbound.io group.
     - organizationrulesets.enterprise.github.m.upbound.io
     # Team management — the maintainers team + its membership and team->repo
     # access (declared in devantler-tech/.github deploy/teams/). Lets a team be


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Corrects a now-inaccurate comment in the github MRD activation policy. It claimed
"~19 UI-managed org rules … adopted Observe-first", but `provider-upjet-github` can
faithfully express only **10 of the org's 20** org rulesets. The updated comment states
the real split (10 adopted Observe-first in `devantler-tech/.github` `deploy/rulesets/`
+ a net-new tag ruleset; the other 10 — `repository_property` conditions,
`code_quality`/`copilot_code_review` rules, `repository`-target — plus push rulesets and
the new Actions workflow-execution-protections stay UI-managed, tracked in
[devantler-tech/.github#69](https://github.com/devantler-tech/.github/issues/69)).

**Comment-only** — no resource or behaviour change. Companion to the adoption PR
[devantler-tech/.github#70](https://github.com/devantler-tech/.github/pull/70).
