### PR TITLE
fix(validate): mirror Coroot/Flagger skipKinds into ksail.prod.yaml

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -164,3 +164,22 @@ spec:
     sourceDirectory: k8s
     kustomizationFile: clusters/prod
     tag: latest
+    validation:
+      # Parity with ksail.yaml: the prod kustomization pulls the same shared
+      # bases (Coroot + Flagger), so `ksail --config ksail.prod.yaml workload
+      # validate` hits the identical CRDs whose CRD-catalog schemas kubeconform
+      # cannot resolve (requires ksail >= 7.26.0):
+      #   - Coroot (coroot.com/v1): the datreeio catalog schema is stale
+      #     (additionalProperties: false, missing newer fields like
+      #     nodeAgent/clickhouse), so kubeconform rejects valid manifests.
+      #   - MetricTemplate / Canary (flagger.app/v1beta1): the Flagger CRDs are
+      #     installed by the flagger HelmRelease at runtime and are not in the
+      #     catalog, so the MetricTemplates and the onboarded Canaries (umami,
+      #     homepage, opencost) can't be schema-checked offline.
+      # Validation-only: the prod CD path is `workload push` (no validateOnPush),
+      # so this field never affects what is deployed. Remove once the upstream
+      # Coroot/Flagger CRD catalog schemas are current (drop from both configs).
+      skipKinds:
+        - Coroot
+        - MetricTemplate
+        - Canary


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #1754.

## What

Add `spec.workload.validation.skipKinds: [Coroot, MetricTemplate, Canary]` to **`ksail.prod.yaml`**, mirroring the block already present in `ksail.yaml`. Both configs build from the **same** `k8s/bases/` (Coroot lives in `bases/infrastructure/coroot`; the Flagger `MetricTemplate`/`Canary` CRs live in `bases/infrastructure/flagger` + `bases/apps/{umami,homepage}`), so the prod config is exposed to the identical un-cataloged CRDs but lacked the matching skips.

## Why (issue option 1: parity with `ksail.yaml`)

`ksail workload validate` is offline (kubeconform against a local schema cache, `--ignore-missing-schemas` default **true**). The documented manual prod command —

```sh
ksail --config ksail.prod.yaml workload validate
```

— is therefore **non-deterministic** for these kinds: it passes when their schema is *absent* from the cache, but the stale datreeio catalog schemas (Coroot `additionalProperties:false`; Flagger CRDs installed by the HelmRelease at runtime, not in the catalog) **reject** valid manifests whenever they *are* cached — which is the failure #1754 was filed for. Mirroring the skips makes the prod command behave identically to local regardless of schema-cache state.

## Safety / scope

- **Validation-only.** The prod CD path is `ksail --config ksail.prod.yaml workload push` with no `validateOnPush`, so `validation.skipKinds` is never read on the deploy path — this field **cannot affect what is deployed**. (`ksail.prod.yaml` is a protected file; this is a draft for maintainer promotion.)
- Removal tracker preserved: the inline comment (and #1754's acceptance criterion) notes these skips should be dropped from **both** configs once the upstream Coroot/Flagger CRD catalog schemas are current.

## Verification

`ksail --config ksail.prod.yaml workload validate` (ksail 7.82.0) → **`✔ 374 files validated`, exit 0** with this change. 

Note (full transparency): in *this* environment the Coroot/Flagger bases already validate cleanly even **without** the skip, because their schemas happen to be absent from the local cache (88 cached schemas, none for these kinds) and `--ignore-missing-schemas` ignores them. This PR's value is **parity + determinism** — it guarantees the documented prod command passes on these shared-bases CRDs on any machine/cache state, not just one where the stale schema isn't cached. The only failure observed without it is the **pre-existing, separately-tracked, flaky** `actual-budget` `login/openid` HelmRelease schema check (+ an intermittent kubeconform `FromStream` race), which is unrelated to this change and not addressed here.
