### PR TITLE
revert(auth): restore Traefik auth-proxy SSO — prod login broke (keep Cilium 1.20.0-pre.3)

### DIFF
--- a/k8s/bases/apps/backstage/httproute.yaml
+++ b/k8s/bases/apps/backstage/httproute.yaml
@@ -20,17 +20,18 @@ spec:
     - backstage.${domain}
   rules:
     # Backstage has no native OIDC in the demo image, so it is fronted by
-    # oauth2-proxy SSO (Dex) exactly like homepage / the Coroot / Longhorn UIs.
-    # Productionising to native Backstage OIDC (a custom image + a Dex static
-    # client) is the follow-up in docs/backstage.md.
-    #
-    # 1) Login dance — oauth2-proxy serves its own /oauth2/* endpoints directly,
-    #    WITHOUT the ExternalAuth filter. The longer /oauth2 PathPrefix wins.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /oauth2
-      filters:
+    # oauth2-proxy forward-auth (Dex SSO) exactly like homepage / the Coroot /
+    # Longhorn UIs: the route backends to oauth2-proxy, which after authentication
+    # hands the request to the auth-proxy (Traefik), which routes by Host to the
+    # backstage Service (see auth-proxy config-map). Productionising to native
+    # Backstage OIDC (a custom image + a Dex static client) is the follow-up in
+    # docs/backstage.md.
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://backstage.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
@@ -40,39 +41,3 @@ spec:
         - name: oauth2-proxy
           namespace: oauth2-proxy
           port: 80
-    # 2) App traffic — the GEP-1494 ExternalAuth filter delegates the per-request
-    #    SSO check to oauth2-proxy and, on allow, routes STRAIGHT to the backend
-    #    Service below (same namespace). SPIKE-VALIDATED (platform#1881, real
-    #    Cilium 1.20.0-pre.3): the filter targets oauth2-proxy's PROXY path (NOT
-    #    /oauth2/auth, which returns a bare 401 with no redirect); an
-    #    unauthenticated check returns 302 → Dex (Cilium passes it to the
-    #    browser), an authed check returns 202. Per-host /oauth2/callback (rule 1
-    #    + Dex redirectURIs) returns the user to THIS host after login.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: ExternalAuth
-          externalAuth:
-            protocol: HTTP
-            backendRef:
-              name: oauth2-proxy
-              namespace: oauth2-proxy
-              port: 80
-            http:
-              # Forward the session cookie (auth state) + X-Forwarded-Proto/Host
-              # so oauth2-proxy recognises the session and builds the correct
-              # per-host https://<host>/oauth2/callback login-return URL.
-              allowedHeaders:
-                - cookie
-                - x-forwarded-proto
-                - x-forwarded-host
-        - type: ResponseHeaderModifier
-          responseHeaderModifier:
-            set:
-              - name: Strict-Transport-Security
-                value: max-age=63072000; includeSubDomains; preload
-      backendRefs:
-        - name: backstage
-          port: 7007

--- a/k8s/bases/apps/backstage/networkpolicy.yaml
+++ b/k8s/bases/apps/backstage/networkpolicy.yaml
@@ -10,11 +10,11 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    # Gateway ingress (Envoy → Backstage) after the ExternalAuth SSO check. The
-    # gateway's Envoy connects DIRECTLY to the backend on allow (no
-    # oauth2-proxy/auth-proxy hop), so the source is the `ingress` identity.
-    - fromEntities:
-        - ingress
+    # Forward-auth: the auth-proxy (Traefik, in the oauth2-proxy namespace)
+    # reaches Backstage after oauth2-proxy / Dex authentication.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
       toPorts:
         - ports:
             - port: "7007"

--- a/k8s/bases/apps/homepage/canary.yaml
+++ b/k8s/bases/apps/homepage/canary.yaml
@@ -1,11 +1,10 @@
 # Blue/green canary for Homepage (the root dashboard, `${domain}`). It sits behind
-# oauth2-proxy SSO (the homepage HTTPRoute's ExternalAuth filter checks auth, then
-# routes to homepage.homepage.svc:80), so a gateway-level weighted split isn't
-# possible. Flagger's `kubernetes` provider does blue/green instead: it builds
-# homepage-primary, runs the analysis against the homepage-canary Service, and
-# promotes by repointing the apex Service to the new version. The public path
-# (httproute.yaml ExternalAuth filter -> homepage apex Service) is untouched and
-# always resolves to the primary.
+# oauth2-proxy (auth-proxy forwards ${domain} -> homepage.homepage.svc:80), so a
+# gateway-level weighted split isn't possible. Flagger's `kubernetes` provider
+# does blue/green instead: it builds homepage-primary, runs the analysis against
+# the homepage-canary Service, and promotes by repointing the apex Service to the
+# new version. The public path (httproute.yaml -> oauth2-proxy -> auth-proxy ->
+# homepage apex Service) is untouched and always resolves to the primary.
 #
 # ⚠️ High blast radius (platform front page) — watch the first rollout.
 # Replicas are owned by the KEDA ScaledObject referenced below (autoscalerRef):

--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -94,14 +94,14 @@ spec:
                 value: 5
               # Graceful drain on termination. The release rolls often (helm
               # revisions + reloader restarts) and the Service's ClientIP
-              # affinity (below) pins each gateway Envoy source to one homepage
+              # affinity (below) pins each auth-proxy pod to one homepage
               # replica. Without draining, a rolling pod stops serving the
-              # instant it is SIGTERMed while the gateway is still routed to it,
+              # instant it is SIGTERMed while auth-proxy is still routed to it,
               # so the rollout window returns 502 Bad Gateway — and the
               # dashboard's ~14 /api/* polls per refresh amplify that into a
-              # latency+error incident at the gateway. A short preStop keeps the
-              # old pod answering until it has been removed from the Service
-              # endpoints and the affinity has rebalanced.
+              # latency+error incident on oauth2-proxy and auth-proxy. A short
+              # preStop keeps the old pod answering until it has been removed
+              # from the Service endpoints and the affinity has rebalanced.
               - op: add
                 path: /spec/template/spec/terminationGracePeriodSeconds
                 value: 30
@@ -116,7 +116,7 @@ spec:
           # round-robins between two pods that each maintain their own
           # kube-apiserver watcher cache — values pop between slightly-stale
           # and slightly-fresh on every refresh. Pinning to ClientIP keeps
-          # each gateway Envoy source stuck to one homepage replica so the
+          # each oauth2-proxy backend stuck to one homepage replica so the
           # widget reads from a consistent cache.
           - target:
               kind: Service

--- a/k8s/bases/apps/homepage/httproute.yaml
+++ b/k8s/bases/apps/homepage/httproute.yaml
@@ -11,16 +11,12 @@ spec:
   hostnames:
     - ${domain}
   rules:
-    # 1) Login dance — oauth2-proxy serves its own /oauth2/* endpoints
-    #    (start / callback / sign_in) directly, WITHOUT the ExternalAuth filter
-    #    (those endpoints must be reachable unauthenticated). The longer /oauth2
-    #    PathPrefix wins over the catch-all rule below. Cross-namespace
-    #    backendRef → oauth2-proxy Service (allow-oauth2-proxy-backends grant).
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /oauth2
-      filters:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
@@ -29,40 +25,4 @@ spec:
       backendRefs:
         - name: oauth2-proxy
           namespace: oauth2-proxy
-          port: 80
-    # 2) App traffic — the GEP-1494 ExternalAuth filter delegates the per-request
-    #    SSO check to oauth2-proxy and, on allow, routes STRAIGHT to the backend
-    #    Service below (same namespace). SPIKE-VALIDATED (platform#1881, real
-    #    Cilium 1.20.0-pre.3): the filter targets oauth2-proxy's PROXY path (NOT
-    #    /oauth2/auth, which returns a bare 401 with no redirect); an
-    #    unauthenticated check returns 302 → Dex (Cilium passes it to the
-    #    browser), an authed check returns 202. Per-host /oauth2/callback (rule 1
-    #    + Dex redirectURIs) returns the user to THIS host after login.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: ExternalAuth
-          externalAuth:
-            protocol: HTTP
-            backendRef:
-              name: oauth2-proxy
-              namespace: oauth2-proxy
-              port: 80
-            http:
-              # Forward the session cookie (auth state) + X-Forwarded-Proto/Host
-              # so oauth2-proxy recognises the session and builds the correct
-              # per-host https://<host>/oauth2/callback login-return URL.
-              allowedHeaders:
-                - cookie
-                - x-forwarded-proto
-                - x-forwarded-host
-        - type: ResponseHeaderModifier
-          responseHeaderModifier:
-            set:
-              - name: Strict-Transport-Security
-                value: max-age=63072000; includeSubDomains; preload
-      backendRefs:
-        - name: homepage
           port: 80

--- a/k8s/bases/apps/homepage/networkpolicy.yaml
+++ b/k8s/bases/apps/homepage/networkpolicy.yaml
@@ -6,13 +6,10 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    # Gateway ingress (Envoy → homepage). With Gateway API ExternalAuth the
-    # gateway's Envoy connects to the backend DIRECTLY after the per-request
-    # ext_authz check (no oauth2-proxy/auth-proxy hop), so the source is the
-    # `ingress` identity — the same identity the oauth2-proxy policy already
-    # trusts on its own port.
-    - fromEntities:
-        - ingress
+    # Traffic from oauth2-proxy (via gateway → oauth2-proxy → homepage)
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
       toPorts:
         - ports:
             - port: "3000"

--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-proxy-config
+  namespace: oauth2-proxy
+data:
+  traefik.yaml: |
+    entryPoints:
+      web:
+        address: ":8080"
+    providers:
+      file:
+        filename: /etc/traefik/dynamic.yaml
+    log:
+      level: INFO
+  dynamic.yaml: |
+    http:
+      routers:
+        homepage:
+          rule: "Host(`${domain}`)"
+          entryPoints: ["web"]
+          service: homepage
+        hubble:
+          rule: "Host(`hubble.${domain}`)"
+          entryPoints: ["web"]
+          service: hubble-ui
+        coroot:
+          rule: "Host(`observability.${domain}`)"
+          entryPoints: ["web"]
+          service: coroot
+        opencost:
+          rule: "Host(`opencost.${domain}`)"
+          entryPoints: ["web"]
+          service: opencost
+        # Hetzner-only: Longhorn is deployed solely on prod. On local/CI the
+        # backend (longhorn-frontend.longhorn-system) does not exist, but this
+        # router is inert there -- no HTTPRoute sends longhorn.${domain} to
+        # oauth2-proxy, so it is never matched (matches how base policies
+        # already scope the prod-only longhorn-system namespace).
+        longhorn:
+          rule: "Host(`longhorn.${domain}`)"
+          entryPoints: ["web"]
+          service: longhorn
+        # Backstage IDP (forward-auth, demo-image scaffold — see docs/backstage.md).
+        backstage:
+          rule: "Host(`backstage.${domain}`)"
+          entryPoints: ["web"]
+          service: backstage
+      services:
+        homepage:
+          loadBalancer:
+            servers:
+              - url: "http://homepage.homepage.svc.cluster.local:80"
+        hubble-ui:
+          loadBalancer:
+            servers:
+              - url: "http://hubble-ui.kube-system.svc.cluster.local:80"
+        coroot:
+          loadBalancer:
+            servers:
+              - url: "http://coroot-coroot.observability.svc.cluster.local:8080"
+        opencost:
+          loadBalancer:
+            servers:
+              - url: "http://opencost.opencost.svc.cluster.local:9090"
+        # Longhorn UI (longhorn-frontend Service :80 -> longhorn-ui pod :8000).
+        # Hetzner-only and inert on local (longhorn-system has no pods there).
+        longhorn:
+          loadBalancer:
+            servers:
+              - url: "http://longhorn-frontend.longhorn-system.svc.cluster.local:80"
+        backstage:
+          loadBalancer:
+            servers:
+              - url: "http://backstage.backstage.svc.cluster.local:7007"

--- a/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/deployment.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-proxy
+  namespace: oauth2-proxy
+  annotations:
+    # Disable Coroot's latency SLO for this proxy (availability SLO stays).
+    # auth-proxy is a low-traffic (~600 requests/day) Host fan-out in front of
+    # several heavy dashboards (Coroot, OpenCost, Hubble, Longhorn);
+    # a few slow first-render responses are enough to blow a 99%-under-500ms SLO
+    # at that volume, making it a permanent false-critical. Warm-path health is
+    # still covered by the availability SLO here and by the per-app SLOs behind
+    # the proxy.
+    coroot.com/slo-latency-objective: 0%
+spec:
+  replicas: ${auth_proxy_replicas:=2}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: auth-proxy
+  template:
+    metadata:
+      labels:
+        app: auth-proxy
+      annotations:
+        configmap.reloader.stakater.com/reload: auth-proxy-config
+    spec:
+      terminationGracePeriodSeconds: 30
+      # Traefik runs with the static file provider (--configFile), not the
+      # Kubernetes provider, so it never calls the Kubernetes API and needs no
+      # ServiceAccount token (kubescape C-0034).
+      automountServiceAccountToken: false
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: auth-proxy
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: traefik
+          image: docker.io/library/traefik:v3.7@sha256:e4d98158c01ad752fc1071d4e9573788747230d902cdde00a772516e692d07c9
+          args:
+            - --configFile=/etc/traefik/traefik.yaml
+          ports:
+            - containerPort: 8080
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/traefik
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
+      volumes:
+        - name: config
+          configMap:
+            name: auth-proxy-config

--- a/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/kustomization.yaml
@@ -1,0 +1,19 @@
+# TODO: Delete this whole component once on Cilium >= 1.20 (stable) and replace the
+# oauth2-proxy reverse-proxy + Traefik host fan-out with the native Gateway API
+# ExternalAuth HTTPRoute filter (GEP-1494). This Traefik instance exists ONLY because
+# oauth2-proxy reverse-proxy mode has a single static upstream and can't host-fan-out;
+# the ExternalAuth filter moves auth onto each HTTPRoute and routes straight to the
+# backend, so this proxy becomes redundant. Filter shipped in Cilium 1.20
+# (cilium/cilium#45739); repo is on 1.19.4, which lacks it. Needs experimental-channel
+# Gateway API CRDs + a netpol/SPIRE ripple + an /oauth2/* bypass route.
+# Execute-ready plan: https://github.com/devantler-tech/platform/issues/1881
+# (supersedes the old cilium/cilium#23797 pointer)
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config-map.yaml
+  - deployment.yaml
+  - networkpolicy.yaml
+  - pod-disruption-budget.yaml
+  - service.yaml

--- a/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/networkpolicy.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-auth-proxy
+  namespace: oauth2-proxy
+spec:
+  endpointSelector:
+    matchLabels:
+      app: auth-proxy
+  ingress:
+    # Authenticated traffic from oauth2-proxy
+    - fromEndpoints:
+        - matchLabels:
+            app: oauth2-proxy
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Backstage upstream (developer portal; Service backstage :7007).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: backstage
+      toPorts:
+        - ports:
+            - port: "7007"
+              protocol: TCP
+    # Homepage upstream
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: homepage
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+    # Hubble UI upstream (kube-system; Service hubble-ui :80 -> pod :8081).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: hubble-ui
+      toPorts:
+        - ports:
+            - port: "8081"
+              protocol: TCP
+    # Coroot UI upstream (metrics/logs/traces/profiles/alerts).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # OpenCost UI upstream.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: opencost
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # Longhorn UI upstream (Hetzner-only). longhorn-frontend forwards to the
+    # longhorn-ui pod on container port 8000; inert on local/CI where the
+    # longhorn-system namespace is absent.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: longhorn-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # DNS resolution
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/pod-disruption-budget.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-proxy
+  namespace: oauth2-proxy
+spec:
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880):
+  # it never deadlocks a node drain regardless of replica count and still bounds
+  # disruption to one pod at a time. auth_proxy_replicas is "2" today, but
+  # minAvailable would silently re-introduce an undrainable node the moment the
+  # floor dropped to 1.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: auth-proxy

--- a/k8s/bases/infrastructure/controllers/auth-proxy/service.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-proxy
+  namespace: oauth2-proxy
+spec:
+  selector:
+    app: auth-proxy
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/k8s/bases/infrastructure/controllers/cilium/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/httproute.yaml
@@ -19,14 +19,12 @@ spec:
   hostnames:
     - hubble.${domain}
   rules:
-    # 1) Login dance — oauth2-proxy serves its own /oauth2/* endpoints directly,
-    #    WITHOUT the ExternalAuth filter (those endpoints must be reachable
-    #    unauthenticated). The longer /oauth2 PathPrefix wins over the catch-all.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /oauth2
-      filters:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://hubble.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
@@ -35,43 +33,4 @@ spec:
       backendRefs:
         - name: oauth2-proxy
           namespace: oauth2-proxy
-          port: 80
-    # 2) App traffic — the GEP-1494 ExternalAuth filter delegates the per-request
-    #    SSO check to oauth2-proxy and, on allow, routes STRAIGHT to the backend
-    #    Service below (same namespace). SPIKE-VALIDATED (platform#1881, real
-    #    Cilium 1.20.0-pre.3): the filter targets oauth2-proxy's PROXY path (NOT
-    #    /oauth2/auth, which returns a bare 401 with no redirect); an
-    #    unauthenticated check returns 302 → Dex (Cilium passes it to the
-    #    browser), an authed check returns 202. Per-host /oauth2/callback (rule 1
-    #    + Dex redirectURIs) returns the user to THIS host after login.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: ExternalAuth
-          externalAuth:
-            protocol: HTTP
-            backendRef:
-              name: oauth2-proxy
-              namespace: oauth2-proxy
-              port: 80
-            http:
-              # Forward the session cookie (auth state) + X-Forwarded-Proto/Host
-              # so oauth2-proxy recognises the session and builds the correct
-              # per-host https://<host>/oauth2/callback login-return URL.
-              allowedHeaders:
-                - cookie
-                - x-forwarded-proto
-                - x-forwarded-host
-        - type: ResponseHeaderModifier
-          responseHeaderModifier:
-            set:
-              - name: Strict-Transport-Security
-                value: max-age=63072000; includeSubDomains; preload
-      backendRefs:
-        # hubble-ui Service (kube-system, port 80 → pod :8081). NOTE: corrects
-        # platform#1881's stale "keda-add-ons-http-interceptor" backend — the
-        # KEDA scale-to-zero for the UIs was removed; Hubble UI is always-on.
-        - name: hubble-ui
           port: 80

--- a/k8s/bases/infrastructure/controllers/cilium/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/networkpolicy.yaml
@@ -1,11 +1,9 @@
 ---
-# Allow the gateway's Envoy to reach Hubble UI on port 8081.
-# Traffic flow (Gateway API ExternalAuth): Envoy --ext_authz--> oauth2-proxy for
-# the per-request SSO check, then Envoy --> hubble-ui DIRECTLY on allow (no
-# auth-proxy hop). The source is the `ingress` identity.
+# Allow auth-proxy to reach Hubble UI on port 8081.
+# Traffic flow: oauth2-proxy -> auth-proxy -> hubble-ui.
 # Hubble UI lives in kube-system which has no default-deny, so this CNP is
 # defense-in-depth: if/when a kube-system default-deny is introduced, the
-# gateway → hubble-ui path stays open while every other path is denied.
+# auth-proxy → hubble-ui path stays open while every other path is denied.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -16,8 +14,10 @@ spec:
     matchLabels:
       k8s-app: hubble-ui
   ingress:
-    - fromEntities:
-        - ingress
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+            app: auth-proxy
       toPorts:
         - ports:
             - port: "8081"

--- a/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/httproute.yaml
@@ -1,7 +1,9 @@
-# Expose the Coroot UI behind oauth2-proxy SSO. Coroot CE has no native OIDC, so
-# SSO is enforced at the gateway: the GEP-1494 ExternalAuth filter (below) runs
-# the per-request auth check against oauth2-proxy and routes straight to the
-# Coroot Service. The Coroot app serves its UI on port 8080.
+# Expose the Coroot UI behind oauth2-proxy SSO (the same forward-auth pattern
+# the Prometheus / Alertmanager UIs used): the route backends to the
+# oauth2-proxy Service; after authentication oauth2-proxy forwards to
+# auth-proxy, which routes by Host to the Coroot Service (see auth-proxy
+# config-map.yaml). Coroot CE has no native OIDC, so this is how SSO is
+# enforced. The Coroot app serves its UI on port 8080.
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -37,13 +39,12 @@ spec:
   hostnames:
     - observability.${domain}
   rules:
-    # 1) Login dance — oauth2-proxy serves its own /oauth2/* endpoints directly,
-    #    WITHOUT the ExternalAuth filter. The longer /oauth2 PathPrefix wins.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /oauth2
-      filters:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://observability.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
@@ -53,39 +54,3 @@ spec:
         - name: oauth2-proxy
           namespace: oauth2-proxy
           port: 80
-    # 2) App traffic — the GEP-1494 ExternalAuth filter delegates the per-request
-    #    SSO check to oauth2-proxy and, on allow, routes STRAIGHT to the backend
-    #    Service below (same namespace). SPIKE-VALIDATED (platform#1881, real
-    #    Cilium 1.20.0-pre.3): the filter targets oauth2-proxy's PROXY path (NOT
-    #    /oauth2/auth, which returns a bare 401 with no redirect); an
-    #    unauthenticated check returns 302 → Dex (Cilium passes it to the
-    #    browser), an authed check returns 202. Per-host /oauth2/callback (rule 1
-    #    + Dex redirectURIs) returns the user to THIS host after login.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: ExternalAuth
-          externalAuth:
-            protocol: HTTP
-            backendRef:
-              name: oauth2-proxy
-              namespace: oauth2-proxy
-              port: 80
-            http:
-              # Forward the session cookie (auth state) + X-Forwarded-Proto/Host
-              # so oauth2-proxy recognises the session and builds the correct
-              # per-host https://<host>/oauth2/callback login-return URL.
-              allowedHeaders:
-                - cookie
-                - x-forwarded-proto
-                - x-forwarded-host
-        - type: ResponseHeaderModifier
-          responseHeaderModifier:
-            set:
-              - name: Strict-Transport-Security
-                value: max-age=63072000; includeSubDomains; preload
-      backendRefs:
-        - name: coroot-coroot
-          port: 8080

--- a/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/networkpolicy.yaml
@@ -24,11 +24,10 @@ spec:
         - ports:
             - port: "8080"
               protocol: TCP
-    # Gateway ingress (Envoy → Coroot UI) after the ExternalAuth SSO check. The
-    # gateway's Envoy connects DIRECTLY to the backend on allow (no
-    # oauth2-proxy/auth-proxy hop), so the source is the `ingress` identity.
-    - fromEntities:
-        - ingress
+    # auth-proxy (oauth2-proxy SSO) reaches the Coroot UI after authentication.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
       toPorts:
         - ports:
             - port: "8080"

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -95,17 +95,6 @@ spec:
           secret: ${dex_client_secret}
           redirectURIs:
             - "https://oauth2-proxy.${domain}/oauth2/callback"
-            # Per-host oauth2-proxy callbacks for the Gateway API ExternalAuth SSO
-            # (platform#1881). With a RELATIVE oauth2-proxy redirect_url, the
-            # callback lands on the originating app host, so each protected host
-            # must be whitelisted here. longhorn is Hetzner-only; listing it in
-            # this base manifest is inert where Longhorn isn't deployed.
-            - "https://${domain}/oauth2/callback"
-            - "https://hubble.${domain}/oauth2/callback"
-            - "https://observability.${domain}/oauth2/callback"
-            - "https://opencost.${domain}/oauth2/callback"
-            - "https://longhorn.${domain}/oauth2/callback"
-            - "https://backstage.${domain}/oauth2/callback"
             - "https://headlamp.${domain}/oidc-callback"
             - "https://budget.${domain}/oidc/callback"
             - "https://vault.${domain}/ui/vault/auth/oidc/oidc/callback"

--- a/k8s/bases/infrastructure/controllers/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kustomization.yaml
@@ -9,6 +9,7 @@ kind: Kustomization
 #       VirtualMachines/DataVolumes run on Hetzner and virt-handler crash-loops
 #       with zero VMs, so prod opts out by simply not referencing them.
 resources:
+  - auth-proxy/
   - cert-manager/
   - cilium/
   - cloudnative-pg/

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/helm-release.yaml
@@ -128,31 +128,18 @@ spec:
         # (the redirect allowlist) keeps both forms intentionally.
         cookie_domains = ["${domain}"]
         whitelist_domains = ["${domain}", ".${domain}"]
-        # Per-host callback (spike-validated approach): a RELATIVE redirect_url
-        # lets oauth2-proxy build https://<this-host>/oauth2/callback from each
-        # request's (gateway-forwarded) X-Forwarded-Proto/Host, so after login the
-        # browser returns to the ORIGINATING app host rather than one central
-        # host. Each app host's /oauth2/callback is whitelisted in Dex's
-        # staticClient redirectURIs and reached via that host's /oauth2/* rule.
-        redirect_url = "/oauth2/callback"
-        # AUTH-ONLY (Gateway API ExternalAuth / GEP-1494, platform#1881): app
-        # traffic no longer flows THROUGH oauth2-proxy. Each app HTTPRoute carries
-        # an `ExternalAuth` filter that calls oauth2-proxy's PROXY path per request
-        # (Envoy ext_authz): on an UNauthenticated check oauth2-proxy returns a
-        # 302 -> Dex (Cilium passes it straight to the browser), on an AUTHED check
-        # the static://202 upstream returns 202 and the gateway routes STRAIGHT to
-        # the backend. The Traefik auth-proxy host fan-out is deleted. The filter
-        # deliberately does NOT target /oauth2/auth — that returns a bare 401 with
-        # no redirect (both behaviours spike-validated on real Cilium 1.20.0-pre.3).
-        upstreams = [ "static://202" ]
+        redirect_url = "https://oauth2-proxy.${domain}/oauth2/callback"
+        upstreams = [ "http://auth-proxy.oauth2-proxy.svc.cluster.local:80" ]
+        # upstream_timeout — max time to await upstream response headers
+        # (default 30s). Kept generous (90s) so a slow first render from one of
+        # the heavy dashboards behind auth-proxy (Coroot, OpenCost, Hubble,
+        # Longhorn) doesn't surface as a 504. Kept under Cloudflare's
+        # ~100s edge timeout so oauth2-proxy answers first.
+        upstream_timeout = "90s"
         # Button-less flow: with skip_provider_button + Dex skipApprovalScreen
         # + a single Dex connector, app -> oauth2-proxy -> Dex -> GitHub -> back
         # needs no extra clicks.
         skip_provider_button = true
-        # reverse_proxy stays true: oauth2-proxy still terminates the /oauth2/*
-        # login dance (start/callback/sign_in), reached via each host's /oauth2/*
-        # HTTPRoute rule, and trusts the gateway's X-Forwarded-* headers (needed to
-        # build the per-host redirect_url above).
         reverse_proxy = true
     ingress:
       enabled: false

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy-default-deny.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy-default-deny.yaml
@@ -7,6 +7,7 @@ spec:
   endpointSelector: {}
   # Selecting all endpoints with empty ingress/egress arrays puts every pod in
   # the namespace into deny-by-default. Other CNPs in the namespace add
-  # specific allow rules per workload (see networkpolicy.yaml).
+  # specific allow rules per workload (see networkpolicy.yaml,
+  # ../auth-proxy/networkpolicy.yaml).
   ingress: []
   egress: []

--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/networkpolicy.yaml
@@ -16,10 +16,15 @@ spec:
             - port: "4180"
               protocol: TCP
   egress:
-    # No app-traffic egress: with Gateway API ExternalAuth (GEP-1494) oauth2-proxy
-    # is an auth-only sidecar — the gateway's Envoy calls it for the per-request
-    # check and routes straight to the backend, so the former egress to the
-    # Traefik auth-proxy upstream is gone (component deleted).
+    # Auth-proxy upstream (forward authenticated traffic to host-routing proxy)
+    - toEndpoints:
+        - matchLabels:
+            app: auth-proxy
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     # Dex token exchange (redeem_url) + JWKS (oidc_jwks_url) over the
     # in-cluster Dex Service. oauth2-proxy does its server-side OIDC calls
     # in-cluster (skip_oidc_discovery; see helm-release.yaml), which the pod

--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -29,8 +29,8 @@ spec:
   # (observed 2026-06-19, observability blind for hours). Reloader (deployed
   # cluster-wide, `--reload-strategy=annotations`) watches the named Secret and
   # rolls the server's pods on change; the annotation goes on the pod template via
-  # podAnnotations, matching the platform's existing convention (oauth2-proxy,
-  # coredns).
+  # podAnnotations, matching the platform's existing convention (auth-proxy,
+  # oauth2-proxy, coredns).
   podAnnotations:
     secret.reloader.stakater.com/reload: coroot-db-app
 

--- a/k8s/bases/infrastructure/flagger/canary-opencost.yaml
+++ b/k8s/bases/infrastructure/flagger/canary-opencost.yaml
@@ -1,6 +1,5 @@
 # Blue/green canary for OpenCost (an infrastructure cost UI), behind oauth2-proxy
-# SSO (the opencost HTTPRoute's ExternalAuth filter -> opencost.opencost.svc:9090).
-# The `kubernetes` provider does
+# (auth-proxy -> opencost.opencost.svc:9090). The `kubernetes` provider does
 # blue/green (no gateway weighting). It builds opencost-primary, analyses against
 # the opencost-canary Service, and promotes by repointing the apex Service.
 #

--- a/k8s/bases/infrastructure/opencost/httproute.yaml
+++ b/k8s/bases/infrastructure/opencost/httproute.yaml
@@ -33,13 +33,12 @@ spec:
   hostnames:
     - opencost.${domain}
   rules:
-    # 1) Login dance — oauth2-proxy serves its own /oauth2/* endpoints directly,
-    #    WITHOUT the ExternalAuth filter. The longer /oauth2 PathPrefix wins.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /oauth2
-      filters:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://opencost.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
@@ -49,39 +48,3 @@ spec:
         - name: oauth2-proxy
           namespace: oauth2-proxy
           port: 80
-    # 2) App traffic — the GEP-1494 ExternalAuth filter delegates the per-request
-    #    SSO check to oauth2-proxy and, on allow, routes STRAIGHT to the opencost
-    #    Service (same namespace) — the apex Service Flagger's blue/green canary
-    #    repoints, unchanged from the old auth-proxy upstream. SPIKE-VALIDATED
-    #    (platform#1881, real Cilium 1.20.0-pre.3): the filter targets
-    #    oauth2-proxy's PROXY path (NOT /oauth2/auth, a bare 401); unauthenticated
-    #    → 302 → Dex (Cilium passes it to the browser), authed → 202. Per-host
-    #    /oauth2/callback (rule 1 + Dex redirectURIs) returns to THIS host.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: ExternalAuth
-          externalAuth:
-            protocol: HTTP
-            backendRef:
-              name: oauth2-proxy
-              namespace: oauth2-proxy
-              port: 80
-            http:
-              # Forward the session cookie (auth state) + X-Forwarded-Proto/Host
-              # so oauth2-proxy recognises the session and builds the correct
-              # per-host https://<host>/oauth2/callback login-return URL.
-              allowedHeaders:
-                - cookie
-                - x-forwarded-proto
-                - x-forwarded-host
-        - type: ResponseHeaderModifier
-          responseHeaderModifier:
-            set:
-              - name: Strict-Transport-Security
-                value: max-age=63072000; includeSubDomains; preload
-      backendRefs:
-        - name: opencost
-          port: 9090

--- a/k8s/bases/infrastructure/opencost/networkpolicy.yaml
+++ b/k8s/bases/infrastructure/opencost/networkpolicy.yaml
@@ -20,11 +20,10 @@ spec:
         - ports:
             - port: "9003"
               protocol: TCP
-    # Gateway ingress (Envoy → OpenCost UI) after the ExternalAuth SSO check. The
-    # gateway's Envoy connects DIRECTLY to the backend on allow (no
-    # oauth2-proxy/auth-proxy hop), so the source is the `ingress` identity.
-    - fromEntities:
-        - ingress
+    # auth-proxy (oauth2-proxy SSO) reaches the OpenCost UI after authentication.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
       toPorts:
         - ports:
             - port: "9090"

--- a/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - ../../../../bases/infrastructure/controllers/external-secrets/
   - ../../../../bases/infrastructure/controllers/dex/
   - ../../../../bases/infrastructure/controllers/oauth2-proxy/
+  - ../../../../bases/infrastructure/controllers/auth-proxy/
   # --- Core: data ---------------------------------------------------------
   - ../../../../bases/infrastructure/controllers/cloudnative-pg/
   # --- Core: docker-provider-local ----------------------------------------

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/httproute.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/httproute.yaml
@@ -1,7 +1,10 @@
-# Expose the Longhorn UI behind oauth2-proxy SSO. The Longhorn frontend ships no
-# built-in authentication, so SSO at the gateway is the only access control: the
-# GEP-1494 ExternalAuth filter (below) runs the per-request auth check against
-# oauth2-proxy and routes straight to the longhorn-frontend Service.
+# Expose the Longhorn UI behind oauth2-proxy SSO (the same forward-auth
+# pattern the other admin UIs use -- Hubble, Prometheus, Alertmanager,
+# OpenCost). The Longhorn frontend ships no built-in authentication, so SSO at
+# the gateway is the only access control: the route backends to oauth2-proxy
+# (not longhorn-frontend); after authentication oauth2-proxy forwards to
+# auth-proxy, which routes longhorn.${domain} by Host to the longhorn-frontend
+# Service (see k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml).
 # The gethomepage.dev annotations surface it on the dashboard under "Storage".
 # Hetzner-only: Longhorn is deployed solely on prod (k8s/providers/hetzner).
 ---
@@ -24,13 +27,12 @@ spec:
   hostnames:
     - longhorn.${domain}
   rules:
-    # 1) Login dance — oauth2-proxy serves its own /oauth2/* endpoints directly,
-    #    WITHOUT the ExternalAuth filter. The longer /oauth2 PathPrefix wins.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /oauth2
-      filters:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://longhorn.${domain}/
         - type: ResponseHeaderModifier
           responseHeaderModifier:
             set:
@@ -39,40 +41,4 @@ spec:
       backendRefs:
         - name: oauth2-proxy
           namespace: oauth2-proxy
-          port: 80
-    # 2) App traffic — the GEP-1494 ExternalAuth filter delegates the per-request
-    #    SSO check to oauth2-proxy and, on allow, routes STRAIGHT to the backend
-    #    Service below (same namespace). SPIKE-VALIDATED (platform#1881, real
-    #    Cilium 1.20.0-pre.3): the filter targets oauth2-proxy's PROXY path (NOT
-    #    /oauth2/auth, which returns a bare 401 with no redirect); an
-    #    unauthenticated check returns 302 → Dex (Cilium passes it to the
-    #    browser), an authed check returns 202. Per-host /oauth2/callback (rule 1
-    #    + Dex redirectURIs) returns the user to THIS host after login.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: ExternalAuth
-          externalAuth:
-            protocol: HTTP
-            backendRef:
-              name: oauth2-proxy
-              namespace: oauth2-proxy
-              port: 80
-            http:
-              # Forward the session cookie (auth state) + X-Forwarded-Proto/Host
-              # so oauth2-proxy recognises the session and builds the correct
-              # per-host https://<host>/oauth2/callback login-return URL.
-              allowedHeaders:
-                - cookie
-                - x-forwarded-proto
-                - x-forwarded-host
-        - type: ResponseHeaderModifier
-          responseHeaderModifier:
-            set:
-              - name: Strict-Transport-Security
-                value: max-age=63072000; includeSubDomains; preload
-      backendRefs:
-        - name: longhorn-frontend
           port: 80

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/networkpolicy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/networkpolicy.yaml
@@ -19,15 +19,15 @@ spec:
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: longhorn-system
-    # Longhorn UI: the client is the gateway's Envoy (post-SSO). With Gateway API
-    # ExternalAuth the gateway connects DIRECTLY to longhorn-frontend after the
-    # ext_authz check (no oauth2-proxy/auth-proxy hop); longhorn-frontend forwards
-    # to the longhorn-ui pod on container port 8000 (Service longhorn-frontend:
-    # 80 -> 8000). Source is the `ingress` identity. Mirrors allow-hubble-ui;
-    # mutual auth (require-mutual-auth) is applied cluster-wide, so only the
-    # L3/L4 allow is needed here.
-    - fromEntities:
-        - ingress
+    # Longhorn UI: the client is auth-proxy (post-SSO): Gateway -> oauth2-proxy
+    # -> auth-proxy -> longhorn-frontend. longhorn-frontend forwards to the
+    # longhorn-ui pod on container port 8000 (Service longhorn-frontend: 80 ->
+    # 8000). Mirrors allow-hubble-ui; mutual auth (require-mutual-auth) is
+    # applied cluster-wide, so only the L3/L4 allow is needed here.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+            app: auth-proxy
       toPorts:
         - ports:
             - port: "8000"

--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -139,7 +139,7 @@ spec:
         # ^https?://.+$). Coroot interpolates it into the `.URL` template
         # variable used in the Slack templates below, so incident/alert links
         # deep-link back to the affected app in this instance. Same host the
-        # HTTPRoute serves the UI on; `${domain}` is substituted by
+        # HTTPRoute + auth-proxy serve the UI on; `${domain}` is substituted by
         # Flux from the per-cluster variables-cluster ConfigMap.
         baseURL: https://observability.${domain}
         webhook:


### PR DESCRIPTION
> 🤖 Generated by Claude Code (interactive session). **Prod incident revert.** The #2281 ExternalAuth cutover broke dashboard login (`/oauth2/callback` → HTTP 500). Restores the known-good auth-proxy SSO; keeps Cilium 1.20.0-pre.3 (not at fault). Re-do the cutover after root-causing the callback 500.