### PR TITLE
fix: resolve recurring Coroot prod alerts (prometheus OOM, dex rollout, umami probe)

### DIFF
--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -69,6 +69,23 @@ spec:
     serviceAccount:
       # Umami needs no Kubernetes API access.
       automountServiceAccountToken: false
+    # Loosen the startup probe. The chart default (probes.startup) fires the first
+    # probe at +30s with only a 3s timeout, but umami's serial cold boot —
+    # npm-run-all → check-db → a cross-node Prisma connect to the CNPG primary →
+    # migration diff → Next.js standalone listen — takes ~27s and /api/heartbeat is
+    # still slow to answer right as that first probe fires, so the 3s timeout trips
+    # "Startup probe failed: context deadline exceeded" (Coroot "Unhealthy" alert)
+    # even though the pod then goes Ready (failureThreshold: 30 is generous). Widen
+    # the per-probe timeout and period so a slightly slow boot no longer alerts;
+    # liveness/readiness keep the chart defaults.
+    probes:
+      startup:
+        enabled: true
+        path: /api/heartbeat
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 8
+        failureThreshold: 30
     umami:
       port: 3000
       # Stable APP_SECRET from OpenBao via External Secrets — the `umami-app`

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -20,6 +20,20 @@ spec:
   # https://github.com/dexidp/helm-charts/blob/master/charts/dex/values.yaml
   values:
     replicaCount: ${dex_replicas:=2}
+    # Zero-downtime rollout. dex re-upgrades whenever a new platform OCI artifact
+    # is pushed (helm-controller re-applies the chart), and with only
+    # ${dex_replicas:=2} replicas the chart's default RollingUpdate
+    # (maxUnavailable 25% → 1 of 2) can terminate a replica before the new one is
+    # Ready — briefly dropping the dex Service to 0 endpoints, which Coroot raises
+    # as dex "no instances available". maxUnavailable: 0 + maxSurge: 1 brings the
+    # replacement up Ready before the old pod is removed, so a rollout never drops
+    # below the running replica count. Independent of the PDB (maxUnavailable
+    # there governs voluntary disruptions/drains, not rollouts).
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
     podSecurityContext:
       runAsUser: 65534
       runAsGroup: 65534

--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -78,6 +78,22 @@ spec:
       cpu: "2"
       memory: 6Gi
   prometheus:
+    # The bundled Prometheus (the metrics TSDB, also queried by OpenCost/Flagger/
+    # KEDA) had no explicit resources, so the auto-vpa floor (~128Mi req / 512Mi
+    # limit) capped it — and a head-compaction / query spike OOMKilled it
+    # (exitCode 137, 2026-06-21), which drops telemetry during the restart and
+    # makes the :9090 endpoint briefly unavailable to in-cluster queriers. Pin a
+    # block in the same pattern as clickhouse/coroot above (auto-vpa runs
+    # controlledValues:RequestsAndLimits, preserving this 4:1 ratio when it sets
+    # the request from live usage): ~512Mi request (above the ~300Mi live working
+    # set) and a 2Gi limit (4x the old OOM ceiling) for compaction/query bursts.
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi
     # 14d metrics retention (matches the old kube-prometheus-stack posture).
     retention: 14d
     storage:


### PR DESCRIPTION
## Why

Triaging the recurring warnings in Coroot (prod) traced most of them to **one
infrastructure cause** (the Cilium SPIRE mutual-auth handshake dialing peer
nodes' *public* IPs on :4250 → firewall `i/o timeout` → 5s cold-connect penalty;
handled separately as it's an upstream/architectural fix). This PR fixes the
**independent** offenders that have clean, root-cause GitOps fixes. Each was
verified live against `admin@prod`.

## Fixes (3 independent commits)

### `fix(coroot)` — bundled Prometheus OOMKilled
The hetzner Coroot patch pins `resources` for the coroot server and ClickHouse
(both added after prior OOMKills) but left the **bundled Prometheus** unset, so it
fell to the auto-vpa floor (~512Mi limit) and was **OOMKilled (exitCode 137) on
2026-06-21**. Pin a 512Mi-request / 2Gi-limit block in the same 4:1 pattern as
ClickHouse. (Live: pod sat at 297Mi/512Mi with a prior OOM — no headroom for
head-compaction/query spikes.)

### `fix(dex)` — "no instances available"
dex re-upgrades on every platform OCI push; with 2 replicas the default
RollingUpdate (`maxUnavailable` 25% → 1 of 2) can drop the Service to **0 ready
endpoints** mid-rollout → Coroot "no instances available". Set
`strategy.rollingUpdate.maxUnavailable: 0` + `maxSurge: 1`.

### `fix(umami)` — startup probe "context deadline exceeded"
The chart-default startup probe fires at +30s with a **3s timeout**, but umami's
serial cold boot (npm-run-all → check-db → cross-node Prisma connect → migration
diff → Next.js listen) takes ~27s and `/api/heartbeat` is still slow right as the
first probe fires → Coroot "Unhealthy". Widen `probes.startup` timeout 3s→8s,
period 5s→10s; liveness/readiness unchanged.

## Validation

- `ksail --config ksail.prod.yaml workload validate` → **80 groups ✔, 0 errors**
  (incl. `coroot`, `dex`, `umami`).
- `ksail workload validate --skip-helm-render` (CI-equivalent) → **477 ✔, 374
  files, 0 errors**.
- chart value keys verified against `helm show values` for dex 0.24.1
  (`strategy`) and umami 2.2.0 (`probes.startup`).

These are 3 independent concerns in one PR for review convenience — happy to
split if you'd prefer separate changelog entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)