### PR TITLE
fix(netpol): generate standard NetworkPolicy default-deny per namespace

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-default-deny.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-default-deny.yaml
@@ -1,10 +1,20 @@
-# Generates a default-deny CiliumNetworkPolicy and a DNS-allow policy
-# in every namespace. This ensures zero-trust networking by default —
-# workloads must explicitly allow the traffic they need.
+# Generates default-deny network policies + a DNS-allow policy in every
+# namespace. This ensures zero-trust networking by default — workloads must
+# explicitly allow the traffic they need.
 #
-# Note: standard NetworkPolicy is NOT generated alongside CiliumNetworkPolicy
-# because Cilium enforces both independently — a standard default-deny would
-# block traffic that CiliumNetworkPolicy explicitly allows.
+# BOTH a CiliumNetworkPolicy and a standard Kubernetes NetworkPolicy default-deny
+# are generated. Cilium enforces both policy types and combines them ADDITIVELY:
+# the effective allow-set for an endpoint is the UNION across every policy source
+# (standard NetworkPolicy + CiliumNetworkPolicy + CiliumClusterwideNetworkPolicy).
+# A pure standard default-deny (podSelector {}, no allow rules) therefore does NOT
+# block traffic that a CiliumNetworkPolicy explicitly allows — it only contributes
+# "isolate these pods", which the Cilium default-deny below already does.
+#
+# Verified in production: the wedding-app namespace runs exactly this pure standard
+# default-deny alongside its CiliumNetworkPolicy allows and serves traffic normally.
+# The standard NetworkPolicy is required because scanners and the CIS benchmark
+# (Kubescape C-0030/C-0260/C-0206) do not recognise CiliumNetworkPolicy as a
+# NetworkPolicy, so without it the cluster's real segmentation is invisible to them.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -12,13 +22,15 @@ metadata:
   annotations:
     policies.kyverno.io/title: Default Deny Network Policy
     policies.kyverno.io/category: Networking, Best Practices
-    policies.kyverno.io/subject: CiliumNetworkPolicy
+    policies.kyverno.io/subject: NetworkPolicy, CiliumNetworkPolicy
     policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/description: >-
       Generates a CiliumNetworkPolicy that activates Cilium's whitelist
-      mode for all endpoints in a namespace (effectively deny-all), plus
-      a companion policy that allows DNS egress to kube-dns so pods can
-      still resolve names.
+      mode for all endpoints in a namespace (effectively deny-all), a
+      companion CiliumNetworkPolicy that allows DNS egress to kube-dns so
+      pods can still resolve names, and a standard Kubernetes NetworkPolicy
+      default-deny so the segmentation is visible to NetworkPolicy-aware
+      scanners and the CIS benchmark.
 spec:
   rules:
     - name: generate-default-deny
@@ -85,3 +97,34 @@ spec:
                         protocol: UDP
                       - port: "53"
                         protocol: TCP
+    # Standard Kubernetes NetworkPolicy mirror of the Cilium default-deny above.
+    # Pure deny (no allow rules); Cilium unions allows across both policy types,
+    # so real traffic keeps flowing via the CiliumNetworkPolicies. This exists so
+    # NetworkPolicy-aware scanners (Kubescape C-0030/C-0260/C-0206) can see that
+    # every namespace is segmented.
+    - name: generate-default-deny-networkpolicy
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      exclude:
+        any:
+          - resources:
+              names:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+      generate:
+        generateExisting: true
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: default-deny
+        synchronize: true
+        namespace: "{{request.object.metadata.name}}"
+        data:
+          spec:
+            podSelector: {}
+            policyTypes:
+              - Ingress
+              - Egress


### PR DESCRIPTION
## Problem

Kubescape's network controls — **C-0030** (Ingress and Egress blocked, 67 findings), **C-0260** (Firewall, 61), **C-0206** (CIS-5.3.2 namespaces have NetworkPolicy), **C-0054**, **C-0049** — fail for every namespace in the cluster, even though the cluster *is* fully segmented. Root cause: Kubescape (and the CIS benchmark) only recognise the standard `networking.k8s.io/v1` `NetworkPolicy` kind; they do **not** understand `CiliumNetworkPolicy`, which is what the platform uses for all segmentation. So the real zero-trust posture is invisible to the scanner.

This is a scanner-visibility gap, **not** a real exposure — and it is fixable at the source (no exception/suppression).

## Fix

Extend the `add-default-deny` Kyverno policy to generate a standard `NetworkPolicy` default-deny (`podSelector: {}`, `policyTypes: [Ingress, Egress]`, **no allow rules**) in every namespace, alongside the existing Cilium default-deny.

Cilium enforces both policy types and combines them **additively** — the effective allow-set for an endpoint is the *union* across every policy source (standard NetworkPolicy + CiliumNetworkPolicy + CiliumClusterwideNetworkPolicy). A pure standard default-deny therefore contributes only "isolate these pods" (which the Cilium default-deny already does) and does **not** block traffic that a CiliumNetworkPolicy explicitly allows.

The prior code comment claimed the opposite ("a standard default-deny would block traffic that CiliumNetworkPolicy explicitly allows"). That is **disproven in production** and is corrected here.

## Verification (three independent methods)

1. **Production evidence** — the `wedding-app` namespace already runs exactly this pure standard default-deny next to its CiliumNetworkPolicy allows, has done so for 35d, and serves live traffic (2 ready replicas, active endpoints on :3000). It **passes** C-0030/C-0260; Cilium-only namespaces fail them.
2. **`kyverno apply`** — the new rule generates a `NetworkPolicy` byte-identical to wedding-app's proven one.
3. **`kubescape` A/B scan** — with the generated NetworkPolicy, C-0030/C-0260/C-0054/C-0049 **pass**; without it they fail.

`kubectl kustomize` builds the `cluster-policies` kustomization cleanly with the new rule present.

## Scope

This is part 1 of a broader, source-level Kubescape hardening effort (no exceptions). It is the one cleanly-central fix; the remaining families (pod securityContext completeness, SA-token automount, probes, privileged-daemon re-architecture, RBAC tightening, Talos host CIS) are value-sensitive and roll out per-workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)