### PR TITLE
fix(security-context): inject pod-level runAsGroup to satisfy C-0013

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -4,10 +4,17 @@
 # - readOnlyRootFilesystem: true (C-0017)
 # - drop ALL capabilities (C-0055)
 # - runAsNonRoot: true (C-0013) — pod + container
+# - runAsGroup: 1000 (C-0013 non-root group) — pod level only
 #
-# NOTE: runAsGroup is intentionally NOT injected because it would
-# override pod-level runAsGroup inheritance at the container level.
-# Charts that need a non-root group should set it explicitly.
+# runAsGroup is injected at the POD level (not the container level): kubescape's
+# C-0013 "non-root-containers" rule requires a non-zero runAsGroup, and a pod-level
+# value satisfies it without overriding any container-level value a chart may set
+# (the earlier concern was specifically about clobbering container inheritance).
+# It sets the process primary GID only — runAsUser and fsGroup are deliberately NOT
+# injected, so image-baked UIDs and volume ownership are left untouched. Verified
+# with kubescape: pod-level runAsGroup alone flips C-0013 to pass with no fsGroup
+# or runAsUser, and every PVC-mounting workload in scope already self-sets fsGroup,
+# so no volume is chowned.
 #
 # Uses +(key) to never overwrite values explicitly set by Helm charts.
 # Excluded namespaces require elevated privileges by design.
@@ -63,6 +70,7 @@ spec:
               +(seccompProfile):
                 type: RuntimeDefault
               +(runAsNonRoot): true
+              +(runAsGroup): 1000
     - name: add-container-security-context
       match:
         any:


### PR DESCRIPTION
## Problem

Kubescape **C-0013** (Non-root containers, 38 findings) fails on workloads that set `runAsNonRoot`/`runAsUser` but no `runAsGroup` — including fully-hardened ones like `cert-manager`, `crossview`, `opencost`, `kro`, `keda`, `external-secrets`, `flagger`. The control's `non-root-containers` rule requires a **non-zero `runAsGroup`**. `add-security-context` previously omitted it on purpose, to avoid clobbering container-level group inheritance.

## Fix

Inject `runAsGroup: 1000` at the **pod** level (not the container level) via the existing conditional-anchor mutation. A pod-level value satisfies C-0013 without the inheritance problem the old comment described (which was specific to *container*-level injection), and Kyverno autogen propagates it to the Deployment/DaemonSet/StatefulSet `spec.template.spec` that the in-cluster kubescape operator actually scans.

### Deliberately scoped to be non-breaking
- **Only `runAsGroup`** (the process primary GID). `runAsUser` and `fsGroup` are **not** injected, so image-baked UIDs and volume ownership are left untouched.
- The `+(runAsGroup)` conditional anchor **skips any workload that already sets it** (verified: a pod with `runAsGroup: 26` keeps `26`, not `1000`).
- Every PVC-mounting workload in scope already self-sets `fsGroup` (verified cluster-wide), so **nothing is chowned**.

## Verification (`kyverno apply` + `kubescape`)

- A chart-like Deployment with no `runAsGroup` is mutated (via autogen) to carry pod-level `runAsGroup: 1000`, and flips **C-0013 / C-0016 / C-0017 / C-0055** to **pass**.
- A self-setting workload (`runAsGroup: 26`) is left unchanged.
- `kubectl kustomize` builds the `cluster-policies` kustomization cleanly.

## What this does *not* fix (separate follow-ups)

C-0211 (CIS-5.7.3, 76 findings) additionally requires pod-level `runAsUser` + `fsGroup` + `fsGroupChangePolicy`. `runAsUser` overrides image-baked UIDs, so it is **value-sensitive and must be set per-workload** — that work is tracked separately and not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)