### PR TITLE
fix(velero): raise kopia repo-maintenance interval to 24h to cut job churn

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -82,6 +82,16 @@ spec:
       volumeSnapshotLocation: []
       defaultVolumesToFsBackup: true
       uploaderType: kopia
+      # Kopia repository maintenance cadence. Velero's built-in default is 1h,
+      # so with one BackupRepository per backed-up namespace it spins up ~16
+      # short-lived `*-kopia-maintain-job-*` pods every hour. That hourly churn
+      # of fast-exiting Job containers is the dominant trigger for the kubescape
+      # node-agent SBOM reap-race and the containerd "find container" NotFound
+      # log noise. Kopia's own default maintenance interval is 24h, which is
+      # ample for repo compaction/GC at this scale, so raise it to cut the churn
+      # ~24x. (Applies to newly-created BackupRepositories; existing ones keep
+      # their stored frequency until recreated.)
+      defaultRepoMaintainFrequency: 24h
       features: ""
 
     # Velero runs a SINGLE replica — this is correct, not a gap, and is why


### PR DESCRIPTION
## Why

Velero's built-in default repo-maintain frequency is **1h**, so with one `BackupRepository` per backed-up namespace (16 here) it spins up ~16 short-lived `*-kopia-maintain-job-*` pods **every hour**. That hourly churn of fast-exiting Job containers is the dominant trigger for two recurring Coroot log-noise alerts:

- `node-agent` (kubescape) `SbomManager - container not found in shared data` (SBOM reap-race), and
- `init` containerd `rpc error: code = NotFound ... find container` (observer racing a just-exited container).

Kopia's own default maintenance interval is **24h**, which is ample for repo compaction/GC at this scale. Setting `configuration.defaultRepoMaintainFrequency: 24h` cuts the maintenance-job churn ~24x (and is also just less wasteful).

## Scope / caveat

This sets the default for **newly-created** BackupRepositories. Existing BRs keep their stored `1h` frequency until recreated, so the churn drops as repos cycle (or they can be patched/recreated out of band). It does not fully eliminate the reap-race alerts (other CronJobs still create short-lived containers); the residual is an upstream kubescape log-level matter.

## Validation

`ksail --config ksail.prod.yaml workload validate` → both velero groups ✔ (`bases/.../velero`, `providers/hetzner/.../velero`). Value path `configuration.defaultRepoMaintainFrequency` verified against `helm show values velero --version 12.0.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)