### PR TITLE
fix(security-context): exclude tofu-controller runner pods from pod-level runAsGroup

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -14,7 +14,13 @@
 # injected, so image-baked UIDs and volume ownership are left untouched. Verified
 # with kubescape: pod-level runAsGroup alone flips C-0013 to pass with no fsGroup
 # or runAsUser, and every PVC-mounting workload in scope already self-sets fsGroup,
-# so no volume is chowned.
+# so no volume is chowned. The one caveat is images with NO baked-in UID (e.g.
+# tofu-controller's tf-runner, which expects runAsUser from its runnerPodTemplate):
+# a pod-level runAsGroup with no runAsUser yields the OCI user string ":1000", which
+# containerd rejects ("user group \"1000\" is specified without user") so the sandbox
+# never starts. The add-pod-security-context rule therefore excludes tofu-controller
+# runner pods — they self-harden via their runnerPodTemplate (runAsNonRoot + seccomp)
+# and the container-level rule still applies.
 #
 # Uses +(key) to never overwrite values explicitly set by Helm charts.
 # Excluded namespaces require elevated privileges by design.
@@ -64,6 +70,15 @@ spec:
                 - observability
                 - velero
                 - chaos-mesh
+          # tofu-controller runner pods ship no image-baked UID, so a pod-level
+          # runAsGroup with no runAsUser breaks containerd sandbox creation (see
+          # the header comment). They are hardened by their own runnerPodTemplate
+          # and the add-container-security-context rule, so exclude them from the
+          # pod-level runAsGroup injection only.
+          - resources:
+              selector:
+                matchLabels:
+                  app.kubernetes.io/created-by: tofu-controller
       mutate:
         patchStrategicMerge:
           spec:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live on prod)

`unifi-tf-runner` is stuck `ContainerCreating`, retrying sandbox creation every ~13s:

```
Failed to create pod sandbox: ... failed to generate user string:
user group "1000" is specified without user
```

The unifi `Terraform` reconcile is wedged at *"Fulfilling prerequisites"* (`lastAppliedRevision` empty) — the UniFi infra cannot be managed while the runner can't start.

## Root cause

`add-security-context` injects a **pod-level `runAsGroup: 1000`** (added in #2292 for kubescape **C-0013**) with **no `runAsUser`**. That is fine for normal app images — their Dockerfile sets a numeric `USER`, so containerd builds a valid `uid:gid` string. But tofu-controller's **`tf-runner` image ships no baked-in numeric USER** (it expects `runAsUser` from the `Terraform` CR's `runnerPodTemplate`, which this cluster deliberately doesn't set). With a GID and no UID, containerd produces the OCI user string `":1000"` and rejects it → the sandbox never starts.

`unifi` is not in the policy's exclude list, and the tf-runner is the one in-scope image without a baked UID, so it is the only victim (all other pods are healthy).

## Fix

Exclude **tofu-controller runner pods** (`app.kubernetes.io/created-by: tofu-controller`) from the **`add-pod-security-context`** rule only — matching the existing namespace-exclude pattern. This:

- **Keeps C-0013 hardening for the whole fleet** — every other pod still gets `runAsGroup: 1000`.
- **Respects the maintainer's explicit intent** (header comment: "runAsUser … deliberately NOT injected, so image-baked UIDs … left untouched") — no blanket `runAsUser`, which would risk file-ownership breakage on images expecting other UIDs.
- **Leaves the runner hardened** — it self-sets `runAsNonRoot` + seccomp via its `runnerPodTemplate`, and the **container-level** rule still applies (`drop ALL`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, `runAsNonRoot`, seccomp).

This restores the runner to its working pre-#2292 state while preserving the new hardening everywhere else.

## Validation

`kyverno apply` (CLI v1.18.1) against the edited policy:

| Pod | pod-level `securityContext` after mutation |
|---|---|
| normal app pod (no tofu-controller label) | `runAsGroup: 1000`, `runAsNonRoot: true`, seccomp ✅ (C-0013 intact) |
| tf-runner pod (`created-by: tofu-controller`) | *empty* ✅ (runAsGroup not injected → sandbox starts) |

- `kubectl kustomize k8s/bases/infrastructure/cluster-policies/` builds clean (41 resources); rendered policy carries the new selector.
- No validate policy requires `runAsGroup`, so excluding the runner introduces no validation regression.

## Notes

- Draft per repo convention; promote to drive the merge.
- Once merged + reconciled, the next tf-runner pod creation will succeed and the unifi Terraform reconcile will proceed.