### PR TITLE
fix(velero): widen memory limit:request ratio to 16:1 to stop backup OOMKills

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -186,9 +186,24 @@ spec:
     metrics:
       enabled: true
 
+    # Velero's memory is extremely bursty: the server idles at ~55Mi but spikes to
+    # ~770Mi for the ~3 minutes of the daily backup (VPA's observed upperBound was
+    # 770Mi). The auto-vpa policy right-sizes the *request* to steady-state (~105Mi)
+    # and, under RequestsAndLimits, scales the *limit* proportionally to the authored
+    # limit:request ratio. At the previous 4:1 ratio (512Mi:128Mi) the effective limit
+    # was only ~419Mi — below the backup peak — so the server was OOMKilled mid-backup
+    # and the daily backup Failed three days running (2026-06-25..27).
+    #
+    # Fix without fighting VPA (auto-vpa's generate rule is immutable, so velero cannot
+    # be excluded from it in place): widen the authored ratio to 16:1 (2Gi:128Mi). VPA
+    # preserves the ratio, so the effective limit is always 16x the request it sets,
+    # and it never sets the request below auto-vpa's 64Mi floor — so the limit is always
+    # >= 1Gi (16 x 64Mi), clearing the 770Mi peak. At the ~105Mi steady-state target the
+    # limit lands ~1.6Gi. (The live pod confirms VPA keeps the ratio: 4:1 authored ->
+    # 419Mi:105Mi observed.) node-agent is unaffected — its own resources, not bursty.
     resources:
       requests:
         cpu: 25m
         memory: 128Mi
       limits:
-        memory: 512Mi
+        memory: 2Gi


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (DR-critical — live on prod)

The prod **daily backups have Failed three days running** — no successful backup since 2026-06-24:

| Backup | Phase |
|---|---|
| `velero-daily-full-20260623` | Completed |
| `velero-daily-full-20260624` | Completed |
| `velero-daily-full-20260625` | **Failed** |
| `velero-daily-full-20260626` | **Failed** |
| `velero-daily-full-20260627` | **Failed** |

The velero server pod has been **OOMKilled** (exit 137) 3× — last at `02:20:05Z`, ~3 min into the `02:17Z` backup window. The Failed backups have the server-died signature: `phase: Failed`, **no recorded item errors**, **no completion timestamp** — the controller died mid-run.

## Root cause

velero's memory is **rare-but-large bursty**: idle **~55Mi**, but ~**770Mi** for the ~3-minute daily backup (VPA's own observed `upperBound` = 770Mi). The `auto-vpa` policy generates a VPA that, in `RequestsAndLimits` mode, right-sizes the *request* to steady-state (~105Mi) and scales the *limit* proportionally to the authored **4:1** ratio → only **~419Mi**, below the peak → OOMKill → Failed backup.

## Fix (chart-only — no policy change)

velero **cannot be excluded from `auto-vpa`**: Kyverno disallows changing an existing generate rule's `match`/`exclude` (*"changes of immutable fields of a rule spec in a generate rule is disallowed"* — verified against the live webhook), so Flux could not apply such a change without breaking the cluster-policies reconcile.

Instead, **widen velero's authored `limit:request` ratio to 16:1** (`2Gi:128Mi`). VPA preserves the authored ratio, so the effective limit is always **16× the request** it sets — and VPA never sets the request below `auto-vpa`'s **64Mi** floor — so the limit is **always ≥ 1Gi** (`16 × 64Mi`), clearing the 770Mi peak. At the ~105Mi steady-state target the limit lands **~1.6Gi**. velero stays fully VPA-managed (consistent with the "VPA everything" policy); only its ratio widens.

## Validation

- **The live velero pod already confirms VPA preserves the authored ratio**: authored `512Mi:128Mi` (4:1) → VPA set `419Mi:105Mi` (≈4:1). Widening to 16:1 therefore yields `limit = 16 × request`.
- **Worst case** (VPA pins request to the 64Mi floor): `limit = 16 × 64Mi = 1Gi ≥ 770Mi peak`. ✅
- `kubectl kustomize k8s/bases/infrastructure/controllers/velero/` builds clean; rendered `limits.memory: 2Gi`, `requests.memory: 128Mi`.

### Why not exclude velero from VPA?
That was the first approach; the live Kyverno webhook **rejected** modifying the immutable generate rule, which would have failed the Flux apply. The ratio approach needs no policy change and keeps velero under VPA.

## Post-merge verification (for the promoter)

After Flux reconciles: the velero pod should come up with `limits.memory` ≈ **1.6Gi** (VPA = 16 × the ~105Mi request), and the next `02:17Z` backup should reach `Completed`.

Draft per repo convention — promote to drive the merge. **DR-critical (3 consecutive failed backups); prompt promotion recommended so tonight's 02:17Z backup succeeds.**