### PR TITLE
fix(kubescape): enable riskAcceptance so SecurityException CRs are applied

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -49,6 +49,16 @@ spec:
       continuousScan: enable
       vulnerabilityScan: enable
       runtimeDetection: enable
+      # Apply the in-cluster SecurityException / ClusterSecurityException CRDs
+      # (k8s/bases/infrastructure/security-exceptions/) to posture results. The
+      # chart gates the operator/kubevuln/scanner RBAC for those CRDs behind this
+      # capability (chart default `disable`), so while it is off the scanner loads
+      # zero exceptions and the dashboard reads "excluding 0 controls" even though
+      # the CRs are deployed and schema-valid. Enabling it creates the RBAC and
+      # activates the CRD exception getter (namespaceSelector.matchExpressions is
+      # resolved against live namespaces). Exemptions stay a LAST RESORT behind
+      # real fixes — keep the security-exceptions set minimal and irreducible.
+      riskAcceptance: enable
       # Run posture/config scanning OFFLINE (air-gapped). This cluster has no
       # ARMO SaaS account, but the chart defaults to submit-mode: the scanner
       # POSTs each posture report to report.armo.cloud and treats the submit as


### PR DESCRIPTION
## Problem

The platform deploys 9 `ClusterSecurityException` CRs (`k8s/bases/infrastructure/security-exceptions/`), but the in-cluster dashboard shows **"excluding 0 resources and 0 controls"** — they have never taken effect. The repo's own docs assumed these "feed the in-cluster operator"; in reality they're orphaned.

## Root cause (traced against the live cluster + chart source)

The kubescape-operator chart gates the RBAC that lets the operator/kubevuln/scanner read `securityexceptions` + `clustersecurityexceptions` behind **`capabilities.riskAcceptance`** (chart default `disable`):

```yaml
# templates/operator/clusterrole.yaml
{{- if eq .Values.capabilities.riskAcceptance "enable" }}
- apiGroups: ["kubescape.io"]
  resources: ["securityexceptions", "clustersecurityexceptions"]
```

The platform never set it, so **no ClusterRole grants securityexception access** (verified live: `kubescape`/`operator`/`kubevuln` clusterroles have none). The scanner logs `Loading exceptions… Loaded exceptions` but loads an empty set.

## Fix

`capabilities.riskAcceptance: enable`. This:
- creates the securityexception RBAC, and
- activates the CRD exception getter, which resolves the CRs' `spec.match.namespaceSelector.matchExpressions` against live namespaces. (Verified in `kubescape/core/cautils/getter/crdexceptionsgetter.go` — the "matchExpressions not applied" caveat there is only for `objectSelector`; `namespaceSelector` — which the platform's CRs use — is resolved via the k8s client.)

## Important follow-up (no-exemptions direction)

Repairing the mechanism makes the existing 9 exceptions **live**, which will suppress the findings they cover (privileged infra, controller RBAC, SA tokens). Per the directive to prefer real fixes, those exceptions will be **trimmed to only the genuinely-irreducible** as real fixes land — e.g. Velero → CSI snapshots removes the velero node-agent exception. Exemptions stay a last resort behind real fixes; this PR only makes a minimal, reviewed exception set *able to function*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)