### PR TITLE
fix(labels): stamp recommended app labels to satisfy C-0076/C-0077

### DIFF
--- a/k8s/bases/components/helmrelease-drift-detection/kustomization.yaml
+++ b/k8s/bases/components/helmrelease-drift-detection/kustomization.yaml
@@ -34,6 +34,10 @@
 #     external-secrets, keda, kubescape, vertical-pod-autoscaler)
 #   * APIService `.spec.caBundle` — aggregated-apiserver cert injection
 #   * CRD conversion `.caBundle` — cert-manager CA injection
+#   * /metadata/labels (Deployment/StatefulSet/DaemonSet) — the add-recommended-
+#     labels Kyverno policy stamps app / app.kubernetes.io/name onto workloads
+#     that lack them (C-0076/C-0077), so the rendered chart metadata never
+#     matches the live (labelled) metadata.
 #
 # This is a Kustomize Component so the policy is defined once and applied to
 # every layer/provider build that renders HelmReleases (see the `components:`
@@ -56,15 +60,18 @@ patches:
               paths:
                 - /spec/replicas
                 - /spec/template
+                - /metadata/labels
             - target:
                 kind: StatefulSet
               paths:
                 - /spec/replicas
                 - /spec/template
+                - /metadata/labels
             - target:
                 kind: DaemonSet
               paths:
                 - /spec/template
+                - /metadata/labels
             - target:
                 kind: ValidatingWebhookConfiguration
               paths:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-recommended-labels.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-recommended-labels.yaml
@@ -1,0 +1,60 @@
+# Stamps the recommended Kubernetes labels onto workloads that don't already
+# carry them, addressing kubescape:
+#   C-0076 Label usage for resources  -> metadata.labels[app]
+#   C-0077 K8s common labels usage     -> metadata.labels + pod-template
+#                                         labels[app.kubernetes.io/name]
+#
+# The value is the workload's own name (a meaningful identifier, not a
+# placeholder) and `+(key)` conditional anchors never overwrite a label a chart
+# already sets. The pod-template label lives under /spec/template, which the
+# helmrelease-drift-detection component already ignores; the workload's own
+# metadata labels are added to that component's ignore list in the same change
+# so Flux does not revert them.
+#
+# Scoped to the three workload kinds the drift-detection component manages
+# (Deployment/StatefulSet/DaemonSet). It does NOT activate the insert-pod-
+# antiaffinity / spread-pods policies (which key off app.kubernetes.io/name):
+# those evaluate their preconditions against the original admission object, not
+# this policy's mutation — verified with `kyverno apply` (no topologySpread /
+# affinity is injected when both run together).
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-recommended-labels
+  annotations:
+    policies.kyverno.io/title: Recommended Labels
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/subject: Workload
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Adds the recommended `app` and `app.kubernetes.io/name` labels (valued by
+      the workload name) to workloads and their pod templates using conditional
+      anchors, so explicit chart labels are never overwritten.
+spec:
+  rules:
+    - name: add-workload-labels
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              +(app): "{{ request.object.metadata.name }}"
+              +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"
+          spec:
+            template:
+              metadata:
+                labels:
+                  +(app.kubernetes.io/name): "{{ request.object.metadata.name }}"

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   # Custom policies (no upstream equivalent)
   - best-practices/add-default-deny.yaml
   - best-practices/add-default-limitrange.yaml
+  - best-practices/add-recommended-labels.yaml
   - best-practices/add-resource-defaults.yaml
   - best-practices/add-security-context.yaml
   - best-practices/auto-vpa.yaml


### PR DESCRIPTION
## Problem

Kubescape **C-0076** (Label usage, 58) and **C-0077** (K8s common labels, 13) — **71 findings** — fail on workloads missing the recommended labels: C-0076 wants `metadata.labels[app]`; C-0077 wants `app.kubernetes.io/name` on **both** the workload metadata and its pod template.

## Fix

A new `add-recommended-labels` Kyverno policy stamps `app` and `app.kubernetes.io/name` — valued by the **workload's own name** (a meaningful identifier, not a placeholder) — onto Deployments/StatefulSets/DaemonSets and their pod templates, with `+(key)` conditional anchors so any chart-set label is preserved.

**Coordinated drift-detection change:** the pod-template label is under `/spec/template` (already drift-ignored); the workload's own `/metadata/labels` is added to the `helmrelease-drift-detection` ignore list for those three kinds, so Flux doesn't revert the Kyverno-stamped labels.

## Verification

- **`kyverno apply` + `kubescape`**: a bare Deployment is labelled and flips **C-0076 + C-0077 → pass**; charts that already set the labels keep their values.
- **No scheduling side-effect** — this was the key risk: `insert-pod-antiaffinity` / `spread-pods` key off `app.kubernetes.io/name` (with `DoNotSchedule`). But they evaluate preconditions against the *original* admission object, not this mutation. Confirmed with `kyverno apply`: running all three policies together injects **no** `topologySpreadConstraints` / `affinity`.
- Both overlays build (`kubectl kustomize`).

## Scope

Scoped to Deployment/StatefulSet/DaemonSet (the kinds drift-detection manages). The handful of Job/CronJob workloads (different template path) are a minor residual left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)