### PR TITLE
fix(security-context): restore pod-level seccomp for tofu-controller runner pods

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -142,3 +142,32 @@ spec:
                           - ALL
                       +(seccompProfile):
                         type: RuntimeDefault
+    # tofu-controller runner pods are EXCLUDED from add-pod-security-context above
+    # (a pod-level runAsGroup with no runAsUser yields the OCI user string ":1000",
+    # which containerd rejects so the sandbox never starts — see the header). They
+    # still must satisfy the require-seccomp-profile validate rule, and
+    # tofu-controller does NOT propagate the runnerPodTemplate's pod-level
+    # securityContext to the created runner pod, so the mutate must supply it. This
+    # rule re-applies the SAFE subset for runner pods only — seccompProfile +
+    # runAsNonRoot, i.e. everything the pod rule injects EXCEPT the runAsGroup that
+    # breaks sandbox creation. The container-level rule already hardens their
+    # containers; this closes the pod-level seccomp gap that excluding them opened.
+    - name: add-tofu-runner-pod-security-context
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              # CREATE only — same immutability rationale as the rules above.
+              operations:
+                - CREATE
+              selector:
+                matchLabels:
+                  app.kubernetes.io/created-by: tofu-controller
+      mutate:
+        patchStrategicMerge:
+          spec:
+            securityContext:
+              +(seccompProfile):
+                type: RuntimeDefault
+              +(runAsNonRoot): true


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## ⚠️ Hotfix — prod merge_group is red

The `apps` Kustomization health check is failing on prod (`Terraform/unifi/unifi` stuck `InProgress`), so every `merge_group` deploy fails. Root cause is a regression from my own #2294.

## What happened

#2294 fixed the `unifi-tf-runner` sandbox error (`user group "1000" is specified without user`) by **excluding tofu-controller runner pods from the whole `add-pod-security-context` mutate rule**. That rule injected the pod-level `seccompProfile`, `runAsNonRoot` **and** `runAsGroup` together. Excluding the runner pods removed the `runAsGroup` (the fix) — but also removed the pod-level **`seccompProfile`**.

`validate-pod-security/require-seccomp-profile` requires a pod-level `spec.securityContext.seccompProfile`, so the runner pod is now **blocked at admission**:

```
admission webhook "validate.kyverno.svc-fail" denied the request:
  Pod/unifi/unifi-tf-runner blocked by validate-pod-security:
  require-seccomp-profile: Pod must use seccomp profile RuntimeDefault or Localhost
```

tofu-controller never creates the runner → `Terraform/unifi` never reaches Ready → `apps` Kustomization health check times out → `merge_group` deploy fails. The UniFi infra itself has no drift (`Plan: no changes`); the impact is that **prod deploys are blocked**.

> ℹ️ #2294's header comment claims runner pods "self-harden via their runnerPodTemplate (runAsNonRoot + seccomp)". That is **empirically false**: tofu-controller does **not** propagate the `runnerPodTemplate.spec.securityContext` to the created pod (verified live — the pod is submitted with no pod-level securityContext; the Kyverno mutate was the only thing supplying seccomp). Worth correcting the header in #2296, which already rewrites it.

## The fix (additive — composes with #2296)

A new rule `add-tofu-runner-pod-security-context` that matches **only** tofu-controller pods and re-applies the **safe subset** of the pod-level hardening — `seccompProfile` + `runAsNonRoot`, **never** `runAsGroup` (the field that breaks the sandbox). It's appended after the existing rules, so it does **not** touch any hunk #2296 edits (header + `add-pod-security-context` fsGroup + container `seLinuxOptions`) → no merge conflict.

## Validation (Kyverno CLI 1.18.1, against a representative runner pod)

- **Mutation:** new rule injects pod-level `{seccompProfile: RuntimeDefault, runAsNonRoot: true}`, no `runAsGroup`.
- **Validate (mutated):** `pass: 3, fail: 0` against `validate-pod-security`.
- **Control (unmutated):** `fail: 1` — `require-seccomp-profile` (reproduces the live denial exactly).
- Server-side dry-run (`kubectl apply --dry-run=server`) — Kyverno policy webhook accepts the new rule.

After this deploys, the existing wedged runner pod has already been deleted (it was Pending since 11:21Z under the old broken mutation); tofu-controller will recreate it cleanly under the corrected policy.

Fixes the live `apps`/`merge_group` breakage introduced by #2294.
