### PR TITLE
fix(vpa): pin leader-election Lease to controller namespace

### DIFF
--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/helm-release.yaml
@@ -26,8 +26,14 @@ spec:
       # is active at a time, standbys take over on failure. Without it, multiple
       # recommenders produce racy recommendations. VPA 1.6.0 supports
       # --leader-elect (extraArgs is a map -> --leader-elect=true).
+      #
+      # The lock Lease defaults to kube-system (VPA hardcodes ResourceNamespace
+      # to metav1.NamespaceSystem), where the recommender SA has no leases grant,
+      # so the election fails forever. Pin it to this namespace, matching the
+      # least-privilege Role in leader-election-rbac.yaml.
       extraArgs:
         leader-elect: true
+        leader-elect-resource-namespace: vertical-pod-autoscaler
       podDisruptionBudget:
         # Drain-safe PDB pattern (#1880/#1882): maxUnavailable: 1 never
         # deadlocks a node drain regardless of replica count, and at the
@@ -49,8 +55,12 @@ spec:
       # HA: leader election runs replicas active/standby -- only one updater is
       # active at a time, standbys take over on failure. Without it, multiple
       # updaters would double-evict pods. VPA 1.6.0 supports --leader-elect.
+      # Pin the lock Lease to this namespace (defaults to kube-system, where the
+      # updater SA has no grant) -- see the recommender block and
+      # leader-election-rbac.yaml.
       extraArgs:
         leader-elect: true
+        leader-elect-resource-namespace: vertical-pod-autoscaler
       podDisruptionBudget:
         # Drain-safe PDB pattern (#1880/#1882) -- see the recommender block.
         maxUnavailable: 1

--- a/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/leader-election-rbac.yaml
+++ b/k8s/bases/infrastructure/controllers/vertical-pod-autoscaler/leader-election-rbac.yaml
@@ -15,10 +15,20 @@
 #
 # logged every few seconds on all four pods -- a constant error stream (Coroot
 # "Log errors") and, worse, leader election never completes so the HA standby
-# can't actually coordinate. Namespaced (the client-go lock Lease lives in each
-# controller's own namespace) and scoped to leases only -- least privilege for
-# acquiring/renewing the lock. The admission-controller already has its own
-# chart-provided lease grant, so it is intentionally not bound here.
+# can't actually coordinate.
+#
+# IMPORTANT: the recommender and updater default their lock Lease namespace to
+# kube-system (VPA's defaultLeaderElectionConfiguration hardcodes
+# ResourceNamespace to metav1.NamespaceSystem), NOT their own namespace -- so a
+# Role here alone is inert and the live error reads `... in the namespace
+# "kube-system"`. helm-release.yaml therefore also pins
+# `--leader-elect-resource-namespace: vertical-pod-autoscaler` on both
+# controllers, so the Lease lands in this namespace where this Role grants
+# access. Keeping the Lease (and grant) namespaced -- rather than granting the
+# workload SAs lease write in the more privileged kube-system -- is the
+# least-privilege choice. Scoped to leases only. The admission-controller
+# already has its own chart-provided lease grant (its Lease is in this
+# namespace), so it is intentionally not bound here.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Symptom (live on prod)

The VPA **recommender** and **updater** flood RBAC-forbidden leader-election errors every ~3s on all four pods:

```
E leaderelection.go:452] "Error retrieving lease lock" err="leases.coordination.k8s.io
\"vpa-recommender-lease\" is forbidden: User \"system:serviceaccount:vertical-pod-autoscaler:
vertical-pod-autoscaler-vpa-recommender\" cannot get resource \"leases\" in API group
\"coordination.k8s.io\" in the namespace \"kube-system\"" lock="kube-system/vpa-recommender-lease"
I leaderelection.go:267] "Failed to acquire lease" lock="kube-system/vpa-recommender-lease"
```

(The updater logs the identical error for `kube-system/vpa-updater`, on `create`.)

**This is not just log noise.** The recommender blocks on `leaderelection.RunOrDie` and its recommendation loop **never starts** — it has *zero* non-leader-election log lines. VPA right-sizing is therefore **stalled cluster-wide**:

- `vpa-recommender-lease` does **not exist** in `kube-system` (NotFound) — the SA can't even create it.
- **20 of 76 VPAs have an empty `.status.recommendation`** (no conditions at all) — incl. `crossplane`, all 5 `flux-system` controllers, `oauth2-proxy/auth-proxy`, `backstage`, `external-dns`, `kro`, `kubescape/node-agent`.
- Workloads that rely on VPA to scale their memory **up** then OOM on their authored limits: `crossplane` was OOMKilled 2026-06-21 (exit 137); `velero` OOMed on backups and needed a manual limit-ratio fix (#2295). Both are symptoms of the same stalled recommender.

## Root cause

The VPA recommender/updater **default their leader-election lock Lease to the `kube-system` namespace** — VPA's `defaultLeaderElectionConfiguration()` hardcodes `ResourceNamespace: metav1.NamespaceSystem`. Leader election was enabled (correctly, for the prod 2-replica HA floor) via `extraArgs.leader-elect: true`, and a `vpa-leader-election` Role/RoleBinding was added to grant the lease — **but in the `vertical-pod-autoscaler` namespace** (the comment assumed *"the client-go lock Lease lives in each controller's own namespace"*, which is **not true for VPA**). So the grant is **inert**: the controllers look for the Lease in `kube-system`, where they have no permission, and the election never completes.

The **admission-controller** is unaffected because its chart-provided Lease genuinely lives in `vertical-pod-autoscaler` (verified live: holder set, 35d old) — which is also the proof that an in-namespace Lease is the right model here.

## Fix

Pin `--leader-elect-resource-namespace: vertical-pod-autoscaler` on **both** the recommender and updater (rendered from the chart's `extraArgs` map, exactly like the existing `--leader-elect=true`). The Lease then lands in `vertical-pod-autoscaler`, where the existing namespaced Role already grants `get/list/watch/create/update/patch` on `leases`.

This realizes the RBAC file's stated **least-privilege** intent — it keeps the Lease and its grant namespaced, rather than the alternative of granting workload SAs lease-write in the more privileged `kube-system`. The misleading comment is corrected to document the kube-system default and the coupling between the two files.

## Verification

- `ksail --config ksail.prod.yaml workload validate` → **✔ 358 files validated** (exit 0).
- `kubectl kustomize` builds clean for the `prod` and `local` overlays and the VPA base dir; both controllers render `--leader-elect-resource-namespace=vertical-pod-autoscaler`.
- Flux substitution unaffected; no secrets touched; bases-only change applies to both overlays.

After merge + reconcile, the recommender/updater should acquire `vertical-pod-autoscaler/{vpa-recommender-lease,vpa-updater}`, the error stream stops, and the 20 empty VPAs start receiving recommendations (the underlying cause of the recent crossplane/velero OOMs).

## Risk

Low. Values + comment only; no behavior change beyond fixing leader election. If the flag were ever rejected the pods would CrashLoop on startup — but `--leader-elect-resource-namespace` is a standard component-base flag present in VPA 1.6.0 (the running image).