### PR TITLE
fix(cnpg): pin PostgreSQL operand image to 18.4 to clear fixable CVEs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -130,6 +130,17 @@
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+tag:\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the PostgreSQL operand image pinned on the platform-owned CloudNativePG Clusters (coroot-db, umami-db, backstage-db — each a postgres-cluster.yaml). These pin spec.imageName explicitly instead of riding the CNPG operator default because the latest GA operator (v1.29.1) still defaults to postgresql:18.3-system-trixie — a now-frozen tag (last rebuilt 2026-05-11) carrying fixable base-OS CVEs (openssl/libssl3, libgnutls30, libc6, python3.13) — and the default only advances to 18.4 in the not-yet-GA v1.30, so the built-in flux manager bumping the cloudnative-pg operator chart does NOT clear them. spec.imageName lives in the Cluster CR (not a chart version or a values.yaml), so the flux, kubernetes, and helm-values managers never see it; a custom manager is the only way to keep it current. Matches the `# renovate:` comment and the imageName line that follows it (mirroring the crossview manager above), resolving from the docker datasource (ghcr.io/cloudnative-pg/postgresql); docker versioning tracks the 18.4-system-trixie -> 18.5-system-trixie minor line while preserving the -system-trixie flavor suffix. The tenant-owned wedding-db pins its own imageName in the external wedding-app artifact and is intentionally not covered here.",
+      "managerFilePatterns": [
+        "/(^|/)postgres-cluster\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+imageName:\\s*\\S+:(?<currentValue>\\S+)"
+      ],
+      "versioningTemplate": "docker"
     }
   ],
   "minor": {

--- a/k8s/bases/apps/backstage/postgres-cluster.yaml
+++ b/k8s/bases/apps/backstage/postgres-cluster.yaml
@@ -20,6 +20,11 @@ metadata:
     kustomize.toolkit.fluxcd.io/force: disabled
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
+  # Pin the PostgreSQL operand image to clear fixable base-OS + PostgreSQL CVEs in
+  # the CNPG operator default (18.3-system-trixie) — same rationale and Renovate
+  # wiring as umami-db. CNPG rolls the image in place across the HA instances.
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie
   # 2 instances (1 primary + 1 streaming replica) = the drain-safe floor: CNPG
   # drains a node by promoting the replica and sets a maxUnavailable replica PDB,
   # so a Talos roll / autoscaler scale-down never blocks and a single node loss

--- a/k8s/bases/apps/umami/postgres-cluster.yaml
+++ b/k8s/bases/apps/umami/postgres-cluster.yaml
@@ -22,6 +22,19 @@ metadata:
     kustomize.toolkit.fluxcd.io/force: disabled
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
+  # Pin the PostgreSQL operand image explicitly instead of riding the CNPG operator
+  # default. The latest GA operator (v1.29.1) still defaults to
+  # postgresql:18.3-system-trixie, whose rolling tag is now frozen (last rebuilt
+  # 2026-05-11) and carries fixable base-OS CVEs (openssl/libssl3, libgnutls30,
+  # libc6, python3.13); the operator default only advances to 18.4 in the
+  # not-yet-GA v1.30, so a chart/operator bump (the built-in flux manager) does NOT
+  # clear them — an explicit pin is the only fix today. 18.4 (2026-05-14) also fixes
+  # 11 PostgreSQL CVEs incl. the RCE-class CVE-2026-6473. Renovate keeps this current
+  # via the postgres-cluster.yaml customManager in .github/renovate.json; CNPG rolls
+  # the image in place (replicas first, then a primary switchover), so the >=2-instance
+  # HA Clusters stay available with no data-loss path (force/prune are disabled above).
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie
   # Run 3 instances (1 primary + 2 streaming replicas) for high availability.
   # A single-instance Cluster makes CNPG create a `<cluster>-primary`
   # PodDisruptionBudget with minAvailable=1 on the only pod, which BLOCKS every

--- a/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
@@ -42,6 +42,11 @@ metadata:
     kustomize.toolkit.fluxcd.io/force: disabled
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
+  # Pin the PostgreSQL operand image to clear fixable base-OS + PostgreSQL CVEs in
+  # the CNPG operator default (18.3-system-trixie) — same rationale and Renovate
+  # wiring as umami-db. CNPG rolls the image in place across the HA instances.
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie
   # Run 3 instances (1 primary + 2 streaming replicas) for high availability —
   # the SAME rationale as umami-db: a single-instance Cluster makes CNPG create a
   # `<cluster>-primary` PDB with minAvailable=1 on the only pod, which BLOCKS


### PR DESCRIPTION
## Problem

All platform-owned CloudNativePG (CNPG) databases run the **operator-default** PostgreSQL image, which is `ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie` on the **latest GA operator (v1.29.1)**. Kubescape flags fixable **CRITICAL/HIGH** base-OS CVEs in that image (openssl/libssl3, libgnutls30, libc6, python3.13), and the `18.3-system-trixie` tag is now **frozen** (last rebuilt 2026-05-11), so it will never receive another base-OS patch.

Live state (prod):

| Cluster | Namespace | instances | image (before) |
|---|---|---|---|
| `coroot-db` | observability | 3 | `postgresql:18.3-system-trixie` |
| `umami-db` | umami | 3 | `postgresql:18.3-system-trixie` |
| `backstage-db` | backstage | 2 | `postgresql:18.3-system-trixie` |

**A chart/operator bump does not fix this.** The operator default is `18.3-system-trixie` at v1.28.3, v1.29.0 **and the current GA v1.29.1**; it only advances to `18.4` in the **not-yet-GA v1.30**. Prod already runs the latest GA operator (chart `0.28.3`) — there is nothing for the built-in `flux` manager to bump that would clear these CVEs.

PostgreSQL **18.4** (released 2026-05-14) additionally fixes **11 PostgreSQL CVEs**, including the RCE-class **CVE-2026-6473**.

## Fix

Pin `spec.imageName: ghcr.io/cloudnative-pg/postgresql:18.4-system-trixie` explicitly on the 3 platform-owned Clusters, and add a Renovate `customManager` (mirroring the existing crossview bundled-postgres pin) so the image stays current — `spec.imageName` lives in the Cluster CR, which the `flux`/`kubernetes`/`helm-values` managers never see.

## Safety / blast radius

- All 3 Clusters are HA (instances ≥ 2) with **quorum synchronous replication** and **off-cluster R2 backups** (Barman Cloud).
- CNPG applies an image change **in place** — it upgrades replicas first, then does a controlled **primary switchover**. No quorum loss.
- `kustomize.toolkit.fluxcd.io/force: disabled` + `prune: disabled` are already set on every Cluster, so there is **no delete/recreate / data-loss path** — the image field is a normal in-place update.
- `18.3 → 18.4` is a PostgreSQL **minor** upgrade (binary swap + restart; no dump/restore).

## Scope notes

- The tenant-owned **`wedding-db`** pins its own `spec.imageName` in the external `wedding-app` OCI artifact (not this repo); per the documented overlay patch philosophy (version choices are tenant-owned), it is bumped in the `wedding-app` source repo, not patched platform-side here.
- `crossview-postgres` is intentionally ephemeral (`persistence: false`) and already pins `postgres:18.4` — out of scope.

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure/` and `.../apps/` build clean; the rendered Clusters carry `imageName: …:18.4-system-trixie` (coroot-db ×1, umami-db + backstage-db ×2).
- `k8s/clusters/local/` and `k8s/clusters/prod/` build clean.
- `renovate.json` is valid JSON; the new `customManager` regex was tested against all three `postgres-cluster.yaml` files and captures `datasource=docker`, `depName=ghcr.io/cloudnative-pg/postgresql`, `currentValue=18.4-system-trixie`.

Opened as **draft** — merging will trigger a rolling restart of these 3 databases (HA-safe, as above); promote when you're ready for that rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)