### PR TITLE
fix(limits): set CPU limits in Kyverno-filtered namespaces (C-0270)

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -1,11 +1,18 @@
 # TODO: Upstream `auto-vpa.yaml` to Kyverno policies repository.
 #
-# kube-system is intentionally NOT excluded: its controllers (cilium,
-# cilium-envoy, spire-agent, coredns, metrics-server, hubble, hcloud
-# ccm/csi, tetragon, cluster-autoscaler) carry ~10Gi of hand-tuned request
-# floors that VPA can right-size to observed usage instead. Static
-# control-plane pods (kube-apiserver/etcd/scheduler/controller-manager) are
-# bare Pods, not Deployment/StatefulSet/DaemonSet, so they never match.
+# kube-system is intentionally NOT excluded by THIS policy's match rules — but
+# be aware Kyverno's GLOBAL resourceFilters (`[*/*,kube-system,*]` and
+# `[*/*,kyverno,*]` in the kyverno ConfigMap) exclude kube-system and kyverno
+# from ALL Kyverno processing, so in practice NO VerticalPodAutoscaler is
+# generated there (0 VPAs live in both). Their controllers (cilium, cilium-envoy,
+# spire-agent, coredns, metrics-server, hubble, hcloud ccm/csi, tetragon,
+# cluster-autoscaler, the kyverno controllers) keep their hand-tuned request
+# floors but are NOT VPA-right-sized; their CPU *limits* are seeded instead by
+# the static CPU-only LimitRanges in k8s/bases/infrastructure/limitranges/ (the
+# only admission path that reaches a globally-filtered namespace — kubescape
+# C-0270). Static control-plane pods (kube-apiserver/etcd/scheduler/
+# controller-manager) are bare mirror Pods, not Deployment/StatefulSet/DaemonSet,
+# so they never match here and bypass the LimitRange too.
 #
 # IN-PLACE RESIZE (no eviction) is active. InPlacePodVerticalScaling went GA
 # in k8s 1.35 (KEP-1287) and prod runs v1.35.5; VPA is 1.6 (its own

--- a/k8s/bases/infrastructure/kustomization.yaml
+++ b/k8s/bases/infrastructure/kustomization.yaml
@@ -11,6 +11,11 @@ resources:
   - external-secrets/
   - flagger/
   - gateway/
+  # CPU-only LimitRanges for the namespaces no Kyverno resource policy can reach
+  # (kube-system + kyverno are in Kyverno's global resourceFilters, so they get
+  # no limit seed and no auto-VPA). Restores a CPU limit so their pods pass
+  # kubescape C-0270. See limitranges/kustomization.yaml for the full writeup.
+  - limitranges/
   # OpenCost lives in the `infrastructure` layer (not `controllers`) because it
   # hard-fails at startup unless it can query Coroot's bundled Prometheus
   # (coroot-prometheus.observability.svc:9090), which the operator only builds from the

--- a/k8s/bases/infrastructure/limitranges/kube-system.yaml
+++ b/k8s/bases/infrastructure/limitranges/kube-system.yaml
@@ -1,0 +1,44 @@
+---
+# CPU-only default LimitRange for kube-system.
+#
+# kube-system is in Kyverno's global resourceFilters (`[*/*,kube-system,*]`), so
+# NONE of the Kyverno resource policies touch it: no `add-resource-defaults`
+# stamp, no generated `default-limitrange`, and no `auto-vpa` VerticalPodAutoscaler
+# (there are 0 VPAs in kube-system on the live cluster — the auto-vpa.yaml comment
+# claiming VPA right-sizes kube-system is defeated by this global filter). Its
+# datapath/control-plane add-ons (cilium, coredns, hubble, spire-agent, hcloud
+# ccm/csi, metrics-server, tetragon, cluster-autoscaler, …) therefore run with no
+# CPU limit and fail kubescape C-0270.
+#
+# Why a generous CPU-ONLY limit:
+#   * default.cpu "2" is a deliberately high ceiling: CPU is compressible and a
+#     limit does NOT affect scheduling (only requests do), so a high limit costs
+#     nothing, never throttles the datapath under burst, and is ~10x cilium's
+#     200m request / much more for the smaller add-ons (honouring the
+#     "high limit when request is low" burst-headroom goal). It comfortably
+#     exceeds every authored request in the namespace (max 200m), so the
+#     LimitRanger can never reject a pod for limit < request.
+#   * NO default.memory: memory is incompressible, so a too-low memory cap
+#     OOMKills. A 512Mi cap on cilium/spire under load would kill the datapath.
+#     Memory limits are intentionally left unset here.
+#   * defaultRequest is a low floor so a container that omits requests is not
+#     handed the 2-core *limit* as its request (LimitRanger copies the limit into
+#     the request when defaultRequest is unset, which would reserve 2 cores).
+#
+# NOTE: the static control-plane pods (kube-apiserver, etcd, kube-scheduler,
+# kube-controller-manager) are kubelet mirror pods and bypass admission entirely,
+# so this LimitRange cannot reach them — and they should not be CPU-limited
+# anyway. They remain covered by the vpa-managed-resources ClusterSecurityException.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: kube-system
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+      defaultRequest:
+        cpu: 15m
+        memory: 128Mi

--- a/k8s/bases/infrastructure/limitranges/kustomization.yaml
+++ b/k8s/bases/infrastructure/limitranges/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+# Static, CPU-only LimitRanges for the namespaces that NO Kyverno-driven
+# resource-limit mechanism can reach.
+#
+# Root cause (kubescape C-0270 "Ensure CPU limits are set"):
+# The platform seeds container CPU/memory limits at pod-admission time via two
+# Kyverno-driven mechanisms — the `add-resource-defaults` mutate policy and the
+# `add-default-limitrange` generate policy (whose generated LimitRange the
+# built-in LimitRanger then enforces). VPA only ever *rescales an existing*
+# limit; it never creates one (see auto-vpa.yaml). So a pod with no
+# admission-seeded CPU limit fails C-0270, and VPA cannot rescue it.
+#
+# Kyverno's GLOBAL resourceFilters (`[*/*,kube-system,*]`, `[*/*,kyverno,*]`,
+# kube-public, kube-node-lease) exclude those namespaces from ALL Kyverno
+# processing — mutate, generate, AND auto-vpa — so their pods get neither a
+# limit seed nor a VPA. `longhorn-system` is not globally filtered, but is
+# explicitly excluded from both limit policies (the 2026-06-20 memory-OOM
+# safeguard) and so lost its CPU limit too.
+#
+# A LimitRange authored as a plain manifest (NOT Kyverno-generated) is immune to
+# the resourceFilters: the built-in LimitRanger admission plugin applies it to
+# every pod regardless. These files restore a CPU limit to those pods.
+#
+# longhorn-system's equivalent lives in the hetzner provider overlay
+# (k8s/providers/hetzner/infrastructure/controllers/longhorn/limitrange.yaml)
+# because Longhorn is prod-only — its namespace does not exist in the local
+# (docker) cluster, so a base manifest targeting it would have nothing to bind.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kube-system.yaml
+  - kyverno.yaml

--- a/k8s/bases/infrastructure/limitranges/kyverno.yaml
+++ b/k8s/bases/infrastructure/limitranges/kyverno.yaml
@@ -1,0 +1,32 @@
+---
+# CPU-only default LimitRange for the kyverno namespace.
+#
+# kyverno is in Kyverno's own global resourceFilters (`[*/*,kyverno,*]`, the
+# standard bootstrap-deadlock safeguard so Kyverno never gates its own pods), so
+# — exactly like kube-system — none of the Kyverno resource policies reach it:
+# no `add-resource-defaults` stamp, no generated `default-limitrange` (which is
+# why kyverno has no LimitRange despite not being in that policy's exclude list),
+# and no `auto-vpa` (0 VPAs in kyverno). Its four controllers (admission /
+# background / cleanup / reports) thus run with no CPU limit and fail C-0270.
+#
+# A static LimitRange bypasses the resourceFilters (the built-in LimitRanger
+# applies it regardless). CPU-only and generous, for the same reasons as the
+# kube-system manifest: a high CPU limit gives the reports/background controllers
+# burst head-room without throttling, while a memory limit is omitted (the
+# reports controller can spike memory on large clusters; an incompressible cap
+# would OOMKill it). defaultRequest.memory is kept (the kyverno namespace carries
+# a requests.memory ResourceQuota, which requires every pod to declare a memory
+# request — the LimitRanger supplies it for any container that omits one).
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: kyverno
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+      defaultRequest:
+        cpu: 15m
+        memory: 128Mi

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
@@ -7,3 +7,8 @@ resources:
   - helm-release.yaml
   - networkpolicy.yaml
   - httproute.yaml
+  # CPU-only LimitRange: restores a CPU limit (dropped when longhorn-system was
+  # excluded from the Kyverno limit policies on 2026-06-20) so longhorn pods pass
+  # kubescape C-0270, while keeping the memory limit unset to preserve the
+  # instance-manager OOM-cascade safeguard. See limitrange.yaml for details.
+  - limitrange.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/limitrange.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/limitrange.yaml
@@ -1,0 +1,39 @@
+---
+# CPU-only default LimitRange for longhorn-system (prod/hetzner only — Longhorn
+# is not deployed on the local docker cluster).
+#
+# Root cause (kubescape C-0270): longhorn-system USED to receive the generic
+# Kyverno-generated `default-limitrange` (cpu 500m + memory 512Mi). On 2026-06-20
+# it was excluded from both add-default-limitrange and add-ns-quota because the
+# *memory* limit OOMKilled instance-manager pods during volume rebuilds, and the
+# resulting IM restart faulted every replica engine on the node and cascaded into
+# CNPG primary failover. Excluding it removed the whole LimitRange, which also
+# dropped the harmless *CPU* limit — so every longhorn pod recreated since
+# (instance-managers on rebuild, longhorn-ui, the CSI sidecars on rollout) runs
+# with no CPU limit and fails C-0270. VPA (longhorn has 10) cannot help: it only
+# rescales an existing limit, never creates one.
+#
+# This restores ONLY the CPU limit and deliberately keeps memory unset, so the
+# OOM-cascade safeguard is preserved:
+#   * default.cpu "2" is generous and compressible — historically longhorn ran
+#     fine under the old 500m CPU cap (the incident was memory, never CPU), so a
+#     4x-higher ceiling cannot throttle a rebuild into failure; a CPU limit only
+#     slows, it never OOMKills, so it cannot trigger the IM-restart cascade.
+#   * NO default.memory — this is the entire point of the longhorn exclusion and
+#     must stay unset (instance-managers must be free to burst memory during a
+#     rebuild).
+#   * defaultRequest is a low floor so a container that omits requests is not
+#     handed the 2-core limit as its request.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limitrange
+  namespace: longhorn-system
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+      defaultRequest:
+        cpu: 15m
+        memory: 128Mi


### PR DESCRIPTION
## Problem

kubescape **C-0270 "Ensure CPU limits are set"** reports ~24 failing workloads (68% compliance). They are concentrated in exactly three namespaces — **`kube-system`, `kyverno`, `longhorn-system`** — which are also the only namespaces on the live cluster with **no `default-limitrange`** at all.

## Root cause

The platform seeds container CPU limits at **pod-admission** time, and VPA then right-sizes from there. There are two seed mechanisms, **both Kyverno-driven**:

1. `add-resource-defaults` (Kyverno *mutate*)
2. `add-default-limitrange` (Kyverno *generate* → the built-in LimitRanger enforces it)

VPA cannot bootstrap a limit — it only *rescales an existing* limit (confirmed live: velero's limit is VPA-scaled to `1666m` from a seeded `500m`). So a pod with **no admission-seeded limit** fails C-0270 and VPA can't rescue it.

Those three namespaces get **no seed**:

| Namespace | Why no seed | VPAs present? |
|---|---|---|
| `kube-system` | Kyverno **global `resourceFilters`** `[*/*,kube-system,*]` skip it in **all** Kyverno processing — mutate, generate, *and* `auto-vpa` | **0** |
| `kyverno` | Kyverno global `resourceFilters` `[*/*,kyverno,*]` (bootstrap-deadlock safeguard) skip it likewise — this is why it has no LimitRange despite *not* being in the policy's exclude list | **0** |
| `longhorn-system` | Explicitly excluded from both limit policies by the 2026-06-20 memory-OOM safeguard, which dropped the **whole** LimitRange (cpu *and* memory) when only the **memory** limit was dangerous | 10 (but nothing to scale) |

So `auto-vpa`'s comment that "kube-system is intentionally NOT excluded … VPA can right-size" is **defeated by the global filter** — there are literally 0 VPAs in `kube-system`/`kyverno`.

## Fix

Add **static, CPU-only `LimitRange`s** (plain manifests — immune to the `resourceFilters`; the built-in LimitRanger applies them regardless) to the three namespaces:

```yaml
default:        { cpu: "2" }          # generous: compressible, no scheduling impact, ~10–200× each request
defaultRequest: { cpu: 15m, memory: 128Mi }
# NO default.memory — an incompressible cap would re-introduce the OOM risk
```

- **CPU `2`** is a deliberately high ceiling. CPU is compressible and limits don't affect scheduling, so it never throttles the datapath (cilium req is `200m`) yet satisfies the control — honouring the "high limit when request is low" burst-headroom intent.
- **No memory limit** — preserves the exact safeguard that motivated the longhorn exclusion (a 512Mi cap OOMKills longhorn instance-managers on rebuild → CNPG failover cascade; same risk for cilium/spire under load).
- `kube-system` + `kyverno` LimitRanges live in the **base** (both clusters); the `longhorn-system` one is in the **hetzner overlay** (Longhorn is prod-only).

Also corrects the misleading `auto-vpa.yaml` comment.

### Residual (by design)
Static control-plane **mirror pods** (`kube-apiserver`/`etcd`/`kube-scheduler`/`kube-controller-manager`) bypass admission, so a LimitRange can't reach them — and they should not be CPU-limited anyway. They stay covered by the existing `vpa-managed-resources` `ClusterSecurityException`.

## Validation
- `kubectl kustomize` builds clean & deterministic for all roots: hetzner infra + controllers (all 3 LimitRanges render, CPU-only), docker infra + controllers (unaffected — they don't pull `limitranges/`).
- All 3 LimitRanges pass `kubectl apply --dry-run=client` (core/v1 schema).
- `ksail workload validate` (local + prod) passes 378 files. (One transient run hit the known ksail render race on an untouched path + the documented actual-budget OIDC offline false-failure — neither related to this change; `kubectl kustomize` is authoritative.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)