### PR TITLE
fix(rbac): scope headlamp SA to cluster-reader, fix C-0187 wildcard exceptions

### DIFF
--- a/k8s/bases/apps/headlamp/clusterrolebinding.yaml
+++ b/k8s/bases/apps/headlamp/clusterrolebinding.yaml
@@ -1,0 +1,27 @@
+---
+# Read-only cluster RBAC for the Headlamp backend ServiceAccount. Replaces the
+# chart's default cluster-admin ClusterRoleBinding, which is disabled in
+# helm-release.yaml (clusterRoleBinding.create: false). Headlamp authenticates
+# user requests with the logged-in user's OIDC token, so its ServiceAccount only
+# needs the platform's read-only cluster-reader role — not a `*/*/*` god-role
+# (Kubescape CIS-5.1.3 / C-0187).
+#
+# This is a separate, differently-named binding (not headlamp-admin) on purpose:
+# a ClusterRoleBinding's roleRef is immutable, so the existing cluster-admin
+# binding cannot be retargeted in place. Helm removes the old binding and this
+# one is created fresh, avoiding the "cannot change roleRef" upgrade failure.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-cluster-reader
+  labels:
+    app.kubernetes.io/name: headlamp
+    app.kubernetes.io/managed-by: ksail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: headlamp
+    namespace: headlamp

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -121,13 +121,18 @@ spec:
     # cluster-admin, but Headlamp runs with OIDC (config.oidc below;
     # unsafeUseServiceAccountToken defaults to false), so every Kubernetes API
     # request is authenticated with the logged-in USER's token — the pod
-    # ServiceAccount is not used to serve user requests. Bind the SA to the
-    # platform's read-only cluster-reader ClusterRole instead of cluster-admin:
-    # no `*/*/*` god-role (clears Kubescape CIS-5.1.3 / C-0187), while still
-    # covering any baseline cluster reads the backend performs. See
-    # k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml.
+    # ServiceAccount is not used to serve user requests.
+    #
+    # Disable the chart's ClusterRoleBinding and bind the SA to the read-only
+    # cluster-reader ClusterRole via our own binding (clusterrolebinding.yaml).
+    # We deliberately do NOT just set clusterRoleName: a ClusterRoleBinding's
+    # roleRef is IMMUTABLE, so retargeting the existing headlamp-admin binding
+    # fails the Helm upgrade ("cannot change roleRef"). Disabling create lets Helm
+    # delete the old cluster-admin binding, and our separate, differently-named
+    # binding is created fresh — no `*/*/*` god-role (clears Kubescape CIS-5.1.3 /
+    # C-0187), while still covering any baseline cluster reads the backend makes.
     clusterRoleBinding:
-      clusterRoleName: cluster-reader
+      create: false
     config:
       watchPlugins: true
       oidc:

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -117,6 +117,17 @@ spec:
           matchLabels:
             app.kubernetes.io/name: headlamp
             app.kubernetes.io/instance: headlamp
+    # Least-privilege RBAC. The chart default binds Headlamp's ServiceAccount to
+    # cluster-admin, but Headlamp runs with OIDC (config.oidc below;
+    # unsafeUseServiceAccountToken defaults to false), so every Kubernetes API
+    # request is authenticated with the logged-in USER's token — the pod
+    # ServiceAccount is not used to serve user requests. Bind the SA to the
+    # platform's read-only cluster-reader ClusterRole instead of cluster-admin:
+    # no `*/*/*` god-role (clears Kubescape CIS-5.1.3 / C-0187), while still
+    # covering any baseline cluster reads the backend performs. See
+    # k8s/bases/infrastructure/cluster-roles/cluster-reader.yaml.
+    clusterRoleBinding:
+      clusterRoleName: cluster-reader
     config:
       watchPlugins: true
       oidc:

--- a/k8s/bases/apps/headlamp/kustomization.yaml
+++ b/k8s/bases/apps/headlamp/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - pvc.yaml
   - helm-release.yaml
   - helm-repository.yaml
+  - clusterrolebinding.yaml
   - httproute.yaml
   - networkpolicy.yaml

--- a/k8s/bases/infrastructure/security-exceptions/controller-rbac.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/controller-rbac.yaml
@@ -37,8 +37,13 @@ spec:
       action: ignore
     - controlID: C-0035
       action: ignore
-    - controlID: C-0187
-      action: ignore
+    # NOTE: C-0187 (wildcard RBAC, CIS-5.1.3) is handled in wildcard-rbac.yaml,
+    # not here — a namespaceSelector exception does not suppress RBAC findings
+    # (Kubescape keys them on the Role/ClusterRole/binding object, so a namespace
+    # match never applies; proven: the namespaced velero-server Role kept failing
+    # despite `velero` being listed below). Headlamp is fixed at the root (SA
+    # scoped to read-only cluster-reader); Flux and Velero are exempted by-design
+    # in wildcard-rbac.yaml via an explicit kind+name resources match.
     - controlID: C-0188
       action: ignore
   match:

--- a/k8s/bases/infrastructure/security-exceptions/kustomization.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - service-account-tokens.yaml
   - upstream-chart-defaults.yaml
   - vpa-managed-resources.yaml
+  - wildcard-rbac.yaml

--- a/k8s/bases/infrastructure/security-exceptions/wildcard-rbac.yaml
+++ b/k8s/bases/infrastructure/security-exceptions/wildcard-rbac.yaml
@@ -1,0 +1,53 @@
+---
+# Wildcard-RBAC exception (Kubescape CIS-5.1.3 / C-0187, "Minimize wildcard use
+# in Roles and ClusterRoles") for the cluster-admin holders that require it BY
+# DESIGN.
+#
+# Why this is a separate CR and not a `namespaceSelector` entry in
+# controller-rbac.yaml: a namespaceSelector does NOT suppress C-0187 findings.
+# Kubescape attaches RBAC findings to the Role/ClusterRole/binding object, not to
+# a namespaced workload, so a namespace match never applies (proven: the
+# namespaced velero-server Role kept failing C-0187 even though `velero` was
+# listed in controller-rbac.yaml's selector). Matching the specific RBAC objects
+# by kind+name is the mechanism that actually works.
+#
+# Deliberately MINIMAL scope so C-0187 still flags any *new*/accidental wildcard
+# or cluster-admin grant elsewhere:
+#   - Flux GitOps reconcilers — kustomize-controller and helm-controller (bound
+#     via cluster-reconciler-flux-system) and flux-operator. cluster-admin is the
+#     GitOps trust model: Flux applies arbitrary manifests cluster-wide and
+#     cannot reconcile resources it lacks permission for.
+#   - Velero — the cluster-admin ClusterRoleBinding plus the namespaced
+#     velero-server Role. The chart's RBAC is all-or-nothing (no scoped mode) and
+#     restore must create/patch arbitrary resource kinds.
+#
+# NOT exempted (intentionally): Headlamp is fixed at the root (its SA is scoped to
+# the read-only cluster-reader role in k8s/bases/apps/headlamp/helm-release.yaml),
+# and longhorn-support-bundle is a transient diagnostic SA created on demand.
+apiVersion: kubescape.io/v1beta1
+kind: ClusterSecurityException
+metadata:
+  name: wildcard-rbac-by-design
+spec:
+  reason: >-
+    Flux GitOps controllers and Velero legitimately require cluster-admin /
+    wildcard RBAC by design: arbitrary-manifest reconciliation (Flux) and
+    cluster-wide backup/restore (Velero). The specific bindings are matched by
+    kind+name so C-0187 still catches any new wildcard or cluster-admin grant.
+  posture:
+    - controlID: C-0187
+      action: ignore
+  match:
+    resources:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: cluster-reconciler-flux-system
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: flux-operator
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: velero-server
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: velero-server


### PR DESCRIPTION
## What

Reduce wildcard / cluster-admin RBAC flagged by Kubescape **CIS-5.1.3 (C-0187)** — *Minimize wildcard use in Roles and ClusterRoles*.

- **Headlamp (root-cause fix)** — replace the chart's default `cluster-admin` ClusterRoleBinding with a read-only binding to `cluster-reader`. Headlamp authenticates every request with the logged-in user's OIDC token (`config.unsafeUseServiceAccountToken: false`), so the pod SA is not used for API calls and does not need cluster-admin. Implemented as `clusterRoleBinding.create: false` + a separate `headlamp-cluster-reader` binding, **not** by setting `clusterRoleName` — a ClusterRoleBinding's `roleRef` is immutable, so retargeting the existing binding in place fails the Helm upgrade.
- **Exceptions (mechanism fix)** — the C-0187 entry in `controller-rbac.yaml` used a `namespaceSelector`, which does **not** suppress RBAC findings: Kubescape keys C-0187 on the Role/ClusterRole/binding object, so a namespace match never applies (proven — the namespaced `velero-server` Role kept failing C-0187 even though `velero` was in the selector). Removed that dead entry and added `wildcard-rbac.yaml`, which matches the by-design holders by **kind+name**:
  - **Flux** GitOps reconcilers (`cluster-reconciler-flux-system`, `flux-operator`) — cluster-admin is the GitOps trust model (applies arbitrary manifests cluster-wide).
  - **Velero** (cluster-admin ClusterRoleBinding + namespaced `velero-server` Role) — the chart's RBAC is all-or-nothing and restore must write arbitrary kinds.

  The match is deliberately scoped to those bindings so C-0187 still flags any **new** accidental cluster-admin grant. `longhorn-support-bundle` (a transient diagnostic SA) is intentionally left unexempted.

## Why

C-0187 is a CIS control — **not** part of the NSA CI gate, so this is non-gating — but reducing standing cluster-admin is good hygiene. Headlamp was the one avoidable god-role; Flux and Velero require broad RBAC by design and are now covered by an exception that actually works (the previous `namespaceSelector` one was a silent no-op).

## Validation (static, no cluster mutated)

- `kubectl kustomize` builds clean for `clusters/local`, `clusters/prod`, and the `providers/{hetzner,docker}/{apps,infrastructure}` roots.
- Headlamp: chart renders **0** ClusterRoleBindings with `create: false` (Helm deletes the old `headlamp-admin`), and the new `headlamp-cluster-reader` binding subjects the `headlamp` SA to `cluster-reader` — no `*/*/*`.
- New `ClusterSecurityException` is schema-valid against the live CRD (`kubectl apply --dry-run=server`).
- Scoped exemption match verified read-only via `kubescape scan --exceptions`: C-0187 drops from 7 to exactly the Flux/Velero relationships suppressed, others retained.

> **v1 rollout fix:** the first revision set `clusterRoleName: cluster-reader`, which retargets the existing binding's immutable `roleRef` (`cannot change roleRef`) and wedged the Helm upgrade in the merge queue (Flux rolled back to cluster-admin). Fixed by recreating the binding under a new name.

> Post-merge check: confirm the in-cluster Kubescape operator dashboard shows C-0187 cleared for Flux/Velero. The operator applies `ClusterSecurityException` CRs additively (unlike the CLI `--exceptions` proxy used here), so the built-in `system:masters` exemption is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)