### PR TITLE
chore(coroot): auto-suppress by-design extensions host-app failed-conns

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/alert-autosuppressor.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/alert-autosuppressor.yaml
@@ -35,6 +35,25 @@
 #      separate `dns-server-errors` (SERVFAIL) builtin still covers genuine DNS
 #      faults for this app, so real "host does not exist" signal is not fully lost.
 #
+#   3. extensions-host-failed-conns - the `network-tcp-connections` ("failed to
+#      connect to N upstream services") warning on `_:Unknown:extensions`. This is
+#      NOT a Kubernetes workload: Coroot groups the Talos host-level processes it
+#      sees via eBPF but cannot map to a pod into per-node "Unknown" apps, and
+#      `extensions` is the Talos system-extension service group (siderolabs/
+#      iscsi-tools etc., one instance per node - see talos/cluster/install-image.yaml).
+#      Its failed connections are benign host noise: (a) stale/transient iSCSI
+#      (port 3260) sessions to targets Coroot cannot map (`external:3260`) during
+#      normal Longhorn volume churn - Longhorn itself stays healthy/attached - and
+#      (b) low-rate host->ksail-operator connects that don't complete while
+#      ksail-operator is itself fully healthy and reachable (verified: kubelet
+#      health probes to it are FORWARDED with zero Cilium drops). Nothing in a Talos
+#      host extension is fixable via a manifest, and a genuine storage fault would
+#      still surface via Longhorn volume health and the instance-manager apps' own
+#      SLOs, so this host-app connectivity signal is the least-actionable place to
+#      lose. Scoped to rule_id + the single app id. NB the sibling
+#      `_:Unknown:kubelet` raises the same rule; it is intentionally NOT suppressed
+#      here until its specific failed upstreams are separately verified benign.
+#
 # PROD-ONLY: Coroot alerting (the Slack webhook) is wired only in the hetzner
 # overlay, so this lives here, not in the base.
 apiVersion: batch/v1
@@ -131,6 +150,17 @@ spec:
                                and (.application_id | endswith(":flux-system:Deployment:tofu-controller")))
                       | .id'); do
                     ids="$ids $id"; echo "match tofu-empty-aaaa: $id"
+                  done
+
+                  # Exemption 3 - Talos host system-extension group benign failed
+                  # TCP connections (see header entry 3). Coroot-synthesised non-k8s
+                  # host app, so a genuine fault surfaces elsewhere (Longhorn volume
+                  # health, instance-manager SLOs), not here.
+                  for id in $(printf '%s' "$ALERTS" | jq -r '.data.alerts[]
+                      | select(.suppressed==false and .resolved_at==null and .rule_id=="network-tcp-connections"
+                               and (.application_id | endswith(":_:Unknown:extensions")))
+                      | .id'); do
+                    ids="$ids $id"; echo "match extensions-host-failed-conns: $id"
                   done
 
                   n=$(echo $ids | wc -w)


### PR DESCRIPTION
## What

Adds **Exemption 3** to the Coroot `alert-autosuppressor` CronJob, suppressing the `network-tcp-connections` ("failed to connect to N upstream services") alert on the `_:Unknown:extensions` application.

## Why it's by-design (not a bug)

`_:Unknown:extensions` is **not a Kubernetes workload**. Coroot groups the Talos **host system-extension** processes it observes via eBPF but can't map to a pod into per-node `Unknown` apps (it does the same for `kubelet` and `init`). `extensions` = the `siderolabs/iscsi-tools` etc. service group baked into the node image (`talos/cluster/install-image.yaml`, `ksail.prod.yaml`), one instance per node.

Its two "failed" upstreams were both traced to healthy targets:

| Upstream | Rate | Explanation |
|---|---|---|
| `external:3260` | ~0.1/s | iSCSI to a target Coroot can't map — stale/transient session during normal Longhorn churn. **All 14 Longhorn volumes `attached`/`healthy`**; instance-managers stable. |
| `ksail-operator` | ~0.33/s | Low-rate host→operator connects that don't complete. **ksail-operator is fully healthy** (7/7 Coroot indicators `ok`) and reachable — Hubble shows its health probes `FORWARDED` with **zero Cilium drops**. |

Nothing in a Talos host extension is fixable via a manifest, and a genuine storage fault would still surface through Longhorn volume health and the `instance-manager` apps' own SLOs — so this host-app connectivity signal is the least-actionable place to lose.

## Scope & safety

- Scoped to `rule_id == network-tcp-connections` **AND** `application_id` ending `:_:Unknown:extensions` — verified against live alert data to match **only** that app (not `kubelet`/`init`/others).
- The sibling `_:Unknown:kubelet` raises the same rule but is **intentionally left alone** pending separate verification of its specific upstreams.
- Same self-healing CronJob pattern as the existing two exemptions (survives DR / coroot-db rebuild; in-cluster API is anonymous-Admin so no credential).

## Validation

- `kubectl kustomize k8s/providers/hetzner/infrastructure` renders the change ✓
- `ksail --config ksail.prod.yaml workload validate` — no coroot errors
- `kubectl apply --dry-run=client` on the file ✓
- jq filter self-tested against the live `/api/.../alerts` payload → matches exactly the one extensions alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)