### PR TITLE
fix(coroot): route only incidents to Slack to cut alert fatigue

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -160,8 +160,22 @@ spec:
         baseURL: https://observability.${domain}
         webhook:
           url: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}
+          # Route only INCIDENTS (SLO/availability breaches -> :fire:) to Slack;
+          # keep Coroot's built-in inspection ALERTS in the UI only (alerts: false).
+          # Background: the #notifications channel was carrying ~250+ [warning]
+          # alerts per window with effectively zero incidents — dominated by
+          # transient "Kubernetes events" (Unhealthy / Longhorn Faulted during node
+          # rolls / VPA ResizeError) and "Network connectivity" flaps (the Cilium +
+          # SPIRE mutual-auth first-packet race documented on the coroot CronJobs)
+          # that fire and resolve on their own. That volume is alert fatigue: it
+          # buries the actionable :fire: incidents and desensitizes responders.
+          # The built-in alerts stay fully visible in the Coroot UI for
+          # investigation; only the Slack fan-out is muted. The alert-autosuppressor
+          # CronJob still trims specific by-design alerts in the UI — it is just no
+          # longer the only thing between the inspection noise and Slack. Flip back
+          # to true if a future check warrants paging on warnings directly.
           incidents: true
-          alerts: true
+          alerts: false
           # Slack-mrkdwn payloads. `json` (json.Marshal) escapes each
           # interpolated field so quotes/newlines can't break the JSON body.
           incidentTemplate: |


### PR DESCRIPTION
## Problem

The `#notifications` Slack channel is flooded with low-signal Coroot alerts. Sampling the recent stream:

| Alert rule | firing count | nature |
|---|---|---|
| Kubernetes events | ~110 | transient (Unhealthy probes, Longhorn `Faulted` during node rolls, VPA `ResizeError`) |
| Network connectivity | ~103 | transient flaps (Cilium + SPIRE mutual-auth first-packet race) |
| Log errors | ~35 | mostly self-resolving |
| Instance availability / DNS / Memory leak | ~8 | incl. the dex false-positive (separately fixed) |

That's **~250+ `[warning]` alerts per window with effectively zero incidents** — all severity `warning`, firing-and-resolving on their own. This is classic alert fatigue: the volume buries the genuinely actionable `:fire:` **incident** notifications (SLO / availability breaches) and desensitizes responders.

## Fix

Set `notificationIntegrations.webhook.alerts: false` (keep `incidents: true`) on the Coroot project. Slack now carries **only incidents**; every built-in inspection **alert remains fully visible in the Coroot UI** for investigation — only the Slack fan-out is muted.

- Incident notifications (the `:fire:` SLO/availability breaches that are actually actionable) are unchanged.
- The `alert-autosuppressor` CronJob still trims specific by-design alerts in the UI; it's just no longer the last line of defense against the inspection noise reaching Slack.
- Fully reversible — flip `alerts` back to `true` if a future check warrants paging on warnings directly.

## Why this lever

The Coroot CRD's only declarative knobs for this are the webhook `incidents` / `alerts` booleans (and the blunt `disableBuiltinAlerts`). The noise is broad and varied across many transient sources, so there's no safe surgical autosuppressor pattern that covers it — and disabling built-in alerts entirely would also remove them from the UI. Routing incidents-only keeps full detail in the UI while making Slack actionable again.

## Validation

`kubectl kustomize k8s/providers/hetzner/infrastructure/` builds clean; the rendered Coroot CR shows `incidents: true` + `alerts: false` on the webhook integration. Comment-only churn aside, this is a one-line behavior change.

Opened as **draft** (config applies to prod via Flux on merge) — promote when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)