### PR TITLE
feat(coroot): add declarative Postgres integration for platform CNPG databases

### DIFF
--- a/k8s/providers/hetzner/apps/backstage/coroot-scrape-networkpolicy.yaml
+++ b/k8s/providers/hetzner/apps/backstage/coroot-scrape-networkpolicy.yaml
@@ -1,0 +1,30 @@
+# Let the Coroot cluster-agent (observability namespace) reach the backstage-db
+# CloudNativePG instances on 5432 for the declarative Postgres integration — the
+# cluster-agent discovers the DB pods via the coroot.com/postgres-scrape
+# annotations the Cluster's inheritedMetadata stamps onto them, then connects to
+# scrape pg_stat_* (see patches/postgres-cluster-patch.yaml).
+#
+# ADDITIVE to allow-backstage (Cilium unions ingress allows across policies):
+# this only adds the cross-namespace observability source on 5432 while
+# allow-backstage keeps permitting intra-namespace + cnpg-system. Scoped to the
+# DB instance pods via CNPG's cnpg.io/cluster label. Mutual auth is enforced
+# automatically by the cluster-wide require-mutual-auth policy (both ends carry
+# SPIRE identities), so no authentication stanza is needed — see the umami
+# sibling policy for the full rationale. Prod-only (hetzner overlay).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-coroot-postgres-scrape
+  namespace: backstage
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: backstage-db
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/k8s/providers/hetzner/apps/backstage/patches/postgres-cluster-patch.yaml
+++ b/k8s/providers/hetzner/apps/backstage/patches/postgres-cluster-patch.yaml
@@ -1,0 +1,48 @@
+# Prod-only Coroot Postgres integration for backstage-db (strategic merge onto
+# the base Cluster). Coroot/SPIRE run only on Hetzner, so this lives in the
+# hetzner overlay. The base Cluster defines NO managed.roles, so adding the
+# block here creates it (nothing to replace).
+#
+#   inheritedMetadata.annotations — CNPG propagates these to the DB instance
+#     Pods so Coroot's cluster-agent can discover and scrape them (it only reads
+#     POD annotations). Credentials come from the CNPG-generated
+#     `backstage-db-app` Secret (kubernetes.io/basic-auth, username=backstage),
+#     the same one Backstage itself consumes. sslmode=require works whether
+#     CNPG's pg_hba uses `host` or `hostssl`.
+#   managed.roles — grant the existing `backstage` login membership in
+#     pg_monitor so Coroot (which logs in AS that role) can read the full
+#     pg_stat_* surface. passwordSecret pins the role to the CNPG-generated
+#     `backstage-db-app` value (which is exactly what the app uses), so CNPG's
+#     role synchronizer converges to that on every reconcile/promotion instead of
+#     re-applying a stale bootstrap password (the cnpg#2029 footgun that bit
+#     umami) — here it is a no-op convergence since CNPG owns that secret.
+#   postgresql.parameters.pg_stat_statements.* — CNPG's managed-extensions
+#     feature auto-adds the library to shared_preload_libraries (one-time rolling
+#     restart) and runs CREATE EXTENSION in every database; fully declarative.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: backstage-db
+  namespace: backstage
+spec:
+  inheritedMetadata:
+    annotations:
+      coroot.com/postgres-scrape: "true"
+      coroot.com/postgres-scrape-port: "5432"
+      coroot.com/postgres-scrape-credentials-secret-name: backstage-db-app
+      coroot.com/postgres-scrape-credentials-secret-username-key: username
+      coroot.com/postgres-scrape-credentials-secret-password-key: password
+      coroot.com/postgres-scrape-param-sslmode: require
+  managed:
+    roles:
+      - name: backstage
+        ensure: present
+        login: true
+        inRoles:
+          - pg_monitor
+        passwordSecret:
+          name: backstage-db-app
+  postgresql:
+    parameters:
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -9,6 +9,16 @@ resources:
   # API it reaches are Hetzner-only — on local/CI clusters the Terraform CRD is
   # absent. Reconciled by the shared `apps` Flux Kustomization like any tenant.
   - unifi/
+  # Prod-only Coroot Postgres integration for the platform-owned CNPG DBs:
+  # additive CiliumNetworkPolicies that let the observability cluster-agent
+  # scrape each on 5432 (the Cluster patches below stamp the
+  # coroot.com/postgres-scrape annotations + pg_monitor + pg_stat_statements).
+  # coroot-db needs none — it is intra-namespace to the agent and already
+  # covered by the base allow-coroot policy. The wedding-app TENANT owns its own
+  # equivalent in its repo's deploy/ (cluster.yaml + networkpolicy.yaml), since
+  # tenant DB instrumentation is tenant self-description, not a platform patch.
+  - umami/coroot-scrape-networkpolicy.yaml
+  - backstage/coroot-scrape-networkpolicy.yaml
 components:
   # Platform-wide HelmRelease drift detection (mode: enabled) — see
   # bases/components/helmrelease-drift-detection.
@@ -26,6 +36,21 @@ patches:
   # spec.interval) fails. Restore the patch from git history if re-enabling.
   - path: headlamp/patches/helm-release-patch.yaml
   - path: wedding-app/patches/kustomization-patch.yaml
+  # Prod-only Coroot Postgres integration for the in-repo CNPG DBs (strategic
+  # merge: inheritedMetadata scrape annotations + pg_stat_statements params, plus
+  # for backstage a pg_monitor managed role). These self-identify, so no target.
+  - path: umami/patches/postgres-cluster-patch.yaml
+  - path: backstage/patches/postgres-cluster-patch.yaml
+  # umami's pg_monitor grant is a JSON6902 append onto its EXISTING managed role
+  # (so it doesn't replace the list / desync the OpenBao-rotation enforcer); a
+  # JSON6902 patch has no embedded identity, so it keeps an explicit target.
+  - target:
+      group: postgresql.cnpg.io
+      version: v1
+      kind: Cluster
+      name: umami-db
+      namespace: umami
+    path: umami/patches/grant-pg-monitor-patch.yaml
   # Pilot: user namespaces (hostUsers: false) on whoami — prod-only; see the
   # patch file for the full rationale. JSON6902 patch (a list of ops) has no
   # embedded identity, so it must keep an explicit target.

--- a/k8s/providers/hetzner/apps/umami/coroot-scrape-networkpolicy.yaml
+++ b/k8s/providers/hetzner/apps/umami/coroot-scrape-networkpolicy.yaml
@@ -1,0 +1,38 @@
+# Let the Coroot cluster-agent (observability namespace) reach the umami-db
+# CloudNativePG instances on 5432 for the declarative Postgres integration —
+# the cluster-agent discovers the DB pods via the coroot.com/postgres-scrape
+# annotations the Cluster's inheritedMetadata stamps onto them, then connects to
+# scrape pg_stat_* (see patches/postgres-cluster-patch.yaml).
+#
+# ADDITIVE, not a replacement for allow-umami: Cilium unions the ingress allows
+# across every policy selecting an endpoint, so this standalone policy only adds
+# the cross-namespace observability source on 5432 while allow-umami keeps
+# permitting intra-namespace + cnpg-system + openbao. Scoped to the DB instance
+# pods via CNPG's cnpg.io/cluster label, mirroring the prod-only allow-coroot-db
+# policy in infrastructure/coroot/.
+#
+# No `authentication` stanza here on purpose: the cluster-wide
+# require-mutual-auth CiliumClusterwideNetworkPolicy already attaches
+# authentication.mode: required to ALL pod-to-pod ingress, and both the
+# cluster-agent and the DB pods carry SPIRE identities, so mutual auth is
+# enforced automatically — exactly how the existing cnpg-system/openbao ingress
+# rules in allow-umami work. The cluster-agent's egress to this namespace is
+# already permitted by the base allow-coroot policy (toEndpoints: namespace
+# Exists). Prod-only (hetzner overlay): Coroot and SPIRE run only on Hetzner.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-coroot-postgres-scrape
+  namespace: umami
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: umami-db
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP

--- a/k8s/providers/hetzner/apps/umami/patches/grant-pg-monitor-patch.yaml
+++ b/k8s/providers/hetzner/apps/umami/patches/grant-pg-monitor-patch.yaml
@@ -1,0 +1,14 @@
+# Grant the `umami` role membership in pg_monitor so Coroot's cluster-agent —
+# which logs in AS the umami role (its credential is umami-db-rotated, referenced
+# by the scrape annotations) — can read the full pg_stat_* surface (other
+# sessions, replication, bgwriter) rather than just its own. JSON6902 `add`
+# appends inRoles to the EXISTING managed role (index 0 = the sole `umami` role
+# in the base Cluster) instead of a strategic merge, which would replace the
+# whole managed.roles list and duplicate/desync the carefully-tuned umami role
+# (passwordSecret umami-db-rotated, the OpenBao-rotation enforcer). pg_monitor is
+# read-only, so this is a minimal privilege addition on a login the app already
+# holds.
+- op: add
+  path: /spec/managed/roles/0/inRoles
+  value:
+    - pg_monitor

--- a/k8s/providers/hetzner/apps/umami/patches/postgres-cluster-patch.yaml
+++ b/k8s/providers/hetzner/apps/umami/patches/postgres-cluster-patch.yaml
@@ -1,0 +1,37 @@
+# Prod-only Coroot Postgres integration for umami-db (strategic merge onto the
+# base Cluster). Coroot/SPIRE run only on Hetzner, so this lives in the hetzner
+# overlay alongside umami's other prod-only wiring. The pg_monitor grant on the
+# `umami` role is a separate JSON6902 patch (grant-pg-monitor-patch.yaml) so it
+# appends to the existing managed role instead of replacing the list.
+#
+#   inheritedMetadata.annotations — CNPG propagates these to the DB instance
+#     Pods (and its other managed objects, harmlessly). Coroot's cluster-agent
+#     only reads POD annotations, so this is the supported way to make a
+#     CNPG-managed Postgres discoverable. It reads the username/password from the
+#     OpenBao-rotated `umami-db-rotated` Secret (kubernetes.io/basic-auth, same
+#     namespace) — the SAME live credential the app uses, so it always tracks
+#     rotations. sslmode=require layers Postgres TLS on top of the WireGuard wire
+#     and works whether CNPG's pg_hba uses `host` or `hostssl`.
+#   postgresql.parameters.pg_stat_statements.* — CNPG's managed-extensions
+#     feature: setting any pg_stat_statements.* parameter makes the operator add
+#     pg_stat_statements to shared_preload_libraries (a one-time rolling restart)
+#     AND run CREATE EXTENSION IF NOT EXISTS in every database — fully
+#     declarative, no Job or superuser step. Feeds Coroot's per-query view.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: umami-db
+  namespace: umami
+spec:
+  inheritedMetadata:
+    annotations:
+      coroot.com/postgres-scrape: "true"
+      coroot.com/postgres-scrape-port: "5432"
+      coroot.com/postgres-scrape-credentials-secret-name: umami-db-rotated
+      coroot.com/postgres-scrape-credentials-secret-username-key: username
+      coroot.com/postgres-scrape-credentials-secret-password-key: password
+      coroot.com/postgres-scrape-param-sslmode: require
+  postgresql:
+    parameters:
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all

--- a/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/postgres-cluster.yaml
@@ -42,6 +42,26 @@ metadata:
     kustomize.toolkit.fluxcd.io/force: disabled
     kustomize.toolkit.fluxcd.io/prune: disabled
 spec:
+  # Coroot Postgres self-integration: stamp the coroot.com/postgres-scrape
+  # annotations onto the DB instance Pods (CNPG inheritedMetadata propagates to
+  # all managed objects, incl. Pods) so Coroot's own cluster-agent discovers and
+  # scrapes this metadata DB. It only reads POD annotations, so inheritedMetadata
+  # is the supported path for a CNPG-managed Postgres. Credentials come from the
+  # CNPG-generated `coroot-db-app` Secret (kubernetes.io/basic-auth,
+  # username=coroot) — the same one the Coroot server consumes. Intra-namespace,
+  # so the base allow-coroot policy already permits the scrape (no extra
+  # NetworkPolicy, unlike the cross-namespace umami/backstage DBs; the wedding-app
+  # tenant ships its own equivalent in its repo's deploy/networkpolicy.yaml).
+  # sslmode=require works whether CNPG's pg_hba uses `host` or `hostssl`.
+  inheritedMetadata:
+    annotations:
+      coroot.com/postgres-scrape: "true"
+      coroot.com/postgres-scrape-port: "5432"
+      coroot.com/postgres-scrape-credentials-secret-name: coroot-db-app
+      coroot.com/postgres-scrape-credentials-secret-username-key: username
+      coroot.com/postgres-scrape-credentials-secret-password-key: password
+      coroot.com/postgres-scrape-param-sslmode: require
+
   # Run 3 instances (1 primary + 2 streaming replicas) for high availability —
   # the SAME rationale as umami-db: a single-instance Cluster makes CNPG create a
   # `<cluster>-primary` PDB with minAvailable=1 on the only pod, which BLOCKS
@@ -75,6 +95,13 @@ spec:
       # replica from a base backup (cheap: the DB is ~32Mi). Set well above
       # normal WAL for this low-write metadata DB, yet well below the 10Gi volume.
       max_slot_wal_keep_size: "3GB"
+      # Enable pg_stat_statements for Coroot's per-query latency/calls view. CNPG's
+      # managed-extensions feature keys off any pg_stat_statements.* parameter: it
+      # adds the library to shared_preload_libraries (a one-time rolling restart)
+      # AND runs CREATE EXTENSION IF NOT EXISTS in every database automatically —
+      # fully declarative, no Job or superuser step.
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
     # Quorum-based SYNCHRONOUS replication — the SAME rationale as umami-db: it
     # guarantees the promoted standby holds every committed transaction, so an
     # unclean primary loss during a longhorn instance-manager restart / node roll
@@ -90,6 +117,22 @@ spec:
     initdb:
       database: coroot
       owner: coroot
+  # Grant the existing `coroot` login membership in pg_monitor so the cluster-agent
+  # (which logs in AS the coroot role via coroot-db-app) can read the full
+  # pg_stat_* surface. passwordSecret pins the role to the CNPG-generated
+  # coroot-db-app value the server already uses, so CNPG's role synchronizer
+  # converges to it on every reconcile/promotion (a no-op here, since CNPG owns
+  # that Secret) rather than re-applying a stale bootstrap password. pg_monitor is
+  # read-only — a minimal addition to a login the Coroot server already holds.
+  managed:
+    roles:
+      - name: coroot
+        ensure: present
+        login: true
+        inRoles:
+          - pg_monitor
+        passwordSecret:
+          name: coroot-db-app
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
Makes the platform-owned CloudNativePG databases — **coroot-db**, **umami-db**, **backstage-db** — discoverable by Coroot's cluster-agent, so they show as integrated Postgres in observability instead of "Integration required".

## Mechanism (fully declarative — no UI, no Job)
- **`inheritedMetadata`** stamps the `coroot.com/postgres-scrape` annotations onto the DB instance Pods (CNPG propagates `inheritedMetadata` to Pods; the cluster-agent only reads Pod annotations). Credentials come from each DB's existing Secret — umami's OpenBao-rotated `umami-db-rotated`, and the CNPG-generated `<cluster>-app` for coroot/backstage.
- **`pg_monitor`** is granted to the app role via a CNPG managed role so Coroot can read the full `pg_stat_*` surface. umami's grant is a **JSON6902 append** onto its existing managed role (so it doesn't replace the OpenBao-rotation enforcer); coroot/backstage add a managed role pinned to `<cluster>-app` (convergence, no rotation risk).
- **`pg_stat_statements`** is enabled via CNPG's *managed-extensions* feature: any `pg_stat_statements.*` parameter auto-adds the library to `shared_preload_libraries` and runs `CREATE EXTENSION` in every database — so it works on existing clusters with no Job or superuser step.
- **Additive `CiliumNetworkPolicy`** lets the observability cluster-agent reach umami-db/backstage-db on 5432; coroot-db is intra-namespace (already covered by `allow-coroot`). Mutual auth is enforced automatically by the cluster-wide `require-mutual-auth` policy.

Prod-only (hetzner overlay), since Coroot and SPIRE run only on Hetzner.

## Tenant split
The `wedding-app` **tenant** owns its DB instrumentation in its own repo — companion draft PR: devantler-tech/wedding-app#136. This PR covers only the platform-owned databases. (`ascoachingogvaner` has no DB of its own — it uses umami.)

## ⚠️ Operational note
Enabling `pg_stat_statements` adds it to `shared_preload_libraries`, which triggers a **one-time CNPG rolling restart** of each of the three databases (replicas first, then a switchover) when this reconciles. Near-zero downtime with the HA + synchronous setups, but it is a switchover per DB.

## Validation
- `kubectl kustomize` builds for all four provider overlays (hetzner apps/infra, docker apps/infra).
- Confirmed via `yq` that each Cluster renders the correct annotations, `pg_monitor` grant, and params — and that umami's `inRoles` **appends** to its existing role (the `umami-db-rotated` enforcer is preserved).
- All six annotation keys verified against the cluster-agent source (`coroot-cluster-agent` `metrics/target.go`, pinned `v1.7.1`); the operator grants the cluster-agent cluster-wide `secrets` read by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)