### PR TITLE
feat(vpa): enable VPA for kube-system and kyverno workloads (prod)

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -3,16 +3,18 @@
 # kube-system is intentionally NOT excluded by THIS policy's match rules — but
 # be aware Kyverno's GLOBAL resourceFilters (`[*/*,kube-system,*]` and
 # `[*/*,kyverno,*]` in the kyverno ConfigMap) exclude kube-system and kyverno
-# from ALL Kyverno processing, so in practice NO VerticalPodAutoscaler is
-# generated there (0 VPAs live in both). Their controllers (cilium, cilium-envoy,
+# from ALL Kyverno processing, so THIS policy never generates a VPA there.
+# Because VPA right-sizing IS wanted for those controllers (cilium, cilium-envoy,
 # spire-agent, coredns, metrics-server, hubble, hcloud ccm/csi, tetragon,
-# cluster-autoscaler, the kyverno controllers) keep their hand-tuned request
-# floors but are NOT VPA-right-sized; their CPU *limits* are seeded instead by
-# the static CPU-only LimitRanges in k8s/bases/infrastructure/limitranges/ (the
-# only admission path that reaches a globally-filtered namespace — kubescape
-# C-0270). Static control-plane pods (kube-apiserver/etcd/scheduler/
-# controller-manager) are bare mirror Pods, not Deployment/StatefulSet/DaemonSet,
-# so they never match here and bypass the LimitRange too.
+# cluster-autoscaler, the kyverno controllers), prod ships equivalent STATIC VPAs
+# (same policy as below) in k8s/providers/hetzner/infrastructure/system-vpas/,
+# which bypass Kyverno entirely; their CPU/memory burst *limits* are seeded by
+# the LimitRanges in k8s/bases/infrastructure/limitranges/ (CPU there, plus a
+# generous prod memory `default` patched on in the hetzner overlay) for VPA to
+# scale ratio-preserving. Static control-plane pods (kube-apiserver/etcd/
+# scheduler/controller-manager) are bare mirror Pods, not Deployment/StatefulSet/
+# DaemonSet, so they match neither this policy nor the static VPAs, and bypass
+# the LimitRange too.
 #
 # IN-PLACE RESIZE (no eviction) is active. InPlacePodVerticalScaling went GA
 # in k8s 1.35 (KEP-1287) and prod runs v1.35.5; VPA is 1.6 (its own

--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -71,18 +71,22 @@ spec:
     # so we must set pod-level seccompProfile + runAsNonRoot via chart values.
     admissionController:
       replicas: ${kyverno_admission_replicas:=2}
-      # Explicit static sizing -- NOT VPA-managed. Kyverno's own admission and
-      # generate policies exclude the kyverno namespace (to avoid an eviction
-      # deadlock during a Kyverno outage), so auto-vpa.yaml never creates a VPA
-      # for these Deployments (verified: zero VPAs in ns/kyverno). That left the
-      # admission controller on the chart-default limits.memory: 384Mi, which
-      # OOMKilled (exit 137) under image-verification + policy-evaluation load.
-      # Because the verify-image-signatures webhooks are failurePolicy: Fail,
-      # the dead admission controller then rejected every Pod/Deployment/Job
-      # CREATE cluster-wide (e.g. ksail-operator FailedCreate -> stuck
-      # HelmRelease upgrade) until it recovered. Pin a generous explicit limit
-      # -- still far under auto-vpa's 6Gi maxAllowed ceiling -- so this pod has
-      # real headroom and a single sizing authority.
+      # Explicit resources = the COLD-START FLOOR. Kyverno's global resourceFilters
+      # exclude ns/kyverno from auto-vpa, so the admission controller was long left
+      # on the chart-default limits.memory: 384Mi, which OOMKilled (exit 137) under
+      # image-verification + policy-evaluation load; because the
+      # verify-image-signatures webhooks are failurePolicy: Fail, the dead
+      # controller then rejected every Pod/Deployment/Job CREATE cluster-wide (e.g.
+      # ksail-operator FailedCreate -> stuck HelmRelease upgrade) until it
+      # recovered. It is now ALSO VPA-managed via a static VPA in
+      # providers/hetzner/infrastructure/system-vpas/ (auto-vpa still can't reach
+      # this namespace), which right-sizes it at steady state; these values remain
+      # as the safe baseline a fresh pod starts on before VPA has a recommendation
+      # (the 1Gi memory limit keeps that window well above the 384Mi OOM
+      # threshold). Eviction is no longer a deadlock risk: the VPA resizes IN PLACE
+      # (no eviction), and with replicas: 2 + the PDB a Recreate fallback or an OOM
+      # only ever takes one replica, so the admission path stays up. Limit stays
+      # far under auto-vpa's 6Gi maxAllowed ceiling.
       resources:
         requests:
           cpu: 100m

--- a/k8s/providers/hetzner/infrastructure/controllers/coredns/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/coredns/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../../../bases/infrastructure/controllers/coredns/
+  - pod-disruption-budget.yaml
 patches:
   - path: patches/corefile-config-map-patch.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/coredns/pod-disruption-budget.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/coredns/pod-disruption-budget.yaml
@@ -1,0 +1,19 @@
+---
+# Prod CoreDNS (KSail/Talos-managed Deployment, 2 replicas) ships no PDB, so a
+# node drain or a VPA Recreate-fallback eviction could take both replicas at once
+# and briefly black-hole cluster DNS. This adds the same drain-safe PDB the
+# docker overlay already has, so at least one replica always serves. Pairs with
+# the coredns VPA in providers/hetzner/infrastructure/system-vpas/.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  # maxUnavailable: 1 is the platform-wide drain-safe PDB pattern (issue #1880):
+  # never deadlocks a drain regardless of replica count, and bounds disruption to
+  # one pod at a time (behaviourally identical to minAvailable: 1 at 2 replicas).
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -84,6 +84,12 @@ resources:
   # TEMPORARILY DISABLED 2026-06-16..#2097 while the pin still read 7.58.3, which
   # predated #5277; the old balloon-pod buffer was already removed in #2087.)
   - overprovisioning/
+  # Prod-only: static VerticalPodAutoscalers for kube-system + kyverno. auto-vpa
+  # (Kyverno) can't reach these namespaces (global resourceFilters), so VPA is
+  # supplied as plain manifests here. Pairs with the LimitRange memory-seed
+  # patches below — together VPA right-sizes requests down while keeping a
+  # generous, no-OOM burst limit. See system-vpas/kustomization.yaml.
+  - system-vpas/
   #
   # NOTE: tenant-owned custom-domain TLS (the ascoachingogvaner.dk Certificate +
   # its simply.com DNS01 solver credential) is NOT a platform resource at all —
@@ -123,4 +129,30 @@ patches:
   # (see the file header). Self-identifies via PersistentVolumeClaim/openbao/
   # vault-snapshots, so no explicit target is needed.
   - path: vault-snapshots-hcloud-patch.yaml
+  # Prod-only: add a generous memory `default` to the kube-system / kyverno
+  # LimitRanges (which are CPU-only in the base). This seeds the memory limit the
+  # system-vpas/ VPAs scale ratio-preserving, so VPA right-sizes the memory
+  # REQUEST down to real usage while the limit stays a generous multiple (no OOM
+  # — the seed is far above every workload's real peak). kube-system 4Gi gives
+  # cilium (512Mi req) ~8:1 and smaller add-ons far more; kyverno 2Gi gives its
+  # 128Mi controllers ~16:1. Kept here (not the base) so the base stays CPU-only
+  # and the memory limit is scoped to prod, where the VPAs that manage it live.
+  - target:
+      version: v1
+      kind: LimitRange
+      name: default-limitrange
+      namespace: kube-system
+    patch: |
+      - op: add
+        path: /spec/limits/0/default/memory
+        value: 4Gi
+  - target:
+      version: v1
+      kind: LimitRange
+      name: default-limitrange
+      namespace: kyverno
+    patch: |
+      - op: add
+        path: /spec/limits/0/default/memory
+        value: 2Gi
 

--- a/k8s/providers/hetzner/infrastructure/system-vpas/kube-system.yaml
+++ b/k8s/providers/hetzner/infrastructure/system-vpas/kube-system.yaml
@@ -1,0 +1,409 @@
+# VPAs for kube-system workloads. Policy mirrors auto-vpa.yaml (see
+# kustomization.yaml for the full rationale). Mirror pods (kube-apiserver, etcd,
+# kube-scheduler, kube-controller-manager) are bare Pods, not controllers, so
+# they are intentionally absent — VPA cannot target them.
+#
+# --- Deployments (updateMode InPlaceOrRecreate, maxAllowed cpu 3 / mem 6Gi) ---
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cilium-operator
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cluster-autoscaler-hetzner-cluster-autoscaler
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cluster-autoscaler-hetzner-cluster-autoscaler
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: coredns
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hcloud-cloud-controller-manager
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: hcloud-csi-controller
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hcloud-csi-controller
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: hubble-relay
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hubble-relay
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hubble-ui
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: metrics-server
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: snapshot-controller
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: snapshot-controller
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: tetragon-operator
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tetragon-operator
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+# --- DaemonSets (updateMode InPlaceOrRecreate, maxAllowed cpu 1 / mem 1Gi so a
+#     per-node pod still fits the smallest autoscale-cx23 worker) ---
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: cilium
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cilium-envoy
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: cilium-envoy
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: hcloud-csi-node
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: hcloud-csi-node
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: spire-agent
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: spire-agent
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: tetragon
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: tetragon
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi
+# --- StatefulSet: spire-server is a singleton on an RWO volume, so updateMode
+#     Initial (apply at next natural restart, never evict) — mirrors auto-vpa. ---
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: spire-server
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: spire-server
+  updatePolicy:
+    updateMode: Initial
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi

--- a/k8s/providers/hetzner/infrastructure/system-vpas/kube-system.yaml
+++ b/k8s/providers/hetzner/infrastructure/system-vpas/kube-system.yaml
@@ -1,9 +1,11 @@
-# VPAs for kube-system workloads. Policy mirrors auto-vpa.yaml (see
-# kustomization.yaml for the full rationale). Mirror pods (kube-apiserver, etcd,
-# kube-scheduler, kube-controller-manager) are bare Pods, not controllers, so
-# they are intentionally absent — VPA cannot target them.
+# VPA targets for kube-system. The shared updatePolicy + resourcePolicy is
+# applied ONCE via patches in kustomization.yaml (so it is not repeated per
+# workload); each entry here is just a targetRef. DaemonSets carry
+# `vpa-tier: daemonset` so the patch can give them the tighter per-node ceiling.
+# Mirror pods (kube-apiserver/etcd/scheduler/controller-manager) are bare Pods,
+# not controllers, so they are intentionally absent — VPA cannot target them.
 #
-# --- Deployments (updateMode InPlaceOrRecreate, maxAllowed cpu 3 / mem 6Gi) ---
+# --- Deployments ---
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -15,20 +17,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: cilium-operator
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -40,20 +28,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: cluster-autoscaler-hetzner-cluster-autoscaler
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -65,20 +39,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: coredns
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -90,20 +50,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: hcloud-cloud-controller-manager
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -115,20 +61,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: hcloud-csi-controller
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -140,20 +72,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: hubble-relay
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -165,20 +83,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: hubble-ui
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -190,20 +94,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: metrics-server
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -215,20 +105,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: snapshot-controller
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -240,149 +116,75 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: tetragon-operator
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
-# --- DaemonSets (updateMode InPlaceOrRecreate, maxAllowed cpu 1 / mem 1Gi so a
-#     per-node pod still fits the smallest autoscale-cx23 worker) ---
+# --- DaemonSets (vpa-tier: daemonset → tighter maxAllowed so a per-node pod
+#     still fits the smallest autoscale-cx23 worker) ---
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: cilium
   namespace: kube-system
+  labels:
+    vpa-tier: daemonset
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
     name: cilium
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "1"
-          memory: 1Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: cilium-envoy
   namespace: kube-system
+  labels:
+    vpa-tier: daemonset
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
     name: cilium-envoy
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "1"
-          memory: 1Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: hcloud-csi-node
   namespace: kube-system
+  labels:
+    vpa-tier: daemonset
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
     name: hcloud-csi-node
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "1"
-          memory: 1Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: spire-agent
   namespace: kube-system
+  labels:
+    vpa-tier: daemonset
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
     name: spire-agent
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "1"
-          memory: 1Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: tetragon
   namespace: kube-system
+  labels:
+    vpa-tier: daemonset
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
     name: tetragon
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "1"
-          memory: 1Gi
-# --- StatefulSet: spire-server is a singleton on an RWO volume, so updateMode
-#     Initial (apply at next natural restart, never evict) — mirrors auto-vpa. ---
+# --- StatefulSet: spire-server is a singleton on an RWO volume; the
+#     kustomization patch overrides its updateMode to Initial (never evict). ---
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -394,16 +196,3 @@ spec:
     apiVersion: apps/v1
     kind: StatefulSet
     name: spire-server
-  updatePolicy:
-    updateMode: Initial
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi

--- a/k8s/providers/hetzner/infrastructure/system-vpas/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/system-vpas/kustomization.yaml
@@ -1,0 +1,42 @@
+---
+# Static VerticalPodAutoscalers for kube-system + kyverno (prod/hetzner only).
+#
+# WHY STATIC (not auto-vpa): `auto-vpa` is a Kyverno *generate* policy, and
+# Kyverno's global resourceFilters (`[*/*,kube-system,*]`, `[*/*,kyverno,*]` in
+# the kyverno ConfigMap) exclude these two namespaces from ALL Kyverno
+# processing — so auto-vpa never creates VPAs there (0 VPAs live). VPA's OWN
+# admission webhook has empty selectors, so it DOES inject recommendations into
+# every namespace; the only missing piece is the VPA objects themselves. These
+# plain manifests supply them, bypassing Kyverno entirely. Names/kinds mirror the
+# live workloads exactly (a VPA whose targetRef misses silently no-ops).
+#
+# POLICY mirrors auto-vpa.yaml so these behave identically to every other
+# VPA in the cluster (controlledValues RequestsAndLimits; minAllowed cpu 50m /
+# mem 64Mi; maxAllowed cpu 3 / mem 6Gi for Deployment/StatefulSet, cpu 1 /
+# mem 1Gi for DaemonSets so a DS pod still fits the smallest autoscale-cx23
+# node; updateMode InPlaceOrRecreate so the datapath/admission pods are RESIZED
+# IN PLACE, never evicted — spire-server is a singleton StatefulSet on an RWO
+# volume, so it uses Initial like auto-vpa's StatefulSet rule).
+#
+# GENEROUS MEMORY RATIO (no OOM): the base LimitRanges
+# (k8s/bases/infrastructure/limitranges/) are CPU-only. The parent hetzner
+# kustomization patches a generous memory `default` onto them (kube-system 4Gi,
+# kyverno 2Gi) so VPA has a memory limit to scale RATIO-PRESERVING:
+#   * VPA right-sizes the memory REQUEST down to real average usage (e.g. cilium
+#     ~250Mi vs its 512Mi request — the capacity win the requests reclaim).
+#   * The limit stays a generous multiple of that request (cilium ~8:1, smaller
+#     add-ons far more), so a load spike has headroom before it ever reaches the
+#     limit — bursts don't OOMKill. The seed (4Gi/2Gi) is far above every
+#     workload's real peak (<~600Mi), which is exactly what keeps it safe: the
+#     2026-06-20 longhorn OOM cascade was a TIGHT 512Mi cap, not a generous one.
+# CPU is compressible, so its generous limit (#2308's default.cpu "2", scaled by
+# VPA) only ever throttles, never kills.
+#
+# longhorn-system is deliberately NOT here: it already has auto-vpa-managed VPAs
+# (it is not globally filtered) and its LimitRange MUST stay memory-unset (the
+# instance-manager OOM-cascade safeguard).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kube-system.yaml
+  - kyverno.yaml

--- a/k8s/providers/hetzner/infrastructure/system-vpas/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/system-vpas/kustomization.yaml
@@ -4,39 +4,84 @@
 # WHY STATIC (not auto-vpa): `auto-vpa` is a Kyverno *generate* policy, and
 # Kyverno's global resourceFilters (`[*/*,kube-system,*]`, `[*/*,kyverno,*]` in
 # the kyverno ConfigMap) exclude these two namespaces from ALL Kyverno
-# processing — so auto-vpa never creates VPAs there (0 VPAs live). VPA's OWN
-# admission webhook has empty selectors, so it DOES inject recommendations into
-# every namespace; the only missing piece is the VPA objects themselves. These
-# plain manifests supply them, bypassing Kyverno entirely. Names/kinds mirror the
-# live workloads exactly (a VPA whose targetRef misses silently no-ops).
+# processing — so auto-vpa never creates VPAs there. Narrowing that global
+# filter would re-expose both namespaces to EVERY mutate/validate policy (several
+# of which don't self-exclude kube-system, e.g. image-signature verification on
+# the third-party system images), so the surgical fix is to author the VPA
+# objects directly here. VPA's own admission webhook has empty selectors, so it
+# injects recommendations into every namespace regardless.
 #
-# POLICY mirrors auto-vpa.yaml so these behave identically to every other
-# VPA in the cluster (controlledValues RequestsAndLimits; minAllowed cpu 50m /
-# mem 64Mi; maxAllowed cpu 3 / mem 6Gi for Deployment/StatefulSet, cpu 1 /
-# mem 1Gi for DaemonSets so a DS pod still fits the smallest autoscale-cx23
-# node; updateMode InPlaceOrRecreate so the datapath/admission pods are RESIZED
-# IN PLACE, never evicted — spire-server is a singleton StatefulSet on an RWO
-# volume, so it uses Initial like auto-vpa's StatefulSet rule).
+# NO PER-WORKLOAD DUPLICATION: the shared updatePolicy + resourcePolicy (which
+# mirrors auto-vpa.yaml) is defined ONCE in the patches below and applied to
+# every VPA via a kind selector. The per-workload files carry only targetRefs.
+#   * base patch  → all VPAs: InPlaceOrRecreate (resize in place, never evict the
+#     datapath/admission pods), controlledValues RequestsAndLimits, minAllowed
+#     cpu 50m/mem 64Mi, maxAllowed cpu 3/mem 6Gi.
+#   * `vpa-tier: daemonset` → tighter maxAllowed cpu 1/mem 1Gi, so a per-node pod
+#     still fits the smallest autoscale-cx23 worker.
+#   * spire-server → updateMode Initial: it is a singleton StatefulSet on an RWO
+#     volume, so it is right-sized only at its next natural restart, never evicted.
 #
 # GENEROUS MEMORY RATIO (no OOM): the base LimitRanges
-# (k8s/bases/infrastructure/limitranges/) are CPU-only. The parent hetzner
+# (k8s/bases/infrastructure/limitranges/) are CPU-only; the parent hetzner
 # kustomization patches a generous memory `default` onto them (kube-system 4Gi,
-# kyverno 2Gi) so VPA has a memory limit to scale RATIO-PRESERVING:
-#   * VPA right-sizes the memory REQUEST down to real average usage (e.g. cilium
-#     ~250Mi vs its 512Mi request — the capacity win the requests reclaim).
-#   * The limit stays a generous multiple of that request (cilium ~8:1, smaller
-#     add-ons far more), so a load spike has headroom before it ever reaches the
-#     limit — bursts don't OOMKill. The seed (4Gi/2Gi) is far above every
-#     workload's real peak (<~600Mi), which is exactly what keeps it safe: the
-#     2026-06-20 longhorn OOM cascade was a TIGHT 512Mi cap, not a generous one.
-# CPU is compressible, so its generous limit (#2308's default.cpu "2", scaled by
-# VPA) only ever throttles, never kills.
+# kyverno 2Gi) so VPA scales the memory limit RATIO-PRESERVING — the request is
+# right-sized down to real usage (cilium ~250Mi vs its 512Mi request) while the
+# limit stays a generous multiple far above any real peak (<~600Mi), so bursts
+# don't OOMKill. CPU is compressible, so its limit only ever throttles.
+#
+# EVICTION SAFETY: in-place resize means no eviction in the normal path; for the
+# Recreate fallback, the eviction-sensitive targets are HA so it is harmless —
+# kyverno controllers + coredns run 2 replicas with PDBs (coredns PDB added in
+# controllers/coredns/), and spire-server uses updateMode Initial.
 #
 # longhorn-system is deliberately NOT here: it already has auto-vpa-managed VPAs
-# (it is not globally filtered) and its LimitRange MUST stay memory-unset (the
+# (not globally filtered) and its LimitRange MUST stay memory-unset (the
 # instance-manager OOM-cascade safeguard).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - kube-system.yaml
   - kyverno.yaml
+patches:
+  # Shared policy for every system VPA (mirrors auto-vpa.yaml).
+  - target:
+      kind: VerticalPodAutoscaler
+    patch: |
+      - op: add
+        path: /spec/updatePolicy
+        value:
+          updateMode: InPlaceOrRecreate
+          minReplicas: 1
+      - op: add
+        path: /spec/resourcePolicy
+        value:
+          containerPolicies:
+            - containerName: "*"
+              controlledResources: ["cpu", "memory"]
+              controlledValues: RequestsAndLimits
+              minAllowed:
+                cpu: 50m
+                memory: 64Mi
+              maxAllowed:
+                cpu: "3"
+                memory: 6Gi
+  # DaemonSets: per-node pods must fit the smallest autoscale-cx23 worker.
+  - target:
+      kind: VerticalPodAutoscaler
+      labelSelector: vpa-tier=daemonset
+    patch: |
+      - op: replace
+        path: /spec/resourcePolicy/containerPolicies/0/maxAllowed
+        value:
+          cpu: "1"
+          memory: 1Gi
+  # spire-server: singleton StatefulSet on an RWO volume — never evict.
+  - target:
+      kind: VerticalPodAutoscaler
+      name: spire-server
+    patch: |
+      - op: replace
+        path: /spec/updatePolicy
+        value:
+          updateMode: Initial

--- a/k8s/providers/hetzner/infrastructure/system-vpas/kyverno.yaml
+++ b/k8s/providers/hetzner/infrastructure/system-vpas/kyverno.yaml
@@ -1,8 +1,10 @@
-# VPAs for the kyverno controllers. Policy mirrors auto-vpa.yaml (see
-# kustomization.yaml). InPlaceOrRecreate resizes in place, so the admission
-# controller is never evicted (no cluster-wide admission gap). The memory
-# request right-sizes UP where needed too — e.g. the admission controller
-# currently uses ~245Mi against its 128Mi request.
+# VPA targets for the kyverno controllers (shared policy applied via
+# kustomization.yaml patches). All four run 2 replicas with PDBs, so an
+# InPlaceOrRecreate resize — or even a Recreate fallback / OOM — only ever takes
+# one replica at a time, never the whole admission path (the cluster-wide
+# admission outage the helm-release's static sizing originally guarded against).
+# The admission controller keeps its explicit helm-release resources as a
+# cold-start floor; VPA scales from there.
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -14,20 +16,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: kyverno-admission-controller
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -39,20 +27,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: kyverno-background-controller
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -64,20 +38,6 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: kyverno-cleanup-controller
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -89,17 +49,3 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: kyverno-reports-controller
-  updatePolicy:
-    updateMode: InPlaceOrRecreate
-    minReplicas: 1
-  resourcePolicy:
-    containerPolicies:
-      - containerName: "*"
-        controlledResources: ["cpu", "memory"]
-        controlledValues: RequestsAndLimits
-        minAllowed:
-          cpu: 50m
-          memory: 64Mi
-        maxAllowed:
-          cpu: "3"
-          memory: 6Gi

--- a/k8s/providers/hetzner/infrastructure/system-vpas/kyverno.yaml
+++ b/k8s/providers/hetzner/infrastructure/system-vpas/kyverno.yaml
@@ -1,0 +1,105 @@
+# VPAs for the kyverno controllers. Policy mirrors auto-vpa.yaml (see
+# kustomization.yaml). InPlaceOrRecreate resizes in place, so the admission
+# controller is never evicted (no cluster-wide admission gap). The memory
+# request right-sizes UP where needed too — e.g. the admission controller
+# currently uses ~245Mi against its 128Mi request.
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kyverno-admission-controller
+  namespace: kyverno
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kyverno-admission-controller
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kyverno-background-controller
+  namespace: kyverno
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kyverno-background-controller
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kyverno-cleanup-controller
+  namespace: kyverno
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kyverno-cleanup-controller
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kyverno-reports-controller
+  namespace: kyverno
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kyverno-reports-controller
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsAndLimits
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        maxAllowed:
+          cpu: "3"
+          memory: 6Gi


### PR DESCRIPTION
## Goal

Right-size resource **requests** in `kube-system` and `kyverno` down to real usage, while keeping a **generous burst limit** so spikes never OOMKill — i.e. actually run VPA in the two namespaces it was silently absent from. Builds on #2308.

## Why not just extend `auto-vpa.yaml`?

It can't reach these namespaces. `auto-vpa` is a Kyverno *generate* policy, and Kyverno's **global `resourceFilters`** (`[*/*,kube-system,*]`, `[*/*,kyverno,*]`) drop both namespaces *before any policy is evaluated* — so it generates 0 VPAs there regardless of the policy's own match rules. Narrowing that global filter would re-expose `kube-system` to **every** mutate/validate policy (several don't self-exclude it — e.g. image-signature verification would start evaluating the third-party system images), a large blast radius for no functional gain. VPA's *own* admission webhook has empty selectors, so it injects recommendations everywhere — the only missing piece is the VPA objects, supplied here as plain manifests.

## What this does

**20 static `VerticalPodAutoscaler`s** (prod/hetzner only — `system-vpas/`), de-duplicated: the shared policy (mirrors `auto-vpa.yaml`) is defined **once** as a kustomize patch; each per-workload entry is just a `targetRef`.

| Namespace | Workloads | Update mode | maxAllowed |
|---|---|---|---|
| `kube-system` | 10 Deployments | `InPlaceOrRecreate` | cpu 3 / mem 6Gi |
| `kube-system` | 5 DaemonSets | `InPlaceOrRecreate` | cpu 1 / mem 1Gi (fits cx23) |
| `kube-system` | `spire-server` (StatefulSet) | `Initial` (never evict) | cpu 3 / mem 6Gi |
| `kyverno` | 4 controllers | `InPlaceOrRecreate` | cpu 3 / mem 6Gi |

### Generous, no-OOM memory ratio
Base LimitRanges (#2308) are CPU-only; the hetzner overlay patches a memory `default` onto them so VPA scales the memory limit **ratio-preserving**:
- `kube-system` → **4Gi** (~8:1 over cilium's 512Mi request; far more for small add-ons)
- `kyverno` → **2Gi** (~16:1 over its 128Mi controllers)

VPA right-sizes the memory *request* down to real usage (cilium uses ~250Mi vs its 512Mi request) while the limit stays a generous multiple **far above any real peak (<~600Mi)** — bursts have headroom and are never OOMKilled. (Safe inverse of the 2026-06-20 longhorn incident, which was a *tight* 512Mi cap.) CPU limits are compressible → throttle only.

### HA so eviction is a non-issue
In-place resize means no eviction in the normal path; for the rare Recreate fallback, the eviction-sensitive targets are HA:
- **kyverno** controllers: already 2 replicas + PDBs → VPA/OOM only ever takes one at a time, so the `failurePolicy: Fail` admission path can't go down cluster-wide (the documented deadlock the static sizing guarded against). The admission controller keeps its helm-release resources as a **cold-start floor** and is now also VPA-managed (comment updated).
- **coredns**: prod (KSail/Talos-managed) had **no PDB** — added the same `maxUnavailable: 1` drain-safe PDB the docker overlay already ships, so a drain/eviction can't drop both DNS replicas.
- **spire-server**: singleton on an RWO volume → `updateMode: Initial`.

### Unchanged
- **`longhorn-system`** — already auto-vpa-managed (not globally filtered); its LimitRange must stay memory-unset (the instance-manager OOM-cascade safeguard).
- **Control-plane mirror pods** (apiserver/etcd/scheduler/cm) — bare Pods, VPA can't target them.

## Validation
- `kubectl kustomize` (authoritative) builds clean & deterministic — all 20 VPAs hydrate via the shared patch (5 DaemonSets at 1/1Gi, 15 at 3/6Gi, spire-server `Initial`), both LimitRange memory patches apply, coredns PDB renders once per overlay, docker overlay unaffected.
- `ksail … workload validate` (local + prod): `✔ system-vpas`, `✔ limitranges`, `✔ kyverno`, `✔ {docker,hetzner}/…/coredns`. The lone `✗ docker/infrastructure/controllers` is the pre-existing ksail render-race / actual-budget OIDC false-failure on a path this PR doesn't touch (clean via `kubectl kustomize`); a CI rerun clears it.

## Rollout note
VPA applies via in-place resize once the recommender has history; the memory limit attaches per-pod at admission (LimitRanger), so the change rolls in gradually — no mass restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added static resource tuning for key system components in the Hetzner infrastructure, including autoscaling guidance for core services.
  * Added a disruption budget for CoreDNS to help keep DNS available during node maintenance.
* **Bug Fixes**
  * Improved default memory settings for system namespaces to better align workload sizing and reduce resource-related failures.
  * Added dedicated autoscaling coverage for Kyverno and multiple `kube-system` workloads for more stable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->