### PR TITLE
fix(kubescape): make ClusterSecurityException posture exceptions take effect

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/cluster-role-binding.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/cluster-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Binds the `kubescape-security-exceptions-reader` ClusterRole (see `cluster-role.yaml`)
+# to the posture scanner's `kubescape` ServiceAccount.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubescape-security-exceptions-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubescape-security-exceptions-reader
+subjects:
+  - kind: ServiceAccount
+    name: kubescape
+    namespace: kubescape

--- a/k8s/bases/infrastructure/controllers/kubescape/cluster-role.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/cluster-role.yaml
@@ -10,7 +10,7 @@
 # the offline (empty) source, so ZERO posture exceptions apply and the dashboard reads
 # "excluding 0 controls" even though the ClusterSecurityException CRs are deployed and
 # schema-valid. This supplements the chart's RBAC; remove it once the chart grants the
-# scanner this access upstream.
+# scanner this access upstream. Bound to the scanner SA by `cluster-role-binding.yaml`.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,16 +19,3 @@ rules:
   - apiGroups: ["kubescape.io"]
     resources: ["securityexceptions", "clustersecurityexceptions"]
     verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kubescape-security-exceptions-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubescape-security-exceptions-reader
-subjects:
-  - kind: ServiceAccount
-    name: kubescape
-    namespace: kubescape

--- a/k8s/bases/infrastructure/controllers/kubescape/exceptions-rbac.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/exceptions-rbac.yaml
@@ -1,0 +1,34 @@
+---
+# Grants the Kubescape posture scanner (`kubescape` ServiceAccount) read access to the
+# SecurityException / ClusterSecurityException CRDs.
+#
+# The scanner's CRD exceptions getter (kubescape image >= v4.0.9, see the HelmRelease
+# `kubescape.image.tag` override) LISTs these CRDs to apply posture exceptions. But the
+# kubescape-operator chart (<= 1.40.2) only grants this RBAC to the operator + kubevuln
+# components — never to the posture scanner SA. Without it the getter's List() is
+# forbidden; the scanner's merged exceptions getter swallows that error and falls back to
+# the offline (empty) source, so ZERO posture exceptions apply and the dashboard reads
+# "excluding 0 controls" even though the ClusterSecurityException CRs are deployed and
+# schema-valid. This supplements the chart's RBAC; remove it once the chart grants the
+# scanner this access upstream.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubescape-security-exceptions-reader
+rules:
+  - apiGroups: ["kubescape.io"]
+    resources: ["securityexceptions", "clustersecurityexceptions"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubescape-security-exceptions-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubescape-security-exceptions-reader
+subjects:
+  - kind: ServiceAccount
+    name: kubescape
+    namespace: kubescape

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -49,15 +49,21 @@ spec:
       continuousScan: enable
       vulnerabilityScan: enable
       runtimeDetection: enable
-      # Apply the in-cluster SecurityException / ClusterSecurityException CRDs
-      # (k8s/bases/infrastructure/cluster-security-exceptions/) to posture results. The
-      # chart gates the operator/kubevuln/scanner RBAC for those CRDs behind this
-      # capability (chart default `disable`), so while it is off the scanner loads
-      # zero exceptions and the dashboard reads "excluding 0 controls" even though
-      # the CRs are deployed and schema-valid. Enabling it creates the RBAC and
-      # activates the CRD exception getter (namespaceSelector.matchExpressions is
-      # resolved against live namespaces). Exemptions stay a LAST RESORT behind
-      # real fixes — keep the cluster-security-exceptions set minimal and irreducible.
+      # Enables Kubescape's risk-acceptance feature, so the operator/kubevuln process
+      # the in-cluster SecurityException / ClusterSecurityException CRDs
+      # (k8s/bases/infrastructure/cluster-security-exceptions/) and emit posture-exception
+      # match events (kubescape#2291). IMPORTANT: this flag alone does NOT make POSTURE
+      # exceptions apply — that needs TWO more things the chart (<= 1.40.2) does not give us:
+      #   (1) the posture scanner reads those CRDs via a CRD exceptions getter that only
+      #       exists in kubescape image >= v4.0.9 (kubescape#2322); chart 1.40.2 still pins
+      #       the scanner to v4.0.8 → see the `kubescape.image.tag` override below; and
+      #   (2) the scanner ServiceAccount needs RBAC to `list` those CRDs, which NO chart
+      #       version grants it (only operator/kubevuln get it) → see `exceptions-rbac.yaml`.
+      # With v4.0.8 + no RBAC the scanner silently loads zero exceptions (its merged getter
+      # swallows the missing/forbidden CRD source and falls back to the offline = empty
+      # primary), so the dashboard reads "excluding 0 controls" even though the CRs are
+      # deployed and schema-valid. Exemptions stay a LAST RESORT behind real fixes — keep
+      # the cluster-security-exceptions set minimal and irreducible.
       riskAcceptance: enable
       # Run posture/config scanning OFFLINE (air-gapped). This cluster has no
       # ARMO SaaS account, but the chart defaults to submit-mode: the scanner
@@ -91,6 +97,20 @@ spec:
       config:
         hostSensor:
           enabled: true
+    kubescape:
+      image:
+        # The posture scanner applies the SecurityException / ClusterSecurityException
+        # CRDs via its CRD exceptions getter, added in kubescape v4.0.9
+        # (kubescape#2291 + #2322). Chart 1.40.2 still pins the scanner to v4.0.8, which
+        # has NO such getter, so posture exceptions are silently ignored no matter how the
+        # CRs are authored or what RBAC exists. Override to v4.0.9 so the getter is present;
+        # it is paired with `exceptions-rbac.yaml`, which grants the scanner SA the `list`
+        # RBAC the getter needs (the chart never grants it). The v4.0.9 merged getter still
+        # swallows a missing-RBAC/CRD source, so this bump cannot break scans on its own.
+        # Drop both once the chart bumps the scanner past v4.0.9 AND grants it the
+        # securityexceptions RBAC. (Same component-image-ahead-of-chart pattern as the
+        # nodeAgent override above.)
+        tag: v4.0.9
     # Hetzner CSI provisions a minimum 10Gi volume; match the PVC request
     # to avoid Helm upgrade failures from PVC shrink rejection.
     persistence:

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -58,7 +58,8 @@ spec:
       #       exists in kubescape image >= v4.0.9 (kubescape#2322); chart 1.40.2 still pins
       #       the scanner to v4.0.8 → see the `kubescape.image.tag` override below; and
       #   (2) the scanner ServiceAccount needs RBAC to `list` those CRDs, which NO chart
-      #       version grants it (only operator/kubevuln get it) → see `exceptions-rbac.yaml`.
+      #       version grants it (only operator/kubevuln get it) → see `cluster-role.yaml`
+      #       + `cluster-role-binding.yaml`.
       # With v4.0.8 + no RBAC the scanner silently loads zero exceptions (its merged getter
       # swallows the missing/forbidden CRD source and falls back to the offline = empty
       # primary), so the dashboard reads "excluding 0 controls" even though the CRs are
@@ -104,7 +105,8 @@ spec:
         # (kubescape#2291 + #2322). Chart 1.40.2 still pins the scanner to v4.0.8, which
         # has NO such getter, so posture exceptions are silently ignored no matter how the
         # CRs are authored or what RBAC exists. Override to v4.0.9 so the getter is present;
-        # it is paired with `exceptions-rbac.yaml`, which grants the scanner SA the `list`
+        # it is paired with `cluster-role.yaml` + `cluster-role-binding.yaml`, which grant
+        # the scanner SA the `list`
         # RBAC the getter needs (the chart never grants it). The v4.0.9 merged getter still
         # swallows a missing-RBAC/CRD source, so this bump cannot break scans on its own.
         # Drop both once the chart bumps the scanner past v4.0.9 AND grants it the

--- a/k8s/bases/infrastructure/controllers/kubescape/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - cilium-network-policy.yaml
-  - exceptions-rbac.yaml
+  - cluster-role.yaml
+  - cluster-role-binding.yaml

--- a/k8s/bases/infrastructure/controllers/kubescape/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - helm-release.yaml
   - helm-repository.yaml
   - cilium-network-policy.yaml
+  - exceptions-rbac.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Kubescape posture exceptions have **no effect**: every `ClusterSecurityException` under `k8s/bases/infrastructure/cluster-security-exceptions/` is deployed and schema-valid, the scanner even logs `Loading exceptions… Loaded exceptions`, yet exempted controls keep failing and the dashboard reads "excluding 0 controls". Enabling `riskAcceptance: enable` alone did not fix it.

## Root cause (two upstream gaps, both required)

The in-cluster **posture scanner** is the component that applies posture exceptions. It reads the `SecurityException` / `ClusterSecurityException` CRDs through the kubescape CLI's **CRD exceptions getter** (`core/cautils/getter/crdexceptionsgetter.go`), which is **always merged in** when running in-cluster (`initutils.go`) and does a dynamic **`list`** on `securityexceptions` + `clustersecurityexceptions` (`kubescape.io/v1beta1`).

Two things block it, and **both** must be fixed:

1. **Scanner image too old.** The CRD exceptions getter was **added in kubescape `v4.0.9`** (`kubescape#2291` *Emit SecurityException events for posture exception matches* + `#2322` *resolve namespaceSelector for cluster exceptions*). Chart `1.40.2` — the **latest** — still pins the scanner to **`v4.0.8`**, which has **no such getter at all** (`raw.githubusercontent.com/.../v4.0.8/.../crdexceptionsgetter.go` → 404; `v4.0.9` → 200). So on v4.0.8 the CRDs are never read, regardless of RBAC.
2. **Scanner lacks RBAC.** Even on v4.0.9 the getter needs `list` on those CRDs, but **no chart version grants the posture-scanner ServiceAccount that access** — the chart only grants it to the `operator` + `kubevuln` ClusterRoles (verified live: `kubectl auth can-i list clustersecurityexceptions --as=system:serviceaccount:kubescape:kubescape` → **no**). The scanner's **merged** exceptions getter **swallows** the resulting forbidden/missing-source error and falls back to the offline (empty) primary source — which is exactly why it still logs `Loaded exceptions` while applying **zero** of them.

`riskAcceptance: enable` (already on `main`) toggles the feature for the operator/kubevuln and event emission, but it does **not** create the scanner RBAC nor back-port the getter into v4.0.8 — so it was necessary-but-insufficient. The comment that claimed it "creates the RBAC and activates the getter" is corrected here.

## Fix

- **Bump the posture scanner image to `v4.0.9`** via `kubescape.image.tag` in the HelmRelease values, so the CRD exceptions getter exists (same component-image-ahead-of-chart pattern as the existing `nodeAgent` override). The v4.0.9 merged getter still silently swallows a missing-RBAC CRD source, so this bump **cannot break scans on its own**.
- **Add `exceptions-rbac.yaml`** — a `ClusterRole` + `ClusterRoleBinding` granting the `kubescape` SA `get/list/watch` on `securityexceptions` + `clustersecurityexceptions`, supplementing the chart RBAC the scanner is missing.
- **Correct the `riskAcceptance` comment** to document the real requirements.

Together: the scanner now has the getter **and** the RBAC, so `ClusterSecurityException` posture exceptions actually load and apply. Drop both overrides once the chart bumps the scanner past v4.0.9 **and** grants it the `securityexceptions` RBAC upstream (worth filing on `kubescape/helm-charts`).

## Validation

- `ksail --config ksail.prod.yaml workload validate` → **464 files validated** (green).
- `kubectl kustomize k8s/bases/infrastructure/controllers/kubescape/` renders the new ClusterRole/Binding + the `v4.0.9` tag; local overlay (kubescape excluded) unaffected.
- Live root-cause confirmation on prod: granting the scanner the CSE-list RBAC flipped `can-i` to `yes`; the v4.0.8 image is the remaining blocker (no getter), confirmed by the version diff above. Final end-to-end (`appliedIgnoreRules` populated, exempted controls dropping) is observable once this deploys (scanner on v4.0.9 + RBAC).

## Follow-up (separate from this mechanism fix)

Once exceptions apply, review individual CSE **match scopes** — e.g. `wildcard-rbac-by-design` matches `kind: ClusterRoleBinding`, but control **C-0187 (“Workload with cluster takeover roles”) flags the workload**, not the binding, so that exception may still not suppress its target until its `match` is retargeted. (Cluster-wide CSEs with no `match`, e.g. `vpa-managed-resources`/`talos-cis-*`, correctly match all kinds.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading in-cluster posture exception resources so scan results can include configured exceptions.
  * Updated the Kubescape deployment to use a scanner image version that supports exception handling.

* **Bug Fixes**
  * Fixed cases where enabling risk acceptance alone did not apply exceptions during scans.
  * Ensured the scanner has the required access to read exception resources in the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->