### PR TITLE
ci: migrate deploy-prod Flux diagnostics to shared diagnose-flux composite

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -289,41 +289,14 @@ runs:
 
     - name: 🩺 Diagnose Flux on failure
       if: failure() && steps.reconcile.outcome == 'failure'
-      shell: bash
-      env:
-        HCLOUD_TOKEN: ${{ inputs.hcloud-token }}
-      run: |
-        set +e
-        echo "::group::Flux Kustomizations"
-        kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A -o wide
-        echo "::endgroup::"
-        echo "::group::Flux HelmReleases"
-        kubectl get helmreleases.helm.toolkit.fluxcd.io -A -o wide
-        echo "::endgroup::"
-        echo "::group::Flux OCIRepositories"
-        kubectl get ocirepositories.source.toolkit.fluxcd.io -A -o wide
-        echo "::endgroup::"
-        echo "::group::Failing Kustomizations describe"
-        for k in infrastructure-controllers infrastructure apps; do
-          echo "--- $k ---"
-          kubectl describe kustomizations.kustomize.toolkit.fluxcd.io "$k" -n flux-system 2>&1 | tail -60
-        done
-        echo "::endgroup::"
-        echo "::group::Flux controller pods"
-        kubectl get pods -n flux-system -o wide
-        echo "::endgroup::"
-        echo "::group::kustomize-controller logs"
-        kubectl logs -n flux-system -l app=kustomize-controller --tail=200
-        echo "::endgroup::"
-        echo "::group::helm-controller logs"
-        kubectl logs -n flux-system -l app=helm-controller --tail=200
-        echo "::endgroup::"
-        echo "::group::source-controller logs"
-        kubectl logs -n flux-system -l app=source-controller --tail=100
-        echo "::endgroup::"
-        echo "::group::Recent events (warnings)"
-        kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp | tail -50
-        echo "::endgroup::"
+      # Shared composite (extracted from the richest platform-template variant,
+      # devantler-tech/actions#367). Its default `kustomizations` input is
+      # `infrastructure-controllers infrastructure apps` — identical to the list
+      # this callsite previously hard-coded — so this is behaviour-preserving for
+      # the describe loop and a strict diagnostics upgrade otherwise (Nodes,
+      # all-pods, failing/CrashLooping pod logs, Job logs, failing-Job describes,
+      # larger --tail values). Failure-path-only: it cannot affect a green deploy.
+      uses: devantler-tech/actions/diagnose-flux@e182f2207fb386ef827f48b3cc9b7deac873046a # v7.1.0
 
     - name: 🔄 Update cluster (Talos machine config)
       # Runs LAST, after manifest delivery, so an unreachable control-plane


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## What

Replace the inline `🩺 Diagnose Flux on failure` step in `.github/actions/deploy-prod/action.yml` (the prod-deploy reconcile failure path) with the shared composite `devantler-tech/actions/diagnose-flux@e182f2207fb386ef827f48b3cc9b7deac873046a # v7.1.0`.

This is the **fourth and final** callsite of the `Diagnose Flux on failure` block that [devantler-tech/actions#367](https://github.com/devantler-tech/actions/issues/367) set out to consolidate. The three platform-template copies were already migrated in [platform-template#46](https://github.com/devantler-tech/platform-template/pull/46) (merged 2026-06-27); this PR completes the sweep.

## Why it is safe

- **Failure-path-only diagnostics.** The step is gated `if: failure() && steps.reconcile.outcome == 'failure'` and only *dumps* Flux/cluster state with `set +e`. It cannot influence a successful deploy — the only observable change is *which* diagnostics print when a deploy has already failed.
- **Behaviour-preserving for the describe loop.** The composite's `kustomizations` input defaults to `infrastructure-controllers infrastructure apps` — byte-identical to the list this callsite previously hard-coded — so no `with:` override is needed.
- **Strict diagnostics upgrade otherwise.** The composite (extracted from platform-template's richest variant) additionally dumps Nodes, all pods, failing/CrashLooping pod logs (current + previous), Job pod logs, and failing-Job describes, with larger `--tail` values (300/300/200/80/100 vs the old 200/200/100/60/50) — exactly when good diagnostics matter most, on a failed real prod deploy.
- **Pin parity.** Pinned to the same SHA (`e182f22…`, v7.1.0) the platform-template callsites use, keeping all four byte-consistent — the whole point of #367.

## Validation

- `yq` parse of the edited `action.yml` confirms the step is a well-formed composite `uses:` step (`name`/`if`/`uses` only; no stray `run`/`shell`/`env`).
- diagnose-flux is unchanged between v7.1.0 and v7.1.1, so the pin is current.
- Net diff: −35 / +8 lines, single file.

Fixes devantler-tech/actions#367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment failure diagnostics, making it easier to troubleshoot Flux-related issues when a deploy does not succeed.
  * Kept the existing failure-only behavior intact, so normal successful deployments are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->