### PR TITLE
feat(security): cosign-verify the infrastructure Flux OCI artifact

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -142,17 +142,24 @@ spec:
     # composite (push → sign → attest); this makes Flux REJECT any infra artifact
     # whose signature is missing or whose signer is not the platform deploy
     # workflow — closing the supply-chain gap #1559 opened for apps but left on
-    # the infra source (#1570). The signer identity was confirmed against the live
-    # signature: the artifact is signed by .github/workflows/ci.yaml (the
-    # merge-queue deploy-prod path) under GitHub's Fulcio OIDC issuer; cd.yaml (the
-    # manual deploy path, same composite/identity flow) is allowed too so a manual
-    # deploy is not rejected. `@.+` keeps the matcher resilient to the per-run ref
-    # (merge_group runs sign under refs/heads/gh-readonly-queue/...).
+    # the infra source (#1570). The signer identity + ref were confirmed against
+    # the live signature with `cosign verify`: the artifact is signed by
+    # .github/workflows/ci.yaml on refs/heads/gh-readonly-queue/main/<pr> (the
+    # merge-queue deploy-prod path — the real prod deploy) under GitHub's Fulcio
+    # OIDC issuer. The subject is pinned to the two *production* deploy refs only
+    # (merge-queue refs off main, plus a manual cd.yaml dispatch from main) rather
+    # than `@.+`, so a signature these workflows might produce on any other ref is
+    # not trusted (defence in depth on a high-blast-radius source).
     verify:
       provider: cosign
       matchOIDCIdentity:
+        # Automatic prod deploy: ci.yaml deploy-prod runs on merge_group, which
+        # signs under the merge-queue ref refs/heads/gh-readonly-queue/main/<pr>.
         - issuer: '^https://token\.actions\.githubusercontent\.com$'
-          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/(ci|cd)\.yaml@.+$'
+          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/ci\.yaml@refs/heads/gh-readonly-queue/main/.+$'
+        # Manual prod deploy: cd.yaml is workflow_dispatch, run from main.
+        - issuer: '^https://token\.actions\.githubusercontent\.com$'
+          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/cd\.yaml@refs/heads/main$'
   provider:
     hetzner:
       # Hetzner account hard cap: at most 10 servers total. Under the in-progress

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -135,6 +135,24 @@ spec:
         - siderolabs/qemu-guest-agent
     localRegistry:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
+    # Cosign keyless signature verification on the flux-system OCIRepository that
+    # KSail generates and owns (rendered onto spec.verify; a hand-written override
+    # would lose the reconcile fight, so it is configured here per ksail#4987).
+    # The manifests artifact is already cosign-signed keyless in the deploy-prod
+    # composite (push → sign → attest); this makes Flux REJECT any infra artifact
+    # whose signature is missing or whose signer is not the platform deploy
+    # workflow — closing the supply-chain gap #1559 opened for apps but left on
+    # the infra source (#1570). The signer identity was confirmed against the live
+    # signature: the artifact is signed by .github/workflows/ci.yaml (the
+    # merge-queue deploy-prod path) under GitHub's Fulcio OIDC issuer; cd.yaml (the
+    # manual deploy path, same composite/identity flow) is allowed too so a manual
+    # deploy is not rejected. `@.+` keeps the matcher resilient to the per-run ref
+    # (merge_group runs sign under refs/heads/gh-readonly-queue/...).
+    verify:
+      provider: cosign
+      matchOIDCIdentity:
+        - issuer: '^https://token\.actions\.githubusercontent\.com$'
+          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/(ci|cd)\.yaml@.+$'
   provider:
     hetzner:
       # Hetzner account hard cap: at most 10 servers total. Under the in-progress


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Closes #1570 — enables keyless **cosign signature verification** on the `flux-system` `OCIRepository` (the platform's own manifests source: the single largest blast radius in the cluster — it defines every controller, policy, and gateway). Extends the supply-chain verification #1559 added for *apps* to the *infrastructure* source.

## This is the issue I'd been self-blocking on — deep investigation dissolved the gate

My 2026-06-26 triage parked #1570 'awaiting maintainer direction' and called signing 'the real remaining gap'. Investigating live proved that wrong:

1. **The SIGN half is already done.** The shared `deploy-prod` composite already signs the manifests artifact keyless (`push → sign → attest`; `cosign sign --yes --recursive` on the digest, plus SBOM attestation). My triage trusted the issue body's stale *'no signing step'* and never re-checked the composite.
2. **So only the VERIFY half remained.** Per #4987 the `flux-system` `OCIRepository` is **KSail-generated and continuously reconciled**, so a hand-written `spec.verify` would lose the reconcile fight. KSail exposes **`spec.cluster.verify`** (`FluxVerifySpec`, present in v7.84.x — platform's exact pin) which it renders onto the generated `OCIRepository`. This PR sets it.

## The matcher is grounded in the real signature, not a guess

This is high blast radius — a wrong identity makes Flux reject the infra artifact and halt all reconciliation — so I read the **live** signature rather than guessing. `cosign verify ghcr.io/devantler-tech/platform/manifests:latest` confirmed the artifact is signed by **`.github/workflows/ci.yaml`** (the merge-queue `deploy-prod` path) under issuer `https://token.actions.githubusercontent.com` — `ci.yaml` matches, `cd.yaml` does not (no manual deploy has signed yet). The matcher allows **both** `ci.yaml` and `cd.yaml` (same composite/identity flow, so a future manual deploy isn't rejected), and `@.+` keeps it resilient to the per-run ref (`merge_group` signs under `refs/heads/gh-readonly-queue/...`).

```yaml
verify:
  provider: cosign
  matchOIDCIdentity:
    - issuer: '^https://token\.actions\.githubusercontent\.com$'
      subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/(ci|cd)\.yaml@.+$'
```

## Validation

- Live signature inspected with cosign (identity confirmed, above).
- `ksail.prod.yaml` parses (yq); config is **schema-valid** against ksail's schema (`provider` enum + `matchOIDCIdentity` shape, no extra keys); ksail **v7.84.1** (platform's exact pin) accepts the field; the render is **unit-tested upstream** (`ocirepository_verify_test.go`).
- Behaviour-preserving until it deploys: the artifact is *already signed*, so verification passes for legitimately-published artifacts; it only starts **rejecting** unsigned/foreign-signed ones.

## Blast radius — why it's a draft

Verification can't be fully exercised without a deploy. It's left as a **draft** so you can promote it when you're ready to watch the first merge-queue `deploy-prod` reconcile with verification on. If anything were wrong with the identity, the symptom would be the `flux-system` `OCIRepository` failing to verify — recoverable by reverting this one-field change.

**Out of scope:** upstream third-party Helm OCI charts (hcloud-csi, longhorn, …) remain unverified — we can't sign upstream artifacts; that's a separate concern, not part of this issue's 'our own infra artifact' fix.