### PR TITLE
feat(homepage): add Enable Banking bookmark link

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -168,6 +168,9 @@ data:
         - Codecov:
             - icon: si-codecov-#F01F7A
               href: https://app.codecov.io
+        - Enable Banking:
+            - icon: mdi-bank-outline
+              href: https://enablebanking.com
         - StepSecurity:
             - icon: si-stepsecurity
               href: https://app.stepsecurity.io


### PR DESCRIPTION
Adds an **Enable Banking** bookmark (`https://enablebanking.com`) under the **Developer Tools** section of the homepage app.

### Changes
- `k8s/bases/apps/homepage/config-map.yaml` — new bookmark entry in `bookmarks.yaml`.

### Notes
- Used `mdi-bank-outline` as the icon since Enable Banking has no Simple Icons (`si-`) glyph.
- Placed under **Developer Tools** (open-banking API service).

### Validation
- `kubectl kustomize k8s/clusters/local/` and `k8s/clusters/prod/` both build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)