### PR TITLE
ci: heal prod when a merge-group deploy fails (restore main)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,6 +178,62 @@ jobs:
           ghcr-token: ${{ secrets.GHCR_TOKEN }}
           hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
 
+  heal-prod-on-failure:
+    name: 🩹 Heal Prod (restore main on merge-group failure)
+    needs: [changes, deploy-prod]
+    # The deploy above runs on the SPECULATIVE merge ref, before the PR lands on
+    # `main`. When it fails the merge group is ejected — but the OCI `latest` tag
+    # (and the prod cluster reconciling it) is left pointing at that ejected
+    # artifact, which never lands on `main`, so prod silently diverges from Git
+    # until some future merge overwrites it (devantler-tech/platform#2026). This
+    # failure-path-only job re-deploys the current tip of `main` via the SAME
+    # composite, so the ejected artifact is immediately replaced by main's signed
+    # artifact and prod reconverges with Git. It has ZERO effect on a green merge
+    # (skipped) and does NOT relax the gate: deploy-prod's failure still fails
+    # `CI - Required Checks` below, so the PR is still ejected. It is intentionally
+    # NOT part of that aggregation — it is best-effort cleanup, not a merge gate.
+    if: >-
+      always() &&
+      github.event_name == 'merge_group' &&
+      needs.changes.outputs.k8s == 'true' &&
+      needs.deploy-prod.result == 'failure'
+    runs-on: ubuntu-latest
+    environment: prod
+    # Same shared lock as deploy-prod / cd.yaml so the heal can never run against
+    # the prod cluster at the same time as another deploy. `needs: deploy-prod`
+    # also guarantees the failed deploy has released the lock before the heal
+    # acquires it, so there is no self-deadlock.
+    concurrency:
+      group: prod-deploy
+      cancel-in-progress: false
+    permissions:
+      contents: read # checkout repository
+      packages: write # push OCI artifacts to GHCR
+      id-token: write # mint OIDC token for cosign keyless signing (Fulcio + Rekor)
+      attestations: write # write SBOM + SLSA provenance attestations (see deploy-prod action)
+    steps:
+      - name: 📑 Checkout main
+        # Deploy the CURRENT tip of `main` (the last state that actually landed in
+        # Git), not the merge group's base_sha, so the heal can never regress prod
+        # below a newer merge that landed while this group was in flight.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: 🩹 Re-deploy main to Production
+        # Reuse the shared deploy composite (push → sign → attest → reconcile →
+        # cluster update) against main's checkout, so the restored artifact is
+        # byte-for-byte a normal main deploy (fully signed/attested) — no drift
+        # from the happy path.
+        uses: ./.github/actions/deploy-prod
+        with:
+          sops-age-key: ${{ secrets.SOPS_AGE_KEY }}
+          kube-config: ${{ secrets.KUBE_CONFIG }}
+          talos-config: ${{ secrets.TALOS_CONFIG }}
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
+          hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
+
   ci-required-checks:
     name: CI - Required Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #2026.

## Problem

`ci.yaml`'s `deploy-prod` job runs on the **`merge_group` speculative merge ref — before the PR lands on `main`**. That pre-merge deploy is a deliberate, useful gate (a deploy that fails prevents the merge). The gap is the **failure path**: once `workload push` has rewritten the OCI `latest` tag, any later merge-group failure ejects the PR but leaves `latest` (and the prod cluster reconciling it) pointing at an artifact that **never landed on `main`**. Prod silently diverges from Git until some future merge overwrites it — the exact thing GitOps exists to prevent. This happened live (PR #1991, 2026-06-11; queue re-wedged 2026-06-22).

## Fix — Option 1 from the issue (heal on failure)

A new **failure-path-only** job `heal-prod-on-failure`:
- triggers **only** when `github.event_name == 'merge_group'` **and** `deploy-prod` actually **failed** (`always() && needs.deploy-prod.result == 'failure'`);
- checks out the **current tip of `main`** and re-runs the **same `./.github/actions/deploy-prod` composite** (push → cosign-sign → SBOM/SLSA attest → reconcile → Talos sync);
- so the ejected artifact is immediately **replaced by `main`'s signed artifact** and prod reconverges with Git.

## Why this is safe

- **Zero happy-path impact** — the job is *skipped* on a green merge.
- **Gate intact** — `deploy-prod`'s failure still fails `CI - Required Checks` (the heal is deliberately **not** in that aggregation), so the PR is still ejected. The heal only cleans up prod afterward.
- **No drift** — reuses the shared composite, so the restored artifact is byte-for-byte a normal `main` deploy (fully signed/attested), not a bespoke partial re-push.
- **No regression** — checks out `main` (not the group's `base_sha`), so it can never push prod *below* a newer merge that landed while this group was in flight; `reconcile` is idempotent.
- **No deadlock** — shares the `prod-deploy` concurrency lock with `deploy-prod`/`cd.yaml`; `needs: deploy-prod` guarantees the failed deploy released the lock before the heal acquires it.
- **Strictly an improvement** — if the heal itself can't reach the cluster (stale creds), prod is left exactly as it is today (status-quo), so the change never makes things worse.

## Validation

- `actionlint .github/workflows/ci.yaml` → clean (exit 0).
- Failure-path-only; happy-path workflow behaviour is unchanged.

## Note

Considered but **not** done here (keeping one concern per PR): Option 2 (SHA-tagged artifacts promoted on merge) is a larger change for the same outcome; Option 3 (document-only) is superseded by self-healing. A DR-runbook note can follow if preferred — though the heal makes the failure mode self-correcting, largely removing the on-call burden a runbook entry would describe.