### PR TITLE
feat(actual-budget): seed Enable Banking bank-sync via OpenBao/ESO + reconcile sidecar

### DIFF
--- a/k8s/bases/apps/actual-budget/config-map.yaml
+++ b/k8s/bases/apps/actual-budget/config-map.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: actual-budget-enablebanking-seed
+  namespace: actual-budget
+data:
+  # Reconciles Actual Budget's Enable Banking credentials (Application ID + PEM
+  # secret key) into the sync-server's internal `secrets` SQLite table from an
+  # ESO-synced Secret (sourced from OpenBao). Actual stores these via the web UI
+  # only — there is no env/config hook — so this writes the SAME rows the UI
+  # would, using the app's own better-sqlite3 (byte-identical TEXT storage) so
+  # OpenBao stays the source of truth.
+  #
+  # Robustness notes:
+  #   - Waits for the server to create account.sqlite + the `secrets` table; it
+  #     never creates or migrates anything itself (no coupling to Actual's
+  #     migration framework — only the trivial 2-column table contract).
+  #   - secretsService.get() reads the DB live (its cache is only filled by the
+  #     UI's set()), so a running server picks up the row with no restart and
+  #     OpenBao rotations propagate on the next sync.
+  #   - Idempotent: writes only when the stored value differs; a missing/empty
+  #     Secret (local/CI, where the OpenBao path is unset) is a no-op.
+  #   - Never throws out of the loop, so it can't crash-loop the pod.
+  seed-enablebanking.cjs: |
+    'use strict';
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const Database = require('better-sqlite3');
+
+    const SERVER_FILES = process.env.ACTUAL_SERVER_FILES || '/data/server-files';
+    const DB_PATH = path.join(SERVER_FILES, 'account.sqlite');
+    const INTERVAL = (Number(process.env.SEED_INTERVAL_SECONDS) || 300) * 1000;
+
+    // Actual's secret-table key -> env var holding the desired value. These key
+    // names are the stable public contract from the sync-server's SecretName enum.
+    const SECRETS = {
+      enablebanking_applicationId: process.env.ENABLEBANKING_APPLICATION_ID,
+      enablebanking_secretKey: process.env.ENABLEBANKING_SECRET_KEY,
+    };
+
+    // OpenBao is seeded with this sentinel (push-secret-seed-actual-budget-
+    // enablebanking) until the operator types in the real values; never write it.
+    const PLACEHOLDER = 'PLACEHOLDER';
+    const configured = (v) => v && v !== PLACEHOLDER;
+
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const log = (...a) =>
+      console.log(new Date().toISOString(), '[enablebanking-seed]', ...a);
+
+    function reconcileOnce() {
+      if (
+        !configured(SECRETS.enablebanking_applicationId) ||
+        !configured(SECRETS.enablebanking_secretKey)
+      ) {
+        log('credentials not configured yet (empty or placeholder); skipping');
+        return;
+      }
+      if (!fs.existsSync(DB_PATH)) {
+        log(`waiting for ${DB_PATH} to be created by the server`);
+        return;
+      }
+
+      const db = new Database(DB_PATH, { fileMustExist: true });
+      try {
+        db.pragma('busy_timeout = 5000');
+        const hasTable = db
+          .prepare(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='secrets'",
+          )
+          .get();
+        if (!hasTable) {
+          log('secrets table not present yet; waiting for server migrations');
+          return;
+        }
+
+        const select = db.prepare('SELECT value FROM secrets WHERE name = ?');
+        // Identical statement to the app's secretsService.set(): a bound JS
+        // string is stored with SQLite TEXT affinity, exactly as the UI writes it.
+        const upsert = db.prepare(
+          'INSERT OR REPLACE INTO secrets (name, value) VALUES (?, ?)',
+        );
+        for (const [name, value] of Object.entries(SECRETS)) {
+          const current = select.get(name)?.value;
+          const currentStr = current == null ? null : current.toString();
+          if (currentStr === value) continue;
+          upsert.run(name, value);
+          log(`reconciled secret '${name}'`);
+        }
+      } finally {
+        db.close();
+      }
+    }
+
+    async function main() {
+      log(
+        `reconciling Enable Banking secrets into ${DB_PATH} every ${
+          INTERVAL / 1000
+        }s`,
+      );
+      for (;;) {
+        try {
+          reconcileOnce();
+        } catch (err) {
+          log('reconcile error (will retry):', err.message);
+        }
+        await sleep(INTERVAL);
+      }
+    }
+
+    main();

--- a/k8s/bases/apps/actual-budget/config-map.yaml
+++ b/k8s/bases/apps/actual-budget/config-map.yaml
@@ -30,29 +30,51 @@ data:
     const SERVER_FILES = process.env.ACTUAL_SERVER_FILES || '/data/server-files';
     const DB_PATH = path.join(SERVER_FILES, 'account.sqlite');
     const INTERVAL = (Number(process.env.SEED_INTERVAL_SECONDS) || 300) * 1000;
+    const SECRET_DIR = process.env.ENABLEBANKING_SECRET_DIR || '/var/run/enablebanking';
 
-    // Actual's secret-table key -> env var holding the desired value. These key
+    // Actual's secret-table key -> filename in the mounted ESO Secret. The key
     // names are the stable public contract from the sync-server's SecretName enum.
-    const SECRETS = {
-      enablebanking_applicationId: process.env.ENABLEBANKING_APPLICATION_ID,
-      enablebanking_secretKey: process.env.ENABLEBANKING_SECRET_KEY,
+    // Read from a MOUNTED Secret (not secretKeyRef env, which freezes at container
+    // start) and re-read every pass, so an ESO refresh after an OpenBao edit —
+    // which kubelet propagates into these projected files in place — is picked up
+    // without a pod restart.
+    const SECRET_FILES = {
+      enablebanking_applicationId: 'application-id',
+      enablebanking_secretKey: 'secret-key',
     };
 
     // OpenBao is seeded with this sentinel (push-secret-seed-actual-budget-
     // enablebanking) until the operator types in the real values; never write it.
     const PLACEHOLDER = 'PLACEHOLDER';
-    const configured = (v) => v && v !== PLACEHOLDER;
+    const configured = (v) => v != null && v.trim() !== '' && v.trim() !== PLACEHOLDER;
+
+    function readSecret(file) {
+      try {
+        return fs.readFileSync(path.join(SECRET_DIR, file), 'utf8');
+      } catch (err) {
+        if (err.code === 'ENOENT') return null; // Secret absent on local/CI
+        throw err;
+      }
+    }
 
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
     const log = (...a) =>
       console.log(new Date().toISOString(), '[enablebanking-seed]', ...a);
 
     function reconcileOnce() {
+      const appId = readSecret(SECRET_FILES.enablebanking_applicationId);
+      const secretKey = readSecret(SECRET_FILES.enablebanking_secretKey);
+      // application-id is a typed identifier (trim stray whitespace); secret-key
+      // is the raw .pem text, stored verbatim exactly as the UI's file.text() does.
+      const desired = {
+        enablebanking_applicationId: appId == null ? null : appId.trim(),
+        enablebanking_secretKey: secretKey,
+      };
       if (
-        !configured(SECRETS.enablebanking_applicationId) ||
-        !configured(SECRETS.enablebanking_secretKey)
+        !configured(desired.enablebanking_applicationId) ||
+        !configured(desired.enablebanking_secretKey)
       ) {
-        log('credentials not configured yet (empty or placeholder); skipping');
+        log('credentials not configured yet (missing, empty, or placeholder); skipping');
         return;
       }
       if (!fs.existsSync(DB_PATH)) {
@@ -79,7 +101,7 @@ data:
         const upsert = db.prepare(
           'INSERT OR REPLACE INTO secrets (name, value) VALUES (?, ?)',
         );
-        for (const [name, value] of Object.entries(SECRETS)) {
+        for (const [name, value] of Object.entries(desired)) {
           const current = select.get(name)?.value;
           const currentStr = current == null ? null : current.toString();
           if (currentStr === value) continue;

--- a/k8s/bases/apps/actual-budget/config-map.yaml
+++ b/k8s/bases/apps/actual-budget/config-map.yaml
@@ -101,12 +101,20 @@ data:
         const upsert = db.prepare(
           'INSERT OR REPLACE INTO secrets (name, value) VALUES (?, ?)',
         );
-        for (const [name, value] of Object.entries(desired)) {
+        // The application-id and secret-key are a matched credential pair —
+        // write both in one transaction so a mid-rotation failure can't leave
+        // Actual with a mixed pair (which would break bank sync until the next
+        // pass).
+        const updates = Object.entries(desired).filter(([name, value]) => {
           const current = select.get(name)?.value;
           const currentStr = current == null ? null : current.toString();
-          if (currentStr === value) continue;
-          upsert.run(name, value);
-          log(`reconciled secret '${name}'`);
+          return currentStr !== value;
+        });
+        if (updates.length > 0) {
+          db.transaction((rows) => {
+            for (const [name, value] of rows) upsert.run(name, value);
+          })(updates);
+          for (const [name] of updates) log(`reconciled secret '${name}'`);
         }
       } finally {
         db.close();

--- a/k8s/bases/apps/actual-budget/external-secret-enablebanking.yaml
+++ b/k8s/bases/apps/actual-budget/external-secret-enablebanking.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: actual-budget-enablebanking
+  namespace: actual-budget
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: actual-budget-enablebanking
+    creationPolicy: Owner
+  # Sourced from OpenBao at apps/actual-budget/enablebanking (typed in by hand).
+  # Consumed by the enablebanking-seed sidecar, which reconciles these into
+  # Actual's internal secrets table — Enable Banking has no env/config hook.
+  data:
+    - secretKey: application-id
+      remoteRef:
+        key: apps/actual-budget/enablebanking
+        property: application-id
+    - secretKey: secret-key
+      remoteRef:
+        key: apps/actual-budget/enablebanking
+        property: secret-key

--- a/k8s/bases/apps/actual-budget/helm-release.yaml
+++ b/k8s/bases/apps/actual-budget/helm-release.yaml
@@ -85,18 +85,12 @@ spec:
             value: /data/server-files
           - name: SEED_INTERVAL_SECONDS
             value: "300"
-          - name: ENABLEBANKING_APPLICATION_ID
-            valueFrom:
-              secretKeyRef:
-                name: actual-budget-enablebanking
-                key: application-id
-                optional: true # absent on local/CI where OpenBao path is unset
-          - name: ENABLEBANKING_SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                name: actual-budget-enablebanking
-                key: secret-key
-                optional: true
+          # The creds come from a MOUNTED Secret (below), not secretKeyRef env:
+          # env is snapshotted at container start, so a later ESO refresh after an
+          # OpenBao edit would never reach the running sidecar. kubelet updates the
+          # projected Secret files in place, and the loop re-reads them each pass.
+          - name: ENABLEBANKING_SECRET_DIR
+            value: /var/run/enablebanking
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -118,10 +112,19 @@ spec:
             mountPath: /data
           - name: tmp
             mountPath: /tmp
+          - name: enablebanking-secret
+            mountPath: /var/run/enablebanking
+            readOnly: true
           - name: enablebanking-seed-script
             mountPath: /scripts
             readOnly: true
     volumes:
+      # optional: absent on local/CI where the OpenBao path is unset — the script
+      # treats missing files (and the PLACEHOLDER sentinel) as "not configured".
+      - name: enablebanking-secret
+        secret:
+          secretName: actual-budget-enablebanking
+          optional: true
       - name: enablebanking-seed-script
         configMap:
           name: actual-budget-enablebanking-seed

--- a/k8s/bases/apps/actual-budget/helm-release.yaml
+++ b/k8s/bases/apps/actual-budget/helm-release.yaml
@@ -62,6 +62,70 @@ spec:
   # https://github.com/community-charts/helm-charts/blob/main/charts/actualbudget/values.yaml
   values:
     replicaCount: ${actual_budget_replicas:=1}
+    # Enable Banking bank-sync credentials live only in the sync-server's internal
+    # `secrets` SQLite table (set via the web UI; no env/config hook). This sidecar
+    # reconciles them there from the ESO-synced `actual-budget-enablebanking` Secret
+    # (OpenBao → ESO), using the app's own better-sqlite3 for byte-identical writes.
+    # See config-map.yaml for the reconciler and its robustness notes.
+    # Image is pinned to the chart appVersion; the reconciler only needs
+    # better-sqlite3 so it is version-insensitive — keep it roughly in sync on bumps.
+    extraContainers:
+      - name: enablebanking-seed
+        image: docker.io/actualbudget/actual-server:26.6.0
+        imagePullPolicy: IfNotPresent
+        # `args` (not `command`) so the image's tini ENTRYPOINT is preserved —
+        # proper PID-1 signal forwarding/zombie reaping, and no dependency on the
+        # tini path (differs between the bookworm/alpine image variants).
+        args: ["node", "/scripts/seed-enablebanking.cjs"]
+        workingDir: /app
+        env:
+          - name: NODE_PATH
+            value: /app/node_modules
+          - name: ACTUAL_SERVER_FILES
+            value: /data/server-files
+          - name: SEED_INTERVAL_SECONDS
+            value: "300"
+          - name: ENABLEBANKING_APPLICATION_ID
+            valueFrom:
+              secretKeyRef:
+                name: actual-budget-enablebanking
+                key: application-id
+                optional: true # absent on local/CI where OpenBao path is unset
+          - name: ENABLEBANKING_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: actual-budget-enablebanking
+                key: secret-key
+                optional: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+          runAsGroup: 1001
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+        volumeMounts:
+          - name: data
+            mountPath: /data
+          - name: tmp
+            mountPath: /tmp
+          - name: enablebanking-seed-script
+            mountPath: /scripts
+            readOnly: true
+    volumes:
+      - name: enablebanking-seed-script
+        configMap:
+          name: actual-budget-enablebanking-seed
+          defaultMode: 0444
     serviceAccount:
       automount: false
     podSecurityContext:

--- a/k8s/bases/apps/actual-budget/kustomization.yaml
+++ b/k8s/bases/apps/actual-budget/kustomization.yaml
@@ -3,7 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - config-map.yaml
   - external-secret.yaml
+  - external-secret-enablebanking.yaml
   - helm-release.yaml
   - helm-repository.yaml
   - http-route.yaml

--- a/k8s/bases/infrastructure/vault-seed/kustomization.yaml
+++ b/k8s/bases/infrastructure/vault-seed/kustomization.yaml
@@ -41,3 +41,5 @@ resources:
   - push-secret-seed-dex-client-secret.yaml
   - push-secret-seed-oauth2-proxy-cookie-secret.yaml
   - push-secret-seed-velero-repo-credentials.yaml
+  - secret-actual-budget-enablebanking-placeholder.yaml
+  - push-secret-seed-actual-budget-enablebanking.yaml

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-actual-budget-enablebanking.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-actual-budget-enablebanking.yaml
@@ -1,0 +1,34 @@
+---
+# Seeds the Enable Banking bank-sync credential path into OpenBao with
+# placeholders. updatePolicy: IfNotExists makes it create-only — once the path
+# exists, the operator's real values (typed into OpenBao at
+# apps/actual-budget/enablebanking) are never overwritten by the placeholder.
+# Read back by the actual-budget `external-secret-enablebanking` ExternalSecret,
+# which the enablebanking-seed sidecar reconciles into Actual's internal secrets
+# table (Enable Banking has no env/config hook). If OpenBao is re-initialized the
+# placeholder re-seeds and the operator re-enters the values.
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: seed-actual-budget-enablebanking
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  updatePolicy: IfNotExists
+  secretStoreRefs:
+    - name: openbao
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: actual-budget-enablebanking-placeholder
+  data:
+    - match:
+        secretKey: application-id
+        remoteRef:
+          remoteKey: apps/actual-budget/enablebanking
+          property: application-id
+    - match:
+        secretKey: secret-key
+        remoteRef:
+          remoteKey: apps/actual-budget/enablebanking
+          property: secret-key

--- a/k8s/bases/infrastructure/vault-seed/secret-actual-budget-enablebanking-placeholder.yaml
+++ b/k8s/bases/infrastructure/vault-seed/secret-actual-budget-enablebanking-placeholder.yaml
@@ -1,0 +1,20 @@
+---
+# Placeholder source for the Enable Banking bank-sync credentials. These are
+# user-fed (not generated, not SOPS), so we seed OpenBao ONCE with placeholders
+# and the operator then types the real Application ID + PEM secret key into
+# OpenBao at apps/actual-budget/enablebanking. The paired PushSecret uses
+# updatePolicy: IfNotExists so this placeholder never overwrites those edits.
+#
+# Not a real secret (literally "PLACEHOLDER"), so it is committed in plaintext —
+# same pattern as velero's stub credential. The actual-budget enablebanking-seed
+# sidecar treats "PLACEHOLDER" as "not configured" and skips writing it into the
+# app's secrets table.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: actual-budget-enablebanking-placeholder
+  namespace: flux-system
+type: Opaque
+stringData:
+  application-id: PLACEHOLDER
+  secret-key: PLACEHOLDER


### PR DESCRIPTION
## What

Sets up [Enable Banking](https://actualbudget.org/docs/advanced/bank-sync/enable-banking) bank sync for Actual Budget, driven from OpenBao via External Secrets.

## Why it's not a plain ExternalSecret

Enable Banking's credentials (**Application ID** + **PEM secret key**) are stored **only** in the sync-server's internal `account.sqlite` `secrets` table, written **exclusively through the web UI**. There is **no `ACTUAL_ENABLEBANKING_*` env / config hook** — verified against `actualbudget/actual` v26.6.0 (the chart's `appVersion`): `load-config.js` / `secrets-service.js` never read `process.env` for these; the UI handler does `secretsService.set(...)`. So the usual `OpenBao → ESO → env/valuesFrom` path (as used for OIDC's `ACTUAL_OPENID_CLIENT_SECRET`) cannot work here.

## How

A **reconcile sidecar** makes it declarative without coupling to Actual's internals:

- **`config-map.yaml`** (`seed-enablebanking.cjs`) + `extraContainers` in the HelmRelease: writes the two rows into `account.sqlite` using the app's **own `better-sqlite3`** (same image, pinned to `appVersion`) → byte-identical TEXT storage to the UI's `set()`.
  - **Waits** for the server to create the DB + `secrets` table — never creates or migrates anything (no coupling to Actual's migration framework, only the trivial 2-column table + the public `SecretName` keys).
  - **Idempotent** (writes only on change), skips the `PLACEHOLDER` sentinel, uses `args:` to keep the image's `tini` PID-1.
  - `secretsService.get()` reads the DB **live** (cache only filled by the UI's `set()`), so a running server picks up values **with no restart** and OpenBao rotations propagate on the next sync.
- **`external-secret-enablebanking.yaml`**: syncs `apps/actual-budget/enablebanking` → Secret `actual-budget-enablebanking` (env `optional` so local/CI are a clean no-op).
- **OpenBao seeding** (`vault-seed/`): a plaintext `PLACEHOLDER` Secret (velero-stub style) + a PushSecret with **`updatePolicy: IfNotExists`**, so OpenBao gets the path once and the operator's later edits are **never overwritten**. The sidecar's sentinel guard prevents the literal `PLACEHOLDER` from being written (vault-seed runs on local too, and prod holds it briefly before the operator edits).

## Operator steps after merge

1. Register the app at enablebanking.com (Production; redirect `https://budget.<domain>/enablebanking/auth_callback`).
2. In OpenBao, update the placeholders at `apps/actual-budget/enablebanking`: `application-id` = the Application ID, `secret-key` = the `.pem` contents.
3. ESO picks up the values → sidecar writes them into Actual's secrets table → Enable Banking shows configured under **More → Bank Sync**.

## Validation

- `scripts/validate-naming.py` ✓
- `kubectl apply --dry-run=client` on both new vault-seed manifests ✓
- `kubectl kustomize` builds: `k8s/bases/apps/actual-budget`, `k8s/providers/docker/infrastructure`, `k8s/providers/hetzner/infrastructure` ✓
- `updatePolicy: IfNotExists` confirmed present in the pinned external-secrets v2.6.0 PushSecret CRD
- `ksail workload validate` surfaces only the documented pre-existing actual-budget OIDC offline false-failure (unrelated; `kubectl kustomize` is authoritative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)