### PR TITLE
feat(homepage): run inside a user namespace (hostUsers: false)

### DIFF
--- a/k8s/providers/hetzner/apps/homepage/patches/helm-release-patch.yaml
+++ b/k8s/providers/hetzner/apps/homepage/patches/helm-release-patch.yaml
@@ -1,0 +1,38 @@
+# Run homepage inside a private user namespace.
+#
+# Sets `hostUsers: false` on the homepage pod (KEP-127, GA in Kubernetes 1.36;
+# beta and on-by-default since 1.30). The container's UID/GID is mapped to an
+# unprivileged subordinate range on the host, so a container-runtime escape
+# lands as a non-root, capability-less host user — defence in depth on top of
+# the restricted securityContext already set by the chart and the cluster's
+# restricted PSS / Kubescape / Tetragon / SPIRE mTLS stack.
+#
+# Why prod-only (hetzner overlay) rather than the base: prod nodes run Talos on
+# real Hetzner kernels where user namespaces and idmap mounts are supported,
+# whereas the local Docker provider runs Talos nested inside Docker where userns
+# support is not guaranteed. This mirrors the whoami pilot (whoami/patches/),
+# the stateless canary that proved the pattern (#1808). homepage is the next
+# step in #1807: it is the apex dashboard (always-on) and its only volume is the
+# read-only `homepage-config` configMap (subPath mounts) — configMap volumes are
+# tmpfs-backed and need no idmap support, so there are no idmap-volume
+# constraints to hit. Stateful workloads (Longhorn/CNPG/OpenBao), which DO need
+# idmap-volume support, are deliberately left for last and are not touched here.
+#
+# Flagger note: the chart's Canary (canary.yaml) copies this source Deployment's
+# pod template wholesale to the homepage-primary Deployment, so `hostUsers:
+# false` propagates to the primary it manages.
+#
+# Mechanism: an RFC 6902 `add` that APPENDS (`/-`) to the base HelmRelease's
+# existing postRenderers[0].kustomize.patches list, so the base's probe/strategy/
+# lifecycle and Service post-render patches are preserved rather than replaced (a
+# strategic-merge patch on the list would replace it).
+- op: add
+  path: /spec/postRenderers/0/kustomize/patches/-
+  value:
+    target:
+      kind: Deployment
+      name: homepage
+    patch: |
+      - op: add
+        path: /spec/template/spec/hostUsers
+        value: false

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -51,11 +51,18 @@ patches:
       name: umami-db
       namespace: umami
     path: umami/patches/grant-pg-monitor-patch.yaml
-  # Pilot: user namespaces (hostUsers: false) on whoami — prod-only; see the
-  # patch file for the full rationale. JSON6902 patch (a list of ops) has no
-  # embedded identity, so it must keep an explicit target.
+  # User namespaces (hostUsers: false) — prod-only; see each patch file for the
+  # full rationale. JSON6902 patches (a list of ops) have no embedded identity,
+  # so they must keep an explicit target. whoami is the proven stateless canary
+  # (#1808); homepage is the next step (#1807) — apex dashboard, configMap-only
+  # volumes, so no idmap-volume constraints.
   - target:
       kind: HelmRelease
       name: whoami
       namespace: whoami
     path: whoami/patches/helm-release-patch.yaml
+  - target:
+      kind: HelmRelease
+      name: homepage
+      namespace: homepage
+    path: homepage/patches/helm-release-patch.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Part of #1807** (k8s 1.36 readiness → user-namespaces adoption).

## What

Extends `hostUsers: false` (user namespaces, KEP-127, GA in Kubernetes 1.36) from the **whoami** stateless canary (#1808, merged) to **homepage** — the explicit next step in #1807's user-namespaces sequence.

```
- [x] Pilot on whoami (stateless canary) — #1808
- [ ] Extend to homepage (apex, always-on; configMap mounts)   ← this PR
```

## Why

User namespaces map the container's UID/GID to an unprivileged subordinate range on the host, so a container-runtime escape lands as a **non-root, capability-less host user** — defence in depth on top of homepage's restricted securityContext, the restricted PSS, Kubescape/Tetragon, and SPIRE mTLS.

## How

Mirrors the whoami pilot exactly:

- New `k8s/providers/hetzner/apps/homepage/patches/helm-release-patch.yaml` — an RFC 6902 `add` that **appends** (`/-`) to the base HelmRelease's existing `postRenderers[0].kustomize.patches` list, so the base's probe/strategy/lifecycle and Service post-render patches are preserved (a strategic-merge patch would replace the list).
- Wires it into `k8s/providers/hetzner/apps/kustomization.yaml` next to the whoami entry, with an explicit `target` (JSON6902 has no embedded identity).

**Prod-only (hetzner overlay):** real Hetzner/Talos kernels support user namespaces and idmap mounts; the nested-Docker local provider does not. **homepage is volume-safe:** its only volume is the read-only `homepage-config` configMap (subPath mounts) — configMap volumes are tmpfs-backed and need no idmap support, so there are no idmap-volume constraints. Stateful workloads (Longhorn/CNPG/OpenBao), which *do* need idmap-volume support, are deliberately left for last per #1807.

**Flagger note:** the chart's Canary copies this source Deployment's pod template wholesale to `homepage-primary`, so `hostUsers: false` propagates to the primary it manages.

## Validation

`ksail --config ksail.prod.yaml workload validate --skip-helm-render` → **474 files validated, exit 0** (`--skip-helm-render` avoids the unrelated docker-overlay render flake, kubeconform#363).

## Promotion / prod check

Draft pending the same prod confirmation the whoami pilot got: after deploy, verify the homepage pod starts, `id` inside the container shows the remapped UID, the configMap subPath mounts resolve, and the Flagger rollout stays clean. Held as a draft so the maintainer promotes once that's confirmed.
