### PR TITLE
chore(talos): reap terminated-pod tombstones (PodGC threshold 100)

### DIFF
--- a/talos/cluster/terminated-pod-gc.yaml
+++ b/talos/cluster/terminated-pod-gc.yaml
@@ -1,0 +1,28 @@
+# Terminated-pod garbage collection (kube-controller-manager PodGC).
+#
+# Kubernetes only reaps terminated pods (phase Succeeded/Failed whose owner
+# still exists) when their cluster-wide count exceeds --terminated-pod-gc-threshold.
+# The upstream default is 12500, so node-shutdown / eviction / OOM tombstones —
+# e.g. the "Completed" cert-manager pods left behind by Talos node reboots during
+# `ksail cluster update` upgrades — accumulate almost indefinitely.
+#
+# Job/CronJob pods are NOT what this controls: those are bounded by each Job's
+# spec.ttlSecondsAfterFinished and each CronJob's successful/failedJobsHistoryLimit
+# (set per-workload across k8s/). This is the catch-all for everything else.
+#
+# 100 is sized for this cluster (3 control planes + 3 static workers + up to 4
+# autoscaler workers = max 10 nodes). It leaves enough headroom that a rolling
+# Talos upgrade — which briefly produces a tombstone per evicted pod on every
+# rebooting node — does not blow past the threshold and start reaping
+# still-useful recent Failed pods mid-roll, while keeping steady-state tombstone
+# clutter low. PodGC deletes oldest-first, so recent failures stay inspectable.
+#
+# cluster.* config only takes effect on control-plane nodes (where
+# kube-controller-manager runs), so this lives in talos/cluster/ alongside the
+# other control-plane component tuning (see audit-logging.yaml).
+#
+# Reference: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection
+cluster:
+  controllerManager:
+    extraArgs:
+      terminated-pod-gc-threshold: "100"


### PR DESCRIPTION
## Problem

The cluster accumulates terminated pods that nothing ever cleans up — most visibly the long tail of `Completed` cert-manager pods (`cert-manager-*`, `cainjector-*`, `webhook-*`). These are **Deployment/ReplicaSet pods left as tombstones** (phase `Succeeded`/`Failed`) after Talos node reboots during `ksail cluster update`, evictions, and OOM kills — *not* Job pods.

Kubernetes only reaps such tombstones (whose owner still exists and still wants the replacement running) when their cluster-wide count exceeds kube-controller-manager's `--terminated-pod-gc-threshold`. The upstream default is **12500**, so in practice they never get collected.

## Why this is the right fix

- **Not a Flux concern.** Flux's `prune` is inventory-based — it only deletes objects it applied from Git and tracks. Runtime-spawned pod children are never in any Flux inventory, so GitOps GC structurally cannot touch them.
- **Not a Job/CronJob concern.** Those are already bounded per-workload via `ttlSecondsAfterFinished` (Jobs) and `successful/failedJobsHistoryLimit` (CronJobs) across `k8s/`. PodGC is the **only** native mechanism for terminated pods whose owner is still alive.
- **Not a custom janitor CronJob.** That would be imperative state-mutation fighting GitOps. On Talos we can set the controller-manager arg at the root cause instead.

## Change

Adds `talos/cluster/terminated-pod-gc.yaml` setting:

```yaml
cluster:
  controllerManager:
    extraArgs:
      terminated-pod-gc-threshold: "100"
```

### Why 100

Sized for this cluster: 3 control planes + 3 static workers + up to 4 autoscaler workers = **max 10 nodes**. 100 leaves enough headroom that a rolling Talos upgrade — which briefly produces a tombstone per evicted pod on every rebooting node — doesn't blow past the threshold and start reaping still-useful recent `Failed` pods mid-roll, while keeping steady-state clutter low. PodGC deletes oldest-first, so recent failures stay inspectable for debugging.

`cluster.*` config only takes effect on control-plane nodes (where kube-controller-manager runs), so the patch lives in `talos/cluster/` alongside `audit-logging.yaml` (which similarly tunes `cluster.apiServer`).

## Validation

- YAML well-formed (parses; `kubectl` only flags missing `apiVersion`/`kind`, expected for a Talos machine-config patch).
- No conflicting `controllerManager` patch elsewhere in `talos/`.
- Outside `k8s/`, so the Kustomize build and `naming` jobs are unaffected.
- Takes effect on the next `ksail --config ksail.prod.yaml cluster update` (control-plane machine-config apply; no node replacement required for a controller-manager arg).