### PR TITLE
fix(openbao): grant external-secrets role write/read on apps/actual-budget path

### DIFF
--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -663,6 +663,20 @@ spec:
               }
               POLICY
 
+              # actual-budget reads its Enable Banking bank-sync credential
+              # (application-id + secret-key) from OpenBao via the shared
+              # `external-secrets` ClusterSecretStore role (apps/actual-budget/
+              # enablebanking); the path is create-seeded with placeholders by
+              # the seed-actual-budget-enablebanking PushSecret in
+              # infrastructure/vault-seed and the operator types the real values
+              # in by hand. Read back by the actual-budget
+              # external-secret-enablebanking ExternalSecret.
+              bao policy write app-actual-budget-readonly - <<'POLICY'
+              path "secret/data/apps/actual-budget/*" {
+                capabilities = ["read"]
+              }
+              POLICY
+
               # crossview reads its bundled-Postgres password, app session secret,
               # and break-glass admin password from OpenBao via the shared
               # `external-secrets` ClusterSecretStore role (apps/crossview/{db,app,
@@ -773,6 +787,9 @@ spec:
               path "secret/data/apps/umami/*" {
                 capabilities = ["create", "update", "read"]
               }
+              path "secret/data/apps/actual-budget/*" {
+                capabilities = ["create", "update", "read"]
+              }
               path "secret/data/apps/crossview/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -812,6 +829,9 @@ spec:
               path "secret/metadata/apps/umami/*" {
                 capabilities = ["create", "update", "read"]
               }
+              path "secret/metadata/apps/actual-budget/*" {
+                capabilities = ["create", "update", "read"]
+              }
               path "secret/metadata/apps/crossview/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -832,7 +852,7 @@ spec:
               bao write auth/kubernetes/role/external-secrets \
                 bound_service_account_names=external-secrets \
                 bound_service_account_namespaces=external-secrets \
-                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,infra-ghcr-readonly,app-fleetdm-readonly,app-wedding-readonly,app-umami-readonly,app-crossview-readonly,app-ascoachingogvaner-readonly,infra-oidc-readonly,infra-unifi-readonly,vault-seed-write \
+                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,infra-ghcr-readonly,app-fleetdm-readonly,app-wedding-readonly,app-umami-readonly,app-actual-budget-readonly,app-crossview-readonly,app-ascoachingogvaner-readonly,infra-oidc-readonly,infra-unifi-readonly,vault-seed-write \
                 ttl=1h
 
               # Dedicated role for the fleetdm VaultDynamicSecret generator.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live prod stall)

The prod `flux-system/infrastructure` Kustomization was stuck `Unknown` (Reconciliation in progress → `HealthCheckFailed` after 20m), which in turn blocked `flux-system/apps` with `dependency 'flux-system/infrastructure' is not ready`.

Root cause traced to the `seed-actual-budget-enablebanking` PushSecret, stuck `InProgress`:

```
set secret failed: could not verify if secret exists in store: cannot read secret data from Vault:
GET http://openbao-active.openbao.svc.cluster.local:8200/v1/secret/data/apps/actual-budget/enablebanking
Code: 403 ... permission denied
```

## Root cause

[#2331](https://github.com/devantler-tech/platform/pull/2331) added both the PushSecret (writes `secret/data/apps/actual-budget/enablebanking`) and the actual-budget `external-secret-enablebanking` ExternalSecret (reads it), both routed through the `openbao` ClusterSecretStore → `external-secrets` Kubernetes auth role. But the OpenBao policies that role carries (defined in `k8s/bases/infrastructure/vault-config/job.yaml`) were never extended to the new `apps/actual-budget` path — they list every other app (fleetdm, wedding-app, umami, crossview, …) but not actual-budget. Result: 403 on write, PushSecret never syncs, infra health check times out, apps blocked.

## Fix

Mirrors the existing crossview pattern exactly:
- new `app-actual-budget-readonly` policy — `read` on `secret/data/apps/actual-budget/*`
- add actual-budget `data` + `metadata` paths to `vault-seed-write` (`create`/`update`/`read`) so the PushSecret can seed
- add `app-actual-budget-readonly` to the `external-secrets` role policy list

The Job carries `kustomize.toolkit.fluxcd.io/force: enabled` (and the infra Kustomization has `force: true`), so Flux recreates it on the next reconcile, re-applies the policies, the PushSecret syncs, and `infrastructure → apps` unblocks.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅
- `kubectl kustomize k8s/providers/hetzner/infrastructure/` ✅ (renders the new path)
- `kubectl apply --dry-run=client` on the Job ✅