### PR TITLE
fix(security-context): pair pod-level runAsUser with injected runAsGroup (#2292 regression)

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -4,20 +4,32 @@
 # - readOnlyRootFilesystem: true (C-0017)
 # - drop ALL capabilities (C-0055)
 # - runAsNonRoot: true (C-0013) — pod + container
-# - runAsGroup: 1000 (C-0013/C-0211 non-root group) — pod level
+# - runAsUser: 1000 + runAsGroup: 1000 (C-0013/C-0211 non-root user+group) — pod level
 # - fsGroup: 1000 + fsGroupChangePolicy: OnRootMismatch (C-0211) — pod level
 # - seLinuxOptions: {level: s0} (C-0211 CIS-5.7.3) — containers + initContainers
 #
 # Together these complete the security context kubescape's CIS-5.7.3 (C-0211) checks
 # (non-root-containers, set-fsgroup-value, set-fsgroupchangepolicy-value,
 # set-seLinuxOptions). Why each is safe to inject cluster-wide:
-# - runAsGroup is injected at the POD level only (never the container level), so it
-#   sets the process primary GID without clobbering a container-level value a chart
-#   sets. Pod-level runAsGroup alone satisfies the non-root-containers rule — no
-#   runAsUser needed (verified with kubescape).
-# - runAsUser is deliberately NOT injected: it would override image-baked UIDs and
-#   break charts (cert-manager, distroless images, …). The non-root rule is already
-#   satisfied by runAsGroup, so runAsUser is unnecessary here.
+# - runAsUser and runAsGroup are injected TOGETHER at the POD level, and only there.
+#   A pod-level runAsGroup with NO runAsUser yields the OCI user string ":1000",
+#   which containerd rejects ("user group \"1000\" is specified without user") so the
+#   pod sandbox never starts. Injecting runAsGroup alone did exactly that to homepage
+#   (its chart sets runAsUser only at the CONTAINER level) and to tofu-controller's
+#   tf-runner. Pairing a matching runAsUser:1000 keeps the pod-level user+group
+#   complete so the sandbox always builds. Both use +(key) conditional anchors: a
+#   chart that sets its own pod-level value keeps it, and a container that sets its
+#   own runAsUser still overrides this pod-level default for that container (so e.g.
+#   homepage's container keeps runAsUser:1000, auth-proxy keeps 65532, etc.).
+# - EXEMPTIONS — images with a baked-in non-1000 UID and no chart-set runAsUser must
+#   NOT be forced to 1000 (cert-manager / trust-manager / origin-ca-issuer = 65532,
+#   keda = 65532, opencost = 1001; tofu-controller tf-runner takes its UID from its
+#   runnerPodTemplate). They are excluded from add-pod-security-context and handled by
+#   add-imageuid-pod-security-context below, which supplies pod-level seccomp,
+#   runAsNonRoot, fsGroup and fsGroupChangePolicy but NEITHER runAsUser NOR runAsGroup
+#   — so they keep their image UID and their sandbox still builds (no group without
+#   user). Add a namespace here only when a workload genuinely cannot run as 1000;
+#   the default (forced 1000:1000) is the more hardened posture.
 # - fsGroup uses a conditional anchor, so any workload that sets its own (every
 #   PVC-mounting workload in scope does) keeps it; only stateless pods get the
 #   default, where it governs emptyDir/projected-volume ownership harmlessly.
@@ -26,16 +38,6 @@
 #   pod ran fine) — but CIS-5.7.3 requires it and it is correct defense-in-depth on
 #   any SELinux node. level: s0 is the default non-privileged MCS level (not Cilium's
 #   spc_t, which is for privileged pods).
-#
-# CAVEAT — images with NO baked-in UID (e.g. tofu-controller's tf-runner, which
-# expects runAsUser from its runnerPodTemplate): a pod-level runAsGroup with no
-# runAsUser yields the OCI user string ":1000", which containerd rejects ("user
-# group \"1000\" is specified without user") so the sandbox never starts. The
-# add-pod-security-context rule therefore excludes tofu-controller runner pods —
-# they self-harden via their runnerPodTemplate (runAsNonRoot + seccomp) and the
-# container-level rule still applies; the add-tofu-runner-pod-security-context rule
-# below re-supplies the pod-level seccomp, runAsNonRoot, fsGroup and
-# fsGroupChangePolicy (everything except the sandbox-breaking runAsGroup).
 #
 # Uses +(key) to never overwrite values explicitly set by Helm charts.
 # Excluded namespaces require elevated privileges by design.
@@ -85,11 +87,19 @@ spec:
                 - observability
                 - velero
                 - chaos-mesh
-          # tofu-controller runner pods ship no image-baked UID, so a pod-level
-          # runAsGroup with no runAsUser breaks containerd sandbox creation (see
-          # the header comment). They are hardened by their own runnerPodTemplate
-          # and the add-container-security-context rule, so exclude them from the
-          # pod-level runAsGroup injection only.
+          # Workloads with an image-baked non-1000 UID and no chart-set runAsUser
+          # (cert-manager/trust-manager/origin-ca-issuer = 65532, keda = 65532,
+          # opencost = 1001). Forcing pod-level runAsUser:1000 would override their
+          # image UID; instead they are handled by add-imageuid-pod-security-context
+          # below, which omits runAsUser/runAsGroup so they keep their UID and the
+          # sandbox still builds.
+          - resources:
+              namespaces:
+                - cert-manager
+                - keda
+                - opencost
+          # tofu-controller runner pods take their UID from their runnerPodTemplate
+          # and ship no image-baked UID; same handling as the namespaces above.
           - resources:
               selector:
                 matchLabels:
@@ -101,6 +111,7 @@ spec:
               +(seccompProfile):
                 type: RuntimeDefault
               +(runAsNonRoot): true
+              +(runAsUser): 1000
               +(runAsGroup): 1000
               +(fsGroup): 1000
               +(fsGroupChangePolicy): OnRootMismatch
@@ -163,18 +174,17 @@ spec:
                         type: RuntimeDefault
                       +(seLinuxOptions):
                         level: s0
-    # tofu-controller runner pods are EXCLUDED from add-pod-security-context above
-    # (a pod-level runAsGroup with no runAsUser yields the OCI user string ":1000",
-    # which containerd rejects so the sandbox never starts — see the header). They
-    # still must satisfy require-seccomp-profile and the rest of C-0211, and
-    # tofu-controller does NOT propagate the runnerPodTemplate's pod-level
-    # securityContext to the created runner pod, so the mutate must supply it. This
-    # rule re-applies everything the pod rule injects EXCEPT the sandbox-breaking
-    # runAsGroup: seccompProfile + runAsNonRoot + fsGroup + fsGroupChangePolicy.
-    # runAsNonRoot keeps non-root-containers satisfied (the runnerPodTemplate
-    # supplies runAsUser); fsGroup + fsGroupChangePolicy here, plus the
-    # container-level seLinuxOptions, make these runner pods C-0211-complete too.
-    - name: add-tofu-runner-pod-security-context
+    # Pods exempt from the pod-level runAsUser/runAsGroup injection in
+    # add-pod-security-context (image-baked non-1000 UIDs: cert-manager, keda,
+    # opencost; and tofu-controller runner pods) still must satisfy the rest of
+    # C-0211 at the pod level. tofu-controller does NOT propagate its
+    # runnerPodTemplate's pod-level securityContext to the created runner pod, and
+    # the excluded namespaces' charts do not all set these either, so re-supply them
+    # here — everything the pod rule injects EXCEPT the sandbox-sensitive
+    # runAsUser/runAsGroup: seccompProfile + runAsNonRoot + fsGroup +
+    # fsGroupChangePolicy. These pods keep their image UID; the sandbox builds because
+    # neither runAsUser nor runAsGroup is set at the pod level (no group without user).
+    - name: add-imageuid-pod-security-context
       match:
         any:
           - resources:
@@ -186,6 +196,15 @@ spec:
               selector:
                 matchLabels:
                   app.kubernetes.io/created-by: tofu-controller
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+              namespaces:
+                - cert-manager
+                - keda
+                - opencost
       mutate:
         patchStrategicMerge:
           spec:


### PR DESCRIPTION
## Problem

`homepage-primary` pods fail to start with:

```
FailedCreatePodSandbox: ... failed to generate user string: user group "1000" is specified without user
```

The `add-security-context` Kyverno ClusterPolicy injects **pod-level** `runAsGroup: 1000` but no `runAsUser`. A pod-level group with no user produces the OCI user string `":1000"`, which containerd rejects when building the **pod sandbox** (the `pause` container, which uses the pod-level `securityContext`). homepage's chart sets `runAsUser` only at the **container** level, so its pod-level sandbox had a group and no user → every new pod is stuck in `ContainerCreating` (primary degraded to 1/3).

This is the #2292/#2296 design: `runAsGroup` was injected pod-level for C-0013/C-0211, the same sandbox failure was hit on tofu-controller's `tf-runner`, and **only tofu-controller was excluded**. `cert-manager`, `keda` and `opencost` are the same latent landmine — their currently-running pods predate the 2026-06-27 policy rollout and would fail identically on the next restart.

## Fix

- **Inject a matching pod-level `runAsUser: 1000`** alongside `runAsGroup: 1000` in `add-pod-security-context` (both via `+()` conditional anchors, so any chart/container that sets its own value still wins). The pod-level user+group pair is now always complete, so the sandbox builds. This is the more-hardened default.
- **Exempt images with a baked-in non-1000 UID and no chart `runAsUser`** — `cert-manager`/`trust-manager`/`origin-ca-issuer` (65532), `keda` (65532), `opencost` (1001) — from the forced uid/gid. Forcing them to 1000 would override their proven image UID on critical infra. They are handled by `add-imageuid-pod-security-context` (generalized from the former tofu-only `add-tofu-runner-pod-security-context` rule), which supplies pod-level `seccompProfile` + `runAsNonRoot` + `fsGroup` + `fsGroupChangePolicy` but **neither `runAsUser` nor `runAsGroup`** — so they keep their image UID and the sandbox still builds (no group without user).

Image UIDs confirmed via `crane config`. Namespace exemptions, not container changes, since these rely purely on the image `USER`.

## Validation

`kustomize build` of the cluster-policies base renders clean. `kyverno apply` (CLI 1.18.1) against pod fixtures:

| Pod | Pod-level result |
|---|---|
| homepage (`homepage` ns, container `runAsUser:1000`) | `runAsUser:1000` + `runAsGroup:1000` + fsGroup/seccomp/runAsNonRoot ✅ |
| cert-manager (`cert-manager` ns, no `runAsUser`) | fsGroup/seccomp/runAsNonRoot, **no runAsUser/runAsGroup** ✅ |
| generic (in-scope ns, no `runAsUser`) | `runAsUser:1000` + `runAsGroup:1000` ✅ |

Compliance: only *adds* securityContext fields (no kubescape NSA/CIS gate regression); the exempted namespaces lose only the pod-level non-root *group* control (C-0211, CIS — already covered by the `pod-security-mutations` ClusterSecurityException), not anything in the NSA CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)