### PR TITLE
fix(openbao): grant actual-budget the missing vault ACL paths

### DIFF
--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -676,6 +676,19 @@ spec:
               }
               POLICY
 
+              # actual-budget reads its Enable Banking bank-sync credentials from
+              # OpenBao via the shared `external-secrets` ClusterSecretStore role
+              # (apps/actual-budget/enablebanking). The value is seeded as a
+              # placeholder by infrastructure/vault-seed and overwritten with the
+              # real credentials out of band. (Its OIDC client secret is read from
+              # the shared infrastructure/oidc/dex path via infra-oidc-readonly,
+              # also on that role — no actual-budget-specific grant needed for it.)
+              bao policy write app-actual-budget-readonly - <<'POLICY'
+              path "secret/data/apps/actual-budget/*" {
+                capabilities = ["read"]
+              }
+              POLICY
+
               # Read-only view of ascoachingogvaner's app path for the shared
               # ClusterSecretStore bundle: the cert-manager simply.com DNS01
               # solver consumes the tenant-owned simply.com API credentials
@@ -776,6 +789,9 @@ spec:
               path "secret/data/apps/crossview/*" {
                 capabilities = ["create", "update", "read"]
               }
+              path "secret/data/apps/actual-budget/*" {
+                capabilities = ["create", "update", "read"]
+              }
               path "secret/data/flux/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -815,6 +831,9 @@ spec:
               path "secret/metadata/apps/crossview/*" {
                 capabilities = ["create", "update", "read"]
               }
+              path "secret/metadata/apps/actual-budget/*" {
+                capabilities = ["create", "update", "read"]
+              }
               path "secret/metadata/flux/*" {
                 capabilities = ["create", "update", "read"]
               }
@@ -832,7 +851,7 @@ spec:
               bao write auth/kubernetes/role/external-secrets \
                 bound_service_account_names=external-secrets \
                 bound_service_account_namespaces=external-secrets \
-                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,infra-ghcr-readonly,app-fleetdm-readonly,app-wedding-readonly,app-umami-readonly,app-crossview-readonly,app-ascoachingogvaner-readonly,infra-oidc-readonly,infra-unifi-readonly,vault-seed-write \
+                policies=infra-backup-readonly,infra-dns-readonly,infra-monitoring-readonly,infra-hcloud-readonly,infra-tls-readonly,infra-ghcr-readonly,app-fleetdm-readonly,app-wedding-readonly,app-umami-readonly,app-crossview-readonly,app-actual-budget-readonly,app-ascoachingogvaner-readonly,infra-oidc-readonly,infra-unifi-readonly,vault-seed-write \
                 ttl=1h
 
               # Dedicated role for the fleetdm VaultDynamicSecret generator.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

Since [#2331](https://github.com/devantler-tech/platform/pull/2331) merged (~07:00Z 2026-06-29), the `seed-actual-budget-enablebanking` PushSecret has been **Errored** on a clean 403:

```
set secret failed: could not verify if secret exists in store: cannot read secret data from Vault:
URL: GET http://openbao-active.openbao.svc.cluster.local:8200/v1/secret/data/apps/actual-budget/enablebanking
Code: 403. * permission denied
```

#2331 added the Enable Banking seed PushSecret (`infrastructure/vault-seed/push-secret-seed-actual-budget-enablebanking.yaml`) and the app's `actual-budget-enablebanking` ExternalSecret, but **never granted the matching OpenBao ACL paths** in `infrastructure/vault-config/job.yaml`. So:

- the **seed** can't write `secret/data/apps/actual-budget/enablebanking` (the live 403 above — `vault-seed-write` has no `actual-budget` path), and
- the **app read** would 403 too once seeded (there is no `app-actual-budget-readonly` policy on the shared `external-secrets` role bundle).

This is the persistent, non-flake failure surfacing in the merge-queue `deploy-prod` HealthCheck wait (distinct from the Cilium first-packet-drop noise tracked by #2337).

## Fix

Three **additive** grants, mirroring the existing umami/crossview apps:

1. New `app-actual-budget-readonly` policy — `read` on `secret/data/apps/actual-budget/*`.
2. `actual-budget` data + metadata write paths on `vault-seed-write` — so the seed PushSecret can write the placeholder.
3. `app-actual-budget-readonly` added to the shared `external-secrets` Kubernetes-auth role bundle — so the app's ExternalSecret can read it back.

All three are additive allow-list entries; no existing access is altered.

## Validation

- `ksail workload validate --skip-helm-render` — **474 files, exit 0** (both local + prod overlays).
- Embedded heredocs balanced; policy blocks copied verbatim from the umami/crossview pattern.

## Blast radius / promotion

Touches prod OpenBao ACLs (additive only). On promotion the `vault-config` Job re-runs and applies the new policies; the seed PushSecret should then sync and the app ExternalSecret resolve. Left as a **draft** for the maintainer to promote and watch the first reconcile.

Fixes the actual-budget 403 introduced by #2331.