### PR TITLE
fix(homepage): set pod-level runAsUser so sandbox accepts injected runAsGroup

### DIFF
--- a/k8s/bases/apps/homepage/helm-release.yaml
+++ b/k8s/bases/apps/homepage/helm-release.yaml
@@ -154,6 +154,20 @@ spec:
     # generous 2-core limit survives its proportional scaling. CPU is
     # compressible and the namespace ResourceQuota caps requests, not limits,
     # so a 2-core ceiling reserves nothing while it idles.
+    # Pod-level runAsUser/runAsGroup. The chart's podSecurityContext default
+    # only sets fsGroup (1000) — runAsUser/runAsGroup live on the CONTAINER
+    # securityContext. The add-security-context Kyverno policy injects a
+    # pod-level runAsGroup: 1000 (C-0013) but deliberately never injects a
+    # pod-level runAsUser (it would clobber image-baked UIDs). With a pod-level
+    # group but no pod-level user, containerd builds the OCI user string ":1000"
+    # and rejects it ("user group \"1000\" is specified without user"), so the
+    # pod sandbox never starts — homepage rolled to 1/2 ready in prod. Supplying
+    # the pod-level runAsUser here pairs with the injected group → "1000:1000",
+    # matching how whoami/dex set pod-level runAsUser. Deep-merges with the
+    # chart default, so fsGroup/fsGroupChangePolicy are preserved.
+    podSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
     resources:
       requests:
         cpu: 15m


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live prod)

`homepage-primary` is degraded at **1/2 ready** in prod. New pods loop in `ContainerCreating`:

```
Failed to create pod sandbox: rpc error: code = Unknown desc = failed to start sandbox ...
failed to generate sandbox container spec options: failed to generate user string:
user group "1000" is specified without user
```

The one surviving replica still serves the apex front page, but the app is one pod-eviction away from a full outage and every rollout/scale-up fails.

## Root cause

The homepage chart (M0NsTeRRR/homepage) sets `runAsUser`/`runAsGroup` on the **container** securityContext only — its `podSecurityContext` default carries just `fsGroup: 1000`.

The `add-security-context` Kyverno policy injects a **pod-level** `runAsGroup: 1000` (for C-0013) but **deliberately never injects a pod-level `runAsUser`** (doing so would clobber image-baked UIDs — see the policy header). A pod-level group with **no** pod-level user makes containerd build the OCI user string `":1000"` and reject it, so the sandbox never starts.

This is the *exact* caveat the policy header documents and already worked around for tofu-controller runner pods in [#2294](https://github.com/devantler-tech/platform/pull/2294). The older homepage pod (created before the pod-level `runAsGroup` injection landed via [#2292](https://github.com/devantler-tech/platform/pull/2292)) lacks the injected group and runs fine; new pods get it and break.

## Fix

Supply a **pod-level** `runAsUser` (+ `runAsGroup`) via the homepage chart values, so the sandbox user string becomes `"1000:1000"`. This mirrors how `whoami` and `dex` avoid the same trap (their charts set pod-level `runAsUser` — confirmed `65534` on both). The partial `podSecurityContext` deep-merges with the chart default, preserving `fsGroup`/`fsGroupChangePolicy`.

```yaml
podSecurityContext:
  runAsUser: 1000
  runAsGroup: 1000
```

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅
- `kubectl kustomize k8s/bases/apps/homepage/` ✅ (rendered HelmRelease carries the new `podSecurityContext`)
- `kubectl apply --dry-run=client` on the HelmRelease ✅