### PR TITLE
fix(crossplane): allow egress to Upbound registry for AWS provider package pulls

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
@@ -20,10 +20,22 @@ spec:
     #     pkg-containers.githubusercontent.com).
     #   api.github.com — the GitHub REST/GraphQL API used by
     #     provider-upjet-github to reconcile org/repo state.
+    #   xpkg.upbound.io + d3qrbvrml4iuq4.cloudfront.net — the Upbound registry
+    #     and its blob CDN, for the provider-aws-iam / provider-family-aws
+    #     package pulls. The registry serves the /v2 API, token endpoint and
+    #     manifests from xpkg.upbound.io itself, then 307-redirects layer blob
+    #     downloads to its CloudFront distribution. Pinned by exact host (not
+    #     *.cloudfront.net) to keep egress tight; if Upbound rotates the
+    #     distribution the blob pull will fail and the new host can be rediscovered
+    #     with: curl -sSI -H "Authorization: Bearer <token>" \
+    #     https://xpkg.upbound.io/v2/upbound/provider-aws-iam/blobs/<digest>
+    #     and read the Location header.
     - toFQDNs:
         - matchName: "ghcr.io"
         - matchName: "pkg-containers.githubusercontent.com"
         - matchName: "api.github.com"
+        - matchName: "xpkg.upbound.io"
+        - matchName: "d3qrbvrml4iuq4.cloudfront.net"
       toPorts:
         - ports:
             - port: "443"
@@ -47,4 +59,6 @@ spec:
               - matchName: "ghcr.io"
               - matchName: "pkg-containers.githubusercontent.com"
               - matchName: "api.github.com"
+              - matchName: "xpkg.upbound.io"
+              - matchName: "d3qrbvrml4iuq4.cloudfront.net"
               - matchPattern: "*.cluster.local"


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live prod)

`provider-aws-iam` and `provider-family-aws` have been **un-installed / un-healthy for ~16h** since the AWS provider foundation ([9f29a670](https://github.com/devantler-tech/platform/commit/9f29a670)) landed:

```
provider-aws-iam      <none>  <none>  xpkg.upbound.io/upbound/provider-aws-iam:v2.6.1     16h
provider-family-aws   <none>  <none>  xpkg.upbound.io/upbound/provider-family-aws:v2.6.1  16h
```

```
UnpackPackage: cannot resolve xpkg.upbound.io/upbound/provider-aws-iam:v2.6.1 to digest:
Get "https://xpkg.upbound.io/v2/": dial tcp 34.111.161.63:443: i/o timeout
```

## Root cause

The `allow-crossplane` CiliumNetworkPolicy deliberately pins egress by FQDN (`ghcr.io` / `pkg-containers.githubusercontent.com` / `api.github.com`) so a compromised pod can't reach arbitrary external hosts. The AWS providers pull from the **Upbound** registry `xpkg.upbound.io`, which isn't in the allowlist — so the core package manager's in-pod OCI pull is dropped by the namespace `default-deny`. DNS resolved (`34.111.161.63`) but the TCP dial was denied → timeout.

The foundation PR added the `Provider` / `DeploymentRuntimeConfig` manifests but never extended this egress policy. `provider-upjet-github` (ghcr.io) is unaffected and stays healthy — which is what pointed at an Upbound-specific egress gap rather than a registry outage.

## Fix

Add the two hosts an Upbound package pull needs, to **both** the `toFQDNs` egress rule and the L7 DNS visibility list:

- **`xpkg.upbound.io`** — `/v2` API, token endpoint and manifests (all same-host).
- **`d3qrbvrml4iuq4.cloudfront.net`** — Upbound's blob CDN. The registry **307-redirects** layer blob downloads here (confirmed against the `Location` header on an authenticated blob `GET`). Pinned by exact host rather than `*.cloudfront.net` to keep egress tight; the policy comment documents how to rediscover the host if Upbound ever rotates the distribution.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅
- `kubectl kustomize k8s/providers/hetzner/infrastructure/` ✅ (rendered policy carries both new hosts)
- `kubectl apply --dry-run=client` on the policy ✅

## Note / follow-up

This unblocks the **package pull** so the providers install and report healthy. When AWS managed resources are actually configured (ProviderConfig + MRs), the provider pods will additionally need egress to the relevant AWS API endpoints (e.g. `iam.amazonaws.com`, `sts.amazonaws.com`) — a separate egress addition for whoever wires up the first AWS resources.