### PR TITLE
fix(coroot): stop Slack incident spam from synthesised host pseudo-apps

### DIFF
--- a/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/patches/coroot-patch.yaml
@@ -149,6 +149,38 @@ spec:
             name: coroot-api-key
             key: key
           description: bundled node-agent + cluster-agent
+      # Mute Slack INCIDENTS for Coroot's synthesised host pseudo-apps. The eBPF
+      # node-agent buckets every process it sees but cannot map to a Kubernetes
+      # object into per-node apps under the `_` namespace (`_/runtime` = the
+      # Talos container runtime/containerd, `_/kubelet`, `_/init`,
+      # `_/extensions` = the system-extension group, …). These are NOT
+      # deployable workloads, and Coroot computes a default availability SLO on
+      # the eBPF-observed request flows anyway. For `_/runtime` those "requests"
+      # are containerd's outbound image pulls to ghcr.io / registry-1.docker.io /
+      # auth.docker.io: a handful of transient registry connection resets at a
+      # very low, bursty rate (≈0.008 req/s) push the error *ratio* over the SLO,
+      # so the incident flaps CRITICAL→resolved every few minutes and spammed
+      # #notifications all evening (2026-06-29) with no actionable cause — image
+      # pulls succeed on kubelet retry and pods run. A genuine host/storage fault
+      # still surfaces on the real workloads' SLOs and Longhorn volume health
+      # (same rationale as the alert-autosuppressor's `_:Unknown:*` entries), so
+      # the least-actionable place to lose signal is these synthesised host apps.
+      # Keep them fully visible in the Coroot UI (this only drops the Slack
+      # fan-out, mirroring the integration-wide alerts:false posture below); flip
+      # incidents back on if a host pseudo-app ever warrants paging.
+      applicationCategories:
+        - name: host-runtime
+          customPatterns:
+            - "_/*"
+          notificationSettings:
+            incidents:
+              enabled: false
+              webhook:
+                enabled: false
+            deployments:
+              enabled: false
+            alerts:
+              enabled: false
       notificationIntegrations:
         # Required by the Coroot CRD whenever any notificationIntegrations are
         # set (`spec.projects[].notificationIntegrations.baseURL`, pattern


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live prod — recent Slack alerts)

`#notifications` flapped **CRITICAL→resolved every few minutes all evening** (2026-06-29):

```
:fire: CRITICAL: _/runtime is not meeting its SLOs
:white_check_mark: _/runtime incident resolved
:fire: CRITICAL: _/runtime is not meeting its SLOs
... (repeating ~hourly+ with sub-minute open/close churn)
```

## Root cause

Coroot's eBPF node-agent buckets every process it sees but **cannot map to a Kubernetes object** into per-node apps under the `_` namespace — `_/runtime` (the Talos container runtime / **containerd**), `_/kubelet`, `_/init`, `_/extensions`, etc. These are **not deployable workloads**, but Coroot still computes a default availability SLO on their eBPF-observed request flows.

Inspected via the Coroot API: `_/runtime` has **0 mapped pod instances**, 6 host-process instances (one per node), and its "dependencies" are container registries (`ghcr.io`, `registry-1.docker.io`, `auth.docker.io`, `pkg-containers.githubusercontent.com`). So its "requests" are **containerd's outbound image pulls**. The error series is tiny — max **≈0.008 req/s**, 8 buckets over 3h — but because pull volume is low and bursty, a couple of transient registry connection resets push the error *ratio* over the availability SLO, so the incident **opens and closes continuously**. No actionable cause: image pulls succeed on kubelet retry and pods run normally. Every other report (Instances/CPU/Memory/Net/DNS/Logs) is OK.

## Fix

The hetzner Coroot project already routes **incidents** to Slack (`incidents: true`) while inspection **alerts** are UI-only (`alerts: false`) specifically to fight alert fatigue. Extend that posture to the synthesised host apps with a **declarative** `applicationCategories` entry:

```yaml
applicationCategories:
  - name: host-runtime
    customPatterns: ["_/*"]      # Coroot's unmapped-host-process namespace
    notificationSettings:
      incidents:  { enabled: false, webhook: { enabled: false } }
      deployments: { enabled: false }
      alerts:     { enabled: false }
```

`_/*` is exclusively Coroot's "couldn't map to Kubernetes" bucket, so this only mutes host pseudo-apps. They stay **fully visible in the Coroot UI** — only the Slack fan-out is dropped. A genuine host/storage fault still surfaces on the real workloads' SLOs and Longhorn volume health (same rationale as the `alert-autosuppressor`'s `_:Unknown:*` entries).

Configured through the Coroot CRD's `spec.projects[].applicationCategories` (operator-managed, shown locked in the UI), so it **survives a coroot-db rebuild / DR restore** with no manual click — unlike a UI/API change.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅
- `kubectl kustomize k8s/providers/hetzner/infrastructure/` ✅ (renders the `host-runtime` category on the Coroot CR)
- `kubectl apply --dry-run=server` on the rendered Coroot CR ✅ (CRD schema-valid; the only raw-build complaint is the `${alertmanager_webhook_url}` Flux post-build placeholder, which Flux substitutes at apply time)