### PR TITLE
fix(actual-budget): exempt enablebanking-seed ConfigMap from Flux envsubst

### DIFF
--- a/k8s/bases/apps/actual-budget/config-map.yaml
+++ b/k8s/bases/apps/actual-budget/config-map.yaml
@@ -3,6 +3,16 @@ kind: ConfigMap
 metadata:
   name: actual-budget-enablebanking-seed
   namespace: actual-budget
+  annotations:
+    # The embedded Node.js script below uses JS template literals (`${DB_PATH}`,
+    # `${name}`, and a multi-line `${ INTERVAL / 1000 }`) that are NOT Flux
+    # post-build variables. The apps Kustomization runs substituteFrom, so Flux's
+    # envsubst tries to expand them and fails to parse the multi-line one
+    # ("envsubst error: variable substitution failed: unable to parse variable
+    # name"), which blocks the entire apps Kustomization. This ConfigMap needs no
+    # Flux substitution, so opt it out — same pattern as the KRO
+    # ResourceGraphDefinitions whose `${...}` are CEL expressions.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   # Reconciles Actual Budget's Enable Banking credentials (Application ID + PEM
   # secret key) into the sync-server's internal `secrets` SQLite table from an


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem (live prod — surfaced during rollout)

With the infrastructure→apps stall cleared by #2343, the `apps` Kustomization finally reconciled past its dependency gate and **immediately failed**:

```
post build failed for 'ConfigMap.v1/actual-budget-enablebanking-seed':
envsubst error: variable substitution failed: unable to parse variable name
```

This blocks the **entire `apps` Kustomization** (all apps).

## Root cause

The `actual-budget-enablebanking-seed` ConfigMap (added in [#2331](https://github.com/devantler-tech/platform/pull/2331)) embeds a Node.js reconcile script using **JS template literals** — `${DB_PATH}`, `${name}`, and crucially a *multi-line* one:

```js
`reconciling Enable Banking secrets into ${DB_PATH} every ${
  INTERVAL / 1000
}s`
```

The `apps` Kustomization runs `substituteFrom`, so Flux's `envsubst` tries to expand every `${...}`. The newline inside `${ ... }` can't be parsed as a variable name → the whole Kustomization fails.

**Why it was latent:** `apps` never reconciled after #2331 merged because it was blocked on the `infrastructure` dependency (the OpenBao policy 403, #2343). The error only surfaced once `infrastructure` went healthy during this rollout. So #2331 shipped *two* coupled defects — the policy gap (#2343) and this envsubst break — the first masking the second.

## Fix

These are not Flux variables; the ConfigMap needs no post-build substitution. Opt it out with `kustomize.toolkit.fluxcd.io/substitute: disabled` — the same pattern the KRO `ResourceGraphDefinition`s already use for their CEL `${...}` expressions.

## Validation

- `kubectl kustomize k8s/clusters/local/` ✅
- `kubectl kustomize k8s/clusters/prod/` ✅
- `kubectl kustomize k8s/bases/apps/actual-budget/` ✅ (rendered ConfigMap carries the annotation)
- `kubectl apply --dry-run=client` ✅

## Rollout note

`infrastructure` is now **Ready** (the #2343 fix applied cleanly after a forced reconcile — the OpenBao policy updated, the seed PushSecret synced). `apps` will go green once this merges and deploys.