### PR TITLE
fix(actual-budget): disable Flux postBuild substitution on enablebanking seed

### DIFF
--- a/k8s/bases/apps/actual-budget/config-map.yaml
+++ b/k8s/bases/apps/actual-budget/config-map.yaml
@@ -3,6 +3,15 @@ kind: ConfigMap
 metadata:
   name: actual-budget-enablebanking-seed
   namespace: actual-budget
+  annotations:
+    # The seed-enablebanking.cjs payload is JavaScript and uses `${...}` template
+    # literals (e.g. `${DB_PATH}`, `${INTERVAL / 1000}`). Flux's Kustomize
+    # postBuild substitution runs over this manifest at deploy time, and
+    # `${INTERVAL / 1000}` is not a valid shell variable name → it fails the
+    # `apps` Kustomization build (`envsubst error: unable to parse variable
+    # name`), wedging every app deploy. This ConfigMap needs no Flux variables,
+    # so substitution is disabled for it wholesale.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   # Reconciles Actual Budget's Enable Banking credentials (Application ID + PEM
   # secret key) into the sync-server's internal `secrets` SQLite table from an


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — `apps` Kustomization is `BuildFailed` on live prod (and wedges the merge queue)

The `apps` Flux Kustomization on **prod is `Ready=False` right now**:

```
post build failed for 'ConfigMap.v1.[noGrp]/actual-budget-enablebanking-seed':
envsubst error: variable substitution failed: unable to parse variable name
```

`actual-budget-enablebanking-seed` embeds a JavaScript payload (`seed-enablebanking.cjs`) that uses JS template literals — `${DB_PATH}`, `${name}`, and critically **`${INTERVAL / 1000}`**. The `apps` Kustomization runs Flux postBuild `substituteFrom` (envsubst) over **every** rendered manifest, and `${INTERVAL / 1000}` is not a valid shell variable name, so the whole build aborts.

Effect:
- **Live**: the `apps` Kustomization stops reconciling — no app on prod gets new changes.
- **CI / merge queue**: every `merge_group` "🚀 Deploy to Prod" run fails at `apps (BuildFailed)` and evicts the PR, **freezing the platform merge queue** (`#2333`/`#2335`/`#2340`/`#2342`/… all kicked out). This is an environment-level deterministic block, not a per-PR fault.

> Note: an earlier, separate wedge cause — `PushSecret/seed-actual-budget-enablebanking` stuck on an OpenBao 403 (draft #2345) — has since cleared on the live cluster (`infrastructure` is `Ready=True`). This envsubst `BuildFailed` is the **current** gating failure.

## Fix

Add `kustomize.toolkit.fluxcd.io/substitute: disabled` to the ConfigMap so Flux skips postBuild substitution for this resource wholesale. It needs **no** Flux variables — its entire payload is application code. This matches the convention already used on the `tenant`/`webapp` `ResourceGraphDefinition`s (which embed CEL `${...}` for the same reason).

## Why this unblocks the queue

Unlike the other queued PRs (which don't touch the broken manifest and keep failing `deploy-prod`), this PR **carries the fix** — its `merge_group` `deploy-prod` builds the corrected `apps` manifest, so envsubst no longer chokes and the deploy passes. Promoting + merging this PR is the deterministic break for the freeze; the live `apps` Kustomization then reconciles on the next sync.

## Validation

- Live root cause reproduced on cluster: `kubectl get kustomization -n flux-system apps` → `Ready=False`, exact envsubst error on this exact ConfigMap.
- `ksail --config ksail.prod.yaml workload validate --skip-helm-render` → **474 files validated** (schema clean, no regression). *(`ksail validate` checks schema but does not run Flux's `substituteFrom` envsubst, so it can't reproduce the build error — the live kustomize-controller does.)*
- `substitute: disabled` is Flux's documented resource-level opt-out of the entire postBuild substitution stage.

`Fixes #2026`-adjacent operate work; primary effect is unwedging prod app delivery + the merge queue.
