### PR TITLE
fix(ci): wait for apps to converge to the pushed revision in the prod deploy gate

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -285,7 +285,71 @@ runs:
         GITHUB_ACTOR: ${{ github.actor }}
         GHCR_TOKEN: ${{ inputs.ghcr-token }}
         HCLOUD_TOKEN: ${{ inputs.hcloud-token }}
-      run: ksail --config ksail.prod.yaml workload reconcile
+        # The OCI manifest digest cosign just resolved and signed — exactly the
+        # bytes Flux's OCIRepository pulls. The Kustomizations' revisions are
+        # "<tag>@<digest>", so we converge-check on this digest. (Empirically the
+        # cosign subject-digest and the OCIRepository .status.artifact.revision
+        # digest are byte-identical.)
+        PUSHED_DIGEST: ${{ steps.cosign-sign.outputs.digest }}
+      # `ksail workload reconcile` TRIGGERS reconciliation of the OCI source and
+      # every Kustomization, but only SNAPSHOTS their Ready status sub-second —
+      # it does NOT wait for the just-pushed revision to propagate down the
+      # bootstrap → infrastructure-controllers → infrastructure → apps dependency
+      # chain. That snapshot races propagation: it reads whatever revision each
+      # Kustomization last reconciled, so it can both (a) FALSE-FAIL a deploy that
+      # FIXES a currently-broken layer (the new healthy revision hasn't built yet,
+      # so it still reads the old failure — e.g. a wedged `apps` BuildFailed) and
+      # (b) FALSE-PASS a deploy that BREAKS a layer (the old healthy revision is
+      # still applied). We therefore use it only to KICK reconciliation, discard
+      # its premature verdict, and gate on an explicit convergence wait: the leaf
+      # Kustomization (`apps`) must actually reconcile the PUSHED digest and report
+      # Ready=True. Because `apps` is last in the dependency chain, its
+      # convergence implies the whole platform artifact converged.
+      run: |
+        set -uo pipefail
+        ksail --config ksail.prod.yaml workload reconcile || \
+          echo "ksail reconcile returned non-zero (premature snapshot) — gating on convergence wait below."
+
+        get() {
+          kubectl --context admin@prod -n flux-system get kustomization apps \
+            -o jsonpath="{$1}" 2>/dev/null || true
+        }
+
+        deadline=$(( SECONDS + 20 * 60 ))
+        last=""
+        while (( SECONDS < deadline )); do
+          attempted=$(get '.status.lastAttemptedRevision')
+          ready=$(get '.status.conditions[?(@.type=="Ready")].status')
+          reason=$(get '.status.conditions[?(@.type=="Ready")].reason')
+          message=$(get '.status.conditions[?(@.type=="Ready")].message')
+
+          if [[ "${attempted}" == *"@${PUSHED_DIGEST}" ]]; then
+            # `apps` has now built the PUSHED artifact (lastAttemptedRevision only
+            # advances once it actually builds, i.e. dependencies are ready).
+            if [[ "${ready}" == "True" ]]; then
+              echo "✅ apps reconciled the pushed revision (${attempted}) and is Ready — prod converged."
+              exit 0
+            fi
+            # A build/substitution error on the pushed artifact is deterministic
+            # (it will never self-heal), so fail fast rather than wait out the
+            # timeout. Health/apply flaps (other reasons) may self-heal, so keep
+            # waiting for those until the deadline.
+            if [[ "${reason}" == "BuildFailed" ]]; then
+              echo "::error::apps failed to BUILD the pushed revision (${attempted}): ${message}"
+              exit 1
+            fi
+          fi
+
+          state="${attempted:-<none>}|${ready:-?}|${reason:-?}"
+          if [[ "${state}" != "${last}" ]]; then
+            echo "waiting for apps to converge: attempted=${attempted:-<none>} ready=${ready:-?} reason=${reason:-?} (want @${PUSHED_DIGEST}, Ready=True)"
+            last="${state}"
+          fi
+          sleep 10
+        done
+
+        echo "::error::apps Kustomization did not reach Ready=True on the pushed revision (@${PUSHED_DIGEST}) within 20m. Last seen: ready=${ready:-?} reason=${reason:-?} message=${message:-?}"
+        exit 1
 
     - name: 🩺 Diagnose Flux on failure
       if: failure() && steps.reconcile.outcome == 'failure'

--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -310,45 +310,55 @@ runs:
         ksail --config ksail.prod.yaml workload reconcile || \
           echo "ksail reconcile returned non-zero (premature snapshot) — gating on convergence wait below."
 
-        get() {
-          kubectl --context admin@prod -n flux-system get kustomization apps \
-            -o jsonpath="{$1}" 2>/dev/null || true
-        }
+        # Collapse newlines/CRs so a multi-line Flux message can't truncate or
+        # break out of a ::error:: workflow-command annotation.
+        sanitize() { printf '%s' "${1:-}" | tr '\n\r' '  '; }
 
         deadline=$(( SECONDS + 20 * 60 ))
         last=""
+        applied="" attempted="" ready="" reason="" message=""
         while (( SECONDS < deadline )); do
-          attempted=$(get '.status.lastAttemptedRevision')
-          ready=$(get '.status.conditions[?(@.type=="Ready")].status')
-          reason=$(get '.status.conditions[?(@.type=="Ready")].reason')
-          message=$(get '.status.conditions[?(@.type=="Ready")].message')
+          # ONE JSON snapshot per poll so the fields can't be stitched from
+          # different reconcile states; --request-timeout bounds each call so a
+          # stalled API request can't outlive the loop deadline.
+          snap=$(kubectl --context admin@prod -n flux-system get kustomization apps \
+            -o json --request-timeout=30s 2>/dev/null || true)
+          if [[ -n "${snap}" ]]; then
+            applied=$(jq -r '.status.lastAppliedRevision // ""' <<<"${snap}")
+            attempted=$(jq -r '.status.lastAttemptedRevision // ""' <<<"${snap}")
+            ready=$(jq -r '(.status.conditions[]? | select(.type=="Ready") | .status) // ""' <<<"${snap}")
+            reason=$(jq -r '(.status.conditions[]? | select(.type=="Ready") | .reason) // ""' <<<"${snap}")
+            message=$(jq -r '(.status.conditions[]? | select(.type=="Ready") | .message) // ""' <<<"${snap}")
 
-          if [[ "${attempted}" == *"@${PUSHED_DIGEST}" ]]; then
-            # `apps` has now built the PUSHED artifact (lastAttemptedRevision only
-            # advances once it actually builds, i.e. dependencies are ready).
-            if [[ "${ready}" == "True" ]]; then
-              echo "✅ apps reconciled the pushed revision (${attempted}) and is Ready — prod converged."
+            # Success only once the pushed revision is APPLIED (not merely
+            # attempted) and the Kustomization is Ready. lastAppliedRevision
+            # advances after a successful apply, so this can't be fooled by a
+            # stale Ready=True carried over from the prior revision while a new
+            # build is still mid-flight.
+            if [[ "${applied}" == *"@${PUSHED_DIGEST}" && "${ready}" == "True" ]]; then
+              echo "✅ apps applied the pushed revision (${applied}) and is Ready — prod converged."
               exit 0
             fi
-            # A build/substitution error on the pushed artifact is deterministic
+            # A build/substitution error on the pushed revision is deterministic
             # (it will never self-heal), so fail fast rather than wait out the
-            # timeout. Health/apply flaps (other reasons) may self-heal, so keep
-            # waiting for those until the deadline.
-            if [[ "${reason}" == "BuildFailed" ]]; then
-              echo "::error::apps failed to BUILD the pushed revision (${attempted}): ${message}"
+            # timeout. lastAttemptedRevision advances when the build is attempted
+            # even though it is never applied. Health/apply flaps (other reasons)
+            # may self-heal, so keep waiting for those until the deadline.
+            if [[ "${attempted}" == *"@${PUSHED_DIGEST}" && "${reason}" == "BuildFailed" ]]; then
+              echo "::error::apps failed to BUILD the pushed revision (${attempted}): $(sanitize "${message}")"
               exit 1
             fi
           fi
 
-          state="${attempted:-<none>}|${ready:-?}|${reason:-?}"
+          state="${applied:-<none>}|${attempted:-<none>}|${ready:-?}|${reason:-?}"
           if [[ "${state}" != "${last}" ]]; then
-            echo "waiting for apps to converge: attempted=${attempted:-<none>} ready=${ready:-?} reason=${reason:-?} (want @${PUSHED_DIGEST}, Ready=True)"
+            echo "waiting for apps to converge: applied=${applied:-<none>} attempted=${attempted:-<none>} ready=${ready:-?} reason=${reason:-?} (want applied @${PUSHED_DIGEST}, Ready=True)"
             last="${state}"
           fi
           sleep 10
         done
 
-        echo "::error::apps Kustomization did not reach Ready=True on the pushed revision (@${PUSHED_DIGEST}) within 20m. Last seen: ready=${ready:-?} reason=${reason:-?} message=${message:-?}"
+        echo "::error::apps Kustomization did not converge to the pushed revision (applied @${PUSHED_DIGEST}, Ready=True) within 20m. Last seen: applied=${applied:-?} attempted=${attempted:-?} ready=${ready:-?} reason=${reason:-?} message=$(sanitize "${message}")"
         exit 1
 
     - name: 🩺 Diagnose Flux on failure


### PR DESCRIPTION
## Problem

The prod `apps` Flux Kustomization has been wedged (`Ready=False`) for days:

```
post build failed for 'ConfigMap.v1.[noGrp]/actual-budget-enablebanking-seed':
envsubst error: variable substitution failed: unable to parse variable name
```

Root cause of the wedge is fixed by #2349 (the `actual-budget-enablebanking-seed` ConfigMap embeds JS template literals like `${INTERVAL / 1000}` that Flux's `substituteFrom` envsubst can't parse — #2349 opts it out with `kustomize.toolkit.fluxcd.io/substitute: disabled`, the same pattern the KRO RGDs use).

But **#2349 cannot land through the merge queue**, and this PR fixes why.

## Root cause (this PR)

The `deploy-prod` gate runs `ksail workload reconcile`, which only **snapshots** each Kustomization's `Ready` status sub-second after pushing the new OCI artifact — it does **not** wait for the pushed revision to propagate down the `bootstrap → infrastructure-controllers → infrastructure → apps` dependency chain. The snapshot races propagation and is wrong in **both** directions:

- **False-fail** — a deploy that *fixes* a currently-broken layer is evicted: the new healthy revision hasn't built yet, so the gate still reads the old failure (the wedged `apps` `BuildFailed`). A `Ready=False` `apps` in `main` therefore **cannot be repaired through the queue** — a catch-22 that traps #2349.
- **False-pass** — a deploy that *breaks* a layer passes: the old healthy revision is still applied at snapshot time. This is how the envsubst-breaking ConfigMap reached `main` and wedged `apps` originally.

Observed in the evicted `merge_group` run for #2349: `ksail` reported all four Kustomizations in the same 0.3s instant (`✗ apps failed` alongside `✔ infrastructure reconciled`), and the diagnostics seconds later showed the chain still mid-propagation (`apps … dependency 'infrastructure' revision is not up to date`).

## Fix

Keep `ksail workload reconcile` purely to **kick** reconciliation, discard its premature verdict, and gate on an explicit **convergence wait**: the leaf Kustomization (`apps`) must actually reconcile the **pushed OCI digest** (the one cosign just signed) and report `Ready=True`. Because `apps` is last in the dependency chain, its convergence implies the whole platform artifact converged.

- Fail fast on a deterministic `BuildFailed` of the pushed revision.
- Otherwise wait out transient health flaps (e.g. the mutual-auth first-packet race, #2337) until a 20m deadline, then fail.
- The existing `Diagnose Flux on failure` step still fires on `steps.reconcile.outcome == 'failure'`, and `cluster update` still only runs on success.

This is an **action-only** change (`.github/actions/deploy-prod/action.yml` is not a `k8s/**` path), so `changes.outputs.k8s == false` → `deploy-prod` is skipped → it merges through the queue **without itself hitting the broken gate**.

## Sequencing

1. Land #2349 once via a one-time merge-queue admin bypass to clear the live prod wedge now.
2. Merge this PR so the gate stops false-failing/false-passing and the catch-22 can't recur.

## Validation

- `yq` parses the action (15 steps); embedded gate script is `shellcheck -s bash` clean.
- No `k8s/**` manifests touched — Kustomize builds unaffected.
- Empirically verified the gate's convergence key: the cosign subject-digest and the OCIRepository `.status.artifact.revision` digest are byte-identical (`sha256:937a90fae2…` in the failed run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)