### PR TITLE
feat(actual-budget): configure OpenID (Dex) declaratively + fix Dex callback path

### DIFF
--- a/k8s/bases/apps/actual-budget/helm-release.yaml
+++ b/k8s/bases/apps/actual-budget/helm-release.yaml
@@ -15,12 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: actual-budget
-  valuesFrom:
-    - kind: Secret
-      name: actual-budget-oidc
-      valuesKey: client-secret
-      targetPath: login.openid.clientSecret
-      optional: true
   postRenderers:
     - kustomize:
         patches:
@@ -59,6 +53,52 @@ spec:
                   periodSeconds: 5
                   timeoutSeconds: 3
                   failureThreshold: 12  # 60s grace beyond initial delay
+              # OpenID/OIDC (Dex) env. The chart only emits the ACTUAL_OPENID_*
+              # block when `ingress.enabled=true` (its deployment template gates
+              # the whole block on the chart Ingress), but we serve via a Gateway
+              # API HTTPRoute with the chart ingress disabled — so the chart drops
+              # every OpenID var and the server's startup auto-enable (it runs
+              # bootstrapOpenId(forced) when a discovery URL is present) never
+              # fires, leaving OpenID disabled. Inject the env directly here. On
+              # the next pod start the server makes OpenID the active login method
+              # (sessions are reset; ENFORCE=true removes the password option).
+              # SERVER_HOSTNAME drives the redirect_uri
+              # https://budget.${domain}/openid/callback, which must be registered
+              # on the Dex public-client (see the dex HelmRelease). The client
+              # secret is the ESO-synced Dex shared secret (actual-budget-oidc).
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: ACTUAL_OPENID_DISCOVERY_URL
+                  value: "https://dex.${domain}/.well-known/openid-configuration"
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: ACTUAL_OPENID_CLIENT_ID
+                  value: "public-client"
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: ACTUAL_OPENID_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: actual-budget-oidc
+                      key: client-secret
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: ACTUAL_OPENID_SERVER_HOSTNAME
+                  value: "https://budget.${domain}"
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: ACTUAL_OPENID_AUTH_METHOD
+                  value: "openid"
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: ACTUAL_OPENID_ENFORCE
+                  value: "true"
   # https://github.com/community-charts/helm-charts/blob/main/charts/actualbudget/values.yaml
   values:
     replicaCount: ${actual_budget_replicas:=1}
@@ -145,12 +185,11 @@ spec:
     persistence:
       enabled: true
       size: 10Gi
+    # `login.method` renders ACTUAL_LOGIN_METHOD unconditionally. The OpenID
+    # details (discovery URL, client id/secret, server hostname, enforce) are
+    # NOT set here: the chart only emits the ACTUAL_OPENID_* env when its own
+    # Ingress is enabled, and we disable it in favour of a Gateway API
+    # HTTPRoute — so those vars are injected via the postRenderer patch above.
+    # token_expiration defaults to "never" upstream, so it is not set.
     login:
       method: "openid"
-      openid:
-        enforce: true
-        providerName: "Dex"
-        discoveryUrl: "https://dex.${domain}/.well-known/openid-configuration"
-        clientId: "public-client"
-        authMethod: "openid"
-        tokenExpiration: "never"

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -110,7 +110,9 @@ spec:
           redirectURIs:
             - "https://oauth2-proxy.${domain}/oauth2/callback"
             - "https://headlamp.${domain}/oidc-callback"
-            - "https://budget.${domain}/oidc/callback"
+            # actual-budget (sync-server) hardcodes its OIDC callback path as
+            # /openid/callback (ACTUAL_OPENID_SERVER_HOSTNAME=https://budget.${domain}).
+            - "https://budget.${domain}/openid/callback"
             - "https://vault.${domain}/ui/vault/auth/oidc/oidc/callback"
             - "https://ksail.${domain}/api/v1/auth/callback"
             # crossview authenticates natively against Dex as this shared


### PR DESCRIPTION
## What

Configures actual-budget to authenticate via **Dex (OpenID Connect)** declaratively, and fixes the Dex redirect URI that would otherwise break the flow.

## Why it was disabled despite `login.method: openid`

The `actualbudget` chart **only emits the `ACTUAL_OPENID_*` env block when its own Ingress is enabled** (`templates/deployment.yaml` gates the entire block on `.Values.ingress.enabled`). The platform serves actual-budget through a Gateway API `HTTPRoute` with the chart ingress **disabled**, so the chart silently dropped every OpenID variable. The server got `ACTUAL_LOGIN_METHOD=openid` but no discovery URL/client/secret — and the sync-server's startup auto-enable (`run()` calls `bootstrapOpenId(forced)` when `openId.discoveryURL` is set) never fired. Result: OpenID showed as "disabled" in the UI, regardless of the seeded config.

(Verified against the deployed image `actualbudget/actual-server:26.6.0` and live state: the `auth` table's active method was `password`; the Deployment had no `ACTUAL_OPENID_*` env.)

## Changes

**`k8s/bases/apps/actual-budget/helm-release.yaml`** — inject the OpenID env directly via the existing Deployment `postRenderer` patch (bypassing the ingress gate):

| Var | Value |
|---|---|
| `ACTUAL_OPENID_DISCOVERY_URL` | `https://dex.${domain}/.well-known/openid-configuration` |
| `ACTUAL_OPENID_CLIENT_ID` | `public-client` (shared Dex confidential client) |
| `ACTUAL_OPENID_CLIENT_SECRET` | `secretKeyRef` → `actual-budget-oidc` (ESO-synced) |
| `ACTUAL_OPENID_SERVER_HOSTNAME` | `https://budget.${domain}` |
| `ACTUAL_OPENID_AUTH_METHOD` | `openid` |
| `ACTUAL_OPENID_ENFORCE` | `true` (OpenID-only; password option removed) |

Also removes the now-inert `login.openid` values + `valuesFrom` (they only rendered under the ingress-gated block; this also retires the offline-empty-clientSecret `ksail validate` false-failure those caused). `token_expiration` defaults to `never` upstream.

**`k8s/bases/infrastructure/controllers/dex/helm-release.yaml`** — the sync-server hardcodes its callback as `/openid/callback` (`accounts/openid.ts`), but the Dex `public-client` registered `https://budget.${domain}/oidc/callback`. Corrected to `/openid/callback`, else the OAuth flow fails with `redirect_uri` mismatch.

## ⚠️ Activation behaviour (on reconcile)

This is an **auth cutover**. When it reconciles and the pod restarts, `bootstrapOpenId` (forced):
- makes **OpenID the active login method** and demotes password;
- with `ENFORCE=true`, **removes the password login option** entirely;
- **deletes all sessions** — everyone must re-log in via Dex;
- **the first user to log in via Dex becomes the server owner.**

Because `ENFORCE=true`, there is no password fallback if the OIDC flow is misconfigured. Suggested verification right after merge: confirm `kubectl -n actual-budget get deploy ... -o jsonpath` shows the `ACTUAL_OPENID_*` env, then log in via Dex at `https://budget.${domain}` before closing existing sessions elsewhere. If anything is off, set `ACTUAL_OPENID_ENFORCE=false` to restore the password fallback.

## Out of scope — End-to-end encryption (cannot be declarative)

E2E encryption can't be configured from GitOps: it's a client-side, user-password operation (the client derives the key from a password you choose, encrypts locally, uploads only ciphertext; the server never holds the key). There is no server/env knob for it in 26.6.0 (only an unrelated upload-size limit). Configuring it declaratively would defeat E2E. It remains a one-time in-app action.

## Validation

- `kubectl kustomize` builds clean for `k8s/providers/hetzner/apps`, `…/infrastructure/controllers`, and both `k8s/clusters/{prod,local}` overlays.
- postRenderer patch parses as 9 well-formed JSON6902 ops (3 existing + 6 OpenID env); client secret uses `secretKeyRef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)