### PR TITLE
fix(autoscaling): break the DaemonSet-VPA node ratchet; keep Longhorn storage off autoscale nodes

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml
@@ -188,36 +188,36 @@ spec:
             resourcePolicy:
               containerPolicies:
                 - containerName: "*"
-                  controlledResources: ["cpu", "memory"]
-                  # RequestsAndLimits (not RequestsOnly): VPA also scales each
-                  # container's limit in proportion to the request it sets,
-                  # preserving the authored limit:request ratio. Under
-                  # RequestsOnly the limit stayed fixed, so any workload whose
-                  # VPA target outgrew its static memory limit was capped below
-                  # its known need and OOMKilled (e.g. a metrics/log store whose
-                  # target outgrew its static limit). The request is bounded by maxAllowed
-                  # below; CPU limits only loosen (less throttling, no OOM).
+                  # CPU ONLY for DaemonSets — VPA must not manage DaemonSet
+                  # MEMORY. VPA keeps ONE usage histogram per container across
+                  # ALL pods of a DaemonSet, so it sizes EVERY node's agent to
+                  # the single busiest node's peak (+15% margin), and that
+                  # request is then multiplied by the node count. On 2026-06-30
+                  # this inflated the per-node agent stack (coroot-node-agent
+                  # 826Mi, kubescape node-agent 523Mi, longhorn-manager 456Mi,
+                  # ...) to ~3.5Gi — exactly 50% of a cx33's allocatable, which
+                  # is the cluster-autoscaler's scale-down utilization
+                  # threshold. Result: every autoscale-cx33 node was
+                  # unremovable EVEN WHEN EMPTY of movable pods (CA counts
+                  # DaemonSet requests in node utilization and KSail exposes no
+                  # ignore-daemonsets-utilization / threshold knob), so any
+                  # transient demand burst minted a permanent node — a one-way
+                  # ratchet (4 stuck autoscale nodes, 2026-06-30). With memory
+                  # uncontrolled here, DaemonSet memory comes from authored
+                  # chart/CR values (the heavy agents author explicit
+                  # request+limit: coroot-node-agent in coroot.yaml, kubescape
+                  # node-agent in its HelmRelease, cilium in its HelmRelease)
+                  # or the namespace LimitRange defaults for the small ones.
+                  # CPU stays VPA-managed (compressible, no OOM risk).
+                  controlledResources: ["cpu"]
+                  # RequestsAndLimits: scales the CPU limit in proportion to
+                  # the request (see the Deployment rule for the rationale).
                   controlledValues: RequestsAndLimits
                   minAllowed:
-                    # CPU floor raised 15m->50m for cold-start headroom. 15m was
-                    # right-sized to STEADY-STATE usage (avg 4.4m), but with
-                    # RequestsAndLimits it also pinned the LIMIT low (e.g. wedding-app
-                    # at 15m req -> 60m limit, authored 4:1 ratio), which throttled
-                    # COLD START: Node/Next.js apps couldn't boot fast enough to pass
-                    # their liveness probe and crashlooped. Only FRESH starts were hit
-                    # — already-running pods, resized in place, kept serving — so it
-                    # surfaced only on a new ReplicaSet. 50m req -> ~200m limit restores
-                    # the headroom the old pods originally cold-started under. Costs
-                    # ~3 cores of (compressible) CPU requests vs 15m; VPA still
-                    # right-sizes above the floor for steady-state. Memory floor kept
-                    # at 64Mi (memory runs ~89% hot).
+                    # CPU floor: see the Deployment rule (cold-start headroom).
                     cpu: "50m"
-                    memory: "64Mi"
                   # Lower upper bound than Deployments/StatefulSets: a DaemonSet
                   # pod must schedule on EVERY node, including autoscale-cx23
-                  # workers (2 vCPU / 4 GB). Bound it to fit a cx23 next to
-                  # the other per-node agents; this still covers the heaviest
-                  # auto-VPA'd DaemonSet observed (kubescape node-agent ~0.7Gi).
+                  # workers (2 vCPU / 4 GB).
                   maxAllowed:
                     cpu: "1"
-                    memory: "1Gi"

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -98,6 +98,20 @@ spec:
       config:
         hostSensor:
           enabled: true
+      # Authored memory sizing — REQUIRED. DaemonSet VPAs are CPU-only (see
+      # cluster-policies/best-practices/auto-vpa.yaml: VPA sized every node's
+      # agent to the busiest node's peak — 523Mi/node × every node — which
+      # ratcheted the cluster-autoscaler on 2026-06-30), so memory must be
+      # authored here. Observed live range is 261–436Mi/node; request ≈
+      # typical usage, limit covers scan-time spikes with headroom (the
+      # kubescape LimitRange default limit is only 512Mi — too tight for scan
+      # bursts). CPU request is the VPA floor; VPA still right-sizes CPU.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 320Mi
+        limits:
+          memory: 1Gi
     kubescape:
       image:
         # The posture scanner applies the SecurityException / ClusterSecurityException

--- a/k8s/bases/infrastructure/coroot/coroot.yaml
+++ b/k8s/bases/infrastructure/coroot/coroot.yaml
@@ -176,6 +176,22 @@ spec:
     image:
       name: ghcr.io/coroot/coroot-node-agent:1.33.3
     priorityClassName: platform-critical
+    # Authored memory sizing — REQUIRED. DaemonSet VPAs are CPU-only (see
+    # cluster-policies/best-practices/auto-vpa.yaml: VPA sized every node's
+    # agent to the busiest node's peak — 826Mi/node × every node — and that
+    # per-node inflation ratcheted the cluster-autoscaler on 2026-06-30), so
+    # memory must be authored here. Without it the observability LimitRange
+    # default (512Mi limit) applies, and this agent's observed live range is
+    # 369–695Mi/node — a 512Mi limit would OOM-crashloop the hotter nodes.
+    # request ≈ typical per-node usage (~450Mi live median); the limit covers
+    # the observed peak with headroom. CPU request is just the VPA floor —
+    # VPA still right-sizes CPU above it.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
     tolerations:
       - operator: Exists
 

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/prefer-baseline-nodes.yaml
@@ -12,18 +12,18 @@
 # load drops. A hard nodeAffinity (or a NoSchedule taint) would defeat burst,
 # which is why the strength is "preferred", not "required".
 #
-# DISCRIMINATOR — KSail contract: autoscaler-provisioned nodes are expected to
-# carry the node label `ksail.io/autoscaled: "true"`; baseline (static) workers
-# and control planes do NOT. There is currently NO Kubernetes node label that
-# distinguishes the two — static workers and autoscaler nodes share an
-# identical Talos worker config (same kubelet --node-labels, same
-# node.longhorn.io/create-default-disk=true, overlapping cx33 instance-type),
-# differing only by node-name prefix (prod-worker-* vs autoscale-*). For this
-# preference to take effect, KSail must stamp this label onto its autoscaler
-# node groups (per-pool kubelet --node-labels in the autoscaler cloud-init).
-# Until that lands this policy is an inert no-op: with the label absent on every
-# node, `DoesNotExist` matches all nodes equally and scheduling is unchanged —
-# so it is safe to ship ahead of the KSail change.
+# DISCRIMINATOR — KSail contract: autoscaler-provisioned nodes carry the node
+# label `ksail.io/autoscaled: "true"`; baseline (static) workers and control
+# planes do NOT. SHIPPED: KSail stamps the label since ksail#5113 (verified on
+# the live prod autoscale-cx33 nodes, 2026-07-01), so this policy is ACTIVE —
+# pods created since then are biased toward the baseline workers. Note the
+# label does NOT gate Longhorn's default-disk creation (that keys exclusively
+# on node.longhorn.io/create-default-disk, still stamped by the shared Talos
+# worker config) — replica placement is handled separately by
+# restrict-storage-to-baseline-workers.yaml in this folder. Also note the bias
+# only helps while the baseline has room: a soft preference cannot drain
+# already-placed pods, and under request pressure the scheduler still uses
+# autoscaler nodes freely (by design).
 #
 # Coverage: mutates Pods directly for the broadest reach (Deployments,
 # StatefulSets, DaemonSets, Jobs, CronJobs, bare and operator-created pods).

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
@@ -80,8 +80,13 @@ spec:
             allowScheduling: false
             evictionRequested: true
     # Background path: retro-patch the autoscale Node CRs that already exist
-    # when this policy lands (mutateExistingOnPolicyUpdate above). Also
-    # re-asserts on any matched Node event, healing manual UI flips.
+    # when this policy lands (mutateExistingOnPolicyUpdate above). The trigger
+    # is restricted to CREATE so Longhorn's steady Node-CR update churn does
+    # not re-enqueue background UpdateRequests for already-patched nodes —
+    # after the retrofit, this rule only fires again when a NEW autoscale
+    # node registers (rare, and a cheap re-assert of all targets). Manual UI
+    # flips are still healed by Kyverno's periodic background scan (hourly by
+    # default), which runs for mutate-existing rules regardless of triggers.
     - name: drain-existing-autoscale-nodes
       match:
         any:
@@ -90,6 +95,8 @@ spec:
                 - longhorn.io/v1beta2/Node
               names:
                 - "autoscale-*"
+              operations:
+                - CREATE
       mutate:
         targets:
           - apiVersion: longhorn.io/v1beta2

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
@@ -22,20 +22,26 @@
 # named autoscale-<pool>-<id>, and Longhorn mirrors the Kubernetes node name
 # into its nodes.longhorn.io CR name.
 #
-# MECHANISM: mutate the Longhorn Node CR at admission —
+# MECHANISM: two mutations set the same two fields —
 #   * allowScheduling: false  → no NEW replica is ever scheduled to the node
 #     (node-level gate; overrides every per-disk allowScheduling);
 #   * evictionRequested: true → belt-and-braces: any replica that slipped on
 #     (e.g. landed before this policy deployed) is actively rebuilt onto a
-#     baseline worker and removed. A no-op on nodes with zero replicas.
+#     baseline worker (rebuild completes BEFORE removal — no redundancy loss)
+#     and removed. A no-op on nodes with zero replicas.
+# Rule 1 mutates at ADMISSION, catching every future autoscale Node CR the
+# moment longhorn-manager creates it. Rule 2 is a mutate-EXISTING rule
+# (mutateExistingOnPolicyUpdate), so deploying/updating this policy also
+# retro-patches CRs that predate it — the 4 replica-hosting autoscale nodes
+# of 2026-06-30 are drained by the policy itself, no manual kubectl needed.
+# It requires the kyverno:background-controller:mutate-longhorn-nodes grant
+# (controllers/longhorn/, one Flux layer earlier — Kyverno rejects the policy
+# at admission if the grant is missing).
 # Longhorn only ever sets these two fields from user action (UI/API), so the
 # mutation fights no controller. Engine instance-managers still run on
 # autoscale nodes while a Longhorn-volume-mounting pod runs there — that is
 # required for I/O and correct; they hold no data and are evictable (see
 # kubernetesClusterAutoscalerEnabled in the longhorn HelmRelease).
-#
-# The existing 4 autoscale nodes' CRs were patched live to the same values on
-# 2026-07-01; this policy makes the contract permanent for every future node.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -53,7 +59,10 @@ metadata:
       workers so the cluster-autoscaler can reclaim idle nodes and no
       replica lives on a node that may be deleted at any time.
 spec:
+  mutateExistingOnPolicyUpdate: true
   rules:
+    # Admission path: every future autoscale Node CR is patched as it is
+    # created (or on any later spec update that slips through).
     - name: disable-replica-scheduling-on-autoscale-nodes
       match:
         any:
@@ -63,6 +72,27 @@ spec:
               names:
                 - "autoscale-*"
       mutate:
+        patchStrategicMerge:
+          spec:
+            allowScheduling: false
+            evictionRequested: true
+    # Background path: retro-patch the autoscale Node CRs that already exist
+    # when this policy lands (mutateExistingOnPolicyUpdate above). Also
+    # re-asserts on any matched Node event, healing manual UI flips.
+    - name: drain-existing-autoscale-nodes
+      match:
+        any:
+          - resources:
+              kinds:
+                - longhorn.io/v1beta2/Node
+              names:
+                - "autoscale-*"
+      mutate:
+        targets:
+          - apiVersion: longhorn.io/v1beta2
+            kind: Node
+            namespace: longhorn-system
+            name: "autoscale-*"
         patchStrategicMerge:
           spec:
             allowScheduling: false

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
@@ -1,0 +1,69 @@
+# Prod-only: keep Longhorn replica storage OFF the ephemeral autoscaler nodes,
+# enforcing the documented compute-only contract for the autoscale-cx* pools
+# (ksail.prod.yaml: "the static workers are ... the only Longhorn storage
+# nodes (autoscaler nodes are compute-only)").
+#
+# WHY THIS EXISTS: autoscaler nodes boot from the SAME Talos worker config as
+# the static workers (talos/workers/node-labels.yaml), so they inherit the
+# node.longhorn.io/create-default-disk=true kubelet label. With
+# createDefaultDiskOnLabeledNodesOnly Longhorn then treats every autoscale
+# node as a storage node: it creates a default disk, and replicaAutoBalance:
+# best-effort actively migrates volume replicas onto it. Observed 2026-06-30:
+# 14 replicas (~72Gi scheduled) living on 4 autoscale-cx33 nodes. That is
+# wrong twice over:
+#   * durability — replicas on nodes the autoscaler may delete at any time;
+#   * elasticity — replica-hosting instance-managers pin the node, so the
+#     autoscaler can never scale it back down (part of the 2026-06-30
+#     stuck-node ratchet).
+# KSail exposes no per-pool node labels/taints, so the label itself cannot be
+# dropped for the autoscaler pools (same gap that keeps prefer-baseline-nodes
+# inert — see its DISCRIMINATOR note). Until KSail can stamp a distinguishing
+# label, the reliable discriminator is the node name: autoscaler nodes are
+# named autoscale-<pool>-<id>, and Longhorn mirrors the Kubernetes node name
+# into its nodes.longhorn.io CR name.
+#
+# MECHANISM: mutate the Longhorn Node CR at admission —
+#   * allowScheduling: false  → no NEW replica is ever scheduled to the node
+#     (node-level gate; overrides every per-disk allowScheduling);
+#   * evictionRequested: true → belt-and-braces: any replica that slipped on
+#     (e.g. landed before this policy deployed) is actively rebuilt onto a
+#     baseline worker and removed. A no-op on nodes with zero replicas.
+# Longhorn only ever sets these two fields from user action (UI/API), so the
+# mutation fights no controller. Engine instance-managers still run on
+# autoscale nodes while a Longhorn-volume-mounting pod runs there — that is
+# required for I/O and correct; they hold no data and are evictable (see
+# kubernetesClusterAutoscalerEnabled in the longhorn HelmRelease).
+#
+# The existing 4 autoscale nodes' CRs were patched live to the same values on
+# 2026-07-01; this policy makes the contract permanent for every future node.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-storage-to-baseline-workers
+  annotations:
+    policies.kyverno.io/title: Restrict Longhorn Storage to Baseline Workers
+    policies.kyverno.io/category: Storage, FinOps
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Node (longhorn.io)
+    policies.kyverno.io/description: >-
+      Disables Longhorn replica scheduling (and requests eviction of any
+      stray replicas) on autoscaler-provisioned nodes, which inherit the
+      storage label from the shared Talos worker config but are ephemeral
+      compute-only capacity. Keeps volume data on the static baseline
+      workers so the cluster-autoscaler can reclaim idle nodes and no
+      replica lives on a node that may be deleted at any time.
+spec:
+  rules:
+    - name: disable-replica-scheduling-on-autoscale-nodes
+      match:
+        any:
+          - resources:
+              kinds:
+                - longhorn.io/v1beta2/Node
+              names:
+                - "autoscale-*"
+      mutate:
+        patchStrategicMerge:
+          spec:
+            allowScheduling: false
+            evictionRequested: true

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
@@ -15,12 +15,15 @@
 #   * elasticity — replica-hosting instance-managers pin the node, so the
 #     autoscaler can never scale it back down (part of the 2026-06-30
 #     stuck-node ratchet).
-# KSail exposes no per-pool node labels/taints, so the label itself cannot be
-# dropped for the autoscaler pools (same gap that keeps prefer-baseline-nodes
-# inert — see its DISCRIMINATOR note). Until KSail can stamp a distinguishing
-# label, the reliable discriminator is the node name: autoscaler nodes are
-# named autoscale-<pool>-<id>, and Longhorn mirrors the Kubernetes node name
-# into its nodes.longhorn.io CR name.
+# KSail now stamps `ksail.io/autoscaled: "true"` on autoscaler nodes
+# (ksail#5113, verified live 2026-07-01) — that activates the soft
+# prefer-baseline-nodes scheduling bias, but it cannot fix THIS problem:
+# Longhorn's default-disk gating keys exclusively on its own
+# node.longhorn.io/create-default-disk label (no "unless other-label" form),
+# and that label is still stamped by the shared worker kubelet config. So the
+# discriminator used here is the node name: autoscaler nodes are named
+# autoscale-<pool>-<id>, and Longhorn mirrors the Kubernetes node name into
+# its nodes.longhorn.io CR name.
 #
 # MECHANISM: two mutations set the same two fields —
 #   * allowScheduling: false  → no NEW replica is ever scheduled to the node

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-mutate-longhorn-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-mutate-longhorn-nodes.yaml
@@ -1,0 +1,30 @@
+# Extra permissions for Kyverno's background controller (prod/hetzner only).
+#
+# The restrict-storage-to-baseline-workers ClusterPolicy (hetzner
+# cluster-policies/, the next Flux layer) uses mutateExisting to force
+# allowScheduling=false + evictionRequested=true onto the Longhorn Node CRs of
+# autoscaler-provisioned nodes (autoscale-*), including the ones that already
+# exist when the policy lands. Kyverno checks this grant at policy admission
+# and rejects the policy without it, so — like the base
+# kyverno:background-controller:mutate-deployments grant — it ships here, one
+# layer earlier (infrastructure-controllers) than the policy (infrastructure),
+# ensuring it is live and aggregated before the policy is admitted. It lives
+# in the longhorn controller folder (not the base kyverno one) because the
+# resource it grants and the policy consuming it are both Hetzner-only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:background-controller:mutate-longhorn-nodes
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -59,6 +59,17 @@ spec:
       # Restrict Longhorn system-managed pods (instance-managers, etc.)
       # to storage nodes. Prevents ~100Mi overhead per non-storage node.
       systemManagedComponentsNodeSelector: "node.longhorn.io/create-default-disk:true"
+      # Tell Longhorn this cluster runs the Cluster Autoscaler: Longhorn then
+      # annotates its system-managed per-node pods (instance-managers, etc.)
+      # as safe-to-evict where no replica pins them, so the autoscaler can
+      # drain and remove an under-utilized node instead of treating every
+      # Longhorn pod as an unevictable blocker. Without this, any node that
+      # ever ran an instance-manager was permanently unremovable (part of the
+      # 2026-06-30 stuck-autoscale-node ratchet). Data safety is unchanged —
+      # Longhorn still refuses to evict a pod that hosts the last healthy
+      # replica; pair with the restrict-storage-to-baseline-workers policy
+      # (cluster-policies/) which keeps replicas off autoscale nodes entirely.
+      kubernetesClusterAutoscalerEnabled: true
       # Rebuild degraded replicas of DETACHED volumes too. A volume can sit
       # detached for long stretches (an app scaled down or disabled, or a PVC
       # between pod reschedules); when an autoscaled node holding a replica

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
@@ -12,6 +12,10 @@ resources:
   # kubescape C-0270, while keeping the memory limit unset to preserve the
   # instance-manager OOM-cascade safeguard. See limit-range.yaml for details.
   - limit-range.yaml
+  # Kyverno background-controller grant for the
+  # restrict-storage-to-baseline-workers policy (hetzner cluster-policies/,
+  # next Flux layer) — must be live before the policy is admitted.
+  - cluster-role-kyverno-mutate-longhorn-nodes.yaml
   # Self-healing cleanup of orphaned Longhorn Node CRs left by autoscaler
   # scale-downs (Longhorn never auto-deletes them). See #2024.
   - service-account-stale-node-cleanup.yaml

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -26,6 +26,12 @@ resources:
   # the hetzner overlay because autoscaling is Hetzner/prod-only; see the file
   # header for the `ksail.io/autoscaled` node-label contract it depends on.
   - cluster-policies/prefer-baseline-nodes.yaml
+  # Prod-only: enforce the compute-only contract for autoscaler nodes at the
+  # Longhorn layer — autoscale-* nodes inherit the storage label from the
+  # shared Talos worker config, so without this Longhorn schedules volume
+  # replicas onto ephemeral nodes (durability risk) and those replicas pin
+  # the node against autoscaler scale-down. See the file header.
+  - cluster-policies/restrict-storage-to-baseline-workers.yaml
   # Prod-only: reconcile Coroot's node Custom Cloud Pricing to Hetzner rates
   # (Coroot otherwise prices non-AWS/GCP/Azure nodes at the GCP-C4 fallback,
   # ~16x the real bill). Lives in this `infrastructure` layer because it targets

--- a/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
@@ -84,16 +84,33 @@ patches:
               maxAllowed:
                 cpu: "3"
                 memory: 6Gi
-  # DaemonSets: per-node pods must fit the smallest autoscale-cx23 worker.
+  # DaemonSets: CPU only — VPA must not manage DaemonSet MEMORY (mirrors the
+  # auto-vpa.yaml DaemonSet rule; full rationale there). VPA keeps one usage
+  # histogram across all pods of a DaemonSet, so it sizes EVERY node's agent
+  # to the busiest node's peak and multiplies that by the node count; that
+  # pushed the per-node agent stack to ~3.5Gi ≈ 50% of a cx33's allocatable —
+  # exactly the cluster-autoscaler's scale-down utilization threshold — making
+  # autoscale nodes unremovable even when empty of movable pods (the
+  # 2026-06-30 four-node ratchet). Memory reverts to the authored values in
+  # the cilium HelmRelease (agent 512Mi, envoy 64Mi, spire-agent 128Mi, ...)
+  # with the generous kube-system LimitRange memory default (4Gi) as the
+  # burst limit. CPU stays managed (compressible, no OOM risk); per-node pods
+  # must still fit the smallest autoscale-cx23 worker.
   - target:
       kind: VerticalPodAutoscaler
       labelSelector: vpa-tier=daemonset
     patch: |
       - op: replace
+        path: /spec/resourcePolicy/containerPolicies/0/controlledResources
+        value: ["cpu"]
+      - op: replace
+        path: /spec/resourcePolicy/containerPolicies/0/minAllowed
+        value:
+          cpu: 50m
+      - op: replace
         path: /spec/resourcePolicy/containerPolicies/0/maxAllowed
         value:
           cpu: "1"
-          memory: 1Gi
   # spire-server: singleton StatefulSet on an RWO volume — never evict.
   - target:
       kind: VerticalPodAutoscaler


### PR DESCRIPTION
## Root cause of the 2026-06-30 overscale (4 extra workers, never reclaimed)

Four `autoscale-cx33` nodes were created 18:21–18:24 UTC on 2026-06-30 and have been stuck ever since (`scaleDown: NoCandidates`). Three stacked causes:

### 1. VPA inflates DaemonSet memory to the busiest node's peak — on every node
VPA keeps **one** usage histogram per container across **all pods of a DaemonSet**, so it sizes every node's agent to the single busiest node's peak (+15% margin), multiplied by the node count: coroot-node-agent **826Mi** (median live usage ~450Mi), kubescape node-agent **523Mi** (~280Mi), longhorn-manager **456Mi**, … on all 10 nodes. Cluster-wide requests reached **~60Gi vs ~30Gi actual usage** (nodes 82–94% *requested*, 26–53% *used*). The June 30 deploy cascade rolled most workloads; admission stamped the inflated targets onto the recreated pods; aggregate demand no longer fit the 3 static cx43 workers → CA correctly added 4 nodes for demand that was ~2× real.

### 2. The scale-down ratchet: DS stack = exactly the CA threshold
The per-node DaemonSet stack summed to **3561Mi = 50% of a cx33's allocatable** — precisely the CA's default scale-down utilization threshold, which **counts DaemonSet pods**. An *empty* cx33 was therefore already unremovable; CA logs confirm all 4 nodes `unremovable: memory requested … above the scale-down utilization threshold`. Every burst mints a permanent node. (KSail exposes no `ignore-daemonsets-utilization`/threshold knob — filed upstream.)

### 3. Longhorn treats ephemeral autoscale nodes as storage nodes
Autoscale nodes boot from the same Talos worker config as static workers, inheriting `node.longhorn.io/create-default-disk=true` ([talos/workers/node-labels.yaml](talos/workers/node-labels.yaml)); `replicaAutoBalance: best-effort` then migrated **14 replicas (~72Gi)** onto them — a durability risk (CA may delete the node) and a scale-down blocker, violating the compute-only pool design documented in `ksail.prod.yaml`. Same missing KSail per-pool-label gap that keeps `prefer-baseline-nodes` inert.

## Fix

- **DaemonSet VPAs go CPU-only** ([auto-vpa.yaml](k8s/bases/infrastructure/cluster-policies/best-practices/auto-vpa.yaml) DS rule + the static kube-system DS-tier VPAs). DS memory reverts to authored values; the heavy agents get explicit authored sizing from observed usage:
  - coroot-node-agent `512Mi req / 1Gi limit` — **required**, its LimitRange default limit (512Mi) is below its 695Mi live peak;
  - kubescape node-agent `320Mi req / 1Gi limit`.
  - cilium & friends already author sane values (512Mi/128Mi/64Mi); kube-system's 4Gi LimitRange memory default remains the burst limit.
  - Effect: per-node DS stack ~3.5Gi → **~2.2Gi (50% → ~31% of a cx33)**; removes **~11Gi** of cluster-wide over-reservation, unblocking both re-fit onto the static workers and future scale-downs.
- **Longhorn** ([hetzner HR](k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml)): `kubernetesClusterAutoscalerEnabled: true` so replica-free instance-managers stop blocking CA eviction.
- **New Kyverno policy** [restrict-storage-to-baseline-workers.yaml](k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml): mutates `autoscale-*` Longhorn Node CRs to `allowScheduling: false` + `evictionRequested: true` — replicas stay on the static workers permanently (node-name is the only reliable discriminator until KSail can stamp per-pool labels).

## Expected convergence after merge

coroot-node-agent and kubescape node-agent roll automatically (CR/HR change) and deflate immediately; other DS agents deflate on their next natural roll. The policy retro-drains the existing 4 replica-hosting autoscale Node CRs on deploy (mutate-existing rule + background-controller RBAC grant shipped one Flux layer earlier) — GitOps-only remediation, no manual kubectl. Once requests deflate below the 50% gate, CA consolidates (`scaleDownUnneededTime: 10m`). Steady state should return to 3 static workers + the 1 deliberate warm CapacityBuffer node.

## Validation

- `kubectl kustomize` — local ✅ prod ✅ hetzner infra ✅ hetzner controllers ✅ docker infra ✅
- `scripts/validate-naming.py` ✅
- Rendered outputs verified: DS VPAs `controlledResources: ["cpu"]` (auto-vpa rule + static cilium et al.), policy present with correct mutation, coroot/kubescape authored resources in place, longhorn setting rendered.

## Follow-ups (upstream)

- KSail: expose CA `ignore-daemonsets-utilization` + `scale-down-utilization-threshold` — filed as [ksail#5673](https://github.com/devantler-tech/ksail/issues/5673) (the structural fix for agent-heavy clusters; this PR fixes the demand side).
- The `ksail.io/autoscaled` per-pool label contract already shipped ([ksail#5113](https://github.com/devantler-tech/ksail/issues/5113), verified live) — `prefer-baseline-nodes` is active as of now; this PR refreshes its stale "inert" header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

