### PR TITLE
feat(vault-config): seed the AWS bootstrap credential path (placeholder + policy + tenant role)

### DIFF
--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -555,6 +555,25 @@ spec:
                 echo "UniFi WireGuard keys already present at secret/infrastructure/unifi/wireguard (leaving as-is)."
               fi
 
+              # --- 1e. Seed placeholder AWS bootstrap credentials (only if absent) ---
+              # provider-aws-iam (the future `aws` tenant, platform#2325) authenticates
+              # with a bootstrap IAM access key; it lives at
+              # secret/infrastructure/aws/bootstrap and is read by the tenant's
+              # aws-bootstrap-credentials ExternalSecret. We seed PLACEHOLDERS here
+              # declaratively (no SOPS) ONLY when the secret is absent, so the
+              # maintainer can overwrite them in place via the OpenBao UI/CLI and a
+              # later Job re-run won't clobber the real values. OpenBao is backed up
+              # (Raft snapshots → R2 via Velero), so these manually-set values are
+              # durable — no GitOps re-seed is needed.
+              if ! bao kv get -mount=secret infrastructure/aws/bootstrap >/dev/null 2>&1; then
+                echo "Seeding placeholder AWS bootstrap credentials at secret/infrastructure/aws/bootstrap..."
+                bao kv put -mount=secret infrastructure/aws/bootstrap \
+                  access_key_id="REPLACE_WITH_AWS_ACCESS_KEY_ID" \
+                  secret_access_key="REPLACE_WITH_AWS_SECRET_ACCESS_KEY"
+              else
+                echo "AWS bootstrap credentials already present at secret/infrastructure/aws/bootstrap (leaving as-is)."
+              fi
+
               # --- 2. Enable Kubernetes auth ---
               if ! bao auth list -format=json | grep -q '"kubernetes/"'; then
                 echo "Enabling Kubernetes auth method..."
@@ -763,6 +782,16 @@ spec:
               }
               POLICY
 
+              # AWS bootstrap IAM access key read by the future `aws` tenant's
+              # ExternalSecret (platform#2325; seeded as a placeholder in step 1e).
+              # Scoped to the aws path only — the tenant role below carries just
+              # this policy, mirroring github-config/unifi isolation.
+              bao policy write infra-aws-readonly - <<'POLICY'
+              path "secret/data/infrastructure/aws/*" {
+                capabilities = ["read"]
+              }
+              POLICY
+
               bao policy write vault-snapshot-readonly - <<'POLICY'
               path "sys/health" {
                 capabilities = ["read"]
@@ -934,6 +963,20 @@ spec:
                 bound_service_account_names=unifi \
                 bound_service_account_namespaces=unifi \
                 policies=infra-unifi-readonly \
+                ttl=1h
+
+              # Dedicated tenant role for the aws tenant (platform#2325).
+              # Authenticates the tenant's own `aws` ServiceAccount (used by its
+              # namespaced SecretStore once the devantler-tech/aws tenant wiring
+              # lands) and carries ONLY `infra-aws-readonly` (read on
+              # secret/data/infrastructure/aws/*) — never the broad
+              # `external-secrets` bundle — so the tenant reads its bootstrap IAM
+              # access key and nothing else. Declared ahead of the namespace/SA:
+              # an auth role is inert config until something authenticates with it.
+              bao write auth/kubernetes/role/aws \
+                bound_service_account_names=aws \
+                bound_service_account_namespaces=aws \
+                policies=infra-aws-readonly \
                 ttl=1h
 
               # Dedicated tenant role for wedding-app. Authenticates the tenant's


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Fixes #2376. Part of #2325 / #2324 — the declarative-AWS-credentials chain that unblocks the ksail EKS epic (devantler-tech/ksail#4328, code-complete but AWS-credential-gated since April). Child 1 (the provider foundation) merged in #2328; this is the platform-side credential path.

## What (one file, three additive blocks — mirrors github-config/unifi exactly)
1. **Seed 1e** — placeholder `access_key_id`/`secret_access_key` at `secret/infrastructure/aws/bootstrap`, **only-if-absent**: the maintainer overwrites the real bootstrap IAM key in place via the OpenBao UI/CLI; later Job re-runs never clobber it (durable via Raft-snapshot backups → R2, same as the GitHub App cred at 1b).
2. **Policy `infra-aws-readonly`** — read on `secret/data/infrastructure/aws/*` only.
3. **Dedicated k8s-auth role `aws`** — bound to SA `aws` in ns `aws`, carrying ONLY `infra-aws-readonly` (never the broad `external-secrets` bundle), ttl=1h — the same tenant isolation as the `github-config`/`unifi` roles. Declared ahead of the namespace/SA: an auth role is inert config until something authenticates with it, so nothing on prod changes behaviour until the tenant wiring lands.

## What this deliberately does NOT do
No SecretStore/ExternalSecret/ProviderConfig yet — those live in the `devantler-tech/aws` tenant repo (next child, needs the net-new-repo custom-property bootstrap), so no Flux object can go not-ready and wedge the apps health check.

## Validation
- `kubectl apply --dry-run=client -f k8s/bases/infrastructure/vault-config/job.yaml`: ✅
- `kubectl kustomize k8s/clusters/local/` + `k8s/clusters/prod/`: ✅ both build
- `ksail workload validate --skip-helm-render` (CI-matching): ✅ 489 files validated