### PR TITLE
fix(policies): split restrict-storage-to-baseline-workers so Kyverno admits it (unfreezes infrastructure)

### DIFF
--- a/k8s/providers/hetzner/infrastructure/cluster-policies/drain-autoscale-node-storage.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/drain-autoscale-node-storage.yaml
@@ -1,0 +1,66 @@
+# Prod-only — the RETROFIT half of restrict-storage-to-baseline-workers.yaml
+# (read that file's header for the full WHY): a mutate-EXISTING Kyverno
+# policy that patches the autoscale Longhorn Node CRs that ALREADY exist when
+# the policy lands (mutateExistingOnPolicyUpdate), so the replica-hosting
+# autoscale nodes observed 2026-06-30 are drained by the policy itself — no
+# manual kubectl needed. It sets the same two fields as the admission half:
+# allowScheduling: false + evictionRequested: true (replicas are rebuilt onto
+# a baseline worker BEFORE removal — no redundancy loss).
+#
+# This is a SEPARATE ClusterPolicy because Kyverno requires EVERY mutate rule
+# to declare mutate.targets when spec.mutateExistingOnPolicyUpdate is set,
+# and the sibling's admission rule has none — combining both rules in one
+# policy is rejected by the validate-policy webhook at apply time
+# ("rules[0].mutate.targets has to be specified when
+# mutateExistingOnPolicyUpdate is set"), which froze the whole
+# `infrastructure` Flux layer (observed live 2026-07-02).
+#
+# It requires the kyverno:background-controller:mutate-longhorn-nodes grant
+# (controllers/longhorn/, one Flux layer earlier — Kyverno rejects the policy
+# at admission if the grant is missing).
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: drain-autoscale-node-storage
+  annotations:
+    policies.kyverno.io/title: Drain Longhorn Storage off Autoscale Nodes (Retrofit)
+    policies.kyverno.io/category: Storage, FinOps
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Node (longhorn.io)
+    policies.kyverno.io/description: >-
+      Retro-patches pre-existing autoscaler-provisioned Longhorn Node CRs to
+      disable replica scheduling and request eviction of any replicas that
+      landed before the restrict-storage-to-baseline-workers admission
+      policy deployed. Split out from that policy because Kyverno requires
+      mutate.targets on every rule when mutateExistingOnPolicyUpdate is set,
+      which an admission mutate rule cannot carry.
+spec:
+  mutateExistingOnPolicyUpdate: true
+  rules:
+    # The trigger is restricted to CREATE so Longhorn's steady Node-CR update
+    # churn does not re-enqueue background UpdateRequests for already-patched
+    # nodes — after the policy-update retrofit, this rule only fires again
+    # when a NEW autoscale node registers (rare, and a cheap re-assert of all
+    # targets). Manual UI flips are still healed by Kyverno's periodic
+    # background scan (hourly by default), which runs for mutate-existing
+    # rules regardless of triggers.
+    - name: drain-existing-autoscale-nodes
+      match:
+        any:
+          - resources:
+              kinds:
+                - longhorn.io/v1beta2/Node
+              names:
+                - "autoscale-*"
+              operations:
+                - CREATE
+      mutate:
+        targets:
+          - apiVersion: longhorn.io/v1beta2
+            kind: Node
+            namespace: longhorn-system
+            name: "autoscale-*"
+        patchStrategicMerge:
+          spec:
+            allowScheduling: false
+            evictionRequested: true

--- a/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
@@ -25,21 +25,23 @@
 # autoscale-<pool>-<id>, and Longhorn mirrors the Kubernetes node name into
 # its nodes.longhorn.io CR name.
 #
-# MECHANISM: two mutations set the same two fields —
+# MECHANISM: two POLICIES set the same two fields on autoscale Node CRs —
 #   * allowScheduling: false  → no NEW replica is ever scheduled to the node
 #     (node-level gate; overrides every per-disk allowScheduling);
 #   * evictionRequested: true → belt-and-braces: any replica that slipped on
 #     (e.g. landed before this policy deployed) is actively rebuilt onto a
 #     baseline worker (rebuild completes BEFORE removal — no redundancy loss)
 #     and removed. A no-op on nodes with zero replicas.
-# Rule 1 mutates at ADMISSION, catching every future autoscale Node CR the
-# moment longhorn-manager creates it. Rule 2 is a mutate-EXISTING rule
-# (mutateExistingOnPolicyUpdate), so deploying/updating this policy also
-# retro-patches CRs that predate it — the 4 replica-hosting autoscale nodes
-# of 2026-06-30 are drained by the policy itself, no manual kubectl needed.
-# It requires the kyverno:background-controller:mutate-longhorn-nodes grant
-# (controllers/longhorn/, one Flux layer earlier — Kyverno rejects the policy
-# at admission if the grant is missing).
+# THIS policy is the ADMISSION half: it patches every future autoscale Node
+# CR the moment longhorn-manager creates it. The retrofit of Node CRs that
+# ALREADY exist lives in the sibling drain-autoscale-node-storage.yaml (a
+# mutate-existing policy). They MUST be two separate ClusterPolicies: Kyverno
+# requires EVERY mutate rule to declare mutate.targets when
+# spec.mutateExistingOnPolicyUpdate is set, and an admission rule has none —
+# the combined single-policy form was rejected by the validate-policy
+# webhook at apply time ("rules[0].mutate.targets has to be specified when
+# mutateExistingOnPolicyUpdate is set"), which froze the whole
+# `infrastructure` Flux layer (observed live 2026-07-02).
 # Longhorn only ever sets these two fields from user action (UI/API), so the
 # mutation fights no controller. Engine instance-managers still run on
 # autoscale nodes while a Longhorn-volume-mounting pod runs there — that is
@@ -60,9 +62,10 @@ metadata:
       storage label from the shared Talos worker config but are ephemeral
       compute-only capacity. Keeps volume data on the static baseline
       workers so the cluster-autoscaler can reclaim idle nodes and no
-      replica lives on a node that may be deleted at any time.
+      replica lives on a node that may be deleted at any time. Admission
+      half; the retrofit of pre-existing Node CRs is
+      drain-autoscale-node-storage.
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     # Admission path: every future autoscale Node CR is patched as it is
     # created (or on any later spec update that slips through).
@@ -75,34 +78,6 @@ spec:
               names:
                 - "autoscale-*"
       mutate:
-        patchStrategicMerge:
-          spec:
-            allowScheduling: false
-            evictionRequested: true
-    # Background path: retro-patch the autoscale Node CRs that already exist
-    # when this policy lands (mutateExistingOnPolicyUpdate above). The trigger
-    # is restricted to CREATE so Longhorn's steady Node-CR update churn does
-    # not re-enqueue background UpdateRequests for already-patched nodes —
-    # after the retrofit, this rule only fires again when a NEW autoscale
-    # node registers (rare, and a cheap re-assert of all targets). Manual UI
-    # flips are still healed by Kyverno's periodic background scan (hourly by
-    # default), which runs for mutate-existing rules regardless of triggers.
-    - name: drain-existing-autoscale-nodes
-      match:
-        any:
-          - resources:
-              kinds:
-                - longhorn.io/v1beta2/Node
-              names:
-                - "autoscale-*"
-              operations:
-                - CREATE
-      mutate:
-        targets:
-          - apiVersion: longhorn.io/v1beta2
-            kind: Node
-            namespace: longhorn-system
-            name: "autoscale-*"
         patchStrategicMerge:
           spec:
             allowScheduling: false

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-mutate-longhorn-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-mutate-longhorn-nodes.yaml
@@ -1,7 +1,8 @@
 # Extra permissions for Kyverno's background controller (prod/hetzner only).
 #
-# The restrict-storage-to-baseline-workers ClusterPolicy (hetzner
-# cluster-policies/, the next Flux layer) uses mutateExisting to force
+# The drain-autoscale-node-storage ClusterPolicy (hetzner cluster-policies/,
+# the next Flux layer — the mutate-existing retrofit half of
+# restrict-storage-to-baseline-workers) uses mutateExisting to force
 # allowScheduling=false + evictionRequested=true onto the Longhorn Node CRs of
 # autoscaler-provisioned nodes (autoscale-*), including the ones that already
 # exist when the policy lands. Kyverno checks this grant at policy admission

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-reports-longhorn-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-reports-longhorn-nodes.yaml
@@ -1,0 +1,29 @@
+# Extra permissions for Kyverno's reports controller (prod/hetzner only).
+#
+# The restrict-storage-to-baseline-workers / drain-autoscale-node-storage
+# ClusterPolicies (hetzner cluster-policies/, the next Flux layer) match
+# longhorn.io/v1beta2/Node, so the reports controller needs read access to
+# that kind to build policy reports — the API server surfaces exactly this on
+# policy admission ("kyverno-reports-controller requires permissions
+# get,list,watch for resource longhorn.io/v1beta2/Node", observed in a
+# server-side dry-run 2026-07-02). Without the grant the reports controller
+# hot-loops on the forbidden list/watch — the same missing-RBAC pattern that
+# melted it on keda.sh/scaledobjects on 2026-07-01 (VPA then inflated its
+# request and leaked autoscaler nodes) — so the grant ships together with the
+# policies that need it, one layer earlier (infrastructure-controllers), like
+# the background-controller grant beside it.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:reports-controller:read-longhorn-nodes
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
@@ -12,10 +12,12 @@ resources:
   # kubescape C-0270, while keeping the memory limit unset to preserve the
   # instance-manager OOM-cascade safeguard. See limit-range.yaml for details.
   - limit-range.yaml
-  # Kyverno background-controller grant for the
-  # restrict-storage-to-baseline-workers policy (hetzner cluster-policies/,
-  # next Flux layer) — must be live before the policy is admitted.
+  # Kyverno background-controller + reports-controller grants for the
+  # restrict-storage-to-baseline-workers / drain-autoscale-node-storage
+  # policies (hetzner cluster-policies/, next Flux layer) — must be live
+  # before the policies are admitted.
   - cluster-role-kyverno-mutate-longhorn-nodes.yaml
+  - cluster-role-kyverno-reports-longhorn-nodes.yaml
   # Self-healing cleanup of orphaned Longhorn Node CRs left by autoscaler
   # scale-downs (Longhorn never auto-deletes them). See #2024.
   - service-account-stale-node-cleanup.yaml

--- a/k8s/providers/hetzner/infrastructure/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/kustomization.yaml
@@ -30,8 +30,12 @@ resources:
   # Longhorn layer — autoscale-* nodes inherit the storage label from the
   # shared Talos worker config, so without this Longhorn schedules volume
   # replicas onto ephemeral nodes (durability risk) and those replicas pin
-  # the node against autoscaler scale-down. See the file header.
+  # the node against autoscaler scale-down. Two policies (admission half +
+  # mutate-existing retrofit half) because Kyverno rejects a single policy
+  # mixing an admission mutate rule with mutateExistingOnPolicyUpdate — see
+  # the file headers.
   - cluster-policies/restrict-storage-to-baseline-workers.yaml
+  - cluster-policies/drain-autoscale-node-storage.yaml
   # Prod-only: reconcile Coroot's node Custom Cloud Pricing to Hetzner rates
   # (Coroot otherwise prices non-AWS/GCP/Azure nodes at the GCP-C4 fallback,
   # ~16x the real bill). Lives in this `infrastructure` layer because it targets


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — prod `infrastructure` Kustomization frozen since 05:39Z

#2370 merged this morning but never applied: its new `restrict-storage-to-baseline-workers` ClusterPolicy combines an **admission** mutate rule with `spec.mutateExistingOnPolicyUpdate: true`, and Kyverno requires **every** mutate rule to declare `mutate.targets` when that flag is set. The validate-policy webhook rejects it:

```
spec.mutateExistingOnPolicyUpdate: Forbidden: rules[0].mutate.targets has to be specified when mutateExistingOnPolicyUpdate is set
```

That fails Flux's server-side dry-run, so **nothing** in the `infrastructure` layer applies (and `apps` is blocked on the dependency) — including #2370's own DaemonSet-VPA ratchet fix, which is why the 4 stuck `autoscale-cx33-*` nodes still cannot scale down.

## Fix

- **Split the policy in two** (Kyverno cannot host both rule shapes in one policy):
  - `restrict-storage-to-baseline-workers` keeps the admission rule (patches every future autoscale Node CR at CREATE);
  - new `drain-autoscale-node-storage` carries the mutate-existing retrofit rule (flag + `targets`, unchanged semantics).
- **Add `kyverno:reports-controller:read-longhorn-nodes`** (aggregate-to-reports-controller): the server-side dry-run warns the reports controller lacks `get,list,watch` on `longhorn.io/v1beta2/Node`. Without it the reports controller hot-loops on the forbidden watch — the exact missing-RBAC pattern that melted it on `keda.sh/scaledobjects` on 2026-07-01 and leaked autoscaler nodes.
- Updated the cross-references in the longhorn kustomization + background-controller grant comments (same-PR doc sync).

## Validation

- `ksail workload validate --skip-helm-render` + `ksail --config ksail.prod.yaml workload validate --skip-helm-render`: **491 files validated** (the one unrelated local-overlay failure without `--skip-helm-render` is the known kubeconform#363 render race).
- `kubectl apply --dry-run=server` of **both** policies against the live prod Kyverno webhook (the exact failure mode): both admitted, nothing persisted.

## Expected effect after merge

`infrastructure` + `apps` reconcile again → #2370's auto-vpa (CPU-only DaemonSet VPAs), authored kubescape/coroot agent memory, `prefer-baseline-nodes`, and the Longhorn replica drain all go live → autoscale node requested-utilization drops below the 50% scale-down threshold → the cluster-autoscaler can finally reclaim the 4 stuck nodes.

Fixes the ReconciliationFailed warning stream on prod (Coroot, 2026-07-02 morning).