### PR TITLE
fix(longhorn): stale-node-cleanup CronJob image has no shell — every run StartErrors

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/cron-job-stale-node-cleanup.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/cron-job-stale-node-cleanup.yaml
@@ -69,7 +69,13 @@ spec:
               type: RuntimeDefault
           containers:
             - name: cleanup
-              image: registry.k8s.io/kubectl:v1.36.2@sha256:b0d792e0d8dfb9bb1b922b78b23137e2a34bb6f9667640353a9d2aadd1fd7761
+              # NOT registry.k8s.io/kubectl: that image is distroless (kubectl
+              # binary only, no /bin/sh), so the shell script below could never
+              # start — every run since the CronJob shipped failed with
+              # StartError exit 128 "stat /bin/sh: no such file or directory"
+              # (observed live 2026-07-02). alpine/k8s ships kubectl + a POSIX
+              # shell; the tag tracks the kubectl minor, matching the cluster.
+              image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem

`longhorn-stale-node-cleanup` has failed on **every** scheduled run since it shipped:

```
StartError (exit 128): ... exec: "/bin/sh": stat /bin/sh: no such file or directory
```

The container runs its script via `/bin/sh -c`, but `registry.k8s.io/kubectl` is distroless — it contains the kubectl binary and nothing else. So the orphaned-Node-CR cleanup (#2024) has never actually executed; the stale CRs it was built to reap are still accumulating, and the failed pods show up in the prod warning feed (observed 2026-07-02).

## Fix

Swap to `docker.io/alpine/k8s:1.36.2` (kubectl + POSIX shell + coreutils), tag-matched to the cluster's kubectl minor and digest-pinned like the previous image. No script/RBAC/securityContext changes — the container already runs as 65532 with `HOME=/tmp` on an emptyDir, which alpine/k8s is fine with.

## Validation

- `ksail --config ksail.prod.yaml workload validate --skip-helm-render`: 491 files validated.
- Third-party image: not matched by the `verify-app-images` policy (ghcr.io/devantler-tech/* only), so no signing gate applies.

After merge, the next 03:17 run (or a manual `kubectl -n longhorn-system create job --from=cronjob/longhorn-stale-node-cleanup`) should finally reap the stale autoscale-* Node CRs.