### PR TITLE
fix(policies): unfreeze the infrastructure layer — scope mutateExistingOnPolicyUpdate to the drain rule

### DIFF
--- a/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-policies/restrict-storage-to-baseline-workers.yaml
@@ -34,7 +34,13 @@
 #     and removed. A no-op on nodes with zero replicas.
 # Rule 1 mutates at ADMISSION, catching every future autoscale Node CR the
 # moment longhorn-manager creates it. Rule 2 is a mutate-EXISTING rule
-# (mutateExistingOnPolicyUpdate), so deploying/updating this policy also
+# (rule-level mutate.mutateExistingOnPolicyUpdate, the same form
+# disable-default-sa-automount and propagate-reloader-to-flagger-primary
+# use — NOT the policy-level spec flag, which Kyverno's webhook rejects
+# here because it then demands mutate.targets on EVERY rule, including the
+# admission-only rule 1 that cannot have them; the policy-level form froze
+# the whole infrastructure Flux layer on 2026-07-02 via its failed
+# server-side dry-run). Deploying/updating this policy thus also
 # retro-patches CRs that predate it — the 4 replica-hosting autoscale nodes
 # of 2026-06-30 are drained by the policy itself, no manual kubectl needed.
 # It requires the kyverno:background-controller:mutate-longhorn-nodes grant
@@ -62,7 +68,6 @@ metadata:
       workers so the cluster-autoscaler can reclaim idle nodes and no
       replica lives on a node that may be deleted at any time.
 spec:
-  mutateExistingOnPolicyUpdate: true
   rules:
     # Admission path: every future autoscale Node CR is patched as it is
     # created (or on any later spec update that slips through).
@@ -80,7 +85,8 @@ spec:
             allowScheduling: false
             evictionRequested: true
     # Background path: retro-patch the autoscale Node CRs that already exist
-    # when this policy lands (mutateExistingOnPolicyUpdate above). The trigger
+    # when this policy lands (rule-level mutateExistingOnPolicyUpdate below —
+    # policy-level is rejected because rule 1 has no targets). The trigger
     # is restricted to CREATE so Longhorn's steady Node-CR update churn does
     # not re-enqueue background UpdateRequests for already-patched nodes —
     # after the retrofit, this rule only fires again when a NEW autoscale
@@ -98,6 +104,7 @@ spec:
               operations:
                 - CREATE
       mutate:
+        mutateExistingOnPolicyUpdate: true
         targets:
           - apiVersion: longhorn.io/v1beta2
             kind: Node

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-reports-read-longhorn-nodes.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/cluster-role-kyverno-reports-read-longhorn-nodes.yaml
@@ -1,0 +1,30 @@
+# Extra permissions for Kyverno's reports controller (prod/hetzner only).
+#
+# The restrict-storage-to-baseline-workers ClusterPolicy (hetzner
+# cluster-policies/, the next Flux layer) matches longhorn.io Nodes. Kyverno's
+# reports controller starts a watch on every resource kind a policy matches,
+# and it can only watch kinds the aggregated view roles cover — without this
+# grant it fails to list/watch longhorn.io nodes and retries in a tight loop,
+# pegging a CPU core, inflating the VPA request, and starving the schedulable
+# budget (the exact failure mode of the 2026-07-01 KEDA ScaledObject incident;
+# see the base kyverno:reports-controller:read-keda grant this mirrors — a
+# server-side dry-run of the policy warns about precisely this permission).
+# Like the sibling mutate grant it ships one layer earlier
+# (infrastructure-controllers) than the policy (infrastructure), and lives in
+# the longhorn folder because both the resource and the consuming policy are
+# Hetzner-only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:reports-controller:read-longhorn-nodes
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
@@ -16,6 +16,10 @@ resources:
   # restrict-storage-to-baseline-workers policy (hetzner cluster-policies/,
   # next Flux layer) — must be live before the policy is admitted.
   - cluster-role-kyverno-mutate-longhorn-nodes.yaml
+  # Kyverno reports-controller read grant for the same policy — without it the
+  # reports controller tight-loops on forbidden longhorn.io node watches (the
+  # 2026-07-01 KEDA-RBAC CPU-leak failure mode). See the file header.
+  - cluster-role-kyverno-reports-read-longhorn-nodes.yaml
   # Self-healing cleanup of orphaned Longhorn Node CRs left by autoscaler
   # scale-downs (Longhorn never auto-deletes them). See #2024.
   - service-account-stale-node-cleanup.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Problem — prod's infrastructure layer is FROZEN (live breakage)

Since #2370 merged (2026-07-02 05:39Z) the `infrastructure` Flux Kustomization on prod fails every reconcile, and `apps` is dependency-blocked behind it:

```
ClusterPolicy/restrict-storage-to-baseline-workers dry-run failed: admission webhook
"validate-policy.kyverno.svc" denied the request: spec.mutateExistingOnPolicyUpdate:
Forbidden: rules[0].mutate.targets has to be specified when mutateExistingOnPolicyUpdate is set
```

This is also what is failing every `merge_group` deploy-prod run (renovate #2375 was evicted) and the Heal-Prod re-deploy — nothing in the infrastructure layer can apply, **including #2370's own DaemonSet-VPA ratchet fix**.

## Root cause

`mutateExistingOnPolicyUpdate` was set at **policy level** (`spec.`), which makes Kyverno's webhook require `mutate.targets` on **every** rule in the policy. Rule 1 is admission-only and cannot carry targets, so the policy is rejected at admission → the layer's server-side dry-run fails → the whole Kustomization freezes.

## Fix

- Move the flag to **rule level** (`mutate.mutateExistingOnPolicyUpdate: true`) on the drain rule only — the exact form the prod-proven `disable-default-sa-automount` and `propagate-reloader-to-flagger-primary` policies already use. Behaviour is unchanged: rule 1 still mutates at admission, rule 2 still retro-patches pre-existing autoscale Node CRs.
- Add the `kyverno:reports-controller:read-longhorn-nodes` aggregated grant. The policy's server-side dry-run explicitly warns the reports controller lacks get/list/watch on `longhorn.io/v1beta2/Node`; without it, the moment the policy admits, the reports controller tight-loops on forbidden watches — the identical failure mode of the 2026-07-01 KEDA ScaledObject CPU-leak incident (#2360). Mirrors `kyverno:reports-controller:read-keda`, shipped one Flux layer earlier like the sibling mutate grant.

## Validation

- `kubectl --context admin@prod apply --dry-run=server` on the fixed policy: **accepted** (`created (server dry run)`) — the exact check that currently fails.
- `kubectl kustomize` builds of `k8s/providers/hetzner/infrastructure/` + `…/controllers/`: OK.
- `scripts/validate-naming.py`: clean.

## Urgency

Prod has been unable to apply any infrastructure-layer change for ~2.5h, the merge queue is evicting every PR via the failed deploy-prod, and the 4 leaked autoscale-cx33 nodes can't drain until #2370's policy actually applies. Recommend promoting ASAP.