### PR TITLE
fix(policies): accept the provider publish-workflow cosign identity in verify-app-images

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -14,9 +14,11 @@ metadata:
     policies.kyverno.io/category: Supply Chain Security
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Requires keyless cosign signatures from the devantler-tech publish-app
-      release pipeline on all non-ksail ghcr.io/devantler-tech/* container
-      images at Pod admission. Third-party images admit unverified.
+      Requires keyless cosign signatures from a devantler-tech release
+      pipeline (the shared publish-app workflow, or a Crossplane provider
+      repo's own publish-provider-package workflow) on all non-ksail
+      ghcr.io/devantler-tech/* container images at Pod admission.
+      Third-party images admit unverified.
 spec:
   failurePolicy: Fail
   validationActions: [Deny]
@@ -49,6 +51,19 @@ spec:
           identities:
             - issuer: https://token.actions.githubusercontent.com
               subjectRegExp: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
+            # Crossplane provider packages (provider-upjet-*): the
+            # crossplane-contrib reusable publish workflow they use cannot
+            # sign, so each provider repo attaches the keyless signature in
+            # its own publish-provider-package.yml follow-up job
+            # (provider-upjet-unifi#12), which is the workflow identity
+            # Fulcio certifies. Their package-runtime Deployments run the
+            # package image itself, so without this identity every
+            # devantler-tech provider pod is denied at admission (observed
+            # on prod 2026-07-02: provider-upjet-unifi stuck 0/1, the whole
+            # UniFi Crossplane migration stalled). Identities in this list
+            # are OR'd per image.
+            - issuer: https://token.actions.githubusercontent.com
+              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
   validations:
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -15,10 +15,11 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Requires keyless cosign signatures from a devantler-tech release
-      pipeline (the shared publish-app workflow, or a Crossplane provider
-      repo's own publish-provider-package workflow) on all non-ksail
-      ghcr.io/devantler-tech/* container images at Pod admission.
-      Third-party images admit unverified.
+      pipeline on all non-ksail ghcr.io/devantler-tech/* container images
+      at Pod admission — the shared publish-app workflow for app images,
+      and a Crossplane provider repo's own publish-provider-package
+      workflow for provider-upjet-* packages (each class verified ONLY
+      against its own identity). Third-party images admit unverified.
 spec:
   failurePolicy: Fail
   validationActions: [Deny]
@@ -51,26 +52,40 @@ spec:
           identities:
             - issuer: https://token.actions.githubusercontent.com
               subjectRegExp: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
-            # Crossplane provider packages (provider-upjet-*): the
-            # crossplane-contrib reusable publish workflow they use cannot
-            # sign, so each provider repo attaches the keyless signature in
-            # its own publish-provider-package.yml follow-up job
-            # (provider-upjet-unifi#12), which is the workflow identity
-            # Fulcio certifies. Their package-runtime Deployments run the
-            # package image itself, so without this identity every
-            # devantler-tech provider pod is denied at admission (observed
-            # on prod 2026-07-02: provider-upjet-unifi stuck 0/1, the whole
-            # UniFi Crossplane migration stalled). Identities in this list
-            # are OR'd per image.
+    # Crossplane provider packages (provider-upjet-*): the crossplane-contrib
+    # reusable publish workflow they use cannot sign, so each provider repo
+    # attaches the keyless signature in its own publish-provider-package.yml
+    # follow-up job (provider-upjet-unifi#12), which is the workflow identity
+    # Fulcio certifies. Their package-runtime Deployments run the package
+    # image itself, so without this identity every devantler-tech provider
+    # pod is denied at admission (observed on prod 2026-07-02:
+    # provider-upjet-unifi stuck 0/1, the whole UniFi Crossplane migration
+    # stalled). Kept as a SEPARATE attestor, verified only against
+    # provider-upjet-* images in the validations below — folding it into
+    # publishapp would let a provider-workflow signature satisfy
+    # verification for ANY app image (identities within one attestor are
+    # OR'd per image).
+    - name: publishprovider
+      cosign:
+        keyless:
+          identities:
             - issuer: https://token.actions.githubusercontent.com
               subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
   validations:
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)
-        .filter(image, image.startsWith('ghcr.io/devantler-tech/') && !image.startsWith('ghcr.io/devantler-tech/ksail'))
+        .filter(image, image.startsWith('ghcr.io/devantler-tech/') && !image.startsWith('ghcr.io/devantler-tech/ksail') && !image.startsWith('ghcr.io/devantler-tech/provider-upjet-'))
         .map(image, verifyImageSignatures(image, [attestors.publishapp]))
         .all(e, e > 0)
       message: >-
         first-party app image is not signed by the publish-app release
         pipeline (keyless cosign, reusable-workflows publish-app.yaml
         identity)
+    - expression: >-
+        (images.containers + images.initContainers + images.ephemeralContainers)
+        .filter(image, image.startsWith('ghcr.io/devantler-tech/provider-upjet-'))
+        .map(image, verifyImageSignatures(image, [attestors.publishprovider]))
+        .all(e, e > 0)
+      message: >-
+        provider-upjet package image is not signed by its repo's
+        publish-provider-package workflow (keyless cosign)


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

Companion to devantler-tech/provider-upjet-unifi#12 — together they unblock the provider on prod.

## Problem

`verify-app-images` only accepts the `reusable-workflows/publish-app.yaml` cosign identity for **all** non-ksail `ghcr.io/devantler-tech/*` images. Crossplane provider packages are published by the crossplane-contrib reusable workflow (`crane copy`, no signing), so `provider-upjet-unifi:v0.1.0` is unsigned and its package-runtime pods are denied at admission — the provider Deployment has been 0/1 since 2026-07-01 22:00Z, the ProviderRevision is `RUNTIME: False`, and the UniFi Crossplane migration is stalled (PolicyViolation/FailedCreate warning stream on prod, 2026-07-02).

## Fix

provider-upjet-unifi#12 adds a keyless cosign signing job to the provider's own `publish-provider-package.yml`; the Fulcio identity that produces is that workflow's ref. This PR accepts it as a second OR'd identity in the existing `publishapp` attestor:

```
^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
```

Scoped to devantler-tech `provider-upjet-*` repos and the fixed workflow filename — the trust gate for app images is unchanged; nothing is excluded from verification.

## Rollout order

1. Merge provider-upjet-unifi#12, re-dispatch **Publish Provider Package** with `version: v0.1.0` (idempotent push + signs the digest).
2. Merge this (note: lands in the `infrastructure` layer, so it only applies once #2378 unfreezes that Kustomization).
3. The pending provider ReplicaSet admits on its own.

## Validation

`ksail --config ksail.prod.yaml workload validate --skip-helm-render`: 489 files validated.