### PR TITLE
chore(kyverno): raise background-controller verbosity to v=4 (diagnostic for #2392)

### DIFF
--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -151,6 +151,16 @@ spec:
               app.kubernetes.io/instance: kyverno
     backgroundController:
       replicas: ${kyverno_background_replicas:=1}
+      # TEMPORARY diagnostic for #2392: the drain-autoscale-node-storage
+      # mutate-existing retrofit generates zero UpdateRequests and logs
+      # NOTHING at the default v=2 -- every rejection path in the policy
+      # controller's ApplyBackgroundChecks is V(4)-only, so the failure is
+      # silent by construction. extraArgs render AFTER the features-derived
+      # --v=2 and klog is last-wins, so this raises verbosity to 4 on this
+      # controller only (admission/cleanup/reports stay at v=2). Revert once
+      # #2392 is root-caused.
+      extraArgs:
+        v: 4
       # The chart auto-enables this controller's PDB whenever replicas > 1 and
       # defaults it to minAvailable: 1 -- the exact shape validate-pdb-drain-safe
       # flags. Pin the drain-safe house pattern (#1880/#1882) instead. The


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

#2392 (reopened): the `drain-autoscale-node-storage` mutate-existing retrofit generates **zero UpdateRequests** even after #2393 removed the `operations: [CREATE]` filter — policy update observed 19:52:50Z, RBAC verified (list/get/watch/update/patch on `nodes.longhorn.io`), yet 0 URs and **zero log lines** from the background controller about this policy.

That silence is by construction: every rejection path in the policy controller's `ApplyBackgroundChecks` chain is `V(4)`-only (see the v1.18.1 code trace in the #2392 reopen comment) — at the default `--v=2` the controller discards the policy without a word. We cannot bisect the 4 remaining discriminators vs the working `propagate-reloader` policy (group-qualified custom kind, `names` filter, `patchStrategicMerge`, spec-vs-rule-level flag) without seeing which branch rejects it.

## What

- Adds `extraArgs: {v: 4}` to `backgroundController` **only** (admission/cleanup/reports controllers stay at v=2).
- Verified against a local render of chart 3.8.1: `extraArgs` renders **after** the features-derived `--v=2`, and klog is last-wins, so the effective verbosity is 4 — no duplicate-flag error.

## Scope & rollback

**Temporary diagnostic** — one controller, log-volume bounded (the background controller only acts on policy/resource events, not admission traffic). A revert PR follows as soon as #2392's root cause is captured from the v=4 logs (next policy re-apply or hourly background scan will emit the rejection branch).

## Validation

- `ksail workload validate` — 492 files ✔ (local overlay)
- `ksail --config ksail.prod.yaml workload validate` — 492 files ✔ (prod overlay)
- `scripts/validate-naming.py` ✔

Relates #2392.