### PR TITLE
feat: accept devantler-tech/actions cosign subjects during the publish-workflow repoint

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -18,3 +18,9 @@ spec:
     matchOIDCIdentity:
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
         subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
+      # publish-app.yaml is moving from devantler-tech/reusable-workflows into
+      # devantler-tech/actions (actions#425 consumer repoint); both subjects are
+      # accepted during the transition — drop the reusable-workflows entry once
+      # the first actions-signed artifact has been published and verified.
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@.+$'

--- a/k8s/bases/apps/github-config/oci-repository.yaml
+++ b/k8s/bases/apps/github-config/oci-repository.yaml
@@ -26,8 +26,14 @@ spec:
     matchOIDCIdentity:
       # Keyless-signed by the shared publish-manifests reusable workflow that
       # .github's cd.yaml calls. Signing runs INSIDE that reusable workflow, so
-      # the cosign OIDC subject is the reusable workflow's path (devantler-tech/
-      # reusable-workflows), NOT .github's own cd.yaml — same convention as the
-      # publish-app.yaml-signed app artifacts.
+      # the cosign OIDC subject is the reusable workflow's path, NOT .github's
+      # own cd.yaml — same convention as the publish-app.yaml-signed app
+      # artifacts. The workflow is moving from devantler-tech/reusable-workflows
+      # into devantler-tech/actions (actions#425 consumer repoint); both
+      # subjects are accepted during the transition — drop the
+      # reusable-workflows entry once the first actions-signed artifact has
+      # been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
         subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-manifests\.yaml@.+$'
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@.+$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -18,3 +18,9 @@ spec:
     matchOIDCIdentity:
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
         subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
+      # publish-app.yaml is moving from devantler-tech/reusable-workflows into
+      # devantler-tech/actions (actions#425 consumer repoint); both subjects are
+      # accepted during the transition — drop the reusable-workflows entry once
+      # the first actions-signed artifact has been published and verified.
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@.+$'


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Deployed artifacts are verified against *where they were signed*. Our signing workflows are moving homes (actions#425) — if a repo moves before the platform trusts the new home, its next release is rejected and its deployment stops.

## What

Trusts artifacts signed from both the old and new home during the migration (org-config, wedding-app, AS Coaching). A follow-up drops the old home once everything has moved.

⚠️ **Merge order:** this PR before any repo that moves its signing (.github#80, ascoachingogvaner#79, wedding-app#149).