### PR TITLE
ci: repoint reusable workflows to actions v8.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/reusable-workflows/.github/workflows/create-release.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/create-release.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     permissions:
       contents: write # create releases and tags
       issues: write # comment on related issues

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   sync-policies:
-    uses: devantler-tech/reusable-workflows/.github/workflows/sync-cluster-policies.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/sync-cluster-policies.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/reusable-workflows/.github/workflows/scan-for-todo-comments.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/reusable-workflows/.github/workflows/update-agent-skills.yaml@c830916321473ec23bb612e41de963b9b01af897 # v5.6.6
+    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
     with:
       dir: .agents/skills
       # Create the update PR with a GitHub App token so it triggers this


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

We merged our reusable CI workflows into `devantler-tech/actions` a week ago, but this repo still runs them from the old `reusable-workflows` repo. Until every repo moves over, the old repo can't be archived — and its leftover automation has now started failing every night (reusable-workflows#350).

## What

Points this repo's CI at the workflows' new home. Same workflows, new address — no behavior change.

Part of devantler-tech/actions#425.

**Note:** needs a direct merge after promotion — the auto-merge bot can't merge workflow-file changes.