### PR TITLE
fix: tenant artifact verification rejects the dual signing identities from #2399

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -16,11 +16,12 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
       # publish-app.yaml is moving from devantler-tech/reusable-workflows into
-      # devantler-tech/actions (actions#425 consumer repoint); both subjects are
-      # accepted during the transition — drop the reusable-workflows entry once
-      # the first actions-signed artifact has been published and verified.
+      # devantler-tech/actions (actions#425 consumer repoint); both repo
+      # subjects are accepted via ONE regex-alternated entry — cosign's keyless
+      # attestation verification rejects MULTIPLE identity entries outright
+      # ("unsupported: multiple identities are not supported at this time").
+      # Narrow the alternation to actions-only once the first actions-signed
+      # artifact has been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'

--- a/k8s/bases/apps/github-config/oci-repository.yaml
+++ b/k8s/bases/apps/github-config/oci-repository.yaml
@@ -29,11 +29,12 @@ spec:
       # the cosign OIDC subject is the reusable workflow's path, NOT .github's
       # own cd.yaml — same convention as the publish-app.yaml-signed app
       # artifacts. The workflow is moving from devantler-tech/reusable-workflows
-      # into devantler-tech/actions (actions#425 consumer repoint); both
-      # subjects are accepted during the transition — drop the
-      # reusable-workflows entry once the first actions-signed artifact has
-      # been published and verified.
+      # into devantler-tech/actions (actions#425 consumer repoint); both repo
+      # subjects are accepted via ONE regex-alternated entry — cosign's keyless
+      # attestation verification rejects MULTIPLE identity entries outright
+      # ("unsupported: multiple identities are not supported at this time"), so
+      # the transition must be expressed inside a single subject regex. Narrow
+      # the alternation to actions-only once the first actions-signed artifact
+      # has been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-manifests\.yaml@.+$'
-      - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-manifests\.yaml@.+$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -16,11 +16,12 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
       # publish-app.yaml is moving from devantler-tech/reusable-workflows into
-      # devantler-tech/actions (actions#425 consumer repoint); both subjects are
-      # accepted during the transition — drop the reusable-workflows entry once
-      # the first actions-signed artifact has been published and verified.
+      # devantler-tech/actions (actions#425 consumer repoint); both repo
+      # subjects are accepted via ONE regex-alternated entry — cosign's keyless
+      # attestation verification rejects MULTIPLE identity entries outright
+      # ("unsupported: multiple identities are not supported at this time").
+      # Narrow the alternation to actions-only once the first actions-signed
+      # artifact has been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Prod's app-delivery layer has been frozen since #2399 deployed (~03:46Z): the signature verifier refuses configurations with more than one accepted identity, so all three tenant apps (github-config, wedding-app, ascoachingogvaner) stopped pulling their artifacts, and every platform merge is now blocked because the queue's prod deploy fails on the stuck apps layer (#2400 was evicted; Heal-Prod fails the same way).

## What
Keeps both the old and new signing workflows trusted during the actions#425 transition, but expresses them as a single identity rule the verifier accepts. What is trusted does not change.

## Operational
Land this before re-queuing anything on platform — merges stay blocked until it deploys. Fixes the regression introduced by #2399.