### PR TITLE
fix(apps): express the cosign transition as one identity — Flux rejects multiple

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -16,11 +16,11 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
+      # Flux's cosign verifier accepts exactly ONE identity ("multiple
+      # identities are not supported at this time"), so the actions#425
+      # transition (publish-app.yaml moving from devantler-tech/
+      # reusable-workflows into devantler-tech/actions) is expressed as one
+      # alternation regex — narrow it to the actions path once the first
+      # actions-signed artifact has been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
-      # publish-app.yaml is moving from devantler-tech/reusable-workflows into
-      # devantler-tech/actions (actions#425 consumer repoint); both subjects are
-      # accepted during the transition — drop the reusable-workflows entry once
-      # the first actions-signed artifact has been published and verified.
-      - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'

--- a/k8s/bases/apps/github-config/oci-repository.yaml
+++ b/k8s/bases/apps/github-config/oci-repository.yaml
@@ -28,12 +28,11 @@ spec:
       # .github's cd.yaml calls. Signing runs INSIDE that reusable workflow, so
       # the cosign OIDC subject is the reusable workflow's path, NOT .github's
       # own cd.yaml — same convention as the publish-app.yaml-signed app
-      # artifacts. The workflow is moving from devantler-tech/reusable-workflows
-      # into devantler-tech/actions (actions#425 consumer repoint); both
-      # subjects are accepted during the transition — drop the
-      # reusable-workflows entry once the first actions-signed artifact has
-      # been published and verified.
+      # artifacts. Flux's cosign verifier accepts exactly ONE identity
+      # ("multiple identities are not supported at this time"), so the
+      # actions#425 transition (the workflow moving from devantler-tech/
+      # reusable-workflows into devantler-tech/actions) is expressed as one
+      # alternation regex — narrow it to the actions path once the first
+      # actions-signed artifact has been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-manifests\.yaml@.+$'
-      - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-manifests\.yaml@.+$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -16,11 +16,11 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
+      # Flux's cosign verifier accepts exactly ONE identity ("multiple
+      # identities are not supported at this time"), so the actions#425
+      # transition (publish-app.yaml moving from devantler-tech/
+      # reusable-workflows into devantler-tech/actions) is expressed as one
+      # alternation regex — narrow it to the actions path once the first
+      # actions-signed artifact has been published and verified.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
-      # publish-app.yaml is moving from devantler-tech/reusable-workflows into
-      # devantler-tech/actions (actions#425 consumer repoint); both subjects are
-      # accepted during the transition — drop the reusable-workflows entry once
-      # the first actions-signed artifact has been published and verified.
-      - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
All three tenant artifact sources (wedding-app, ascoachingogvaner, github-config) stopped verifying on prod right after #2399: Flux's cosign verifier accepts exactly one signing identity, so the transitional second entry broke verification outright (`unsupported: multiple identities are not supported at this time`). The `apps` layer can no longer pull tenant updates, and this is failing merge-queue deploys (evicted #2400's first run).

## What
Collapses each pair of identities into one entry whose subject pattern accepts both the old and the new signing workflow — the same trust set #2399 intended, in a form Flux supports. The narrowing step (drop the old path once actions-signed artifacts verify) stays as planned; tightening the ref matcher stays tracked in #2402.

**Merge-order note:** land ASAP — the merge queue keeps evicting PRs on the failed apps health check until this applies.