### PR TITLE
fix(rgd): single regex-alternated cosign identity for tenant artifact verification

### DIFF
--- a/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
@@ -167,8 +167,15 @@ spec:
           verify:
             provider: cosign
             matchOIDCIdentity:
+              # publish-app.yaml is moving from devantler-tech/reusable-workflows into
+              # devantler-tech/actions (actions#425 consumer repoint); both repo
+              # subjects are accepted via ONE regex-alternated entry — cosign's keyless
+              # attestation verification rejects MULTIPLE identity entries outright
+              # ("unsupported: multiple identities are not supported at this time").
+              # Narrow the alternation to actions-only once the first actions-signed
+              # artifact has been published and verified.
               - issuer: '^https://token\.actions\.githubusercontent\.com$'
-                subject: '^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$'
+                subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'
     # --- Flux Kustomization (one of two variants by `sops`) ---------------
     # The impersonating Kustomization that reconciles the tenant's own artifact
     # under its namespaced `edit` SA. Two variants because the SOPS `decryption`


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
RGD-instantiated tenants pin artifact verification to the reusable-workflows signing identity. When those tenants repoint their cd workflows to devantler-tech/actions (the actions#425 train), verification would fail — and adding a second identity entry is exactly what froze the apps layer yesterday (#2399 → #2404), since cosign rejects multiple identities outright.

## What
The RGD template now uses the same single regex-alternated subject as the merged #2404, accepting both repos in one entry. Narrow to actions-only later with the #2404 cleanup.

Fixes #2405 · Relates to #2402

**Note:** local-overlay validation green (492 files); prod-overlay `ksail workload validate` hit the known kubeconform#363 render race repeatedly this session (shifting corruption lines in untouched helm-rendered CRDs) — kustomize builds of the affected layers pass.