### PR TITLE
feat(aws): aws tenant credential plumbing (SecretStore + ProviderConfig)

### DIFF
--- a/k8s/providers/hetzner/apps/aws/external-secret.yaml
+++ b/k8s/providers/hetzner/apps/aws/external-secret.yaml
@@ -1,0 +1,44 @@
+---
+# AWS bootstrap IAM credentials from OpenBao, rendered as the shared AWS
+# credentials-file (INI) blob the Crossplane ProviderConfig consumes
+# (provider-config.yaml, secretRef → key `credentials`). The upbound family
+# providers pass it verbatim to the AWS SDK's shared-credentials loader, so the
+# format is the standard `[default]` profile. Read via the tenant's NAMESPACED
+# `openbao` SecretStore (secret-store.yaml) — NOT the shared cluster store —
+# authorised by the infra-aws-readonly OpenBao policy on the dedicated `aws`
+# role.
+# SEEDING: the vault-config Job seeds PLACEHOLDERS at
+# secret/infrastructure/aws/bootstrap on first run (only if absent). GATE:
+# overwrite them in place via the OpenBao UI/CLI with a real bootstrap IAM
+# access key before activating any AWS managed resources (platform#2326).
+# OpenBao is backed up (Raft → R2), so the value is durable.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: aws-bootstrap-credentials
+  namespace: aws
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: SecretStore
+  target:
+    name: aws-bootstrap-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        credentials: |
+          [default]
+          aws_access_key_id = {{ .access_key_id }}
+          aws_secret_access_key = {{ .secret_access_key }}
+  data:
+    - secretKey: access_key_id
+      remoteRef:
+        key: infrastructure/aws/bootstrap
+        property: access_key_id
+    - secretKey: secret_access_key
+      remoteRef:
+        key: infrastructure/aws/bootstrap
+        property: secret_access_key

--- a/k8s/providers/hetzner/apps/aws/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/aws/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - service-account.yaml
+  - network-policy.yaml
+  - secret-store.yaml
+  - provider-config.yaml
+  - external-secret.yaml

--- a/k8s/providers/hetzner/apps/aws/namespace.yaml
+++ b/k8s/providers/hetzner/apps/aws/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws
+  labels:
+    # The aws tenant holds only Crossplane Managed Resources, the
+    # ProviderConfig, and credential Secrets — no pods run here (the provider
+    # runs in crossplane-system). Restricted PSS is enforced regardless.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/k8s/providers/hetzner/apps/aws/network-policy.yaml
+++ b/k8s/providers/hetzner/apps/aws/network-policy.yaml
@@ -1,0 +1,18 @@
+# Default-deny NetworkPolicy mirroring the runtime Kyverno-generated
+# CiliumNetworkPolicy (cluster-policies/best-practices/add-default-deny.yaml), so
+# the static Kubescape scan sees this namespace as network-restricted (C-0054).
+# It is behaviourally redundant with the runtime default-deny this namespace
+# already runs under. The aws tenant runs NO pods — the Crossplane provider runs
+# in crossplane-system, Flux in flux-system, ESO in external-secrets — so the
+# namespace holds only managed resources, the ProviderConfig, and credential
+# Secrets, and needs no per-workload allow policy.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: aws
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/k8s/providers/hetzner/apps/aws/provider-config.yaml
+++ b/k8s/providers/hetzner/apps/aws/provider-config.yaml
@@ -1,0 +1,23 @@
+# Namespaced ProviderConfig (Crossplane v2): authenticates the upbound AWS
+# family providers (provider-aws-iam today, EKS later) with the bootstrap IAM
+# access key. Referenced by the namespaced AWS managed resources in this
+# namespace (providerConfigRef name: default) once platform#2326 activates the
+# IAM kinds. Applied by the platform's `apps` Kustomization (flux-system),
+# alongside the credential ExternalSecret — not by the tenant SA, which will
+# only apply the managed resources from the devantler-tech/aws repo.
+#
+# spec.credentials.secretRef.namespace is a REQUIRED field (the CRD enforces it
+# even for a namespaced ProviderConfig) and is a value, not the resource
+# namespace, so it is set explicitly to where the credentials Secret lives.
+apiVersion: aws.m.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+  namespace: aws
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: aws
+      name: aws-bootstrap-credentials
+      key: credentials

--- a/k8s/providers/hetzner/apps/aws/secret-store.yaml
+++ b/k8s/providers/hetzner/apps/aws/secret-store.yaml
@@ -1,0 +1,31 @@
+# Tenant-scoped, namespaced SecretStore for the aws tenant. The tenant must NOT
+# use the shared cluster-scoped `openbao` ClusterSecretStore (whose role can read
+# every infra + app path); the `restrict-tenant-secret-stores` Kyverno policy
+# blocks tenant ExternalSecrets from referencing it.
+#
+# Authenticates as the tenant's own `aws` ServiceAccount via the dedicated `aws`
+# OpenBao Kubernetes auth role (k8s/bases/infrastructure/vault-config/job.yaml),
+# which carries only the `infra-aws-readonly` policy — read on
+# secret/data/infrastructure/aws/* and nothing else. The tenant can therefore
+# reach its bootstrap IAM credentials and no other secret.
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: openbao
+  namespace: aws
+  labels:
+    app.kubernetes.io/managed-by: ksail
+spec:
+  provider:
+    vault:
+      # openbao-active = unsealed Raft leader only; the plain `openbao` Service
+      # also round-robins onto sealed-but-Ready standbys (503 "Vault is sealed").
+      server: "http://openbao-active.openbao.svc.cluster.local:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "aws"
+          serviceAccountRef:
+            name: "aws"

--- a/k8s/providers/hetzner/apps/aws/service-account.yaml
+++ b/k8s/providers/hetzner/apps/aws/service-account.yaml
@@ -1,0 +1,15 @@
+---
+# The aws tenant's ServiceAccount. For now it only authenticates the namespaced
+# SecretStore (secret-store.yaml) to OpenBao via the dedicated `aws` Kubernetes
+# auth role; once the devantler-tech/aws tenant repo lands (platform#2325), its
+# Flux Kustomization will also run AS this SA with namespace-scoped authority,
+# mirroring the unifi tenant. No pods use it (the Crossplane provider runs in
+# crossplane-system), so the token is not mounted.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws
+  namespace: aws
+  labels:
+    app.kubernetes.io/managed-by: ksail
+automountServiceAccountToken: false

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -9,6 +9,12 @@ resources:
   # API it reaches are Hetzner-only — on local/CI clusters the Terraform CRD is
   # absent. Reconciled by the shared `apps` Flux Kustomization like any tenant.
   - unifi/
+  # Prod-only tenant: AWS-as-code via the upbound Crossplane family providers
+  # (providers/hetzner/apps/aws/ — platform#2325). Credential plumbing only for
+  # now (namespace, SecretStore, bootstrap-IAM ExternalSecret, ProviderConfig);
+  # the devantler-tech/aws repo sync lands in a follow-up increment. Hetzner-only
+  # because Crossplane (and the provider packages) are prod-only.
+  - aws/
   # Prod-only Coroot Postgres integration for the platform-owned CNPG DBs:
   # additive CiliumNetworkPolicies that let the observability cluster-agent
   # scrape each on 5432 (the Cluster patches below stamp the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The EKS work in ksail (its oldest open substantive issue) is blocked on declarative AWS test credentials. The provider install and the OpenBao seed/role already landed; the missing link is the tenant-side plumbing that actually authenticates the AWS providers.

## What
Adds the `aws` tenant namespace with its scoped SecretStore, the bootstrap-IAM ExternalSecret, and the ProviderConfig the AWS providers authenticate with — mirroring the unifi tenant pattern. No managed resources are activated yet; the devantler-tech/aws repo and Flux sync follow as the next increment.

Part of #2325.

**Operational note:** the OpenBao value at `infrastructure/aws/bootstrap` is still the seeded placeholder — overwrite it with a real bootstrap IAM key before #2326 activates any AWS kinds.