### PR TITLE
ci: bump devantler-tech/actions pins to v8.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,7 +242,7 @@ jobs:
     permissions: {}
     steps:
       - name: 📊 Evaluate job results
-        uses: devantler-tech/actions/aggregate-job-checks@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
+        uses: devantler-tech/actions/aggregate-job-checks@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
         with:
           job-results: >-
             ${{ needs.changes.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/actions/.github/workflows/create-release.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
+    uses: devantler-tech/actions/.github/workflows/create-release.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
     permissions:
       contents: write # create releases and tags
       issues: write # comment on related issues

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   sync-policies:
-    uses: devantler-tech/actions/.github/workflows/sync-cluster-policies.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
+    uses: devantler-tech/actions/.github/workflows/sync-cluster-policies.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@061b345a7351b0caf23055caea63ccd08b75e20e # v8.0.0
+    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
     with:
       dir: .agents/skills
       # Create the update PR with a GitHub App token so it triggers this


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why:** The `TODOs` workflow has been failing on `main` since the actions SHA-pinning requirement took effect — the released `v8.0.0` reusable workflows still referenced sibling actions by tag internally, which the runtime rejects. This is the final step of the known heal chain now that `actions#427` merged and `v8.0.1` shipped.

**What:** Bumps all five `devantler-tech/actions` pins (todos, release, update-skills, sync-cluster-policies, ci) from `v8.0.0` to `v8.0.1`, which resolves those self-references at the same commit. Restores `main` to green.

Operational note: merge-queue repo — after promotion, enqueue with a bare `gh pr merge` (no strategy flag).