### PR TITLE
fix(talos): trust provider-upjet-* publish-provider-package.yml signing identity

### DIFF
--- a/talos/cluster/image-verification.yaml
+++ b/talos/cluster/image-verification.yaml
@@ -49,6 +49,17 @@ rules:
     keyless:
       issuer: https://token.actions.githubusercontent.com
       subjectRegex: ^https://github\.com/devantler-tech/ksail/\.github/workflows/cd\.yaml@refs/tags/v.+$
+  # Crossplane PROVIDER package images (ghcr.io/devantler-tech/provider-upjet-*)
+  # are signed by each provider repo's OWN publish-provider-package.yml — a
+  # different keyless identity than publish-app.yaml, because the upstream
+  # crossplane-contrib publish reusable workflow can't run publish-app.yaml.
+  # Mirrors the verify-app-images ImageValidatingPolicy provider-upjet-*
+  # attestor (#2382). MUST precede the catch-all below (first-match-wins) or the
+  # catch-all's publish-app.yaml identity rejects these (ImagePullBackOff).
+  - image: ghcr.io/devantler-tech/provider-upjet-*
+    keyless:
+      issuer: https://token.actions.githubusercontent.com
+      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
   # First-party APP images signed by reusable-workflows/publish-app.yaml.
   - image: ghcr.io/devantler-tech/*
     keyless:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
provider-upjet-unifi has been stuck on prod for ~39h: its runtime pods pass Kyverno admission (the `verify-app-images` IVP was extended for provider packages in #2382) but then fail at the containerd **image pull** with Talos-level signature verification (`ImagePullBackOff`). Root cause: the Talos `ImageVerificationConfig` catch-all `ghcr.io/devantler-tech/*` only trusts the `reusable-workflows/publish-app.yaml` keyless identity, and rules are **first-match-wins** — so provider packages (signed by their own `publish-provider-package.yml`) match the catch-all first and are rejected.

## What
Adds a specific `ghcr.io/devantler-tech/provider-upjet-*` rule **before** the catch-all, trusting the `publish-provider-package.yml` identity — the node-level mirror of the #2382 IVP attestor. Unblocks the UniFi Crossplane provider migration. Additive and non-disruptive (defense-in-depth pull-time verification only).

Applied live to the running nodes out-of-band to unblock now; this PR makes it the source of truth so the next `ksail`/`cd.yaml` machine-config apply keeps it.