### PR TITLE
fix(unifi): quote allow_insecure as string in provider credentials

### DIFF
--- a/k8s/providers/hetzner/apps/unifi/external-secret.yaml
+++ b/k8s/providers/hetzner/apps/unifi/external-secret.yaml
@@ -28,10 +28,13 @@ spec:
       engineVersion: v2
       type: Opaque
       data:
-        # Build the blob with dict|toJson so values are JSON-escaped and the types
-        # match the provider config: allow_insecure is a bool (not the string
-        # "false"), api_url/api_key are properly quoted/escaped.
-        credentials: '{{ dict "api_url" .api_url "api_key" .api_key "site" "default" "allow_insecure" false | toJson }}'
+        # Build the blob with dict|toJson so values are JSON-escaped. The provider
+        # unmarshals EVERY credentials value as a Go `string`, so allow_insecure
+        # MUST be the string "false" (not a JSON bool) — a bare bool makes the
+        # provider fail with `cannot unmarshal bool into Go value of type string`
+        # (CannotConnectToProvider on every managed resource). api_url/api_key are
+        # properly quoted/escaped by toJson.
+        credentials: '{{ dict "api_url" .api_url "api_key" .api_key "site" "default" "allow_insecure" "false" | toJson }}'
   data:
     - secretKey: api_url
       remoteRef:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
With provider-upjet-unifi finally running on prod (its image now passes Talos signature verification — see the Talos ImageVerificationConfig fix), every UniFi managed resource (DNS records, WireGuard client/route) immediately failed with `CannotConnectToProvider: cannot unmarshal bool into Go value of type string`. The provider unmarshals the whole credentials blob with all-string values, but the ExternalSecret rendered `allow_insecure` as a JSON **bool**. This was a latent bug — the provider had never started before, so it was never exercised.

## What
Render `allow_insecure` as the string `"false"` (the repo's own docs already specify the string form). Unblocks the UniFi Crossplane migration's actual reconciliation.

Applies on the next platform deploy (cd.yaml republishes the manifests artifact → Flux reconciles the ExternalSecret → Secret regenerates).