### PR TITLE
ci: bump devantler-tech/actions pins to v9.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,7 +242,7 @@ jobs:
     permissions: {}
     steps:
       - name: 📊 Evaluate job results
-        uses: devantler-tech/actions/aggregate-job-checks@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
+        uses: devantler-tech/actions/aggregate-job-checks@5aa2657f976103d716f585266a0fa4e964594df2 # v9.0.0
         with:
           job-results: >-
             ${{ needs.changes.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/actions/.github/workflows/create-release.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
+    uses: devantler-tech/actions/.github/workflows/create-release.yaml@5aa2657f976103d716f585266a0fa4e964594df2 # v9.0.0
     permissions:
       contents: write # create releases and tags
       issues: write # comment on related issues

--- a/.github/workflows/sync-cluster-policies.yaml
+++ b/.github/workflows/sync-cluster-policies.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   sync-policies:
-    uses: devantler-tech/actions/.github/workflows/sync-cluster-policies.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
+    uses: devantler-tech/actions/.github/workflows/sync-cluster-policies.yaml@5aa2657f976103d716f585266a0fa4e964594df2 # v9.0.0
     with:
       kyverno-policies-dir: k8s/bases/infrastructure/cluster-policies/samples
     secrets:

--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@5aa2657f976103d716f585266a0fa4e964594df2 # v9.0.0
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-skills.yaml
+++ b/.github/workflows/update-skills.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@bd78711c15f1e473e3ba75b0d5e8aece26019660 # v8.0.1
+    uses: devantler-tech/actions/.github/workflows/update-agent-skills.yaml@5aa2657f976103d716f585266a0fa4e964594df2 # v9.0.0
     with:
       dir: .agents/skills
       # Create the update PR with a GitHub App token so it triggers this


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
`main` has been red on every push: the **TODOs** job fails because the v8.0.1 actions pin (#2413) shipped *before* the fix for that job was released. The fix landed in `devantler-tech/actions` v9.0.0.

## What
Bumps all 5 `devantler-tech/actions` pins from v8.0.1 → v9.0.0, which carries the TODOs-job fix. The only real change in the v8.0.1→v9.0.0 range is that one fix — the major-version bump is release-please catching up on breaking changes that already shipped in v8.0.0, none of which touch the actions platform uses. Final step of the actions self-ref heal chain; greens `main`.

Needs a direct merge (enqueue) after promotion.