### PR TITLE
fix(autoscaler): drop cx33 as an overflow node type

### DIFF
--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -17,8 +17,6 @@ KSail (static baseline)
 └── 3 static workers (cx33, 4 vCPU / 8 GB, guaranteed minimum, Longhorn storage nodes)
 
 Cluster Autoscaler (dynamic workers, managed by KSail)
-├── Pool: autoscale-cx23 → 0-4 × CX23 (2 vCPU, 4 GB)
-├── Pool: autoscale-cx33 → 0-4 × CX33 (4 vCPU, 8 GB)
 ├── Pool: autoscale-cx43 → 0-4 × CX43 (8 vCPU, 16 GB)
 ├── Pool: autoscale-cx53 → 0-4 × CX53 (16 vCPU, 32 GB)
 ├── maxNodesTotal: 10 (total cluster nodes incl. baseline: 6 static + 4 autoscaler)
@@ -75,16 +73,6 @@ spec:
         maxNodesTotal: 10
         scaleDownUnneededTime: "10m"
         pools:
-          - name: autoscale-cx23
-            serverType: cx23
-            location: fsn1
-            min: 0
-            max: 4
-          - name: autoscale-cx33
-            serverType: cx33
-            location: fsn1
-            min: 0
-            max: 4
           - name: autoscale-cx43
             serverType: cx43
             location: fsn1

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/pod-template.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/pod-template.yaml
@@ -9,13 +9,14 @@
 #
 # === Sizing (TUNE ME) ===
 # 2 CPU / 4Gi per chunk x replicas: 1 (see capacity-buffer.yaml) == one warm
-# spare node. The smallest overflow pool is cx33 (4 vCPU / 8 GB; see
-# ksail.prod.yaml). A fresh cx33 must also run the per-node kube-system
+# spare node. The smallest overflow pool is cx43 (8 vCPU / 16 GB; see
+# ksail.prod.yaml — cx33 was dropped as an overflow type because its per-node
+# DaemonSet overhead left it above the scale-down utilization threshold and
+# unable to be reclaimed). A fresh cx43 must also run the per-node kube-system
 # DaemonSets (cilium, spire-agent, tetragon, hcloud-csi node, ...), which take
-# ~0.3 CPU / ~1.5 GB, so the chunk is deliberately set BELOW raw allocatable to
-# guarantee it still fits a brand-new cx33 (otherwise the autoscaler would jump
-# to a pricier cx43). 2 CPU / 4Gi is also far too large to squeeze onto the
-# already-loaded baseline workers, so it reliably forces a new autoscaler node.
+# ~0.3 CPU / ~1.5 GB, so the chunk stays comfortably below raw allocatable.
+# 2 CPU / 4Gi is also far too large to squeeze onto the already-loaded baseline
+# workers, so it reliably forces a new autoscaler node.
 # Widen the buffer by raising capacity-buffer.yaml's replicas (one warm node per
 # chunk) or this per-chunk request -- bounded by ksail.prod.yaml's
 # maxNodesTotal: 10.

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -23,18 +23,26 @@ spec:
     # Cost-optimized overflow: one pool per cost-optimized Hetzner x86
     # shared-vCPU type (the CX line), so the autoscaler can pick the smallest
     # *adequate* node for whatever can't schedule on the static workers. Sizes
-    # double cleanly per step (cx33 4c/8G → cx43 8c/16G →
-    # cx53 16c/32G; ~€4.99/€8.11/€14.99/€28.11 gross/mo in fsn1). All pools
-    # scale to zero (min: 0) so idle capacity costs nothing; the static
-    # workers are the guaranteed baseline and the only Longhorn storage nodes
-    # (autoscaler nodes are compute-only). CAX/ARM is cheaper but needs an ARM
-    # Talos image — not applicable to this x86 cluster.
+    # double cleanly per step (cx43 8c/16G → cx53 16c/32G;
+    # ~€8.11/€14.99 gross/mo in fsn1). All pools scale to zero (min: 0) so idle
+    # capacity costs nothing; the static workers are the guaranteed baseline and
+    # the only Longhorn storage nodes (autoscaler nodes are compute-only).
+    # CAX/ARM is cheaper but needs an ARM Talos image — not applicable here.
+    #
+    # cx33 (4c/8G) is deliberately EXCLUDED as an overflow type. The per-node
+    # kube-system + observability DaemonSets (cilium, coroot, kubescape,
+    # longhorn-manager, tetragon, …) request ~3Gi combined — already ~40% of an
+    # 8G cx33's allocatable — so a cx33 overflow node sits above the 50%
+    # scale-down-utilization threshold on DaemonSets ALONE and can NEVER be
+    # reclaimed (it stays pinned indefinitely, and on a maxed hcloud account
+    # that starves the Talos-snapshot slot). cx43 (16G) amortizes that fixed
+    # overhead to ~19%, so an idle overflow node can actually scale back down.
     #
     # expander: [LeastNodes, LeastWaste] — an ordered priority chain (upstream
     # cluster-autoscaler --expander=least-nodes,least-waste). LeastNodes runs
     # FIRST: on scale-up it keeps the node groups that meet the pending pods
     # with the FEWEST total new nodes (preferring the largest adequate type,
-    # cx53 > cx43 > cx33, to consolidate a burst onto fewer, bigger servers).
+    # cx53 > cx43, to consolidate a burst onto fewer, bigger servers).
     # LeastWaste is the tiebreaker: among the groups LeastNodes leaves tied,
     # pick the one with the least idle CPU/memory.
     # NB this list form requires KSail's expander-list support ("feat: support a
@@ -75,11 +83,6 @@ spec:
         # (renovate-managed) must reach it first.
         capacityBuffers: true
         pools:
-          - name: autoscale-cx33
-            serverType: cx33
-            location: fsn1
-            min: 0
-            max: 4
           - name: autoscale-cx43
             serverType: cx43
             location: fsn1


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The cx33 (8G) autoscaler overflow nodes can **never scale back down**. Each node's baseline DaemonSets (cilium, coroot, kubescape, longhorn-manager, tetragon, …) request ~3Gi — already ~40% of a cx33 — which is *above* the 50% scale-down-utilization threshold on DaemonSets alone. So idle overflow nodes stay pinned indefinitely, and on a maxed-out hcloud account that also starves the Talos-snapshot server slot (wedging the merge queue).

## What
Remove cx33 from the autoscaler overflow pools; the smallest overflow type is now cx43 (16G), where the fixed DaemonSet overhead is ~19% and idle nodes can actually be reclaimed. Control-plane/worker sizing is unchanged. Already applied live to the running cluster-autoscaler; this PR makes it the source of truth for the next deploy.