### PR TITLE
fix(longhorn): default to a WaitForFirstConsumer StorageClass

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/helm-release.yaml
@@ -99,8 +99,15 @@ spec:
       engineReplicaTimeout: "30"
 
     persistence:
-      # Longhorn is the default StorageClass (replaces hcloud for new PVCs).
-      defaultClass: true
+      # The chart-managed `longhorn` StorageClass uses volumeBindingMode: Immediate,
+      # binding a PVC (and provisioning its Longhorn volume) BEFORE the consuming pod
+      # is scheduled — which strands stateful pods on whatever node the volume landed
+      # on (incl. autoscaler overflow nodes) and defeats scale-down. So the cluster
+      # default is now the sibling `longhorn-wffc` class (WaitForFirstConsumer,
+      # storage-class-longhorn-wffc.yaml). This `longhorn` class is KEPT but demoted to
+      # non-default so existing PVCs and CNPG clusters that name it still resolve; move
+      # workloads onto longhorn-wffc per-workload (reclaimPolicy is Delete — no bulk PVC deletes).
+      defaultClass: false
       defaultClassReplicaCount: ${longhorn_replica_count:=3}
       # RWX support via Longhorn's built-in NFS server.
       defaultFsType: ext4

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
   - namespace.yaml
   - helm-repository.yaml
   - helm-release.yaml
+  # Default WaitForFirstConsumer StorageClass (see storage-class-longhorn-wffc.yaml);
+  # the chart's `longhorn` class is demoted to non-default in helm-release.yaml.
+  - storage-class-longhorn-wffc.yaml
   - cilium-network-policy.yaml
   - http-route.yaml
   # CPU-only LimitRange: restores a CPU limit (dropped when longhorn-system was

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/storage-class-longhorn-wffc.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/storage-class-longhorn-wffc.yaml
@@ -24,7 +24,8 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 parameters:
-  numberOfReplicas: "${longhorn_replica_count:=3}"
+  # Mirrors the chart default (longhorn_replica_count, default 3); keep in sync.
+  numberOfReplicas: "3"
   staleReplicaTimeout: "30"
   fromBackup: ""
   fsType: ext4

--- a/k8s/providers/hetzner/infrastructure/controllers/longhorn/storage-class-longhorn-wffc.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/longhorn/storage-class-longhorn-wffc.yaml
@@ -1,0 +1,35 @@
+---
+# longhorn-wffc — Longhorn StorageClass with volumeBindingMode WaitForFirstConsumer,
+# and the cluster default. New PVCs bind lazily: the scheduler places the consuming
+# pod FIRST (honouring node affinity and the restrict-storage-to-baseline-workers
+# policy), then the Longhorn volume is provisioned where the pod landed. This stops
+# stateful pods being dragged onto autoscaler overflow nodes by an eagerly-bound
+# volume (which blocked scale-down) and lets the cluster-autoscaler simulate scale-up
+# correctly.
+#
+# The chart-managed `longhorn` StorageClass (volumeBindingMode: Immediate) is demoted
+# to non-default (persistence.defaultClass: false in helm-release.yaml) but KEPT: it is
+# referenced by name from existing PVCs and CNPG clusters (spec.storage.storageClass:
+# longhorn), so it must keep resolving. Migrating those workloads onto this class is a
+# deliberate, per-workload follow-up — never a bulk PVC delete, because reclaimPolicy
+# is Delete. Parameters mirror `kubectl get sc longhorn` so volumes are otherwise identical.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-wffc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "${longhorn_replica_count:=3}"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: ext4
+  dataLocality: disabled
+  unmapMarkSnapChainRemoved: ignored
+  disableRevisionCounter: "true"
+  dataEngine: v1
+  backupTargetName: default


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The default `longhorn` StorageClass uses `volumeBindingMode: Immediate`, so a PVC binds and its volume is provisioned **before** the pod is scheduled. Stateful pods then get dragged onto whatever node the volume landed on — including autoscaler overflow nodes — where they block scale-down and defeat the restrict-storage-to-baseline-workers intent. It also breaks the cluster-autoscaler’s scale-up simulation.

## What
Adds a `longhorn-wffc` StorageClass (`WaitForFirstConsumer`, identical Longhorn parameters) and makes it the cluster default; demotes the chart’s `longhorn` class to non-default but keeps it. New default-SC PVCs now bind lazily so the scheduler places the pod first and the volume follows.

## Safe rollout — no data loss (this is Phase 1 only)
- **Existing data is untouched.** The `longhorn` class is kept (CNPG clusters and 14 live PVCs reference it by name); only its default annotation moves.
- **Phase 2 (separate, per-DB, not in this PR):** migrate the stranded stateful workloads (umami-db, wedding-db, crossview-postgres, coroot/backstage CNPG) onto `longhorn-wffc` one at a time via CNPG replica-recreation / Longhorn backup→restore, verifying data each time. **Never bulk-delete PVCs — `reclaimPolicy: Delete` destroys the volume.**
- **After promotion, verify:** `longhorn` SC still exists (non-default) and `longhorn-wffc` is the sole default before anything creates new PVCs.

Pairs with the autoscaler scale-down knobs (ksail#5756) and the cx33 removal (#2420) to complete node right-sizing.