### PR TITLE
fix(cnpg): move platform Postgres clusters to the longhorn-wffc StorageClass

### DIFF
--- a/k8s/bases/apps/backstage/cluster.yaml
+++ b/k8s/bases/apps/backstage/cluster.yaml
@@ -34,7 +34,7 @@ spec:
   instances: 2
   storage:
     size: 2Gi
-    storageClass: longhorn
+    storageClass: longhorn-wffc
   # Quorum synchronous replication so a failover never strands the old primary on
   # a diverged timeline (the 2026-06-19 umami/wedding rejoin incident): number: 1
   # acks each commit only once the standby holds the WAL, so the promoted standby

--- a/k8s/bases/apps/backstage/cluster.yaml
+++ b/k8s/bases/apps/backstage/cluster.yaml
@@ -5,7 +5,7 @@
 # POSTGRES_* env (see helm-release.yaml) — the same CNPG-generated-secret pattern
 # coroot-db uses, so there is no OpenBao rotation to keep in sync.
 #
-# longhorn is hardcoded because Backstage is a prod-only app (CNPG + longhorn are
+# longhorn-wffc is hardcoded because Backstage is a prod-only app (CNPG + longhorn are
 # absent from the local/docker overlay), matching umami and the tenants.
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster

--- a/k8s/bases/apps/umami/cluster.yaml
+++ b/k8s/bases/apps/umami/cluster.yaml
@@ -55,7 +55,7 @@ spec:
   enableSuperuserAccess: true
   storage:
     size: 5Gi
-    storageClass: longhorn
+    storageClass: longhorn-wffc
   # Quorum-based SYNCHRONOUS replication so a failover can never strand the old
   # primary. Background: on 2026-06-19 the longhorn instance-manager on a storage
   # worker was replaced; the CNPG primaries pinned to that node lost their RWO

--- a/k8s/bases/apps/umami/cluster.yaml
+++ b/k8s/bases/apps/umami/cluster.yaml
@@ -5,7 +5,7 @@
 # `umami-db-app`, keys: username/password/dbname/host/port/uri). The Umami
 # HelmRelease consumes that Secret via `database.external.existingSecret`.
 #
-# longhorn is hardcoded because Umami is a prod-only app (it is excluded from the
+# longhorn-wffc is hardcoded because Umami is a prod-only app (it is excluded from the
 # local/docker overlay, which has no CNPG operator or longhorn — same as the
 # wedding-app and ascoachingogvaner tenants).
 apiVersion: postgresql.cnpg.io/v1

--- a/k8s/providers/hetzner/infrastructure/coroot/cluster.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cluster.yaml
@@ -89,7 +89,7 @@ spec:
     # ample headroom; the longhorn StorageClass has allowVolumeExpansion=true, so
     # CNPG (1.29) resizes the existing PVCs in place — no recreation needed.
     size: 10Gi
-    storageClass: longhorn
+    storageClass: longhorn-wffc
   postgresql:
     parameters:
       # Bound replication-slot WAL retention so a replica that is down during a

--- a/k8s/providers/hetzner/infrastructure/coroot/cluster.yaml
+++ b/k8s/providers/hetzner/infrastructure/coroot/cluster.yaml
@@ -86,7 +86,7 @@ spec:
     # all three instances ("Not enough disk space"), so the coroot-db Cluster
     # never went Ready and the `infrastructure` Kustomization's health check
     # timed out — wedging infrastructure -> apps platform-wide. 10Gi gives WAL
-    # ample headroom; the longhorn StorageClass has allowVolumeExpansion=true, so
+    # ample headroom; the longhorn-wffc StorageClass has allowVolumeExpansion=true, so
     # CNPG (1.29) resizes the existing PVCs in place — no recreation needed.
     size: 10Gi
     storageClass: longhorn-wffc


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Phase 2 of node right-sizing. The four CNPG databases still hardcode the `Immediate`-binding `longhorn` StorageClass, which strands their replicas on autoscaler overflow nodes (verified: `umami-db-8` is on a cx33 node). `longhorn-wffc` (WaitForFirstConsumer) is now live and default (#2421).

## What
Repoints the three **platform** CNPG clusters — backstage-db, umami-db, coroot-db — to `longhorn-wffc`. This changes only **newly-created** PVCs; every running instance keeps its current volume, so **deploying this is a no-op for live databases**. The actual data move happens operationally, one replica at a time (re-cloned from the primary, primary switched last), per `docs/dr/cnpg-storageclass-migration.md`.

## Operational sequence (must be in this order)
1. **Merge + deploy this PR first** (so recreated instances land on longhorn-wffc, not longhorn).
2. Then I recreate instances per DB with verification gates — starting with umami-db as the pilot; backstage-db gets a fresh backup first (it has none).
3. wedding-db lives in the wedding-app repo — handled separately.

No data loss: the primary is never touched until all its replicas are migrated.