### PR TITLE
fix(kyverno): raise image-verification webhook timeout to 30s

### DIFF
--- a/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kyverno/helm-release.yaml
@@ -87,6 +87,28 @@ spec:
     # so we must set pod-level seccompProfile + runAsNonRoot via chart values.
     admissionController:
       replicas: ${kyverno_admission_replicas:=2}
+      container:
+        # Raise the global webhook timeout from the chart/Kyverno default 10s to
+        # the maximum allowed 30s. The fail-closed image-verification policies
+        # (verify-app-images / verify-ksail-images, both failurePolicy: Fail) do a
+        # keyless cosign verification at Pod admission that reaches ghcr.io + the
+        # Sigstore TUF CDN; a COLD verify (a first-seen image digest, e.g. a fresh
+        # app release) under load can exceed 10s and return
+        # "context deadline exceeded", which — because the webhook is fail-closed —
+        # DENIES a legitimate first-party pod. During a deploy-prod merge_group run
+        # that stalls the `apps` health check and evicts the whole merge queue
+        # (observed 2026-07-04: wedding-app RS FailedCreate x19 over ~4h; #2431).
+        # This is the ONLY working lever in Kyverno v1.18.1: a PER-POLICY
+        # spec.webhookConfiguration.timeoutSeconds is intentionally NOT set on the
+        # IVPOLs because it switches Kyverno to finegrained per-policy webhooks,
+        # which are broken for multiple IVPOLs in v1.18.1 (see the note in
+        # cluster-policies/best-practices/verify-ksail-images.yaml). The image
+        # verification result cache (imageVerifyCacheEnabled, default on, TTL 60m)
+        # already fast-paths REPEAT admissions of an already-verified digest; this
+        # only widens the window for the first COLD verify to complete. Security
+        # posture is unchanged: still fail-closed, just given time to succeed.
+        extraArgs:
+          webhookTimeout: 30
       # Explicit resources = the COLD-START FLOOR. Kyverno's global resourceFilters
       # exclude ns/kyverno from auto-vpa, so the admission controller was long left
       # on the chart-default limits.memory: 384Mi, which OOMKilled (exit 137) under


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

A network/latency blip at Sigstore or the registry should never be able to wedge the entire platform merge queue — but today it can, and right now it **is**. The image-verification policy is a fail-closed 10-second admission webhook; a first-seen app image occasionally takes longer than that to verify, so a legitimate release gets denied (`context deadline exceeded`) and the deploy stalls (seen live on the wedding-app v1.14.1 rollout).

## What

Gives image verification more time to complete (raises the webhook timeout from 10s to the maximum 30s) so a slow-but-valid verification succeeds instead of being denied. Security posture is unchanged — images are still fail-closed and must be signed. This is the only working lever on the current Kyverno version (a per-policy timeout is broken there), and the verification cache already fast-paths repeat checks.

## Operational note — promoting this unwedges the queue now

The merge queue is currently stuck on this exact timeout: the wedding-app v1.14.1 rollout can’t admit its new pod, so every `deploy-prod` health check fails and PRs (#2427, #2430) keep getting evicted. Those PRs can’t fix it because they don’t change the timeout. **This one does**: its deploy reconciles the Kyverno change (infrastructure) before the apps health check, so the raised timeout is live in time for wedding-app to admit — it merges where the others can’t. The old wedding-app pod is still serving, so there is no user-facing outage; only the rollout and the queue are blocked.

Fixes #2431