### PR TITLE
fix(dex): source GitHub OAuth client secret from a Secret, not plaintext env

### DIFF
--- a/k8s/bases/infrastructure/controllers/dex/external-secret.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/external-secret.yaml
@@ -1,0 +1,33 @@
+# dex-github-connector: the GitHub OAuth App client secret for Dex's `github`
+# connector, materialized from OpenBao by External Secrets and consumed by the
+# HelmRelease through a secretKeyRef env var (CLIENT_SECRET) instead of a
+# plaintext env value. Keeping the secret out of the Deployment PodSpec is what
+# clears Kubescape C-0012 (Applications credentials in configuration files) for
+# the dex workload: a plaintext `value:` is readable by anyone with get/pods or
+# get/deployments in this namespace and is stored unencrypted in the object.
+#
+# Source: infrastructure/oidc/github (property client-secret) — seeded into
+# OpenBao from the SOPS bootstrap secret (variables-cluster) by the
+# seed-github-app PushSecret (infrastructure/vault-seed/push-secrets.yaml), i.e.
+# the same value Flux previously substituted as ${github_app_client_secret}.
+# Read through the shared `external-secrets` ClusterSecretStore role, which
+# already bundles infra-oidc-readonly (secret/data/infrastructure/oidc/*) — see
+# infrastructure/vault-config/job.yaml — so no policy change is needed.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dex-github-connector
+  namespace: dex
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+  target:
+    name: dex-github-connector
+    creationPolicy: Owner
+  data:
+    - secretKey: client-secret
+      remoteRef:
+        key: infrastructure/oidc/github
+        property: client-secret

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -92,9 +92,19 @@ spec:
                     value: max-age=63072000; includeSubDomains; preload
     envVars:
       - name: CLIENT_ID
+        # Public GitHub App identifier, not a credential — safe as a plain value.
         value: ${github_app_client_id}
       - name: CLIENT_SECRET
-        value: ${github_app_client_secret}
+        # Sourced from a Secret rather than a plaintext env value so the real
+        # GitHub OAuth client secret never lands in the Deployment PodSpec
+        # (readable by anyone with get pods/deployments here, stored unencrypted
+        # in the object). Materialized from OpenBao by external-secret.yaml.
+        # Removing the former `value: ${github_app_client_secret}` is what clears
+        # Kubescape C-0012 for the dex workload.
+        valueFrom:
+          secretKeyRef:
+            name: dex-github-connector
+            key: client-secret
     config:
       issuer: https://dex.${domain}
       oauth2:

--- a/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/helm-release.yaml
@@ -144,7 +144,8 @@ spec:
             clientID: $CLIENT_ID
             clientSecret: $CLIENT_SECRET
             redirectURI: https://dex.${domain}/callback
-            # CLIENT_ID/CLIENT_SECRET come from envVars (Flux substitution).
+            # CLIENT_ID comes from envVars (Flux substitution); CLIENT_SECRET is
+            # injected into env via a secretKeyRef (see external-secret.yaml).
             # Dex resolves $VAR references from process env at runtime.
             teamNameField: slug
             useLoginAsID: false

--- a/k8s/bases/infrastructure/controllers/dex/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - namespace.yaml
   - helm-release.yaml
   - helm-repository.yaml
+  - external-secret.yaml
   - cilium-network-policy.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Dex's GitHub login secret was sitting in **plain text inside the running Dex Deployment**, where anyone who can read workloads in that namespace could see it (and it's stored unencrypted in the object). A cluster security scan (Kubescape **C-0012**) flags it as a real credential exposure. Of the six resources the scan lists, this is the **only genuine one** — the other five (velero node-agent/velero, crossplane, the flux-system and crossview ConfigMaps) are non-secret values that merely match credential-shaped names.

## What
Dex now reads that secret from the platform secret store (OpenBao) instead of carrying it in its own config, so the credential no longer appears in the Deployment. **No behaviour change for users** — Dex logs in exactly as before.

**Operational note:** the secret has been living in the cluster in plain text, so it's worth **rotating it in GitHub** once this merges.