### PR TITLE
fix(kubescape): except GitOps-managed CronJobs from C-0026 posture control

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/gitops-managed-cronjobs.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/gitops-managed-cronjobs.yaml
@@ -1,0 +1,66 @@
+---
+# Kubescape control C-0026 "Kubernetes CronJob" is a MANUAL-APPROVAL control: it
+# lists every CronJob in the cluster so an operator can confirm each is legitimate
+# (remediation: "Watch Kubernetes CronJobs and make sure they are legitimate"). It
+# has no hardening remedy — a CronJob cannot be configured to "pass" it — so the
+# only way to clear a reviewed, legitimate CronJob from the posture dashboard is a
+# ClusterSecurityException.
+#
+# Every CronJob on this cluster is declared in this GitOps repo (or an upstream
+# Helm chart it deploys) and reaches the cluster only through Flux after pull-request
+# review — so the PR review IS the C-0026 "approve" step. The current CronJobs and
+# why each is legitimate:
+#   * kube-system/hubble-generate-certs           — Cilium Hubble mTLS cert rotation (Cilium chart)
+#   * kubescape/kubescape-scheduler               — Kubescape posture-scan scheduler (Kubescape chart)
+#   * kubescape/kubevuln-scheduler                — Kubescape image-vuln-scan scheduler (Kubescape chart)
+#   * longhorn-system/longhorn-stale-node-cleanup — prunes stale Longhorn node objects for gone
+#                                                   autoscaled nodes (platform)
+#   * observability/cluster-heartbeat             — external-uptime heartbeat ping (platform)
+#   * observability/coroot-alert-autosuppressor   — re-asserts by-design Coroot alert suppressions (platform)
+#   * observability/coroot-custom-cloud-pricing   — applies Hetzner per-unit pricing to Coroot (platform)
+#   * openbao/vault-snapshot                      — OpenBao raft-snapshot backup (platform)
+#   * umami/umami-provision-tenants               — provisions Umami tenant websites (platform)
+# The fleetdm namespace is pre-listed too: the app is disabled on prod today (its
+# namespace does not exist), but its Helm chart ships a `fleet-vulnprocessing`
+# CronJob, so listing it now means re-enabling fleetdm won't silently re-trip
+# C-0026 — same convention the sibling service-account-tokens.yaml uses for it.
+#
+# SCOPE — deliberately namespace-scoped, NOT cluster-wide. C-0026 is a "watch for
+# unexpected CronJobs" control, so it is exempted ONLY in the platform-infrastructure
+# namespaces that legitimately run CronJobs today. A CronJob appearing in any OTHER
+# namespace (an app / tenant namespace, or somewhere it has no business being) still
+# fails C-0026 and surfaces on the dashboard for review — the watch signal is
+# preserved. Add a namespace here only when it legitimately gains a GitOps-managed
+# CronJob (same accepted pattern as service-account-tokens.yaml).
+apiVersion: kubescape.io/v1beta1
+kind: ClusterSecurityException
+metadata:
+  name: gitops-managed-cronjobs
+spec:
+  reason: >-
+    C-0026 lists every CronJob for manual approval and has no hardening remedy.
+    All CronJobs on this cluster are GitOps-managed platform components delivered
+    by Flux after PR review (the review is the approval): Cilium Hubble cert
+    rotation, the Kubescape scan schedulers, Longhorn stale-node cleanup, the
+    observability heartbeat / Coroot alert-autosuppressor / Coroot cloud-pricing
+    jobs, the OpenBao raft-snapshot backup, and Umami tenant provisioning.
+    Namespace-scoped to the infrastructure namespaces that run these, so a CronJob
+    in any unexpected namespace still surfaces for review.
+  posture:
+    - controlID: C-0026
+      action: ignore
+  match:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - kube-system
+            - kubescape
+            - longhorn-system
+            - observability
+            - openbao
+            - umami
+            # Disabled on prod today, but its chart ships a fleet-vulnprocessing
+            # CronJob — pre-listed so re-enabling fleetdm won't re-trip C-0026.
+            - fleetdm

--- a/k8s/bases/infrastructure/cluster-security-exceptions/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - admission-controllers.yaml
   - cilium-network-policies.yaml
   - controller-rbac.yaml
+  - gitops-managed-cronjobs.yaml
   - health-probes.yaml
   - helm-chart-metadata.yaml
   - image-verification.yaml

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -204,6 +204,27 @@ data:
         ]
       },
       {
+        "name": "gitops-managed-cronjobs",
+        "policyType": "postureExceptionPolicy",
+        "actions": [
+          "alertOnly"
+        ],
+        "reason": "C-0026 lists every CronJob for manual approval and has no hardening remedy; all CronJobs are GitOps-managed platform components delivered by Flux after PR review (the review is the approval). Namespace-scoped so a CronJob in any unexpected namespace still surfaces for review. fleetdm is pre-listed (disabled on prod, but its chart ships a fleet-vulnprocessing CronJob).",
+        "resources": [
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "namespace": "^(kube-system|kubescape|longhorn-system|observability|openbao|umami|fleetdm)$"
+            }
+          }
+        ],
+        "posturePolicies": [
+          {
+            "controlID": "^C-0026$"
+          }
+        ]
+      },
+      {
         "name": "admission-controllers",
         "policyType": "postureExceptionPolicy",
         "actions": [


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The Kubescape posture dashboard flags **C-0026 "Kubernetes CronJob"** as failing for every CronJob in the cluster (the screenshot showed `coroot-custom-cloud-pricing`). C-0026 is a manual-approval control that simply lists CronJobs for an operator to confirm each is legitimate — it has no hardening fix. Every CronJob here is a GitOps-managed platform component delivered by Flux after PR review, so the finding is dashboard noise that hides real signal.

## What

Adds a namespace-scoped Kubescape `ClusterSecurityException` that clears C-0026 for the infrastructure namespaces that legitimately run CronJobs (covering all 9 current CronJobs), and mirrors it into the Headlamp dashboard ConfigMap. Scoped by namespace — not cluster-wide — so a CronJob appearing in an unexpected namespace still surfaces for review.

## Notes

- This cleans the in-cluster Kubescape / Headlamp posture dashboard (the surface that flagged it). It does **not** move the CI NSA compliance score — C-0026 is not an NSA-framework control.
- If the `validate` check goes red, it is the known, unrelated `external-secrets` render flake (ksail#5371), not this change — re-run it.
