### PR TITLE
fix(velero): run the velero server as non-root

### DIFF
--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -45,9 +45,57 @@ spec:
         # Safe to bump again once a release ships one of those PRs.
         image: velero/velero-plugin-for-aws:v1.14.2
         imagePullPolicy: IfNotPresent
+        # Non-root hardening for the plugin-copy initContainer (Kubescape
+        # C-0013). It only copies the AWS plugin binary into the shared
+        # `plugins` emptyDir, so it needs neither root nor a writable root FS —
+        # readOnlyRootFilesystem is safe here (unlike the main server below).
+        # UID 65532 matches this image's baked nonroot user.
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
           - mountPath: /target
             name: plugins
+
+    # Non-root securityContext for the velero SERVER (Kubescape C-0013 non-root
+    # containers, plus C-0016 no-privilege-escalation and C-0055 drop-ALL).
+    # The velero namespace is excluded from the cluster-wide
+    # add-security-context Kyverno mutation (its node-agent DaemonSet needs
+    # host access), so the server Deployment must declare its own — pod- and
+    # container-level runAsNonRoot + runAsUser:65532 is exactly what C-0013
+    # inspects on the rendered Deployment template.
+    #
+    # readOnlyRootFilesystem is deliberately LEFT FALSE on the server: velero
+    # writes to the ROOT filesystem at /tmp — /tmp/credentials/<ns>, /tmp/udmrepo
+    # (Kopia config when $HOME is unset) and the go-plugin unix socket — and the
+    # chart mounts no emptyDir at /tmp, so a read-only root would break every
+    # backup. C-0017 stays covered by the velero infrastructure-privileged /
+    # pod-security-mutations ClusterSecurityException. (The plugin-copy
+    # initContainer above CAN use readOnlyRootFilesystem:true.)
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      fsGroup: 65532
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
 
     # Mount our SOPS-derived R2 credentials secret instead of the chart's
     # generated one. The chart only consults it; it never writes to it.


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The Kubescape dashboard flags the velero **server** as running as root (control C-0013, non-root containers). It's a backup controller with no need for root — it was left unhardened only because the velero namespace is excluded from the cluster-wide securityContext mutation (that exclusion exists for velero's privileged node-agent, not the server).

## What

Runs the velero server and its plugin-copy init container as a non-root user via the chart securityContext values, so the Deployment passes C-0013 for real. The privileged node-agent DaemonSet is untouched and stays covered by its existing exception. Backups are unaffected — read-only-root-filesystem is intentionally left off the server (it writes to /tmp), so no backup path changes.

Part of #2435