### PR TITLE
fix(cilium): run the cilium-operator as non-root

### DIFF
--- a/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/cilium/helm-release.yaml
@@ -109,6 +109,36 @@ spec:
       replicas: ${cilium_replicas:=2}
       # Restart on cilium-config changes (same rationale as rollOutCiliumPods).
       rollOutPods: true
+      # Non-root securityContext for the cilium-OPERATOR only (Kubescape
+      # C-0013). The operator-generic image ships no USER, so it runs as root
+      # by default; but it is a pure control-plane controller (reads a
+      # read-only config-map and the read-only SPIRE agent socket, no host FS,
+      # binds only high ports), so it runs fine as non-root. This ONLY touches
+      # the cilium-operator Deployment — the agent, envoy, hubble, clustermesh
+      # and spire securityContexts (privileged by design) are untouched.
+      #
+      # NOTE: the chart's `cilium.operator.securityContext` helper REPLACES the
+      # container securityContext wholesale (it is not a deep-merge), so the
+      # chart-default `capabilities.drop: [ALL]` and
+      # `allowPrivilegeEscalation: false` must be re-stated here or they are
+      # lost. readOnlyRootFilesystem is intentionally omitted (unverified for
+      # the distroless operator image; an operator crash-loop would degrade the
+      # CNI control plane and the SPIRE identity resync that gates pod-to-pod
+      # mTLS in this cluster).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      podSecurityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       # memory 256Mi -> 128Mi: live prod usage is 36-77Mi across both
       # replicas (2026-06-03). 128Mi keeps the operator in Burstable QoS
       # (request > 0 -- the BestEffort escape that matters) with ~1.7x


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The Kubescape dashboard flags the cilium-operator as running as root (control C-0013, non-root containers). It's a control-plane controller with no host access and no need for root — its image just ships no USER, so it defaults to root.

## What

Runs the **cilium-operator only** as a non-root user via the chart's operator securityContext values, so it passes C-0013. The cilium agent, envoy, hubble, clustermesh and spire (privileged by design) are untouched.

**Promote with care:** this is on the pinned pre-release CNI chart (1.20.0-pre.3), and an operator crash-loop would degrade the CNI control plane and SPIRE mTLS resync. `readOnlyRootFilesystem` was intentionally left off (unverified for the distroless operator image). Worth a live check that the operator pods come up healthy after rollout.

Part of #2435