### PR TITLE
fix(kubescape): remount scanner config.json so offline posture scans persist

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -142,3 +142,35 @@ spec:
         limits:
           cpu: 500m
           memory: 1Gi
+  # Offline-mode chart bug (kubescape-operator 1.40.2): the scanner Deployment
+  # mounts the empty `kubescape-volume` emptyDir onto the FILE path
+  # /home/nonroot/.kubescape/config.json (subPath config.json). When the target
+  # does not exist kubelet MATERIALISES it as a DIRECTORY, so ksserver's
+  # config-write (GenerateAccountID) fails with `open .../config.json: is a
+  # directory`; the scan aborts at finalize ("scanning failed"), the aggregate
+  # ConfigurationScanSummary is never written, and NO posture
+  # (Cluster)SecurityException is ever applied — so every by-design exception
+  # (e.g. C-0007) renders as failed and the compliance dashboard freezes.
+  # Strictly offline-specific: with kubescapeOffline disabled the chart mounts
+  # the volume at the parent DIR, so only the config.json FILE is created.
+  # Upstream fix kubescape/helm-charts#862 (issue #857) remounts at the parent
+  # dir; it is merged to main (2026-06-24) but NOT in any released chart (latest
+  # is 1.40.2), so reproduce it here via post-render until a chart release ships
+  # it — then bump spec.chart.spec.version and DELETE this postRenderer. The
+  # `test` op pins the assumption (kubescape-volume is volumeMounts[1] on chart
+  # 1.40.2, verified against the live Deployment) so a future mount-order change
+  # fails the reconcile loudly instead of silently remounting the wrong volume.
+  # Offline mode and submit=false are untouched — no cloud egress is re-enabled.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kubescape
+            patch: |
+              - op: test
+                path: /spec/template/spec/containers/0/volumeMounts/1/mountPath
+                value: /home/nonroot/.kubescape/config.json
+              - op: replace
+                path: /spec/template/spec/containers/0/volumeMounts/1/mountPath
+                value: /home/nonroot/.kubescape


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The in-cluster Kubescape compliance dashboard (Headlamp) is **frozen** — it serves stale data from 2026-06-27 and shows controls like **C-0007 "Roles with delete capabilities" as 0 of 26 passed**. Root cause: an offline-mode bug in the kubescape chart mounts the scanner's config *file* as a directory, so **every scan aborts before it finishes** — no fresh results are stored and none of the platform's by-design posture exceptions are ever applied (aggregate compliance reads 0.00 on every framework).

## What

Reproduces the merged upstream fix ([kubescape/helm-charts#862](https://github.com/kubescape/helm-charts/pull/862), issue [#857](https://github.com/kubescape/helm-charts/issues/857)) with a Flux post-render that remounts the config volume correctly, so scans finalize again, the dashboard refreshes, and the exception CRs already shipped in #2316 finally take effect. Offline/air-gapped mode is untouched — **no cloud submit is re-enabled**. Revert this once the chart ships a release containing the upstream fix.

**Note:** this unblocks the whole dashboard but does not on its own make C-0007 pass — that control's exception needs a separate match-type fix (follow-up PR). After promotion Flux reconciles the HelmRelease; a fresh scan should then persist and the score reappear. Related: #2264.