### PR TITLE
fix(security): make C-0002 exec-into-container exception effective for infra controllers

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/controller-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/controller-rbac.yaml
@@ -31,19 +31,18 @@ spec:
       action: ignore
     - controlID: C-0031
       action: ignore
-    - controlID: C-0002
-      action: ignore
     - controlID: C-0063
       action: ignore
     - controlID: C-0035
       action: ignore
-    # NOTE: C-0187 (wildcard RBAC, CIS-5.1.3) is handled in wildcard-rbac.yaml,
-    # not here — a namespaceSelector exception does not suppress RBAC findings
-    # (Kubescape keys them on the Role/ClusterRole/binding object, so a namespace
-    # match never applies; proven: the namespaced velero-server Role kept failing
-    # despite `velero` being listed below). Headlamp is fixed at the root (SA
-    # scoped to read-only cluster-reader); Flux and Velero are exempted by-design
-    # in wildcard-rbac.yaml via an explicit kind+name resources match.
+    # NOTE: RBAC-review controls are NOT suppressible here. Kubescape anchors
+    # their findings on the RBAC Role/ClusterRole/binding object, not on a
+    # namespaced workload, so a namespaceSelector match never applies (proven:
+    # the namespaced velero-server binding kept failing despite `velero` being
+    # listed below). They are handled by explicit kind+name `match.resources` CRs:
+    #   - C-0187 (wildcard RBAC, CIS-5.1.3) → wildcard-rbac.yaml
+    #   - C-0002 (exec into container)      → exec-into-container-rbac.yaml
+    # Headlamp is fixed at the root (SA scoped to read-only cluster-reader).
     - controlID: C-0188
       action: ignore
   match:

--- a/k8s/bases/infrastructure/cluster-security-exceptions/exec-into-container-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/exec-into-container-rbac.yaml
@@ -21,13 +21,14 @@
 # avoids.
 #
 # Covered (each genuinely requires pods/exec and cannot be scoped away):
-#   - Velero — namespaced velero-server Role (all-or-nothing chart RBAC) plus its
-#     cluster-admin ClusterRoleBinding; restore must exec/patch arbitrary kinds.
+#   - Velero — namespaced velero-server RoleBinding/Role (all-or-nothing chart
+#     RBAC) plus its cluster-admin ClusterRoleBinding; restore must exec/patch
+#     arbitrary kinds.
 #   - CloudNativePG — its ClusterRole explicitly grants `create pods/exec` to
 #     manage/inspect Postgres instances.
-#   - Flux — helm-controller (via cluster-reconciler-flux-system) and flux-operator
-#     hold cluster-admin; arbitrary-manifest reconciliation is the GitOps trust
-#     model.
+#   - Flux — kustomize-controller and helm-controller (both bound via
+#     cluster-reconciler-flux-system) and flux-operator hold cluster-admin;
+#     arbitrary-manifest reconciliation is the GitOps trust model.
 #
 # NOT covered (intentionally): the two tenant Flux-impersonation SAs
 # (wedding-app, ascoachingogvaner) inherit pods/exec only via the built-in `edit`
@@ -41,8 +42,9 @@ spec:
   reason: >-
     Velero (all-or-nothing backup/restore RBAC + cluster-admin), CloudNativePG
     (operator execs into Postgres pods — explicit pods/exec grant), and the Flux
-    GitOps reconcilers helm-controller and flux-operator (cluster-admin trust
-    model) legitimately hold pods/exec by design. The specific RBAC bindings are
+    GitOps reconcilers kustomize-controller, helm-controller (both via the
+    cluster-reconciler-flux-system binding), and flux-operator (cluster-admin
+    trust model) legitimately hold pods/exec by design. The specific RBAC bindings are
     matched by kind+name so C-0002 still catches any new exec grant.
   posture:
     - controlID: C-0002
@@ -63,7 +65,7 @@ spec:
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
         name: cloudnative-pg
-      # Flux helm-controller — cluster-admin via cluster-reconciler CRB
+      # Flux kustomize-/helm-controller — cluster-admin via cluster-reconciler CRB
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
         name: cluster-reconciler-flux-system

--- a/k8s/bases/infrastructure/cluster-security-exceptions/exec-into-container-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/exec-into-container-rbac.yaml
@@ -1,0 +1,73 @@
+---
+# Exec-into-container exception (Kubescape C-0002, "Prevent containers from
+# allowing command execution") for the infrastructure controllers that
+# legitimately hold `pods/exec` BY DESIGN.
+#
+# Why this is a kind+name `match.resources` CR and NOT a `namespaceSelector`
+# entry in controller-rbac.yaml: C-0002 is an RBAC-review control — Kubescape
+# anchors the finding on the RBAC *binding* object (the WorkloadConfigurationScan
+# is stored under the RoleBinding/ClusterRoleBinding WLID, kind `ServiceAccount`
+# is only the reported subject), NOT on a namespaced workload. A namespaceSelector
+# therefore never applies (identical to C-0187 — see wildcard-rbac.yaml — where
+# the namespaced velero-server binding kept failing despite `velero` being listed
+# in controller-rbac.yaml's selector). Matching the specific binding objects by
+# kind+name is the mechanism that actually suppresses these findings.
+#
+# Deliberately MINIMAL scope — the bindings are matched individually so C-0002
+# still flags any *new*/accidental exec grant elsewhere. The shared roles
+# (`cluster-admin`, `crd-controller-flux-system`, built-in `edit`) are NOT
+# matched by name: doing so would blanket-except C-0002 for every subject bound
+# to them (including future grants), the exact over-suppression this scoping
+# avoids.
+#
+# Covered (each genuinely requires pods/exec and cannot be scoped away):
+#   - Velero — namespaced velero-server Role (all-or-nothing chart RBAC) plus its
+#     cluster-admin ClusterRoleBinding; restore must exec/patch arbitrary kinds.
+#   - CloudNativePG — its ClusterRole explicitly grants `create pods/exec` to
+#     manage/inspect Postgres instances.
+#   - Flux — helm-controller (via cluster-reconciler-flux-system) and flux-operator
+#     hold cluster-admin; arbitrary-manifest reconciliation is the GitOps trust
+#     model.
+#
+# NOT covered (intentionally): the two tenant Flux-impersonation SAs
+# (wedding-app, ascoachingogvaner) inherit pods/exec only via the built-in `edit`
+# ClusterRole. That is a fixable over-grant, not a by-design need — it is removed
+# at the ROOT by scoping the tenant reconciler role, not suppressed here.
+apiVersion: kubescape.io/v1beta1
+kind: ClusterSecurityException
+metadata:
+  name: exec-into-container-rbac
+spec:
+  reason: >-
+    Velero (all-or-nothing backup/restore RBAC + cluster-admin), CloudNativePG
+    (operator execs into Postgres pods — explicit pods/exec grant), and the Flux
+    GitOps reconcilers helm-controller and flux-operator (cluster-admin trust
+    model) legitimately hold pods/exec by design. The specific RBAC bindings are
+    matched by kind+name so C-0002 still catches any new exec grant.
+  posture:
+    - controlID: C-0002
+      action: ignore
+  match:
+    resources:
+      # Velero — namespaced binding + Role, and the cluster-admin CRB
+      - apiGroup: rbac.authorization.k8s.io
+        kind: RoleBinding
+        name: velero-server
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: velero-server
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: velero-server
+      # CloudNativePG — CRB whose ClusterRole explicitly grants pods/exec
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: cloudnative-pg
+      # Flux helm-controller — cluster-admin via cluster-reconciler CRB
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: cluster-reconciler-flux-system
+      # Flux operator — cluster-admin CRB
+      - apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRoleBinding
+        name: flux-operator

--- a/k8s/bases/infrastructure/cluster-security-exceptions/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - admission-controllers.yaml
   - cilium-network-policies.yaml
   - controller-rbac.yaml
+  - exec-into-container-rbac.yaml
   - health-probes.yaml
   - helm-chart-metadata.yaml
   - image-verification.yaml

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -95,7 +95,7 @@ data:
         "actions": [
           "alertOnly"
         ],
-        "reason": "Infra controllers (Velero, CloudNativePG, Flux helm-controller and flux-operator) legitimately hold pods/exec by design; matched by kind+name on the RBAC binding so C-0002 still catches new exec grants. Tenant SAs are scoped at the root instead, not excepted here.",
+        "reason": "Infra controllers (Velero, CloudNativePG, Flux kustomize-/helm-controller and flux-operator) legitimately hold pods/exec by design; matched by kind+name on the RBAC binding so C-0002 still catches new exec grants. Tenant SAs are scoped at the root instead, not excepted here.",
         "resources": [
           {
             "designatorType": "Attributes",

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -79,9 +79,6 @@ data:
             "controlID": "^C-0031$"
           },
           {
-            "controlID": "^C-0002$"
-          },
-          {
             "controlID": "^C-0063$"
           },
           {
@@ -89,6 +86,63 @@ data:
           },
           {
             "controlID": "^C-0188$"
+          }
+        ]
+      },
+      {
+        "name": "exec-into-container-rbac",
+        "policyType": "postureExceptionPolicy",
+        "actions": [
+          "alertOnly"
+        ],
+        "reason": "Infra controllers (Velero, CloudNativePG, Flux helm-controller and flux-operator) legitimately hold pods/exec by design; matched by kind+name on the RBAC binding so C-0002 still catches new exec grants. Tenant SAs are scoped at the root instead, not excepted here.",
+        "resources": [
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^RoleBinding$",
+              "name": "^velero-server$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^Role$",
+              "name": "^velero-server$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^ClusterRoleBinding$",
+              "name": "^velero-server$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^ClusterRoleBinding$",
+              "name": "^cloudnative-pg$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^ClusterRoleBinding$",
+              "name": "^cluster-reconciler-flux-system$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^ClusterRoleBinding$",
+              "name": "^flux-operator$"
+            }
+          }
+        ],
+        "posturePolicies": [
+          {
+            "controlID": "^C-0002$"
           }
         ]
       },


### PR DESCRIPTION
## Why

The Kubescape compliance dashboard reports **C-0002 (Prevent containers from allowing command execution)** as failing for Velero, CloudNativePG, and the Flux reconcilers — even though these controllers are already listed in our RBAC exception. The exception silently does nothing: C-0002 is an RBAC-review control whose findings are anchored on the RBAC *binding* object, and our entry lived under a `namespaceSelector`, which Kubescape never applies to that class of finding (the same limitation we already worked around for C-0187). So legitimate, by-design `pods/exec` holders keep showing as violations, adding noise to the security posture.

## What

Moves C-0002 to a dedicated exception that matches the specific RBAC bindings by kind+name — the mechanism already proven to work for C-0187 — and mirrors it into the Headlamp dashboard's exception ConfigMap. Scope stays minimal (individual bindings, not shared roles like `cluster-admin`/`edit`), so C-0002 still catches any *new* exec grant. Removes the inert C-0002 entry from the namespaceSelector exception so the config no longer implies a suppression that isn't happening.

The two tenant service accounts (wedding-app, ascoachingogvaner) also surface in C-0002; they're a fixable over-grant rather than a by-design need and are handled at the root in a **separate PR** (scoping their Flux-impersonation role), not excepted here.

Scoped to Velero + CNPG + Flux. Kubescape's live posture pipeline is currently degenerate (separate issue), so the match can't be verified in-cluster pre-merge — confidence is inherited from the identical, working C-0187 exception on the same binding objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)