### PR TITLE
fix(security): scope tenant Flux-impersonation role to drop pods/exec (C-0002)

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/role-binding-ascoachingogvaner.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/role-binding-ascoachingogvaner.yaml
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: edit
+  name: tenant-edit
 subjects:
 - kind: ServiceAccount
   name: ascoachingogvaner

--- a/k8s/bases/apps/wedding-app/role-binding.yaml
+++ b/k8s/bases/apps/wedding-app/role-binding.yaml
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: edit
+  name: tenant-edit
 subjects:
 - kind: ServiceAccount
   name: wedding-app

--- a/k8s/bases/infrastructure/cluster-roles/cert-manager-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/cert-manager-tenant-edit.yaml
@@ -10,7 +10,12 @@
 # gets cert-manager from the chart's own aggregated role).
 #
 # Namespaced Issuer + Certificate only — never the cluster-scoped ClusterIssuer,
-# which remains platform territory.
+# which remains platform territory. CertificateRequests are read-only: cert-manager's
+# controller mints them from a tenant's Certificate under its own identity, so a
+# tenant never creates them directly — read access covers issuance debugging.
+# NOTE: RBAC alone cannot stop a tenant Certificate from *referencing* a
+# ClusterIssuer via `spec.issuerRef.kind` — that boundary needs admission
+# enforcement, tracked separately.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -21,7 +26,6 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources:
       - certificates
-      - certificaterequests
       - issuers
     verbs:
       - get
@@ -31,3 +35,10 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificaterequests
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/bases/infrastructure/cluster-roles/cert-manager-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/cert-manager-tenant-edit.yaml
@@ -1,0 +1,33 @@
+# Aggregate ClusterRole that extends the tenant role (`tenant-edit`) with
+# cert-manager verbs, so a tenant that manages its own certificates (e.g.
+# ascoachingogvaner issues a cert for its simply.com domain via a namespaced
+# Issuer + Certificate) can own them from its deploy artifact.
+#
+# The built-in `edit` grants these already (cert-manager's chart ships an
+# `aggregate-to-edit` ClusterRole), so this piece exists to preserve that
+# capability now that tenants bind to the scoped `tenant-edit` instead of `edit`.
+# It is labelled ONLY `devantler.tech/aggregate-to-tenant-edit` (edit already
+# gets cert-manager from the chart's own aggregated role).
+#
+# Namespaced Issuer + Certificate only — never the cluster-scoped ClusterIssuer,
+# which remains platform territory.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-tenant-edit
+  labels:
+    devantler.tech/aggregate-to-tenant-edit: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificates
+      - certificaterequests
+      - issuers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/k8s/bases/infrastructure/cluster-roles/cilium-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/cilium-tenant-edit.yaml
@@ -21,6 +21,7 @@ metadata:
   name: cilium-tenant-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    devantler.tech/aggregate-to-tenant-edit: "true"
 rules:
   - apiGroups: ["cilium.io"]
     resources:

--- a/k8s/bases/infrastructure/cluster-roles/cnpg-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/cnpg-tenant-edit.yaml
@@ -1,6 +1,7 @@
-# Aggregate ClusterRole that extends the built-in 'edit' ClusterRole with
-# CNPG tenant verbs so any ServiceAccount bound to 'edit' (e.g. wedding-app)
-# can create and manage CloudNativePG Cluster resources in its namespace.
+# Aggregate ClusterRole that extends the tenant role (`tenant-edit`, and the
+# built-in `edit`) with CNPG tenant verbs so a tenant ServiceAccount (e.g.
+# wedding-app) can create and manage CloudNativePG Cluster resources in its
+# namespace.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -8,6 +9,7 @@ metadata:
   name: cnpg-tenant-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    devantler.tech/aggregate-to-tenant-edit: "true"
 rules:
   - apiGroups: ["postgresql.cnpg.io"]
     resources:

--- a/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/external-secrets-tenant-edit.yaml
@@ -22,6 +22,7 @@ metadata:
   name: external-secrets-tenant-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    devantler.tech/aggregate-to-tenant-edit: "true"
 rules:
   - apiGroups: ["external-secrets.io"]
     resources:

--- a/k8s/bases/infrastructure/cluster-roles/gateway-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/gateway-tenant-edit.yaml
@@ -1,6 +1,6 @@
-# Aggregate ClusterRole that extends the built-in 'edit' ClusterRole with
-# Gateway API verbs so any ServiceAccount bound to 'edit' can manage
-# HTTPRoute resources in its namespace.
+# Aggregate ClusterRole that extends the tenant role (`tenant-edit`, and the
+# built-in `edit`) with Gateway API verbs so a tenant ServiceAccount can manage
+# HTTPRoute / ReferenceGrant resources in its namespace.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -8,6 +8,7 @@ metadata:
   name: gateway-tenant-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    devantler.tech/aggregate-to-tenant-edit: "true"
 rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources:

--- a/k8s/bases/infrastructure/cluster-roles/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/kustomization.yaml
@@ -3,9 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster-reader.yaml
+  - cert-manager-tenant-edit.yaml
   - cilium-tenant-edit.yaml
   - cnpg-tenant-edit.yaml
   - external-secrets-tenant-edit.yaml
   - gateway-tenant-edit.yaml
+  - tenant-base-edit.yaml
+  - tenant-edit.yaml
   - tenant-external-dns.yaml
   - tenant-external-dns-global.yaml

--- a/k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
@@ -1,0 +1,125 @@
+# Core namespaced-admin capability for tenants — the equivalent of the built-in
+# `edit` ClusterRole's core-Kubernetes rules, MINUS the exec-family pod
+# subresources (`pods/exec`, `pods/attach`, `pods/portforward`, `pods/proxy`).
+#
+# Aggregated into `tenant-edit` via the `devantler.tech/aggregate-to-tenant-edit`
+# label. A tenant's Flux reconciliation identity manages its own workloads,
+# config, secrets and networking with this role; it never needs to exec into a
+# pod, so those subresources are omitted — that is what clears Kubescape C-0002
+# at the root for tenants.
+#
+# Deliberately excludes, versus built-in `edit`: the exec-family subresources
+# above; `serviceaccounts` impersonation and `*/proxy` (privilege-escalation
+# surface a manifest-reconciler does not need); and the operator-CRD rules `edit`
+# dynamically aggregates (KubeVirt, CDI, cert-manager, Flux, Kyverno, …) — tenant
+# CRD access is granted explicitly via the sibling `*-tenant-edit` pieces.
+#
+# On a major Kubernetes upgrade, re-check this against `kubectl get clusterrole
+# edit` and add any new CORE (non-operator, non-exec) resources a tenant may
+# legitimately manage.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-base-edit
+  labels:
+    devantler.tech/aggregate-to-tenant-edit: "true"
+rules:
+  # Core resources — create/manage (NO pods/exec, pods/attach, pods/portforward,
+  # pods/proxy, services/proxy, or serviceaccounts impersonation).
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - persistentvolumeclaims
+      - pods
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - secrets
+      - serviceaccounts
+      - services
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  # Core resources — read (incl. pod logs/status for debugging).
+  - apiGroups: [""]
+    resources:
+      - bindings
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - pods
+      - pods/log
+      - pods/status
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+      - secrets
+      - serviceaccounts
+      - services
+      - services/status
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  # Workloads.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/scale
+      - replicasets
+      - replicasets/scale
+      - statefulsets
+      - statefulsets/scale
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources:
+      - controllerrevisions
+      - daemonsets
+      - daemonsets/status
+      - deployments
+      - deployments/scale
+      - deployments/status
+      - replicasets
+      - replicasets/scale
+      - replicasets/status
+      - statefulsets
+      - statefulsets/scale
+      - statefulsets/status
+    verbs: ["get", "list", "watch"]
+  # Autoscaling.
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers", "horizontalpodautoscalers/status"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update", "get", "list", "watch"]
+  # Batch.
+  - apiGroups: ["batch"]
+    resources: ["cronjobs", "cronjobs/status", "jobs", "jobs/status"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update", "get", "list", "watch"]
+  # Disruption budgets.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets", "poddisruptionbudgets/status"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update", "get", "list", "watch"]
+  # Networking.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "ingresses/status", "networkpolicies"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update", "get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  # Leader-election / coordination for tenant workloads.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  # Events.
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "patch"]

--- a/k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/tenant-base-edit.yaml
@@ -9,8 +9,9 @@
 # at the root for tenants.
 #
 # Deliberately excludes, versus built-in `edit`: the exec-family subresources
-# above; `serviceaccounts` impersonation and `*/proxy` (privilege-escalation
-# surface a manifest-reconciler does not need); and the operator-CRD rules `edit`
+# above; `serviceaccounts/token` (TokenRequest), `serviceaccounts` impersonation
+# and `*/proxy` (privilege-escalation surface a manifest-reconciler does not
+# need — Flux impersonates via headers, it never mints SA tokens); and the operator-CRD rules `edit`
 # dynamically aggregates (KubeVirt, CDI, cert-manager, Flux, Kyverno, …) — tenant
 # CRD access is granted explicitly via the sibling `*-tenant-edit` pieces.
 #
@@ -40,9 +41,6 @@ rules:
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
   - apiGroups: [""]
     resources: ["pods/eviction"]
-    verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["serviceaccounts/token"]
     verbs: ["create"]
   # Core resources — read (incl. pod logs/status for debugging).
   - apiGroups: [""]

--- a/k8s/bases/infrastructure/cluster-roles/tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/tenant-edit.yaml
@@ -35,4 +35,3 @@ aggregationRule:
 # `rules` is intentionally OMITTED: the ClusterRole aggregation controller owns
 # and populates it from the labelled pieces. Declaring `rules: []` here would make
 # Flux's server-side apply fight the controller for that field on every reconcile.
-

--- a/k8s/bases/infrastructure/cluster-roles/tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/tenant-edit.yaml
@@ -1,0 +1,38 @@
+# The role a self-service tenant's ServiceAccount is bound to (via the tenant
+# RGD and each tenant's registration RoleBinding). Flux's kustomize-controller
+# IMPERSONATES this SA (`spec.serviceAccountName`) to reconcile the tenant's
+# manifests, so this role is the tenant's entire in-namespace capability.
+#
+# It is an AGGREGATED role — the same mechanism the built-in `edit` uses — so
+# tenant capability is composed from small, purpose-scoped pieces carrying the
+# `devantler.tech/aggregate-to-tenant-edit` label:
+#   - tenant-base-edit          — core namespaced-admin (workloads, config,
+#                                 secrets, networking) WITHOUT pods/exec
+#   - cilium-tenant-edit        — CiliumNetworkPolicy
+#   - cnpg-tenant-edit          — CloudNativePG Cluster/backups/…
+#   - external-secrets-tenant-edit — SecretStore/ExternalSecret/…
+#   - gateway-tenant-edit       — HTTPRoute/ReferenceGrant/…
+#   - cert-manager-tenant-edit  — Certificate/Issuer
+# A tenant that needs a new CRD gets a new `*-tenant-edit` piece — the existing
+# opt-in pattern — instead of the whole cluster's `edit` surface.
+#
+# WHY this exists instead of binding tenants to the built-in `edit`: `edit`
+# grants `create pods/exec` (+ attach/portforward/proxy), which a Flux
+# reconciliation identity never uses, and which Kubescape flags as C-0002
+# ("Prevent containers from allowing command execution"). Dropping the exec
+# subresources here removes that finding at the ROOT for every tenant rather than
+# suppressing it. `edit` also dynamically aggregates unrelated operator CRDs
+# (KubeVirt, CDI, Kyverno, Flux, …) that tenants have no reason to manage; this
+# role grants only the pieces above.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tenant-edit
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        devantler.tech/aggregate-to-tenant-edit: "true"
+# `rules` is intentionally OMITTED: the ClusterRole aggregation controller owns
+# and populates it from the labelled pieces. Declaring `rules: []` here would make
+# Flux's server-side apply fight the controller for that field on every reconcile.
+

--- a/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
@@ -92,8 +92,11 @@ spec:
             app.kubernetes.io/managed-by: ksail
         roleRef:
           apiGroup: rbac.authorization.k8s.io
+          # Scoped tenant namespace-admin role (aggregated from *-tenant-edit
+          # pieces) — like the built-in `edit` but WITHOUT pods/exec, so tenants
+          # do not trip Kubescape C-0002. See cluster-roles/tenant-edit.yaml.
           kind: ClusterRole
-          name: edit
+          name: tenant-edit
         subjects:
           - kind: ServiceAccount
             name: ${serviceAccount.metadata.name}
@@ -178,7 +181,7 @@ spec:
                 subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'
     # --- Flux Kustomization (one of two variants by `sops`) ---------------
     # The impersonating Kustomization that reconciles the tenant's own artifact
-    # under its namespaced `edit` SA. Two variants because the SOPS `decryption`
+    # under its namespaced `tenant-edit` SA. Two variants because the SOPS `decryption`
     # block is a field of the Kustomization spec (not a separable resource) and
     # must be present ONLY for SOPS tenants — a `decryption.secretRef: sops-age`
     # on a tenant with no `sops-age` Secret would wedge reconciliation.
@@ -239,7 +242,7 @@ spec:
             secretRef:
               name: sops-age
     # --- external-dns RBAC (only when the tenant runs external-dns) -------
-    # Privileged cross-namespace reads a tenant's `edit` RoleBinding cannot
+    # Privileged cross-namespace reads a tenant's `tenant-edit` RoleBinding cannot
     # self-grant: HTTPRoutes (own namespace), the shared Gateway (kube-system),
     # and Namespaces (cluster-wide informer). Capabilities live in the
     # tenant-external-dns / tenant-external-dns-global ClusterRoles

--- a/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
@@ -181,7 +181,7 @@ spec:
                 subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'
     # --- Flux Kustomization (one of two variants by `sops`) ---------------
     # The impersonating Kustomization that reconciles the tenant's own artifact
-    # under its namespaced `tenant-edit` SA. Two variants because the SOPS `decryption`
+    # under its namespaced SA (bound to the `tenant-edit` role). Two variants because the SOPS `decryption`
     # block is a field of the Kustomization spec (not a separable resource) and
     # must be present ONLY for SOPS tenants — a `decryption.secretRef: sops-age`
     # on a tenant with no `sops-age` Secret would wedge reconciliation.


### PR DESCRIPTION
## Why

The two tenant service accounts (wedding-app, ascoachingogvaner) show up under Kubescape **C-0002 (exec into container)**. They inherit `pods/exec` only because their Flux GitOps impersonation identity is bound to the built-in `edit` role — but a manifest reconciler never execs into pods, so this is an unused over-grant. `edit` also pulls in unrelated operator CRDs (KubeVirt, CDI, Kyverno, …) tenants have no business managing. This fixes the finding at the root rather than suppressing it.

## What

Replaces the tenants' `edit` binding with a purpose-built, aggregated `tenant-edit` role — the same aggregation mechanism as the built-in `edit`, composed from small opt-in `*-tenant-edit` pieces — that grants core namespace-admin **without** the exec/attach/portforward/proxy subresources, plus the tenant CRD extensions they actually use (Cilium, CNPG, external-secrets, Gateway, and a new cert-manager piece). Repoints the tenant template (RGD) and both existing tenants.

**Verified:** the role grants create on every resource kind the two tenants currently deploy, and grants no exec — so it removes the finding without breaking reconciliation.

## Notes for the reviewer

- **Model change:** tenants move from full built-in `edit` to an explicit, opt-in tenant role. A future tenant needing a new CRD adds a `*-tenant-edit` piece — the pattern already in use — rather than inheriting the whole cluster's `edit` surface.
- **Deploy mechanics:** `roleRef` is immutable, so the two existing RoleBindings are recreated on apply; the apps layer already runs `force: true`, which handles this. Brief, self-healing.
- Complements the infra-controller C-0002 exception in a separate PR; together they clear all six C-0002 subjects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)