### PR TITLE
fix(kubescape): repair offline config.json mount so posture scans persist

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -142,3 +142,41 @@ spec:
         limits:
           cpu: 500m
           memory: 1Gi
+  # WORKAROUND — chart 1.40.2 breaks the posture scanner under `kubescapeOffline:
+  # enable` (above). In that mode the chart mounts the EMPTY `kubescape-volume`
+  # emptyDir directly AT the file path /home/nonroot/.kubescape/config.json
+  # (subPath config.json); kubelet auto-creates a non-existent subPath as a
+  # DIRECTORY, so config.json is a directory, not a file. The v4.0.9 scanner's
+  # account-ID step then fails EVERY scan with "open
+  # /home/nonroot/.kubescape/config.json: is a directory" — AFTER generating
+  # results locally but BEFORE persisting them, so workloadconfigurationscans
+  # stop updating and the C-0030/C-0054/C-0260 ClusterSecurityException (and the
+  # whole compliance score) never refresh. Re-point the mount at the PARENT dir
+  # /home/nonroot/.kubescape (config.json is then a real writable file inside it,
+  # co-existing with the nested host-scanner.yaml mount) — exactly the fix already
+  # on the chart's unreleased main, which removed the offline conditional. Strategic
+  # -merge patches key volumeMounts by mountPath, so delete the broken entry and
+  # re-add the corrected one. Drop this postRenderer once a chart > 1.40.2 ships
+  # the mount fix (kubescape/helm-charts).
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kubescape
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kubescape
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: kubescape
+                        volumeMounts:
+                          - mountPath: /home/nonroot/.kubescape/config.json
+                            $patch: delete
+                          - name: kubescape-volume
+                            mountPath: /home/nonroot/.kubescape
+                            subPath: config.json


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why:** The Kubescape compliance dashboard has been stuck at 0 with a wave of false "network policy" failures (C-0030 *Ingress and Egress blocked*, plus C-0054/C-0260) since 2026-06-27. Root cause: the posture scanner has been silently failing to *save* its results on every scan, so the platform's existing cluster-wide exemption for those controls — we enforce network segmentation with CiliumNetworkPolicies, which Kubescape doesn't recognise as native NetworkPolicy — never actually gets applied to the live results.

**What:** Fixes the scanner's config-file mount (a chart 1.40.2 bug that only triggers in offline/air-gapped mode) so it can write its state and persist results again, restoring live compliance scoring and the C-0030/C-0054/C-0260 exemption. Keeps offline mode and the scanner version the exemption feature needs. Mirrors the fix already on the chart's unreleased upstream `main`; a temporary workaround to remove once a chart > 1.40.2 ships it.

Hotfix for broken posture scanning (no prior issue). Needs a direct merge after promotion (own PR — auto-merge is bot-only).