### PR TITLE
fix(kyverno): use one alternated publish-app identity so app-image verification admits again

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -52,14 +52,21 @@ spec:
         keyless:
           # The publish-app workflow moved from reusable-workflows into the
           # actions monorepo (reusable-workflows is being archived); both
-          # identities are accepted during the transition so images signed by
-          # either repo's publish-app.yaml admit. Identities within one attestor
-          # are OR'd, so a match against either satisfies verification.
+          # identities are accepted during the transition via ONE identity
+          # whose subjectRegExp alternates the repo — the same shape as the
+          # tenants' Flux OCIRepository verify blocks. Do NOT list a second
+          # identity entry instead: the IVPOL engine verifies cosign v3
+          # bundles through sigstore-go, which rejects more than one identity
+          # per verification ("unsupported: multiple identities are not
+          # supported at this time" — sigstore/cosign pkg/cosign/verify.go),
+          # so a second entry fail-closes EVERY image this attestor gates
+          # (observed live 2026-07-04: wedding-app v1.14.1 denied at
+          # admission for hours, wedging the whole merge queue). Narrow the
+          # alternation to actions-only once every first-party app image in
+          # prod ships actions-signed.
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@.+$
-            - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/reusable-workflows/\.github/workflows/publish-app\.yaml@.+$
+              subjectRegExp: ^https://github\.com/devantler-tech/(actions|reusable-workflows)/\.github/workflows/publish-app\.yaml@.+$
     # Crossplane provider packages (provider-upjet-*): the crossplane-contrib
     # reusable publish workflow they use cannot sign, so each provider repo
     # attaches the keyless signature in its own publish-provider-package.yml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Every new first-party app pod (wedding-app v1.14.1 and anything the `publishapp` attestor gates) has been denied at admission since #2429 deployed, wedging the whole merge queue — every `deploy-prod` run fails its `apps` health check and evicts. The real root cause (verified in the live kyverno logs) is not the webhook timeout: cosign v3 bundle verification rejects an attestor holding **two** identity entries outright ("multiple identities are not supported"), so #2429's transition attestor fail-closed everything it gates.

## What

Collapses the two `publish-app` identities into one identity with an alternated `subjectRegExp` — the same OR, in the shape the tenants' Flux OCIRepository verify blocks already use, verified working against the blocked wedding-app image (`cosign verify` exit 0). Documents the single-identity constraint in the policy so the next identity change doesn't repeat this.

Note: this PR itself must cross the wedged queue; if its own `merge_group` deploy gets evicted on the wedding-app health check, a direct/admin merge is the unwedge (same circularity #2429 hit).
