### PR TITLE
feat: deploy Kyverno Policy Reporter (UI + kyverno plugin)

### DIFF
--- a/k8s/bases/infrastructure/controllers/auth-proxy/cilium-network-policy.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/cilium-network-policy.yaml
@@ -70,6 +70,15 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
+    # Policy Reporter UI upstream (policy-reporter-ui Service :8080). Prod-only;
+    # inert on local/CI where the policy-reporter namespace has no pods.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: policy-reporter
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
     # DNS resolution
     - toEndpoints:
         - matchLabels:

--- a/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
+++ b/k8s/bases/infrastructure/controllers/auth-proxy/config-map.yaml
@@ -47,6 +47,14 @@ data:
           rule: "Host(`backstage.${domain}`)"
           entryPoints: ["web"]
           service: backstage
+        # Kyverno Policy Reporter UI. Prod-only (the app lives in the
+        # `infrastructure` layer, pulled in full only by the hetzner overlay), so
+        # this router is inert on local/CI -- no HTTPRoute sends
+        # policy-reporter.${domain} to oauth2-proxy there (same as coroot/opencost).
+        policy-reporter:
+          rule: "Host(`policy-reporter.${domain}`)"
+          entryPoints: ["web"]
+          service: policy-reporter
       services:
         homepage:
           loadBalancer:
@@ -74,3 +82,9 @@ data:
           loadBalancer:
             servers:
               - url: "http://backstage.backstage.svc.cluster.local:7007"
+        # Policy Reporter UI (policy-reporter-ui Service :8080). Prod-only and
+        # inert on local (the policy-reporter namespace has no pods there).
+        policy-reporter:
+          loadBalancer:
+            servers:
+              - url: "http://policy-reporter-ui.policy-reporter.svc.cluster.local:8080"

--- a/k8s/bases/infrastructure/kustomization.yaml
+++ b/k8s/bases/infrastructure/kustomization.yaml
@@ -22,6 +22,11 @@ resources:
   # that layer's health check would wait for OpenCost to become Ready, but the CR
   # that produces its Prometheus can't be applied until the layer is Ready.
   - opencost/
+  # Kyverno Policy Reporter (core + UI + kyverno-plugin) visualises the
+  # PolicyReport / ClusterPolicyReport CRs Kyverno emits. In the `infrastructure`
+  # layer (not `controllers`) so it lands a layer after Kyverno, which installs
+  # the wgpolicyk8s.io CRDs it watches.
+  - policy-reporter/
   # KRO RGDs (Tenant #1932 / WebApp #1933) + their aggregated KRO
   # ClusterRoles. In `infrastructure` (not `infrastructure-controllers`) so the
   # RGD CRs land a layer after the KRO controller that installs the RGD CRD.

--- a/k8s/bases/infrastructure/policy-reporter/cilium-network-policy.yaml
+++ b/k8s/bases/infrastructure/policy-reporter/cilium-network-policy.yaml
@@ -1,0 +1,59 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-policy-reporter
+  namespace: policy-reporter
+spec:
+  endpointSelector: {}
+  ingress:
+    # Intra-namespace: the UI queries the core REST API and the kyverno-plugin,
+    # all on :8080.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: policy-reporter
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # auth-proxy (oauth2-proxy SSO) reaches the UI after authentication.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # Coroot's host-networked eBPF node-agent scrapes the core /metrics on :8080.
+    # The scrape appears as the host / remote-node entity rather than a
+    # namespaced endpoint.
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Kube API: the core watches (Cluster)PolicyReports / openreports and lists
+    # namespaces; the kyverno-plugin reads Kyverno policies and CRDs.
+    - toEntities:
+        - kube-apiserver
+    # Intra-namespace API calls (UI -> core / kyverno-plugin on :8080).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: policy-reporter
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # DNS resolution.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/k8s/bases/infrastructure/policy-reporter/helm-release.yaml
+++ b/k8s/bases/infrastructure/policy-reporter/helm-release.yaml
@@ -1,0 +1,75 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  labels:
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  # Kyverno (infrastructure-controllers layer) installs the wgpolicyk8s.io
+  # PolicyReport/ClusterPolicyReport CRDs this app watches; the infrastructure
+  # layer already waits for infrastructure-controllers, and this dependsOn makes
+  # the ordering explicit so the core never starts before Kyverno is Ready.
+  dependsOn:
+    - name: kyverno
+      namespace: kyverno
+  interval: 10m
+  timeout: 10m
+  chart:
+    spec:
+      chart: policy-reporter
+      version: 3.7.4
+      sourceRef:
+        kind: HelmRepository
+        name: policy-reporter
+  # https://github.com/kyverno/policy-reporter/blob/3.7.4/charts/policy-reporter/values.yaml
+  values:
+    # The UI reaches the core over its REST API; it is off by default and the UI
+    # is useless without it. The chart auto-wires the UI's default cluster to
+    # http://policy-reporter:8080 (+ the kyverno plugin) so no clusters config is
+    # needed here.
+    rest:
+      enabled: true
+
+    # Expose Prometheus policy-result metrics on :8080/metrics for Coroot's
+    # node-agent to scrape. `simple` mode keeps label cardinality bounded. No
+    # prometheus-operator here, so the ServiceMonitor sub-chart stays disabled
+    # (see monitoring below) -- same as opencost.
+    metrics:
+      enabled: true
+      mode: simple
+
+    # Explicit cold-start floor; auto-vpa right-sizes at steady state. CPU limit
+    # intentionally unset (compressible) per the house pattern.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
+
+    ui:
+      enabled: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+
+    plugin:
+      kyverno:
+        # Surfaces Kyverno policy details, sources and (optionally) exceptions in
+        # the UI; the UI auto-discovers it at http://policy-reporter-kyverno-plugin:8080.
+        enabled: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+
+    # No prometheus-operator in the cluster, so skip the ServiceMonitor the
+    # monitoring sub-chart would create (matches opencost's metrics wiring).
+    monitoring:
+      enabled: false

--- a/k8s/bases/infrastructure/policy-reporter/helm-repository.yaml
+++ b/k8s/bases/infrastructure/policy-reporter/helm-repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+spec:
+  url: https://kyverno.github.io/policy-reporter

--- a/k8s/bases/infrastructure/policy-reporter/http-route.yaml
+++ b/k8s/bases/infrastructure/policy-reporter/http-route.yaml
@@ -1,0 +1,50 @@
+# Expose the Policy Reporter UI behind oauth2-proxy SSO (the same forward-auth
+# pattern as the Coroot / OpenCost UIs): the route backends to the oauth2-proxy
+# Service; after authentication oauth2-proxy forwards to auth-proxy, which routes
+# policy-reporter.${domain} by Host to the policy-reporter-ui Service (see
+# auth-proxy config-map.yaml). Policy Reporter UI has no native SSO, so this is
+# how access is gated. The UI serves on port 8080.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Policy Reporter
+    gethomepage.dev/description: Kyverno PolicyReport dashboards and analytics.
+    gethomepage.dev/group: Security
+    # Policy Reporter isn't in the dashboard-icons/selfh.st sets Homepage
+    # resolves, so point at the upstream Kyverno brand logo (same upstream-URL
+    # pattern the Coroot / Cilium / OpenBao routes use). Homepage fetches icons
+    # client-side, so the cluster egress NetworkPolicy doesn't block it.
+    gethomepage.dev/icon: https://raw.githubusercontent.com/kyverno/kyverno/main/img/logo.png
+    # Status dot: key on the UI pod. app.kubernetes.io/instance=policy-reporter is
+    # shared by the core and kyverno-plugin pods too, so target the UI explicitly
+    # via app.kubernetes.io/name=policy-reporter-ui (same reason coroot/opencost
+    # pin a specific selector).
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=policy-reporter-ui
+spec:
+  parentRefs:
+    - name: platform
+      namespace: kube-system
+      sectionName: https
+  hostnames:
+    - policy-reporter.${domain}
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Auth-Request-Redirect
+                value: https://policy-reporter.${domain}/
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload
+      backendRefs:
+        - name: oauth2-proxy
+          namespace: oauth2-proxy
+          port: 80

--- a/k8s/bases/infrastructure/policy-reporter/kustomization.yaml
+++ b/k8s/bases/infrastructure/policy-reporter/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - helm-repository.yaml
+  - http-route.yaml
+  - cilium-network-policy.yaml

--- a/k8s/bases/infrastructure/policy-reporter/namespace.yaml
+++ b/k8s/bases/infrastructure/policy-reporter/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: policy-reporter
+  labels:
+    # The chart ships a fully restricted-compliant securityContext for the core,
+    # UI and kyverno-plugin (runAsNonRoot, runAsUser 1234, readOnlyRootFilesystem,
+    # capabilities drop ALL, seccompProfile RuntimeDefault) at the container
+    # level, and creates no hook/Job pods -- so PSA `restricted` enforces cleanly
+    # without relying on Kyverno's add-security-context mutation (unlike opencost,
+    # whose upstream chart ships only a partial securityContext).
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest


### PR DESCRIPTION
## Why
We run Kyverno on prod but have no way to *see* the PolicyReports it produces — policy pass/fail and violations are only visible via raw `kubectl`. This gives that posture a dashboard.

## What
Deploys Kyverno **Policy Reporter** (core + UI + Kyverno plugin) as a new prod-only infrastructure app. The UI is reachable at `policy-reporter.<domain>` behind the existing oauth2-proxy SSO, and its policy-result metrics are picked up by Coroot. It sits in the infrastructure layer (after Kyverno) and, like coroot/opencost, only ships to prod — the local/CI overlay is unaffected.

## Notes
- **Draft** — deploys only once promoted & merged.
- No database configured: reports are re-derived from the live PolicyReport CRs, so it's stateless by design. A persistent store can be added later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)