### PR TITLE
fix: permit the Policy Reporter HTTPRoute to backend oauth2-proxy (SSO)

### DIFF
--- a/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
+++ b/k8s/bases/infrastructure/controllers/oauth2-proxy/reference-grant.yaml
@@ -21,6 +21,12 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: opencost
+    # The Policy Reporter UI HTTPRoute (policy-reporter) backends to the
+    # oauth2-proxy Service for SSO. Prod-only (the app ships only via the hetzner
+    # overlay); inert on local/CI where the policy-reporter namespace has no HTTPRoute.
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: policy-reporter
     # Hetzner-only: the Longhorn UI HTTPRoute (longhorn-system) backends to the
     # oauth2-proxy Service for SSO. Inert on local/CI where longhorn-system has
     # no HTTPRoute.


### PR DESCRIPTION
## Why
Policy Reporter (#2459) is deployed and all its pods are healthy, but the UI is **unreachable in the browser**: its HTTPRoute backends cross-namespace to the shared oauth2-proxy SSO Service, and the `policy-reporter` namespace was missing from the `ReferenceGrant` that permits that reference. Gateway API therefore denied the backend (`ResolvedRefs=False / RefNotPermitted`), so no traffic reaches the UI.

## What
Adds the `policy-reporter` HTTPRoute to the `allow-oauth2-proxy-backends` ReferenceGrant, exactly like the other SSO-fronted UIs (coroot/opencost/longhorn). Once merged, the route resolves and `policy-reporter.<domain>` loads.

## Notes
- **Hotfix for a live break** — a one-line follow-up to #2459; needs prompt promotion to restore access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)