### PR TITLE
fix(actual-budget): allow egress to Enable Banking API

### DIFF
--- a/k8s/bases/apps/actual-budget/cilium-network-policy.yaml
+++ b/k8s/bases/apps/actual-budget/cilium-network-policy.yaml
@@ -23,6 +23,18 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # Enable Banking bank-sync API. The sync-server calls this host server-side
+    # (GET /aspsps to list a country's banks, then auth/sessions/accounts);
+    # BASE_URL is https://api.enablebanking.com in actual-server. Without this
+    # allow, the default-deny egress drops the ASPSP-list request and the
+    # "Choose your bank" dropdown is empty. Pinned by FQDN (same rationale as
+    # dex above) so a compromised pod cannot exfiltrate elsewhere.
+    - toFQDNs:
+        - matchName: "api.enablebanking.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # DNS resolution. rules.dns engages Cilium's L7 DNS proxy so the toFQDNs
     # allow-list above can be enforced; matchPattern "*" leaves resolution
     # itself unrestricted (the FQDN list constrains where traffic may go).


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why:** Linking a bank in Actual Budget via Enable Banking shows an empty "Choose your bank" list, so bank sync can't be set up at all. The app's default-deny egress policy only permitted OIDC and DNS, silently blocking the sync-server's call to Enable Banking.

**What:** Adds an FQDN-pinned egress allow to `api.enablebanking.com` (443) on the actual-budget network policy — the single host Enable Banking bank sync uses — so the bank list loads and the full link/sync flow works. Kept FQDN-pinned (not open egress) to preserve the existing exfiltration guardrail.