### PR TITLE
fix(crossview): stop auto-vpa OOM-killing the dashboard under load

### DIFF
--- a/k8s/bases/apps/crossview/helm-release.yaml
+++ b/k8s/bases/apps/crossview/helm-release.yaml
@@ -26,6 +26,38 @@ spec:
       createNamespace: false
     app:
       replicas: ${crossview_replicas:=1}
+      # Crossview is a bursty, near-idle dashboard: ~14Mi RSS while nobody is
+      # looking at it, but a single dashboard load lists Crossplane resources
+      # cluster-wide (every managed resource across all provider CRDs, plus
+      # composites/claims/XRDs/providers/functions) and spikes to ~240Mi+ — a
+      # ~17x jump — with the frontend firing those lists concurrently.
+      #
+      # auto-vpa (the Kyverno-generated VerticalPodAutoscaler, controlledValues:
+      # RequestsAndLimits) right-sizes the memory REQUEST to that low idle/steady
+      # histogram and, preserving the authored limit:request ratio, drags the
+      # LIMIT down with it. At the chart's default 4:1 ratio (1Gi:256Mi) a
+      # transient-low request recommendation (~100Mi, e.g. after a VPA-recommender
+      # restart) pins the limit near ~400Mi — below the load burst — and the pod
+      # is OOMKilled mid-request. Every dashboard widget then shows "Error
+      # loading", so Crossview looks like it lost kube-API access when it hasn't:
+      # the SA token, RBAC (wildcard get/list/watch) and network are all fine.
+      #
+      # Fix (same auto-vpa footgun the homepage HelmRelease documents): author
+      # resources explicitly with a WIDE memory ratio (8:1). VPA still scales the
+      # request to the observed working set, but the preserved 8:1 ratio keeps the
+      # limit generous at every request level — ~800Mi even at the ~100Mi low
+      # bootstrap, ~1.9Gi at the ~240Mi steady target — so the burst is absorbed.
+      # The limit is a ceiling, not a reservation (idle still reserves only the
+      # request), and the auto-vpa maxAllowed (6Gi) remains the runaway/leak
+      # guard. CPU stays at the chart default: compressible, VPA-managed, never
+      # the OOM cause.
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: "1"
+          memory: 2Gi
       extraEnv:
         # Crossview keys several behaviours off NODE_ENV (lib/env.go ->
         # Environment): with it set to `production` the session-cookie middleware


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why**
The Crossview dashboard (crossview.platform.devantler.tech) shows "Error loading" on every Crossplane widget and looks like it has lost Kubernetes API access. It hasn't — the pod is repeatedly **OOM-killed** while a dashboard loads. Crossview sits near-empty at idle, but a dashboard load lists Crossplane resources cluster-wide and briefly needs ~17× that memory; the cluster's auto-VPA had right-sized its memory limit down toward the idle footprint, so the pod dies mid-request and every widget fails.

**What**
Give Crossview an explicit, generous memory limit so the auto-VPA keeps enough burst headroom — the same fix already applied to the homepage dashboard for this exact VPA behaviour. No new dependency and no behaviour change; requests are unchanged so it reserves no extra node memory at idle, and the VPA's 6Gi cap still guards against leaks.

Operational: own PR — needs a direct merge after promotion.