### PR TITLE
feat(autoscaling): add the SIG descheduler for pod rebalancing and node consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A high-level inventory of what Flux reconciles onto the cluster. The manifests l
 - **Identity / SSO** — Dex (OIDC) with oauth2-proxy / auth-proxy; see [`docs/oidc-kubectl.md`](docs/oidc-kubectl.md)
 - **Policy & runtime security** — Kyverno, Kubescape, Tetragon; see [`docs/runtime-security.md`](docs/runtime-security.md)
 - **Storage** — Longhorn (replicated block/RWX, prod via Hetzner CSI), CloudNativePG (PostgreSQL operator); see [`docs/rwx-storage.md`](docs/rwx-storage.md)
-- **Autoscaling** — Cluster Autoscaler (nodes), Vertical Pod Autoscaler, KEDA request-rate autoscaling (homepage/umami); see [`docs/node-autoscaling.md`](docs/node-autoscaling.md)
+- **Autoscaling** — Cluster Autoscaler (nodes), SIG Descheduler (pod rebalancing + node consolidation), Vertical Pod Autoscaler, KEDA request-rate autoscaling (homepage/umami); see [`docs/node-autoscaling.md`](docs/node-autoscaling.md)
 - **Progressive delivery** — Flagger (Gateway API canary deployments with SLO-gated automated rollback, metrics from Coroot); see [`docs/progressive-delivery.md`](docs/progressive-delivery.md)
 - **Observability** — Coroot (self-hosted, eBPF: metrics, logs, traces, profiling, service map, SLO alerting), OpenCost (cost); see [`docs/dr/alerting.md`](docs/dr/alerting.md)
 - **Backup / DR** — Velero with CloudNativePG backups; see [`docs/dr/`](docs/dr)

--- a/docs/node-autoscaling.md
+++ b/docs/node-autoscaling.md
@@ -131,6 +131,54 @@ Add a new entry to the `pools` list in `ksail.prod.yaml` and run
 
 ---
 
+## Pod rebalancing & consolidation (descheduler)
+
+The Cluster Autoscaler only ever **adds or removes nodes** — it never moves a
+running pod. Over time placement degrades (replica clumps after a node failure,
+pods left on nodes that now violate their affinity, half-empty `autoscale-cx*`
+nodes the autoscaler can't drain because one pod is stuck there). On clouds with
+Karpenter that gap is closed by its *consolidation* feature, but **Karpenter has
+no Hetzner provider** — so the platform pairs the autoscaler with the
+[Kubernetes SIG Descheduler](https://github.com/kubernetes-sigs/descheduler)
+instead: the descheduler evicts misplaced pods (the scheduler re-places them),
+and the autoscaler reclaims any node that empties out
+(`scaleDownUnneededTime: 10m`).
+
+It runs as a `HelmRelease` in `kube-system`
+(`k8s/providers/hetzner/infrastructure/controllers/descheduler/`), as a
+single-replica Deployment on a 30-minute descheduling loop. Enabled strategies:
+
+- **Placement repair** — `RemovePodsViolatingNodeAffinity` (required affinity),
+  `RemovePodsViolatingNodeTaints`, `RemovePodsViolatingInterPodAntiAffinity`,
+  `RemovePodsViolatingTopologySpreadConstraint` (hard constraints only), and
+  `RemoveDuplicates` (re-spread replica clumps after node churn).
+- **Consolidation** — `HighNodeUtilization` drains nearly-empty nodes
+  (< 15% requested CPU **and** memory) toward the rest of the cluster so the
+  autoscaler can delete them. The threshold is deliberately low: with the
+  default scheduler scoring, evicted pods gravitate back toward empty-ish nodes
+  (including the over-provisioning warm spare), so aggressive packing needs the
+  `MostAllocated` scoring strategy first — tracked in
+  [#2471](https://github.com/devantler-tech/platform/issues/2471).
+
+Guardrails (all in the `HelmRelease` values):
+
+- Evictions go through the **eviction API**, so PodDisruptionBudgets are always
+  honored.
+- **PVC-backed pods are never evicted** (`PodsWithPVC` protection): CNPG
+  clusters, Longhorn-attached workloads, openbao, spire-server. Stateful moves
+  stay deliberate runbook operations (see `docs/dr/`).
+- All default protections stay on: DaemonSet, mirror/static, system-critical,
+  terminating, local-storage, and failed bare pods are untouchable.
+- `nodeFit: true` — a pod is only evicted if it provably fits on another node.
+- Blast-radius caps: at most **2 evictions per node and 2 per namespace** per
+  30-minute cycle.
+
+Evictions surface as Kubernetes Events (visible in Coroot); watch for pods
+bouncing between nodes every cycle — that's the signal a threshold is fighting
+the scheduler and should be tuned down.
+
+---
+
 ## Troubleshooting
 
 ### Autoscaler not scaling up

--- a/k8s/providers/hetzner/infrastructure/controllers/descheduler/helm-release.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/descheduler/helm-release.yaml
@@ -1,0 +1,92 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: descheduler
+  namespace: kube-system
+  labels:
+    helm.toolkit.fluxcd.io/crds: enabled
+    helm.toolkit.fluxcd.io/remediation: enabled
+spec:
+  interval: 10m
+  timeout: 10m
+  chart:
+    spec:
+      chart: descheduler
+      # appVersion 0.36.0. Renovate tracks the chart version.
+      version: 0.36.0
+      sourceRef:
+        kind: HelmRepository
+        name: descheduler
+  # https://artifacthub.io/packages/helm/descheduler/descheduler
+  #
+  # WHY: Karpenter has no Hetzner provider, so its consolidation behaviour is
+  # rebuilt from the Hetzner-native pair — the Cluster Autoscaler
+  # (provision/deprovision, installed by ksail.prod.yaml autoscaler.node.*)
+  # plus this descheduler (rebalance/consolidate running pods, which the
+  # autoscaler never moves). See #2468 and docs/node-autoscaling.md.
+  values:
+    # Long-running Deployment (not the default CronJob): a continuous
+    # descheduling loop, and a stable target for the static VPA
+    # (../../vertical-pod-autoscalers/descheduler.yaml) to observe/right-size.
+    kind: Deployment
+    deschedulingInterval: 30m
+    replicas: 1
+    deschedulerPolicy:
+      # Blast-radius caps: one cycle may move at most 2 pods per node and 2 per
+      # namespace, so a misjudged policy degrades slowly and visibly (evictions
+      # are Events, ingested by Coroot) instead of storming the cluster.
+      maxNoOfPodsToEvictPerNode: 2
+      maxNoOfPodsToEvictPerNamespace: 2
+      profiles:
+        - name: rebalance
+          pluginConfig:
+            - name: DefaultEvictor
+              args:
+                # Only evict a pod that provably fits on another node.
+                nodeFit: true
+                podProtections:
+                  # All default protections stay ON (DaemonSet, mirror/static,
+                  # terminating, system-critical, local-storage, failed bare
+                  # pods). The eviction API additionally honors PDBs.
+                  extraEnabled:
+                    # Never touch PVC-backed pods: CNPG clusters, Longhorn
+                    # attachments, openbao, spire-server, clickhouse-keeper.
+                    # Stateful moves stay deliberate operations with their own
+                    # runbooks (see docs/dr/), never background churn.
+                    - PodsWithPVC
+            - name: RemovePodsViolatingNodeAffinity
+              args:
+                nodeAffinityType:
+                  - requiredDuringSchedulingIgnoredDuringExecution
+            - name: RemovePodsViolatingNodeTaints
+            - name: RemovePodsViolatingInterPodAntiAffinity
+            # Hard (DoNotSchedule) constraints only — the plugin default. Soft
+            # ScheduleAnyway spreads (the platform's usual pattern) are left to
+            # the scheduler so this never fights a deliberate soft placement.
+            - name: RemovePodsViolatingTopologySpreadConstraint
+            - name: RemoveDuplicates
+            - name: HighNodeUtilization
+              args:
+                # Consolidation seed: only nearly-empty nodes (< 15% requested
+                # cpu AND memory) are drained toward the rest of the cluster,
+                # so a lingering autoscale-cx* node empties and the Cluster
+                # Autoscaler reclaims it (scaleDownUnneededTime: 10m). The
+                # threshold is deliberately LOW: with the default scheduler
+                # scoring, evicted pods gravitate back to empty-ish nodes
+                # (including the overprovisioning warm spare) — full
+                # Karpenter-style packing needs MostAllocated scoring, tracked
+                # in #2471; raise this threshold when that lands.
+                thresholds:
+                  cpu: 15
+                  memory: 15
+          plugins:
+            deschedule:
+              enabled:
+                - RemovePodsViolatingNodeAffinity
+                - RemovePodsViolatingNodeTaints
+                - RemovePodsViolatingInterPodAntiAffinity
+            balance:
+              enabled:
+                - RemoveDuplicates
+                - RemovePodsViolatingTopologySpreadConstraint
+                - HighNodeUtilization

--- a/k8s/providers/hetzner/infrastructure/controllers/descheduler/helm-repository.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/descheduler/helm-repository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: descheduler
+  namespace: kube-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/descheduler/

--- a/k8s/providers/hetzner/infrastructure/controllers/descheduler/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/descheduler/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-repository.yaml
+  - helm-release.yaml

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -20,6 +20,12 @@ resources:
   # has no ExternalSecret dependency, so unlike external-dns it stays in this
   # wait-gated controllers layer.)
   - crossplane/
+  # Prod-only: the SIG Descheduler — rebalances RUNNING pods (violated affinity/
+  # taints/spread, replica clumps) and drains nearly-empty nodes so the
+  # ksail-managed Cluster Autoscaler can reclaim them. Karpenter has no Hetzner
+  # provider, so CA (provision/deprovision) + descheduler (rebalance/consolidate)
+  # is the Hetzner-native consolidation pair — see docs/node-autoscaling.md.
+  - descheduler/
   # NB: external-dns moved to ../external-dns/ (the `infrastructure` layer):
   # its Cloudflare token now arrives via an OpenBao ExternalSecret, and the
   # ClusterSecretStore only exists once `infrastructure` reconciles — in this

--- a/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/descheduler.yaml
+++ b/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/descheduler.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: descheduler
+  namespace: kube-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: descheduler

--- a/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
@@ -46,6 +46,7 @@ resources:
   - cilium.yaml
   - cluster-autoscaler-hetzner-cluster-autoscaler.yaml
   - coredns.yaml
+  - descheduler.yaml
   - hcloud-cloud-controller-manager.yaml
   - hcloud-csi-controller.yaml
   - hcloud-csi-node.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Karpenter-style node consolidation isn't available on Hetzner (Karpenter has no Hetzner provider), so under-used paid autoscale nodes can linger and pod placement degrades after node churn — the Cluster Autoscaler adds/removes nodes but never moves a running pod.

## What

Adds the Kubernetes SIG Descheduler to prod: it continuously repairs pod placement (violated affinity/taints/spread, replica clumps) and drains nearly-empty nodes so the existing Cluster Autoscaler reclaims them. Conservative guardrails: PDB-honoring evictions only, stateful (PVC-backed) pods never touched, at most 2 evictions per node/namespace per 30-minute cycle. Docs updated in the same PR.

**New dependency:** SIG `descheduler` Helm chart (kubernetes-sigs) / `registry.k8s.io` image, pinned and Renovate-tracked.

Full bin-packing aggressiveness is deliberately deferred until the scheduler scoring change lands — see #2471.

Fixes #2468
