### PR TITLE
fix(kubescape): anchor the remaining literal CSE name matchers

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/exec-into-container-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/exec-into-container-rbac.yaml
@@ -54,22 +54,22 @@ spec:
       # Velero — namespaced binding + Role, and the cluster-admin CRB
       - apiGroup: rbac.authorization.k8s.io
         kind: RoleBinding
-        name: velero-server
+        name: ^velero-server$
       - apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: velero-server
+        name: ^velero-server$
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
-        name: velero-server
+        name: ^velero-server$
       # CloudNativePG — CRB whose ClusterRole explicitly grants pods/exec
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
-        name: cloudnative-pg
+        name: ^cloudnative-pg$
       # Flux kustomize-/helm-controller — cluster-admin via cluster-reconciler CRB
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
-        name: cluster-reconciler-flux-system
+        name: ^cluster-reconciler-flux-system$
       # Flux operator — cluster-admin CRB
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
-        name: flux-operator
+        name: ^flux-operator$

--- a/k8s/bases/infrastructure/cluster-security-exceptions/wildcard-rbac.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/wildcard-rbac.yaml
@@ -41,13 +41,13 @@ spec:
     resources:
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
-        name: cluster-reconciler-flux-system
+        name: ^cluster-reconciler-flux-system$
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
-        name: flux-operator
+        name: ^flux-operator$
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRoleBinding
-        name: velero-server
+        name: ^velero-server$
       - apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: velero-server
+        name: ^velero-server$


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Kubescape matches security-exception resource names as unanchored regexes, so a literal like `flux-operator` can silently suppress findings on future RBAC objects whose names merely contain it — quietly widening an exception's blast radius.

## What
Anchors the last 10 literal matchers (in the exec-into-container and wildcard-RBAC exceptions) with `^…$`, matching what the Headlamp mirror already does. Same fix CodeRabbit flagged as Major on the secret-reader exception in #2442; no behaviour change for the intended matches.

Related to #2441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)