### PR TITLE
feat(kubescape): enable VEX generation for reachability-aware CVE triage

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -61,6 +61,14 @@ spec:
       # upstream propagates keepLocal into the continuous-scan command path.
       continuousScan: disable
       vulnerabilityScan: enable
+      # kubevuln emits an OpenVEX document per scanned image (stored in-cluster
+      # as OpenVulnerabilityExchangeContainer CRs), marking CVEs not_affected
+      # when the workload's ApplicationProfile shows the vulnerable component
+      # is never loaded. Documents only carry relevancy verdicts for workloads
+      # whose profile is complete; partial-profile workloads still get a VEX
+      # shell, which fills in as their pods naturally roll. Feeds the
+      # reachable-CVE CI gate (#2149) a machine-readable suppression source.
+      vexGeneration: enable
       runtimeDetection: enable
       # Enables Kubescape's risk-acceptance feature, so the operator/kubevuln process
       # the in-cluster SecurityException / ClusterSecurityException CRDs

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -68,6 +68,8 @@ spec:
       # whose profile is complete; partial-profile workloads still get a VEX
       # shell, which fills in as their pods naturally roll. Feeds the
       # reachable-CVE CI gate (#2149) a machine-readable suppression source.
+      # Upstream marks the capability experimental — the VEX CRs are advisory
+      # data only, so a regression cannot break scanning itself.
       vexGeneration: enable
       runtimeDetection: enable
       # Enables Kubescape's risk-acceptance feature, so the operator/kubevuln process


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The CVE pipeline now produces real vulnerability data, but nothing downstream can tell which CVEs are actually reachable — the noise-reduction verdicts exist only inside Kubescape's own summaries.

## What
Enables Kubescape's VEX generation, so each scanned image gets a standard OpenVEX document (stored in-cluster) marking CVEs not-affected when runtime observation shows the vulnerable component is never loaded. This gives the planned reachable-CVE CI gate a machine-readable suppression source.

Part of #2450.