### PR TITLE
fix(crossview): grant the OIDC user port-forward in the crossview namespace

### DIFF
--- a/k8s/bases/apps/crossview/kustomization.yaml
+++ b/k8s/bases/apps/crossview/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - helm-release.yaml
   - external-secret.yaml
   - cilium-network-policy.yaml
+  - role.yaml
+  - role-binding.yaml

--- a/k8s/bases/apps/crossview/role-binding.yaml
+++ b/k8s/bases/apps/crossview/role-binding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: crossview-portforward
+  namespace: crossview
+  labels:
+    app.kubernetes.io/managed-by: ksail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crossview-portforward
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: "oidc:${admin_email}"

--- a/k8s/bases/apps/crossview/role.yaml
+++ b/k8s/bases/apps/crossview/role.yaml
@@ -1,0 +1,24 @@
+---
+# Least-privilege RBAC for opening Crossview through Headlamp: since the
+# public route was dropped (Crossview 4.5.0 re-embed), the Headlamp plugin's
+# port-forward is the ONLY entry point, and Headlamp's port-forward handler
+# authorizes it against the signed-in user's own RBAC (`create` on
+# `pods/portforward`). The OIDC identity is deliberately read-only cluster-wide
+# (see k8s/bases/infrastructure/cluster-role-bindings/oidc-view.yaml), and a
+# port-forward tunnel to the dashboard pod mutates nothing — so the write-verb
+# grant is scoped to exactly this namespace instead of widening the cluster
+# roles.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: crossview-portforward
+  namespace: crossview
+  labels:
+    app.kubernetes.io/managed-by: ksail
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/portforward
+    verbs:
+      - create


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

Opening Crossview from Headlamp fails with "Unreachable" for the OIDC web session (your 14:25 screenshot). #2497 made the Headlamp plugin's port-forward the only entry point, and Headlamp authorizes port-forwards against the signed-in user's own RBAC — but the OIDC identity is read-only cluster-wide by design, so the check is denied (verified in the headlamp backend log and by impersonation). It passed pre-merge verification because admin credentials don't hit the user-RBAC path.

## What

Grants `create pods/portforward` to the OIDC user, scoped to the crossview namespace only — the tunnel to the dashboard mutates nothing, so the cluster-wide read-only posture stays intact.

Follow-up to #2497.