### PR TITLE
fix(crossview): grant get on pods/portforward for the WebSocket streaming upgrade

### DIFF
--- a/k8s/bases/apps/crossview/role.yaml
+++ b/k8s/bases/apps/crossview/role.yaml
@@ -2,12 +2,15 @@
 # Least-privilege RBAC for opening Crossview through Headlamp: since the
 # public route was dropped (Crossview 4.5.0 re-embed), the Headlamp plugin's
 # port-forward is the ONLY entry point, and Headlamp's port-forward handler
-# authorizes it against the signed-in user's own RBAC (`create` on
-# `pods/portforward`). The OIDC identity is deliberately read-only cluster-wide
-# (see k8s/bases/infrastructure/cluster-role-bindings/oidc-view.yaml), and a
+# authorizes it against the signed-in user's own RBAC. The OIDC identity is
+# deliberately read-only cluster-wide (see
+# k8s/bases/infrastructure/cluster-role-bindings/oidc-view.yaml), and a
 # port-forward tunnel to the dashboard pod mutates nothing — so the write-verb
 # grant is scoped to exactly this namespace instead of widening the cluster
-# roles.
+# roles. Both verbs are required: the plugin's SSAR pre-check and SPDY dialing
+# authorize as `create`, but the WebSocket streaming upgrade the backend
+# actually performs is a GET the apiserver authorizes as `get` — with `create`
+# alone the check passes and the forward itself is then forbidden.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -22,3 +25,4 @@ rules:
       - pods/portforward
     verbs:
       - create
+      - get


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
"Open Crossview" still fails with *Unreachable* after #2498 (your 15:41 screenshot). The Headlamp log shows why: the plugin's permission pre-check and #2498's Role use the `create` verb, but the port-forward the backend then actually performs is a WebSocket upgrade the API server authorizes as `get` on the same subresource — so the check passes and the forward itself is denied.

## What
Adds `get` alongside `create` on `pods/portforward` in the crossview-scoped Role — same least-privilege scope as #2498, one verb wider. Verified the denial signature in the live Headlamp log (13:41Z); after merge, retrying the plugin button should complete the forward.

Follow-up to #2498.