### PR TITLE
fix(apps): make actual-budget openid schema offline-resolvable

### DIFF
--- a/k8s/bases/apps/actual-budget/helm-release.yaml
+++ b/k8s/bases/apps/actual-budget/helm-release.yaml
@@ -15,12 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: actual-budget
-  valuesFrom:
-    - kind: Secret
-      name: actual-budget-oidc
-      valuesKey: client-secret
-      targetPath: login.openid.clientSecret
-      optional: true
   postRenderers:
     - kustomize:
         patches:
@@ -210,8 +204,15 @@ spec:
     # (disabled here), so they are inert at runtime. The active OpenID config is
     # the ACTUAL_OPENID_* env injected by the postRenderer above. Do NOT remove
     # this block: dropping it fails the chart schema and wedges the apps
-    # Kustomization (the helm upgrade never succeeds). clientSecret comes from the
-    # ESO-synced `actual-budget-oidc` Secret via `valuesFrom` above.
+    # Kustomization (the helm upgrade never succeeds).
+    #
+    # Schema-satisfaction uses the oneOf's `existingSecret` branch (discoveryUrl +
+    # existingSecret), which resolves STATICALLY — so an offline render (ksail's
+    # in-process Helm validate) and a live upgrade both match exactly one branch.
+    # The empty `clientSecret` keeps the inline-secret branch unmatched, so
+    # exactly one branch matches. Do NOT re-introduce a `clientSecret` /
+    # `valuesFrom` injection: with both a clientSecret and existingSecret present,
+    # TWO branches match and the oneOf's "exactly one" fails, wedging the upgrade.
     login:
       method: "openid"
       openid:
@@ -221,3 +222,6 @@ spec:
         clientId: "public-client"
         authMethod: "openid"
         tokenExpiration: "never"
+        existingSecret:
+          name: actual-budget-oidc
+          clientSecretKey: client-secret


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
Actual-budget's OpenID config satisfied the chart's values-schema through an on-cluster-only Secret injection, so any offline validation (ksail's in-process Helm render, being re-enabled in #2273) couldn't resolve it and silently skipped validating actual-budget's rendered manifests. CI was never actually checking this app.

## What
Switches the schema-satisfaction to the statically-resolvable `existingSecret` branch so offline render and live upgrade both validate. The running app is unchanged — verified render is byte-identical (the chart gates this config behind an ingress we don't use; the live OIDC config stays the injected env), and OIDC login is unaffected.

Prod-values change, so promote deliberately. Unblocks proper offline validation once #2273 lands.

Fixes #2385
