### PR TITLE
feat: enable the Hetzner floating-IP stable API endpoint on prod

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -182,6 +182,15 @@ spec:
       # is steady and well within 8 GB).
       workerServerType: cx43
       location: fsn1
+      # Stable API endpoint (#2120): provision a Hetzner floating IP and render
+      # it as the Kubernetes/Talos API endpoint + certificate SANs, plus a
+      # control-plane Talos VIP block so the elected leader owns the address.
+      # The existing control-plane node IPs stay in the SANs, so current
+      # KUBE_CONFIG/TALOS_CONFIG secrets keep working; a CP-node recreate no
+      # longer breaks the endpoint (DR runbook Scenario 9). floatingIPLocation
+      # defaults to the cluster location (fsn1). Applying rolls the CP machine
+      # configs (VIP + SANs); ksail >= v7.120.0 required (CI pins 7.156.0).
+      floatingIPEnabled: true
       networkCidr: 10.0.0.0/16
       placementGroupStrategy: Spread
       fallbackLocations:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why.** Prod's kubeconfig/talosconfig point at the first control-plane node's public IP, so a CP-node recreate breaks the API endpoint (the reason DR runbook Scenario 9 exists). Verified live this run: the API endpoint is currently `https://49.13.53.183:6443` — control-plane-2's public IP.

**What.** Enables the ksail floating-IP feature (`floatingIPEnabled: true`) on the prod config — a released capability (ksail v7.120.0; CI pins 7.156.0). ksail provisions a Hetzner floating IP and renders it as the stable Kubernetes/Talos API endpoint. Existing control-plane node IPs stay in the certificate SANs, so current `KUBE_CONFIG`/`TALOS_CONFIG` secrets keep working. `ksail --config ksail.prod.yaml workload validate` passes (528 files).

**Operational note (blast radius).** Promoting this rolls the control-plane machine configs (adds the Talos VIP + cert SANs). It's non-breaking for current kubeconfigs; after it settles, re-point the context at the floating IP so CP-recreate endpoint breakage goes away. A DR-runbook Scenario-9 docs update follows once this lands.

Fixes #2492
Part of #2120