### PR TITLE
docs: refresh stale Talos/Kubernetes version comments in prod config

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -107,15 +107,15 @@ spec:
     # Pin Kubernetes deliberately so 'ksail cluster update' doesn't roll nodes
     # to ksail's newer default when that default outruns what the pinned Talos
     # version supports (rejected with "kubelet image is not valid: version of
-    # Kubernetes ... is too new"). Talos v1.12.4 supports Kubernetes 1.30-1.35;
+    # Kubernetes ... is too new"). Talos v1.13.5 supports Kubernetes 1.31-1.36;
     # bump in lockstep with Talos rather than letting the default drift.
     #
     # In-place Pod resize (InPlacePodVerticalScaling, beta and ON by default
     # from k8s 1.33) lets VPA -- already 1.6 with updateMode InPlaceOrRecreate
     # -- resize pods, including the kube-system datapath now under auto-vpa, in
     # place instead of evicting them. Upgraded one minor at a time
-    # (1.32 -> 1.33 -> 1.34); landed on 1.34 because 1.33 reaches EOL
-    # 2026-06-28. Talos v1.12.4's ceiling is Kubernetes 1.35.
+    # (1.32 -> 1.33 -> 1.34 -> 1.35 -> 1.36); now on 1.36.2. Talos v1.13.5's
+    # ceiling is Kubernetes 1.36.
     kubernetesVersion: v1.36.2
     talos:
       # Pin Talos to match the ISO so 'ksail cluster update' doesn't attempt


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

**Why.** `ksail.prod.yaml`'s inline comments still claimed *"Talos v1.12.4 supports Kubernetes 1.30-1.35"*, but prod has since been bumped to Talos v1.13.5 / Kubernetes v1.36.2 (confirmed live: all nodes on v1.36.2). The stale text was left behind by the Renovate Talos bump (#1801) and misleads anyone reading the pin rationale.

**What.** Comment-only refresh of the two version-support statements to match the live pins. No behavioural change; `ksail --config ksail.prod.yaml workload validate` passes (528 files).

Addresses the "stale doc to fix" checkbox in #1807 (the k8s 1.36 bump itself is already live on prod; the other items in that tracking issue — the user-namespaces pilot, PSI metrics, VolumeGroupSnapshot — stay open).

Part of #1807