### PR TITLE
feat(tenant): optional ResourceQuota/LimitRange guardrails on the KRO Tenant RGD

### DIFF
--- a/docs/TENANTS.md
+++ b/docs/TENANTS.md
@@ -6,6 +6,15 @@ Kubernetes manifests (`deploy/`) as a **signed OCI artifact** to GHCR; the
 platform pulls that artifact with a Flux `OCIRepository` + `Kustomization` and
 runs it in a dedicated, locked-down namespace.
 
+> **KRO `Tenant` CR fast path.** The platform-registration half below (step 2)
+> is the original hand-copied skeleton. A local-first pilot now generates that
+> same skeleton from a small typed `Tenant` custom resource via
+> [kro](https://kro.run) — see [`tenant-abstraction.md`](./tenant-abstraction.md)
+> (the ADR, including the opt-in `resourceQuota`/`limitRange` guardrails) and
+> the live examples under
+> [`k8s/providers/docker/apps/`](../k8s/providers/docker/apps). This file still
+> documents the pre-KRO flow in full; reconciling the two is an open follow-up.
+
 There are two halves to onboarding, in two repos:
 
 1. **The tenant repo** — created from the

--- a/docs/tenant-abstraction.md
+++ b/docs/tenant-abstraction.md
@@ -98,10 +98,15 @@ its own issue, behaviour-preservingly, render-diffed vs the current instances):
 
 - **Arbitrary per-tenant `ExternalSecret`s beyond `ghcr-auth`** — e.g. `wedding-app`'s object-store /
   db-backup secrets — via a typed `secrets` list on the `Tenant` schema, so no tenant hand-writes an
-  ExternalSecret.
-- **Namespace `ResourceQuota` / `LimitRange`** — a standard multi-tenancy guardrail the RGD does not yet
-  emit; add as an optional typed input.
+  ExternalSecret. Needs kro's `forEach` collections (one `ExternalSecret` per declared entry) plus a
+  nested CEL `.map()` to build each one's `data:` list — kro has no offline CEL validator, so this
+  needs a live-cluster verification pass before it ships (parked on #2521).
+- ~~**Namespace `ResourceQuota` / `LimitRange`**~~ — **done** (#2522): optional `resourceQuota` /
+  `limitRange` inputs, each with its own `enabled` toggle (mirrors the existing `externalDns`/`sops`
+  boolean pattern — no `forEach`/CEL `.map()` needed, so this one *is* safely static-validatable).
+  Default `enabled: false` on both ⇒ no behaviour change for existing tenants.
 - **Stateful `WebApp` shapes** — CNPG-backed apps (e.g. `wedding-db`) so the `WebApp` archetype covers
-  database-backed workloads, not only stateless Deployments.
+  database-backed workloads, not only stateless Deployments (#2523).
 - **Onboarding docs** — keep [`TENANTS.md`](./TENANTS.md) in sync with the ~5-line CR onboarding as the
-  schema grows.
+  schema grows. `TENANTS.md` still documents only the pre-KRO hand-copy flow — reconciling it with the
+  KRO `Tenant`/`WebApp` CR path (this ADR) is itself an open follow-up.

--- a/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
@@ -44,6 +44,33 @@ spec:
   schema:
     apiVersion: v1alpha1
     kind: Tenant
+    # Nested types for the optional multi-tenancy guardrails (#2522). Each
+    # carries its own `enabled` toggle rather than relying on CEL `has()`
+    # presence-detection on the parent object — this mirrors the RGD's own
+    # already-live `externalDns`/`sops` boolean-toggle pattern (and kro's own
+    # documented convention, e.g. `schema.spec.ingress.enabled`) instead of an
+    # unproven pattern, since KRO's structural-schema defaulting is guaranteed
+    # to materialise a nested boolean default even when the tenant omits the
+    # parent field entirely, but `has()` on a whole optional object is not
+    # exercised anywhere else in this file.
+    types:
+      TenantResourceQuota:
+        enabled: boolean | default=false
+        # Total across all pods in the namespace (both request AND limit —
+        # kept as one pair per field to keep the CR small; split into
+        # separate requests/limits inputs only if a tenant needs the nuance).
+        cpu: string | default="4"
+        memory: string | default="4Gi"
+        pods: string | default="20"
+      TenantLimitRange:
+        enabled: boolean | default=false
+        # Per-container defaults applied to any Pod that does not set its own
+        # requests/limits — the standard Kubernetes LimitRange `default` /
+        # `defaultRequest` pair.
+        defaultCPU: string | default="500m"
+        defaultMemory: string | default="512Mi"
+        defaultRequestCPU: string | default="100m"
+        defaultRequestMemory: string | default="128Mi"
     spec:
       # Tenant name — used verbatim as the namespace, ServiceAccount,
       # OCIRepository/Kustomization name, and ghcr-auth target. Required.
@@ -57,6 +84,12 @@ spec:
       # tenant namespace, applied separately — secret material is NEVER inlined
       # into a Tenant spec.
       sops: boolean | default=false
+      # Standard multi-tenancy guardrails (#1932 follow-up #2522): a
+      # namespace-wide ResourceQuota and a per-container default LimitRange.
+      # Both default to `enabled: false` — no behaviour change for existing
+      # tenants until a tenant opts in.
+      resourceQuota: TenantResourceQuota
+      limitRange: TenantLimitRange
   resources:
     # --- Core skeleton (always rendered) ---------------------------------
     - id: tenantNamespace
@@ -151,6 +184,52 @@ spec:
           policyTypes:
             - Ingress
             - Egress
+    # --- Optional multi-tenancy guardrails (#2522) -------------------------
+    # Namespace-wide ResourceQuota, gated on `resourceQuota.enabled` (default
+    # false — omitted ⇒ no behaviour change for existing tenants). Combines
+    # requests and limits into one value per resource so the CR stays small;
+    # split into separate inputs only if a tenant needs the extra nuance.
+    - id: resourceQuota
+      includeWhen:
+        - ${schema.spec.resourceQuota.enabled}
+      template:
+        apiVersion: v1
+        kind: ResourceQuota
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${tenantNamespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+        spec:
+          hard:
+            requests.cpu: ${schema.spec.resourceQuota.cpu}
+            requests.memory: ${schema.spec.resourceQuota.memory}
+            limits.cpu: ${schema.spec.resourceQuota.cpu}
+            limits.memory: ${schema.spec.resourceQuota.memory}
+            pods: ${schema.spec.resourceQuota.pods}
+    # Per-container default requests/limits, gated on `limitRange.enabled`
+    # (default false). Applies only to a Container that omits its own
+    # requests/limits — an explicit workload spec always wins.
+    - id: limitRange
+      includeWhen:
+        - ${schema.spec.limitRange.enabled}
+      template:
+        apiVersion: v1
+        kind: LimitRange
+        metadata:
+          name: ${schema.spec.name}
+          namespace: ${tenantNamespace.metadata.name}
+          labels:
+            app.kubernetes.io/managed-by: ksail
+        spec:
+          limits:
+            - type: Container
+              default:
+                cpu: ${schema.spec.limitRange.defaultCPU}
+                memory: ${schema.spec.limitRange.defaultMemory}
+              defaultRequest:
+                cpu: ${schema.spec.limitRange.defaultRequestCPU}
+                memory: ${schema.spec.limitRange.defaultRequestMemory}
     - id: ociRepository
       template:
         apiVersion: source.toolkit.fluxcd.io/v1


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The KRO `Tenant` abstraction (see the [ADR](docs/tenant-abstraction.md)) does not yet emit a namespace `ResourceQuota` or per-container `LimitRange` — a standard multi-tenancy guardrail against a tenant consuming unbounded cluster resources.

## What
Adds optional `resourceQuota` / `limitRange` inputs to the `Tenant` RGD schema, each with its own `enabled` toggle (default `false`). When enabled, the RGD emits the matching object in the tenant namespace; existing tenants are unaffected. Follows the RGD's own already-proven boolean-toggle pattern (`externalDns`/`sops`), so it needed no new kro features — statically validated via `ksail workload validate` (the RGD file validates cleanly; the 3 unrelated failures in the same run are a network-fetch timeout on an unrelated schema and a pre-existing HelmRelease YAML issue, both present on unmodified `main`).

Fixes #2522
Part of #1932

Documented in `docs/tenant-abstraction.md` and pointed to from `docs/TENANTS.md` per the issue's acceptance criteria.