### PR TITLE
fix(ci): cache kubeconform schemas in Validate Manifests job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,10 +98,26 @@ jobs:
           sudo install /tmp/ksail /usr/local/bin/ksail
           ksail --version
 
+      - name: 📥 Restore kubeconform schema cache
+        # ksail's kubeconform client fetches JSON schemas from
+        # raw.githubusercontent.com/yannh/kubernetes-json-schema on every cold run
+        # and has nowhere to persist them across ephemeral CI runners — heavy,
+        # repeated traffic across every PR is what tripped upstream 429
+        # rate-limiting portfolio-wide (2026-07-09). This restores (and, at job
+        # end, re-saves) the local cache dir the client already builds internally
+        # (`validator.Opts.Cache`); no ksail-side change needed.
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ksail/kubeconform
+          key: kubeconform-schema-cache-v1-${{ github.run_id }}
+          restore-keys: |
+            kubeconform-schema-cache-v1-
+
       - name: ✅ Validate manifests (local + prod overlays)
         # Schema-aware kubeconform validation with Flux variable substitution,
         # building both cluster overlays. Fully static: no cluster, no SOPS key
-        # (Secrets are skipped), no network (offline schema cache).
+        # (Secrets are skipped); schema fetches are cached by the step above so
+        # repeat runs make no network calls for already-seen schemas.
         #
         # --skip-helm-render: INTERIM workaround for the still-open ksail#5362 —
         # the default in-process Helm render is non-deterministic (concurrent

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,10 +103,14 @@ jobs:
         # raw.githubusercontent.com/yannh/kubernetes-json-schema on every cold run
         # and has nowhere to persist them across ephemeral CI runners — heavy,
         # repeated traffic across every PR is what tripped upstream 429
-        # rate-limiting portfolio-wide (2026-07-09). This restores (and, at job
-        # end, re-saves) the local cache dir the client already builds internally
-        # (`validator.Opts.Cache`); no ksail-side change needed.
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        # rate-limiting portfolio-wide (2026-07-09). Restore/save are split (rather
+        # than the single `actions/cache` step) so the save below can run with
+        # `if: always()` — the validate step below is exactly what's exercising
+        # this cache and can itself fail on an uncached/rate-limited schema fetch;
+        # a save gated on job success would then never persist the schemas it did
+        # manage to fetch, and every retry would cold-start again.
+        id: kubeconform-cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform
           key: kubeconform-schema-cache-v1-${{ github.run_id }}
@@ -129,6 +133,18 @@ jobs:
         run: |
           ksail workload validate --skip-helm-render
           ksail --config ksail.prod.yaml workload validate --skip-helm-render
+
+      - name: 📤 Save kubeconform schema cache
+        # Runs even if the validate step above failed (see the restore step's
+        # note) so any schemas fetched before a rate-limit hit still persist for
+        # the next run's restore-keys prefix match. Skipped only on an exact
+        # primary-key hit (impossible here since the key includes
+        # `github.run_id`, but keeps the step correct if that ever changes).
+        if: always() && steps.kubeconform-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ksail/kubeconform
+          key: ${{ steps.kubeconform-cache.outputs.cache-primary-key }}
 
       - name: 🔎 Scan manifests (Kubescape NSA) — hard gate
         # Static NSA-CISA security scan, gated on the compliance score: the job

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
         # the next run's restore-keys prefix match. Skipped only on an exact
         # primary-key hit (impossible here since the key includes
         # `github.run_id`, but keeps the step correct if that ever changes).
-        if: always() && steps.kubeconform-cache.outputs.cache-hit != 'true'
+        if: "!cancelled() && steps.kubeconform-cache.outputs.cache-hit != 'true'"
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ksail/kubeconform


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
A portfolio-wide `raw.githubusercontent.com` 429 rate-limit is currently failing kubeconform schema fetches across ksail and platform CI. This repo's own `🧪 Validate Manifests` job (`ksail workload validate`) is one of the affected checks, hitting the same rate limit on repeated cold fetches.

## What
Adds an `actions/cache` step that persists `~/.cache/ksail/kubeconform` — the schema-cache directory the `ksail` binary already builds internally — across CI runs. Companion fix to [devantler-tech/actions#476](https://github.com/devantler-tech/actions/pull/476) (same fix for ksail's own Test/Coverage jobs); this one is independent and stands alone.