### PR TITLE
ci: bump TODO workflow actions pin

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@fec61388ed0c4ec4d6d93e3f1a8b8d17e7d40a72 # v9.0.4
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@23a6d6ad0152839e3012a885b3029931628f1b9b # v9.0.5
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary
- Bumps the platform TODOs reusable workflow pin from devantler-tech/actions v9.0.4 to v9.0.5.
- v9.0.5 is the current Actions release SHA and no longer references the unpinned `wandalen/wretry.action@v3.8.0_js_action` path that broke platform `main` TODOs.

## Validation
- `actionlint .github/workflows/todos.yaml`
- `git diff --check`
- Checked default `yamllint`; it reports the same pre-existing long-line/default-style warnings on the old file before this change.