### PR TITLE
ci: bump TODO workflow actions pin to v9.0.6

### DIFF
--- a/.github/workflows/todos.yaml
+++ b/.github/workflows/todos.yaml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   todos:
-    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@23a6d6ad0152839e3012a885b3029931628f1b9b # v9.0.5
+    uses: devantler-tech/actions/.github/workflows/scan-for-todo-comments.yaml@8835de82ebb5450c332e963bd9ffb4a6286bdd29 # v9.0.6
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The platform `TODOs` workflow is red on `main`. The pinned `actions` v9.0.5 pulls in an unpinned nested action reference, which platform's SHA-pinning policy rejects before the TODO scan can even run — so the check fails at setup on every push.

## What

Bumps the TODO workflow pin to `actions` v9.0.6, which drops the external retry wrapper while keeping the retry behaviour. Restores the workflow to green on `main`.

Hotfix for the `main` breakage. Needs a direct merge after promotion.
