### PR TITLE
fix(opencost): patch ui probe timeouts

### DIFF
--- a/k8s/bases/infrastructure/opencost/helm-release.yaml
+++ b/k8s/bases/infrastructure/opencost/helm-release.yaml
@@ -88,6 +88,14 @@ spec:
                           preStop:
                             sleep:
                               seconds: 15
+                      # Chart 2.5.26 exposes timeoutSeconds only for the
+                      # exporter probes. Patch the UI probes until the chart
+                      # has matching values for opencost-ui.
+                      - name: opencost-ui
+                        livenessProbe:
+                          timeoutSeconds: 5
+                        readinessProbe:
+                          timeoutSeconds: 5
   # https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/values.yaml
   #
   # Lightweight FinOps cost allocation. Points at Coroot's bundled Prometheus


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary
- add a Flux post-renderer patch for the `opencost-ui` liveness/readiness probe `timeoutSeconds`
- keep the OpenCost chart `2.5.26` bump from #2554 while covering the UI probe gap that the chart values do not expose

## Validation
- `git diff --check`
- `python3 scripts/validate-embedded-json.py`
- `kubectl kustomize k8s/clusters/local/`
- `kubectl kustomize k8s/clusters/prod/`
- `ksail workload validate` and `ksail --config ksail.prod.yaml workload validate` were also run against this same patch before #2554 merged; both reached `bases/infrastructure/opencost validated`, then failed on the known CloudNativePG/kubeconform render-stream corruption tracked by platform#2273 / ksail#5362.