### PR TITLE
feat(aws): activate EKS CI identity resources

### DIFF
--- a/k8s/providers/hetzner/apps/aws/flux-kustomization.yaml
+++ b/k8s/providers/hetzner/apps/aws/flux-kustomization.yaml
@@ -1,9 +1,9 @@
 # Applies the AWS desired state from the devantler-tech/aws OCI artifact into
-# this namespace, AS the namespace-scoped `aws` ServiceAccount — so once
-# platform#2326 activates the IAM managed-resource kinds, the MRs are created
-# with only the authority a namespaced Role grants that SA (none is bound yet:
-# the artifact is an empty scaffold today, and RBAC is widened strictly
-# alongside ManagedResourceActivationPolicy entries, mirroring unifi). It is
+# this namespace, AS the namespace-scoped `aws` ServiceAccount. The dedicated
+# Role grants only the namespaced IAM kinds activated by platform#2564; the
+# artifact remains empty until the follow-up identity slice, so this capability
+# lands without creating AWS resources. RBAC is widened only alongside explicit
+# ManagedResourceActivationPolicy entries, mirroring unifi. It is
 # itself applied by the `apps` Flux Kustomization; it must NOT dependsOn it
 # (deadlock) — it retries benignly until the provider (infrastructure layer)
 # has established the namespaced aws CRDs.

--- a/k8s/providers/hetzner/apps/aws/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/aws/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - service-account.yaml
+  - role.yaml
+  - role-binding.yaml
   - network-policy.yaml
   - secret-store.yaml
   - provider-config.yaml

--- a/k8s/providers/hetzner/apps/aws/role-binding.yaml
+++ b/k8s/providers/hetzner/apps/aws/role-binding.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-managed-resources
+  namespace: aws
+  labels:
+    app.kubernetes.io/managed-by: ksail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aws-managed-resources
+subjects:
+  - kind: ServiceAccount
+    name: aws
+    namespace: aws

--- a/k8s/providers/hetzner/apps/aws/role.yaml
+++ b/k8s/providers/hetzner/apps/aws/role.yaml
@@ -1,0 +1,26 @@
+---
+# Least-privilege RBAC for the aws tenant ServiceAccount. The tenant artifact
+# is applied as this ServiceAccount, so it receives namespace-local authority
+# over exactly the namespaced provider-aws-iam kinds activated for the EKS CI
+# identity. ProviderConfig and credential resources remain platform-owned.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aws-managed-resources
+  namespace: aws
+  labels:
+    app.kubernetes.io/managed-by: ksail
+rules:
+  - apiGroups:
+      - iam.aws.m.upbound.io
+    resources:
+      - openidconnectproviders
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/k8s/providers/hetzner/apps/aws/service-account.yaml
+++ b/k8s/providers/hetzner/apps/aws/service-account.yaml
@@ -1,8 +1,7 @@
 ---
-# The aws tenant's ServiceAccount. For now it only authenticates the namespaced
-# SecretStore (secret-store.yaml) to OpenBao via the dedicated `aws` Kubernetes
-# auth role; once the devantler-tech/aws tenant repo lands (platform#2325), its
-# Flux Kustomization will also run AS this SA with namespace-scoped authority,
+# The aws tenant's ServiceAccount authenticates the namespaced SecretStore to
+# OpenBao and applies the devantler-tech/aws artifact through Flux. Its Role is
+# namespace-scoped and enumerates only the activated AWS managed-resource kinds,
 # mirroring the unifi tenant. No pods use it (the Crossplane provider runs in
 # crossplane-system), so the token is not mounted.
 apiVersion: v1

--- a/k8s/providers/hetzner/infrastructure/crossplane/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - deployment-runtime-config-aws-iam.yaml
   - deployment-runtime-config-upjet-unifi.yaml
   - managed-resource-activation-policy.yaml
+  - managed-resource-activation-policy-aws.yaml
   - managed-resource-activation-policy-unifi.yaml

--- a/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy-aws.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy-aws.yaml
@@ -1,0 +1,14 @@
+# provider-aws-iam declares SafeStart, so its ManagedResourceDefinitions
+# install Inactive. Activate only the namespaced IAM kinds required by the
+# default-off EKS CI identity slice (platform#2564 / platform#2326). The role
+# carries its least-privilege permissions as an inline policy, avoiding the
+# separate Policy and RolePolicyAttachment CRDs and their apiserver/RBAC cost.
+---
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: aws
+spec:
+  activate:
+    - openidconnectproviders.iam.aws.m.upbound.io
+    - roles.iam.aws.m.upbound.io

--- a/k8s/providers/hetzner/infrastructure/crossplane/provider-aws-iam.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/provider-aws-iam.yaml
@@ -1,8 +1,9 @@
-# provider-aws-iam — the IAM family member, the only one needed now (EKS =
-# provider-aws-eks, added as a sibling member when the EKS-test identity work
-# needs it, platform#2326). Its package version must match provider-family-aws
-# (see provider-family-aws.yaml). Resource-bounded via
-# deployment-runtime-config-aws-iam.yaml.
+# provider-aws-iam — the IAM family member and the only one needed for the EKS
+# CI identity (platform#2326). The workflow creates its ephemeral cluster with
+# eksctl, so no Crossplane EKS family member is required. Its package version
+# must match provider-family-aws (see provider-family-aws.yaml).
+# Resource-bounded via deployment-runtime-config-aws-iam.yaml.
+---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The AWS tenant cannot declare its short-lived EKS CI identity while SafeStart
keeps the required IAM resources inactive and the tenant has no authority to
apply them.

## What

Activates only the two required namespaced IAM resource types and grants the
tenant exact namespace-local authority. The tenant artifact stays empty, so
this change creates no AWS resources.

Fixes #2564.
Part of #2326.
