### PR TITLE
ci: make CodeRabbit docstring pre-merge check non-blocking

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+reviews:
+  pre_merge_checks:
+    docstrings:
+      # Non-blocking: CodeRabbit's docstring metric under-counts any PR that
+      # modifies already-documented code (the existing docstring is outside the
+      # diff hunk, so it earns no credit), which makes documented changes score
+      # far below the 80% threshold and permanently blocks draft promotion —
+      # and most of this repo is YAML manifests, where docstring coverage does
+      # not apply. Keep the signal visible but non-blocking rather than wedging
+      # the review gate (same rationale as ksail's .coderabbit.yaml).
+      mode: warning

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   pre_merge_checks:
     docstrings:


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

CodeRabbit's docstring-coverage pre-merge check only credits docstrings inside the PR diff, so documented changes routinely score below its 80% threshold and show a red pre-merge check that blocks draft promotion — on a repo that is mostly YAML manifests, where the metric doesn't even apply.

## What

Adds the same `.coderabbit.yaml` ksail already ships (proven there): the docstring check stays visible but becomes non-blocking. Alternative if preferred: flip Docstring Coverage to warning once in the CodeRabbit org dashboard, which fixes all repos at once and makes these per-repo files unnecessary — then close this PR.

Part of devantler-tech/monorepo#2108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review configuration to treat low documentation coverage as a warning rather than a blocking issue.
  * Added explanatory guidance for documentation checks in repositories with extensive manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->