### PR TITLE
fix(velero): restore R2 backups and maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -270,11 +270,11 @@
       ]
     },
     {
-      "description": "velero-plugin-for-aws is PINNED at v1.14.0 (k8s/bases/infrastructure/controllers/velero/helm-release.yaml): v1.14.1's AWS SDK update serializes the always-set-but-empty PutObject Tagging field as a literal empty x-amz-tagging header, which Cloudflare R2 rejects with 501 NotImplemented — every backup then fails at the final metadata upload. Exclude exactly v1.14.1 and keep automerge OFF for this image so the next release is only merged after a maintainer confirms it ships the upstream fix (velero-io/velero-plugin-for-aws#299 / #303); CI cannot catch this regression because the system-test cluster has no R2 backend. automerge:false placed last so it overrides the minor/patch automerge defaults above.",
+      "description": "velero-plugin-for-aws is HARD-PINNED at v1.14.0 (k8s/bases/infrastructure/controllers/velero/helm-release.yaml): v1.14.1's AWS SDK update serializes the always-set-but-empty PutObject Tagging field as a literal empty x-amz-tagging header, which Cloudflare R2 rejects with 501 NotImplemented — every backup then fails at the final metadata upload. v1.14.2 was deployed without that fix and reproduced the outage, so allow only v1.14.0 until a maintainer explicitly verifies a released upstream fix (velero-io/velero-plugin-for-aws#299 / #303) against R2 and intentionally relaxes this rule; CI cannot catch the regression because the system-test cluster has no R2 backend. automerge:false placed last so it overrides the minor/patch automerge defaults above.",
       "matchPackageNames": [
         "velero/velero-plugin-for-aws"
       ],
-      "allowedVersions": "!/^v?1\\.14\\.1$/",
+      "allowedVersions": "/^v?1\\.14\\.0$/",
       "automerge": false
     },
     {

--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -77,10 +77,10 @@ spec:
     # inspects on the rendered Deployment template.
     #
     # readOnlyRootFilesystem is deliberately LEFT FALSE on the server: velero
-    # writes to the ROOT filesystem at /tmp — /tmp/credentials/<ns>, /tmp/udmrepo
-    # (Kopia config when $HOME is unset) and the go-plugin unix socket — and the
-    # chart mounts no emptyDir at /tmp, so a read-only root would break every
-    # backup. C-0017 stays covered by the velero infrastructure-privileged /
+    # writes credentials and the go-plugin unix socket under /tmp, and the chart
+    # mounts no emptyDir there. Kopia uses /scratch/udmrepo through HOME below,
+    # but a read-only root would still break the other write paths. C-0017 stays
+    # covered by the velero infrastructure-privileged /
     # pod-security-mutations ClusterSecurityException. (The plugin-copy
     # initContainer above CAN use readOnlyRootFilesystem:true.)
     podSecurityContext:

--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -35,15 +35,19 @@ spec:
       repository: velero/velero
     initContainers:
       - name: velero-plugin-for-aws
-        # PINNED at v1.14.0 — do NOT bump to v1.14.1. Its AWS SDK update
+        # PINNED at v1.14.0 — do NOT bump until a release is explicitly verified
+        # to include the R2 tagging fix. The AWS SDK update in v1.14.1
         # serializes the always-set-but-empty PutObject Tagging field as a
         # literal empty `x-amz-tagging` header, and Cloudflare R2 rejects any
         # tagging header with `501 NotImplemented` — every backup then fails
-        # at the final metadata upload ("error putting object .../velero-backup.json").
+        # at the final metadata upload
+        # ("error putting object .../velero-backup.json").
         # Upstream fix (skip the header when no tags are configured) is open
         # but unreleased: velero-io/velero-plugin-for-aws#299 / #303.
-        # Safe to bump again once a release ships one of those PRs.
-        image: velero/velero-plugin-for-aws:v1.14.2
+        # v1.14.2 was deployed on 2026-07-04 without that fix and broke every
+        # nightly backup, so Renovate is hard-pinned too. Safe to relax only
+        # after a release ships one of those PRs and succeeds against R2.
+        image: velero/velero-plugin-for-aws:v1.14.0
         imagePullPolicy: IfNotPresent
         # Non-root hardening for the plugin-copy initContainer (Kubescape
         # C-0013). It only copies the AWS plugin binary into the shared
@@ -106,6 +110,15 @@ spec:
     # Cloudflare R2 backup target. Bucket + endpoint come from the shared
     # variables-base ConfigMap; prefix is reused per consumer (PR #3).
     configuration:
+      # The server and its generated repository-maintenance Jobs run as UID
+      # 65532. That image user has no passwd-backed home, so Kopia otherwise
+      # resolves its config directory to root-owned /udmrepo and maintenance
+      # fails with permission denied. Repository-maintenance Jobs inherit the
+      # deployment environment; point HOME at the existing writable /scratch
+      # emptyDir so both paths use /scratch/udmrepo without weakening non-root.
+      extraEnvVars:
+        - name: HOME
+          value: /scratch
       backupStorageLocation:
         - name: default
           provider: aws


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Summary

- restore the known-good `velero-plugin-for-aws:v1.14.0` pin after v1.14.2 reproduced the empty `x-amz-tagging` regression against Cloudflare R2
- hard-pin Renovate to that exact Docker tag until a released fix is deliberately verified against R2
- set `HOME=/scratch` through `configuration.extraEnvVars`, which generated repository-maintenance Jobs inherit, so non-root Kopia uses the existing writable scratch volume instead of root-owned `/udmrepo`

## Live evidence

- every nightly backup from July 4 through July 10 is `Failed` with R2 `501 NotImplemented: Header 'x-amz-tagging' with value '' not implemented`; the outage begins immediately after #2409 deployed v1.14.2
- all 16 `BackupRepository` objects last completed maintenance on July 4, then retained three consecutive `mkdir /udmrepo: permission denied` failures
- generated maintenance Jobs run as UID/GID 65532, mount `/scratch` as an `emptyDir`, and inherit the server environment; the controller is retrying the full set about every five minutes
- the BackupStorageLocation remains `Available`, so this is configuration drift rather than an R2 outage

## Safety and trade-off

The repair keeps the Velero server and maintenance Jobs non-root, leaves privilege escalation disabled and capabilities dropped, adds no writable root filesystem exception, and does not change backup scope, credentials, retention, or storage endpoints.

v1.14.2 included dependency/CVE refreshes, so restoring v1.14.0 is an explicit temporary security trade-off. The newer image is unusable with the production R2 backend because it makes every backup fail; the exact Renovate pin prevents another silent bump, and it should be relaxed promptly once a fixed release is explicitly verified against R2.

## Validation

- failing-first local Velero recovery assertions now pass for the plugin pin, exact Renovate constraint, writable home, and retained non-root guards
- chart 12.1.0 renders the actual values as plugin v1.14.0, `HOME=/scratch`, `VELERO_SCRATCH_DIR=/scratch`, UID 65532, and `runAsNonRoot: true`
- base and Hetzner controller Kustomize renders contain the same safe values
- KSail v7.164.0 local validation: 107 kustomizations and 536 files pass
- KSail v7.164.0 production validation: 107 kustomizations and 536 files pass
- Kubescape NSA scan passes the 85 compliance floor
- embedded JSON and manifest naming validators pass
- `kubectl apply --dry-run=client` and `git diff --check` pass

## Rollout verification

After promotion and merge, verify the Flux HelmRelease rollout, confirm each repository records a successful maintenance run, and confirm a fresh backup completes without the R2 tagging error before relaxing either pin.

Fixes #2571
