### PR TITLE
fix(talos): mount the audit-log path so audit events reach the host

### DIFF
--- a/talos/cluster/enable-audit-logging.yaml
+++ b/talos/cluster/enable-audit-logging.yaml
@@ -86,3 +86,12 @@ cluster:
       - hostPath: /var/etc/kubernetes/audit
         mountPath: /etc/kubernetes/audit
         readonly: true
+      # Write-through for the audit log itself: without this volume the API
+      # server writes audit-log-path inside its own container filesystem and
+      # the log never reaches the host's EPHEMERAL partition — host-side
+      # consumers (the observability audit-log forwarder DaemonSet) then find
+      # no /var/log/audit/kube directory at all. Matches Sidero's documented
+      # audit-log pattern (writable hostPath mounted at the same path).
+      - hostPath: /var/log/audit/kube
+        mountPath: /var/log/audit/kube
+        readonly: false


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The kube-apiserver audit log never reaches the host: the audit-logging Talos patch configures the log path but mounts no volume for it, so the log stays inside the API server's container filesystem. That makes any host-side consumer impossible — it is exactly what kicked the promoted audit-log forwarder (#2582) out of the merge queue tonight (its DaemonSet found no /var/log/audit/kube on any control-plane node).

## What

Adds the missing writable extraVolume for /var/log/audit/kube to the audit-logging patch, following Sidero's documented audit-log pattern. Applies via the normal cluster-update step (API server static pods re-render; no reboot).

**Merge-order gate:** land and deploy this before re-queuing #2582 — the deploy reconciles workloads before it syncs Talos config, so #2582 alone fails again.

Part of #2318