### PR TITLE
feat(security): extend user namespaces to umami and backstage

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -84,8 +84,9 @@ spec:
               kinds:
                 - Pod
               selector:
-                matchLabels:
-                  cnpg.io/cluster: "*"
+                matchExpressions:
+                  - key: cnpg.io/cluster
+                    operator: Exists
       mutate:
         patchStrategicMerge:
           spec:

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/add-security-context.yaml
@@ -73,6 +73,19 @@ spec:
               namespaceSelector:
                 matchLabels:
                   pod-security.devantler.tech/user-namespaces: enabled
+      # CNPG-managed pods (instances and their initdb/join jobs, all labelled
+      # cnpg.io/cluster) stay on host user namespaces even in an opted-in
+      # namespace: their Longhorn PVCs would need idmapped-mount support,
+      # which is unvalidated (#1807 sequences stateful workloads last). This
+      # lets mixed namespaces (stateless app + CNPG database) opt in safely.
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  cnpg.io/cluster: "*"
       mutate:
         patchStrategicMerge:
           spec:

--- a/k8s/providers/hetzner/apps/backstage/patches/enable-user-namespaces.yaml
+++ b/k8s/providers/hetzner/apps/backstage/patches/enable-user-namespaces.yaml
@@ -1,0 +1,15 @@
+# Opt backstage into the label-gated `add-user-namespaces` Kyverno rule
+# (#1807). Hetzner-only: real Talos kernels support user namespaces; the
+# nested local Docker provider stays default-off. The backstage web pod is
+# stateless (secret/env config + a disk-backed emptyDir scratch mount for the
+# scaffolder), so it has no idmapped-volume dependency. The backstage-db CNPG
+# pods in this namespace are NOT affected: the rule excludes
+# cnpg.io/cluster-labelled pods until Longhorn idmapped-mount support is
+# validated (stateful last, #1807).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage
+  labels:
+    pod-security.devantler.tech/user-namespaces: enabled

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -57,7 +57,11 @@ patches:
       namespace: umami
     path: umami/patches/grant-pg-monitor.yaml
   # User namespaces (hostUsers: false) — prod-only and default-off. These
-  # namespace-label patches opt the two proven stateless workloads into the
-  # add-security-context Kyverno rule. Local/CI and stateful workloads stay out.
+  # namespace-label patches opt proven-stateless workloads into the
+  # add-security-context Kyverno rule. Local/CI and stateful workloads stay
+  # out; in mixed namespaces (umami, backstage) the rule itself excludes the
+  # CNPG database pods via their cnpg.io/cluster label.
   - path: whoami/patches/enable-user-namespaces.yaml
   - path: homepage/patches/enable-user-namespaces.yaml
+  - path: umami/patches/enable-user-namespaces.yaml
+  - path: backstage/patches/enable-user-namespaces.yaml

--- a/k8s/providers/hetzner/apps/umami/patches/enable-user-namespaces.yaml
+++ b/k8s/providers/hetzner/apps/umami/patches/enable-user-namespaces.yaml
@@ -1,0 +1,15 @@
+# Opt umami into the label-gated `add-user-namespaces` Kyverno rule (#1807).
+# Hetzner-only: real Talos kernels support user namespaces; the nested local
+# Docker provider stays default-off. The umami web pods (Flagger primary
+# included — Flagger clones the pod template wholesale) and the
+# provision-tenants CronJob pods are stateless (env + emptyDir scratch only),
+# so they have no idmapped-volume dependency. The umami-db CNPG pods in this
+# namespace are NOT affected: the rule excludes cnpg.io/cluster-labelled pods
+# until Longhorn idmapped-mount support is validated (stateful last, #1807).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: umami
+  labels:
+    pod-security.devantler.tech/user-namespaces: enabled


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
The user-namespaces rollout (#1807) proved `hostUsers: false` on whoami and homepage, but the remaining stateless apps live in namespaces shared with their CNPG databases, which must stay on host user namespaces until Longhorn idmapped-mount support is validated.

## What
The Kyverno opt-in rule now excludes CNPG-labelled pods, letting mixed namespaces opt in safely; umami and backstage are labelled in (prod-only, default-off elsewhere). Verified with the real Kyverno engine: app pods get the mutation, database pods don't.

Part of #1807