### PR TITLE
feat(security): extend user namespaces to crossview

### DIFF
--- a/k8s/providers/hetzner/apps/crossview/patches/enable-user-namespaces.yaml
+++ b/k8s/providers/hetzner/apps/crossview/patches/enable-user-namespaces.yaml
@@ -1,0 +1,15 @@
+# Opt crossview into the label-gated `add-user-namespaces` Kyverno rule
+# (#1807). Hetzner-only: real Talos kernels support user namespaces; the
+# nested local Docker provider stays default-off. Crossview is fully
+# stateless on disk: the chart's persistence is disabled, so the web pod and
+# the bundled Postgres pod write only to emptyDir mounts (data lives in the
+# in-cluster Postgres whose data dir is itself an emptyDir by design) — no
+# PVC, no idmapped-volume dependency. The namespace has no CNPG pods, so the
+# rule's cnpg.io/cluster exclude is moot here.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossview
+  labels:
+    pod-security.devantler.tech/user-namespaces: enabled

--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -65,3 +65,4 @@ patches:
   - path: homepage/patches/enable-user-namespaces.yaml
   - path: umami/patches/enable-user-namespaces.yaml
   - path: backstage/patches/enable-user-namespaces.yaml
+  - path: crossview/patches/enable-user-namespaces.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
Continues the k8s-1.36-readiness user-namespaces rollout (#1807): each proven-stateless app gets `hostUsers: false` so container UIDs stop mapping to real host UIDs — a meaningful container-escape hardening.

## What
Opts the crossview namespace into the existing label-gated Kyverno rule (hetzner overlay only). The per-app volume audit confirmed crossview is the only remaining stateless candidate: chart persistence is disabled, so all writes are emptyDir. headlamp and actual-budget carry PVCs (stateful — deferred per the lane's stateful-last rule) and fleetdm is disabled.

Part of #1807.