### PR TITLE
fix(crossplane): allow AWS identity API egress

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
@@ -30,12 +30,18 @@ spec:
     #     with: curl -sSI -H "Authorization: Bearer <token>" \
     #     https://xpkg.upbound.io/v2/upbound/provider-aws-iam/blobs/<digest>
     #     and read the Location header.
+    #   sts.us-east-1.amazonaws.com + iam.amazonaws.com — the narrowly scoped
+    #     AWS identity APIs used by provider-aws-iam. The provider calls STS
+    #     GetCallerIdentity before reconciling IAM resources, then uses the
+    #     global IAM endpoint for the managed OIDC provider and role.
     - toFQDNs:
         - matchName: "ghcr.io"
         - matchName: "pkg-containers.githubusercontent.com"
         - matchName: "api.github.com"
         - matchName: "xpkg.upbound.io"
         - matchName: "d3qrbvrml4iuq4.cloudfront.net"
+        - matchName: "sts.us-east-1.amazonaws.com"
+        - matchName: "iam.amazonaws.com"
       toPorts:
         - ports:
             - port: "443"
@@ -61,4 +67,6 @@ spec:
               - matchName: "api.github.com"
               - matchName: "xpkg.upbound.io"
               - matchName: "d3qrbvrml4iuq4.cloudfront.net"
+              - matchName: "sts.us-east-1.amazonaws.com"
+              - matchName: "iam.amazonaws.com"
               - matchPattern: "*.cluster.local"

--- a/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/crossplane/cilium-network-policy.yaml
@@ -30,7 +30,7 @@ spec:
     #     with: curl -sSI -H "Authorization: Bearer <token>" \
     #     https://xpkg.upbound.io/v2/upbound/provider-aws-iam/blobs/<digest>
     #     and read the Location header.
-    #   sts.us-east-1.amazonaws.com + iam.amazonaws.com — the narrowly scoped
+    #   sts.eu-central-1.amazonaws.com + iam.amazonaws.com — the narrowly scoped
     #     AWS identity APIs used by provider-aws-iam. The provider calls STS
     #     GetCallerIdentity before reconciling IAM resources, then uses the
     #     global IAM endpoint for the managed OIDC provider and role.
@@ -40,7 +40,7 @@ spec:
         - matchName: "api.github.com"
         - matchName: "xpkg.upbound.io"
         - matchName: "d3qrbvrml4iuq4.cloudfront.net"
-        - matchName: "sts.us-east-1.amazonaws.com"
+        - matchName: "sts.eu-central-1.amazonaws.com"
         - matchName: "iam.amazonaws.com"
       toPorts:
         - ports:
@@ -67,6 +67,6 @@ spec:
               - matchName: "api.github.com"
               - matchName: "xpkg.upbound.io"
               - matchName: "d3qrbvrml4iuq4.cloudfront.net"
-              - matchName: "sts.us-east-1.amazonaws.com"
+              - matchName: "sts.eu-central-1.amazonaws.com"
               - matchName: "iam.amazonaws.com"
               - matchPattern: "*.cluster.local"

--- a/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/deployment-runtime-config-aws-iam.yaml
@@ -11,6 +11,15 @@ spec:
         spec:
           containers:
             - name: package-runtime
+              # IAM is global, but the provider validates credentials through
+              # STS before each reconciliation. Pin that call to the planned
+              # EKS region so the runtime and its exact-host egress policy stay
+              # aligned instead of falling back to us-east-1.
+              env:
+                - name: AWS_REGION
+                  value: eu-central-1
+                - name: AWS_STS_REGIONAL_ENDPOINTS
+                  value: regional
               # Kubescape C-0017 (immutable container filesystem) + the hardening
               # set Kyverno injects at admission (Kubescape scans this stored spec,
               # not the live pod). The upjet runtime writes Terraform workspaces to


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The Crossplane-managed AWS OIDC provider cannot reconcile because `crossplane-system` is default-deny and the AWS IAM provider's credential-validation call has no permitted STS path. The provider previously fell back to `us-east-1`; the planned EKS region is `eu-central-1`, so the runtime and its exact-host network policy must select the same regional endpoint.

## What

- pin the AWS IAM provider runtime to `AWS_REGION=eu-central-1`
- force regional STS endpoint selection with `AWS_STS_REGIONAL_ENDPOINTS=regional`
- allow only `sts.eu-central-1.amazonaws.com:443` for credential validation
- allow only the global `iam.amazonaws.com:443` endpoint needed to reconcile the OIDC provider and IAM role
- mirror both hosts in the Cilium DNS-proxy allow-list so FQDN enforcement remains fail-closed
- retain exact-host least privilege; no wildcard or `world:443` access

Part of #2326.

## Validation

- failing-first structural assertions proved the `eu-central-1` endpoint and runtime region settings were absent, then passed after the change
- `python3 scripts/validate-embedded-json.py`
- `python3 scripts/validate-naming.py`
- `kubectl kustomize k8s/clusters/local/`
- `kubectl kustomize k8s/clusters/prod/`
- current Hetzner controller render contains the regional STS host exactly twice and no `us-east-1` STS host
- current Hetzner infrastructure render contains the AWS region and regional-STS environment settings
- `ksail workload validate` — 539 files validated
- `ksail --config ksail.prod.yaml workload validate` — 539 files validated
- `ksail --config ksail.prod.yaml workload scan --framework nsa --compliance-threshold 85`
- `git diff --check`
- all new commits are GPG-signed and verified

## Notes

This changes no credential or managed AWS resource. Merging it will roll the AWS IAM provider runtime so it adopts the selected region; after deployment, the live OIDC provider should be verified `Synced=True` before the recovery slice is considered complete.
