### PR TITLE
test(storage): add a default-off userns Longhorn smoke harness

### DIFF
--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -15,6 +15,11 @@ resources:
   # the devantler-tech/aws repo sync lands in a follow-up increment. Hetzner-only
   # because Crossplane (and the provider packages) are prod-only.
   - aws/
+  # Default-off disposable proof for user namespaces + Longhorn idmapped mounts
+  # (platform#2599). Activate in a short-lived PR by uncommenting this resource,
+  # capture the completed Job's logs, then remove it again so its generic
+  # ephemeral PVC and Longhorn volume are garbage-collected.
+  # - userns-longhorn-smoke/
   # Prod-only Coroot Postgres integration for the platform-owned CNPG DBs:
   # additive CiliumNetworkPolicies that let the observability cluster-agent
   # scrape each on 5432 (the Cluster patches below stamp the

--- a/k8s/providers/hetzner/apps/userns-longhorn-smoke/job.yaml
+++ b/k8s/providers/hetzner/apps/userns-longhorn-smoke/job.yaml
@@ -1,0 +1,154 @@
+---
+# Disposable production-only proof that a user-namespaced pod can use a
+# Longhorn-backed generic ephemeral volume. The component is deliberately
+# omitted from the parent kustomization until a short-lived activation PR.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: userns-longhorn-smoke
+  namespace: userns-longhorn-smoke
+  labels:
+    app.kubernetes.io/name: userns-longhorn-smoke
+    app.kubernetes.io/component: storage-smoke-test
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: userns-longhorn-smoke
+        app.kubernetes.io/component: storage-smoke-test
+    spec:
+      # Explicit as both the acceptance condition and a guard against the
+      # namespace-scoped Kyverno mutation being unavailable during bootstrap.
+      hostUsers: false
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: write-sentinel
+          image: docker.io/library/busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              set -eu
+              uid_map="$(cat /proc/self/uid_map)"
+              gid_map="$(cat /proc/self/gid_map)"
+              uid_host_start="$(printf '%s\n' "$uid_map" | awk 'NR == 1 { print $2 }')"
+              gid_host_start="$(printf '%s\n' "$gid_map" | awk 'NR == 1 { print $2 }')"
+              test "$uid_host_start" -gt 0
+              test "$gid_host_start" -gt 0
+
+              printf '%s\n' "$uid_map" > /smoke/init-uid-map
+              printf '%s\n' "$gid_map" > /smoke/init-gid-map
+              printf 'init-user=%s:%s\n' "$(id -u)" "$(id -g)" > /smoke/sentinel
+              sync
+
+              printf 'init uid_map:\n%s\n' "$uid_map"
+              printf 'init gid_map:\n%s\n' "$gid_map"
+              cat /smoke/sentinel
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+            seLinuxOptions:
+              level: s0
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - name: smoke-data
+              mountPath: /smoke
+      containers:
+        - name: verify-round-trip
+          image: docker.io/library/busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              set -eu
+              uid_map="$(cat /proc/self/uid_map)"
+              gid_map="$(cat /proc/self/gid_map)"
+              uid_host_start="$(printf '%s\n' "$uid_map" | awk 'NR == 1 { print $2 }')"
+              gid_host_start="$(printf '%s\n' "$gid_map" | awk 'NR == 1 { print $2 }')"
+              test "$uid_host_start" -gt 0
+              test "$gid_host_start" -gt 0
+              test -s /smoke/init-uid-map
+              test -s /smoke/init-gid-map
+              grep -q '^init-user=' /smoke/sentinel
+
+              printf 'main-user=%s:%s\n' "$(id -u)" "$(id -g)" >> /smoke/sentinel
+              grep -q '^main-user=' /smoke/sentinel
+
+              printf 'main uid_map:\n%s\n' "$uid_map"
+              printf 'main gid_map:\n%s\n' "$gid_map"
+              printf 'init uid_map:\n'
+              cat /smoke/init-uid-map
+              printf 'init gid_map:\n'
+              cat /smoke/init-gid-map
+              cat /smoke/sentinel
+
+              rm /smoke/init-uid-map /smoke/init-gid-map /smoke/sentinel
+              test ! -e /smoke/sentinel
+              printf 'userns-longhorn-round-trip=passed\n'
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+            seLinuxOptions:
+              level: s0
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - name: smoke-data
+              mountPath: /smoke
+      volumes:
+        - name: smoke-data
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: userns-longhorn-smoke
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: longhorn-wffc
+                resources:
+                  requests:
+                    storage: 256Mi

--- a/k8s/providers/hetzner/apps/userns-longhorn-smoke/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/userns-longhorn-smoke/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - job.yaml

--- a/k8s/providers/hetzner/apps/userns-longhorn-smoke/namespace.yaml
+++ b/k8s/providers/hetzner/apps/userns-longhorn-smoke/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: userns-longhorn-smoke
+  labels:
+    app.kubernetes.io/managed-by: ksail
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.devantler.tech/user-namespaces: enabled


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Summary

- add a production-only, isolated user-namespace smoke component
- verify init-to-main read/write through a 256Mi generic ephemeral `longhorn-wffc` claim
- log and assert non-zero host UID/GID mappings from both containers
- keep the component omitted from the Hetzner apps entry point by default

## Why

The stateless user-namespace rollout is proven, but Longhorn idmapped-mount
behaviour is not. This disposable harness lets a short-lived follow-up activation
test the real production kernel and storage stack without putting application data
at risk.

## Safety and rollout

This PR changes no currently rendered local or production object. Activation is an
explicit one-line follow-up, followed by log capture and a cleanup change that
removes the Job, its Pod-owned generic ephemeral PVC, and the reclaim-delete
Longhorn volume before any stateful application opts in.

The Job is fixed-name, bounded to 300 seconds, has no retry or service-account
token, runs with `hostUsers: false`, and uses restricted pod/container security
contexts plus an existing digest-pinned BusyBox image.

## Validation

- failing-first component render (missing directory) before implementation
- `kubectl kustomize k8s/providers/hetzner/apps/userns-longhorn-smoke`
- render assertions: exactly one Namespace and one Job; expected userns/storage fields
- full local and prod renders contain zero `userns-longhorn-smoke` resources
- `python3 scripts/validate-naming.py`
- `python3 scripts/validate-embedded-json.py`
- `ksail workload validate` (109 kustomizations, 541 files)
- `ksail --config ksail.prod.yaml workload validate` (109 kustomizations, 541 files)
- `ksail --config ksail.prod.yaml workload scan --framework nsa --compliance-threshold 85`
- `git diff --check`

Fixes #2599
Part of #1807
