### PR TITLE
chore(ci): bump KSAIL_VERSION to 7.166.3

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       env:
         # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
-        KSAIL_VERSION: "7.166.2"
+        KSAIL_VERSION: "7.166.3"
       run: |
         curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
         tar -xzf /tmp/ksail.tar.gz -C /tmp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         env:
           # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
-          KSAIL_VERSION: "7.166.2"
+          KSAIL_VERSION: "7.166.3"
         run: |
           curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
           tar -xzf /tmp/ksail.tar.gz -C /tmp

--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -78,7 +78,7 @@ jobs:
         # pin current in both places.
         env:
           # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
-          KSAIL_VERSION: "7.166.2"
+          KSAIL_VERSION: "7.166.3"
         run: |
           curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
           tar -xzf /tmp/ksail.tar.gz -C /tmp


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
ksail v7.166.3 ships the floating-IP endpoint-reachability fix (ksail#6071, merged today): without this bump the platform's CI/deploy lane keeps using a ksail that can persist a dead cluster endpoint.

## What
Bumps the renovate-annotated `KSAIL_VERSION` pin from 7.166.2 to 7.166.3 (release assets verified live). The next deploy self-heals prod's recorded dead endpoint.

Part of ksail#6070