### PR TITLE
test(storage): activate userns Longhorn smoke proof

### DIFF
--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -15,11 +15,10 @@ resources:
   # the devantler-tech/aws repo sync lands in a follow-up increment. Hetzner-only
   # because Crossplane (and the provider packages) are prod-only.
   - aws/
-  # Default-off disposable proof for user namespaces + Longhorn idmapped mounts
-  # (platform#2599). Activate in a short-lived PR by uncommenting this resource,
-  # capture the completed Job's logs, then remove it again so its generic
-  # ephemeral PVC and Longhorn volume are garbage-collected.
-  # - userns-longhorn-smoke/
+  # Short-lived activation of the disposable userns + Longhorn idmapped-mount
+  # proof (platform#2604). Capture the completed Job's logs, then remove this
+  # resource again so its generic ephemeral PVC and volume are garbage-collected.
+  - userns-longhorn-smoke/
   # Prod-only Coroot Postgres integration for the platform-owned CNPG DBs:
   # additive CiliumNetworkPolicies that let the observability cluster-agent
   # scrape each on 5432 (the Cluster patches below stamp the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why

The default-off `userns-longhorn-smoke` harness landed in #2600. The next sequenced step is a short-lived prod activation that proves a user-namespaced pod can complete an init-to-main read/write round trip on a Longhorn-backed generic ephemeral volume before any real stateful workload opts in.

## What

- activates only `userns-longhorn-smoke/` in the prod-only Hetzner apps overlay
- records the activation/cleanup lifecycle in the adjacent comment
- changes no application workload, storage policy, or local-cluster render

After the merge-group deployment, the engineer will wait for the Job to complete, capture its UID/GID mapping and sentinel logs, check warning events, then remove the component and verify its namespace/PVC/PV/Longhorn volume are gone.

## Validation

- failing-first assertion: the active resource line and prod component render were absent before the change
- feature states: Hetzner apps render includes the Job; local cluster render still excludes it
- `python3 scripts/validate-embedded-json.py`
- `python3 scripts/validate-naming.py`
- `kubectl kustomize k8s/clusters/local/`
- `kubectl kustomize k8s/clusters/prod/`
- `kubectl kustomize k8s/providers/hetzner/apps/`
- `ksail workload validate` — 109 kustomizations / 541 YAML files
- `ksail --config ksail.prod.yaml workload validate` — 109 kustomizations / 541 YAML files
- `ksail workload scan --framework nsa --compliance-threshold 85`
- `git diff --check`

## Scope

Part of #2604 and parent #1807. The cleanup PR will close #2604 after live proof and garbage-collection verification.
