### PR TITLE
feat(crossplane): activate iam Policy MRD for the eks-ci permissions boundary

### DIFF
--- a/k8s/providers/hetzner/apps/aws/role.yaml
+++ b/k8s/providers/hetzner/apps/aws/role.yaml
@@ -15,6 +15,7 @@ rules:
       - iam.aws.m.upbound.io
     resources:
       - openidconnectproviders
+      - policies
       - roles
     verbs:
       - get

--- a/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy-aws.yaml
+++ b/k8s/providers/hetzner/infrastructure/crossplane/managed-resource-activation-policy-aws.yaml
@@ -1,8 +1,11 @@
 # provider-aws-iam declares SafeStart, so its ManagedResourceDefinitions
 # install Inactive. Activate only the namespaced IAM kinds required by the
 # default-off EKS CI identity slice (platform#2564 / platform#2326). The role
-# carries its least-privilege permissions as an inline policy, avoiding the
-# separate Policy and RolePolicyAttachment CRDs and their apiserver/RBAC cost.
+# carries its least-privilege permissions as an inline policy; the single
+# Policy kind is activated for the eks-ci-smoke-boundary permissions boundary
+# (aws#4 security hardening: roles the CI principal creates must carry a
+# boundary, so it cannot mint-and-pass an unbounded role). Broad
+# Policy/RolePolicyAttachment use stays deliberately off.
 ---
 apiVersion: apiextensions.crossplane.io/v1alpha1
 kind: ManagedResourceActivationPolicy
@@ -11,4 +14,5 @@ metadata:
 spec:
   activate:
     - openidconnectproviders.iam.aws.m.upbound.io
+    - policies.iam.aws.m.upbound.io
     - roles.iam.aws.m.upbound.io


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
A review of the EKS CI identity (aws#4) found a privilege-escalation path: the CI role could create an IAM role with arbitrary permissions and pass it to EC2, escaping its smoke-test scope. The fix caps every role it creates with a permissions boundary — which needs the `Policy` managed-resource kind active, currently off by design (#2564).

## What
Activates `policies.iam.aws.m.upbound.io` in the aws activation policy and grants the aws tenant RBAC over it — one kind, only for the boundary; broad Policy/RolePolicyAttachment use stays off. Consumed by the boundary manifest in aws#4, which should merge after this.

Part of #2326.

**Note:** the merge queue is currently wedged on the pending `GHCR_TOKEN` rotation (see #2611) — this draft is mergeable once that secret is rotated.