### PR TITLE
test(storage): restore userns smoke harness default-off

### DIFF
--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -15,10 +15,11 @@ resources:
   # the devantler-tech/aws repo sync lands in a follow-up increment. Hetzner-only
   # because Crossplane (and the provider packages) are prod-only.
   - aws/
-  # Short-lived activation of the disposable userns + Longhorn idmapped-mount
-  # proof (platform#2604). Capture the completed Job's logs, then remove this
-  # resource again so its generic ephemeral PVC and volume are garbage-collected.
-  - userns-longhorn-smoke/
+  # Default-off disposable proof for user namespaces + Longhorn idmapped mounts
+  # (platform#2599). Activate in a short-lived PR by uncommenting this resource,
+  # capture the completed Job's logs, then remove it again so its generic
+  # ephemeral PVC and Longhorn volume are garbage-collected.
+  # - userns-longhorn-smoke/
   # Prod-only Coroot Postgres integration for the platform-owned CNPG DBs:
   # additive CiliumNetworkPolicies that let the observability cluster-agent
   # scrape each on 5432 (the Cluster patches below stamp the


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## What changed

- restored the disposable `userns-longhorn-smoke` component to its documented default-off state in the Hetzner apps overlay
- retained the standalone Namespace + Job component for future regression checks
- left local/CI behavior and real application user-namespace opt-ins unchanged

## Why

The short-lived production proof from #2604/#2605 remained declaratively active after completing. Read-only pre-removal evidence now proves that the Job completed successfully, both init and main containers used non-zero subordinate UID/GID mappings, the Longhorn-backed write/read round trip passed, the volume detached normally, and no attributable Warning events remain.

Refs #2619
Parent: #1807

This PR intentionally does **not** auto-close #2619. The issue must stay open until the merge-queue rollout has pruned the Namespace, Job/Pod, PVC/PV, and corresponding Longhorn volume and that cleanup is verified.

## Validation

- failing-first default-off render assertion: RED found two smoke resources before the change; GREEN found zero in Docker/Hetzner default renders
- standalone component render: exactly one restricted Namespace and one bounded, no-retry, tokenless Job with `hostUsers: false` and a 256Mi RWO `longhorn-wffc` generic-ephemeral claim
- `python3 scripts/validate-naming.py`
- `python3 scripts/validate-embedded-json.py`
- raw local, production, Hetzner apps, and standalone Kustomize renders
- KSail 7.167.0 local validation: 109 kustomizations / 541 files
- KSail 7.167.0 production validation: 109 kustomizations / 541 files
- `ksail workload scan --framework nsa --compliance-threshold 85`
- `git diff --check`
- independent diff review: clean

## Rollout follow-up

After promotion and merge-queue deployment, verify the smoke Namespace, Job/Pod, PVC/PV, and Longhorn volume are absent; then record the cleanup on #1807 and close #2619 manually.