### PR TITLE
fix(aws): make the eks-ci permissions boundary platform-owned

### DIFF
--- a/k8s/providers/hetzner/apps/aws/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/aws/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - secret-store.yaml
   - provider-config.yaml
   - policy-eks-ci-smoke-boundary.yaml
+  - role-eks-ci.yaml
   - external-secret.yaml
   - oci-repository.yaml
   - flux-kustomization.yaml

--- a/k8s/providers/hetzner/apps/aws/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/aws/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - network-policy.yaml
   - secret-store.yaml
   - provider-config.yaml
+  - policy-eks-ci-smoke-boundary.yaml
   - external-secret.yaml
   - oci-repository.yaml
   - flux-kustomization.yaml

--- a/k8s/providers/hetzner/apps/aws/policy-eks-ci-smoke-boundary.yaml
+++ b/k8s/providers/hetzner/apps/aws/policy-eks-ci-smoke-boundary.yaml
@@ -18,10 +18,33 @@
 #
 # The allowlist is the union of what eksctl-created cluster/node/IRSA roles
 # exercise in the smoke path (EKS control plane, node compute/networking, ECR
-# pulls, CNI, logs/metrics, SSM agent channels); deliberately NO iam:* or
+# pulls, CNI, logs/metrics, SSM agent). A permissions boundary must ALLOW an
+# action for the attached policy to be effective, so two gaps found in review
+# (#2631) are covered explicitly:
+#
+#   - the full AmazonSSMManagedInstanceCore action set, not just
+#     ssm:GetParameter(s) — without UpdateInstanceInformation / PutInventory /
+#     the association+document reads, the SSM agent never registers and node SSM
+#     access fails silently even though the message channels are allowed;
+#   - iam:CreateServiceLinkedRole, CONDITIONED on iam:AWSServiceName for the
+#     named AWS services only. AmazonEKSClusterPolicy grants this, and the first
+#     Service/Ingress LoadBalancer in an account without the
+#     elasticloadbalancing service-linked role would otherwise be denied by the
+#     boundary despite elasticloadbalancing:* being allowed.
+#
+# Apart from that one conditioned action there is deliberately NO iam:* and no
 # sts:AssumeRole* — a bounded role stays inside the compute plane even if an
-# arbitrary inline policy is put on it. If a future smoke needs an action
-# outside the cap, the failure names it and this file is the tuning point.
+# arbitrary inline policy is put on it, and it cannot mint arbitrary IAM
+# identities. If a future smoke needs an action outside the cap, the failure
+# names it and this file is the tuning point.
+#
+# NOTE (DR / fresh cluster): this is the first AWS managed resource in the apps
+# layer, so it reconciles against the provider's bootstrap credential. On a
+# rebuild where the OpenBao value is still the seeded REPLACE_WITH_AWS_*
+# placeholder, provider-aws-iam will call IAM with an invalid credential and
+# this object stays NotReady. Restoring the real AWS bootstrap credential is a
+# prerequisite of the apps layer on a DR rebuild; the general "a pending
+# bootstrap must not stall delivery" hardening is tracked in #2626.
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: Policy
 metadata:
@@ -56,13 +79,44 @@ spec:
               "kms:CreateGrant",
               "kms:DescribeKey",
               "logs:*",
+              "ssm:DescribeAssociation",
+              "ssm:DescribeDocument",
+              "ssm:GetDeployablePatchSnapshotForInstance",
+              "ssm:GetDocument",
+              "ssm:GetManifest",
               "ssm:GetParameter",
               "ssm:GetParameters",
+              "ssm:ListAssociations",
+              "ssm:ListInstanceAssociations",
+              "ssm:PutComplianceItems",
+              "ssm:PutConfigurePackageResult",
+              "ssm:PutInventory",
+              "ssm:UpdateAssociationStatus",
+              "ssm:UpdateInstanceAssociationStatus",
+              "ssm:UpdateInstanceInformation",
               "ssmmessages:*",
               "sts:GetCallerIdentity",
               "sts:TagSession"
             ],
             "Resource": "*"
+          },
+          {
+            "Sid": "ServiceLinkedRolesForNamedServicesOnly",
+            "Effect": "Allow",
+            "Action": "iam:CreateServiceLinkedRole",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "iam:AWSServiceName": [
+                  "autoscaling.amazonaws.com",
+                  "eks.amazonaws.com",
+                  "eks-nodegroup.amazonaws.com",
+                  "elasticloadbalancing.amazonaws.com",
+                  "spot.amazonaws.com",
+                  "spotfleet.amazonaws.com"
+                ]
+              }
+            }
           }
         ]
       }

--- a/k8s/providers/hetzner/apps/aws/policy-eks-ci-smoke-boundary.yaml
+++ b/k8s/providers/hetzner/apps/aws/policy-eks-ci-smoke-boundary.yaml
@@ -52,6 +52,16 @@ metadata:
   namespace: aws
   labels:
     app.kubernetes.io/managed-by: ksail
+  annotations:
+    # The top-level `apps` Kustomization runs force: true, but this is a
+    # Crossplane managed resource with the default deletionPolicy: Delete — a
+    # force delete/recreate on immutable-field drift would cascade into DELETING
+    # the backing AWS IAM policy (the same class of failure that wiped coroot-db
+    # on 2026-06-18). The tenant Kustomization avoids force for exactly this
+    # reason; these platform-owned MRs opt out per-resource instead (#2631
+    # review). Flux can still update them in place; a genuine immutable conflict
+    # is an operator decision, not an automatic replace.
+    kustomize.toolkit.fluxcd.io/force: disabled
 spec:
   forProvider:
     description: >-

--- a/k8s/providers/hetzner/apps/aws/policy-eks-ci-smoke-boundary.yaml
+++ b/k8s/providers/hetzner/apps/aws/policy-eks-ci-smoke-boundary.yaml
@@ -1,0 +1,71 @@
+---
+# Permissions boundary for every IAM role the eks-ci principal creates
+# (eksctl-st-eks-* cluster/nodegroup/IRSA roles). The eks-ci Role conditions
+# iam:CreateRole on this boundary (iam:PermissionsBoundary) and holds no
+# iam:*PermissionsBoundary or role-update actions, so a workflow that assumes
+# eks-ci cannot mint a role more privileged than this cap and pass it to EC2 to
+# escape the smoke-test scope.
+#
+# PLATFORM-OWNED ON PURPOSE (#2612 review). The eks-ci Role itself lives in the
+# PUBLIC devantler-tech/aws artifact, which Flux applies as the namespace-scoped
+# `aws` ServiceAccount. If this boundary lived there too, the artifact it is
+# supposed to constrain could rewrite it — a boundary the bounded party can edit
+# caps nothing. So it is applied here, by the platform's own `apps`
+# Kustomization, and the tenant SA is granted NO write verbs on iam `policies`
+# (see role.yaml). The tenant references the boundary by ARN only:
+#
+#   arn:aws:iam::939001610192:policy/eks-ci-smoke-boundary
+#
+# The allowlist is the union of what eksctl-created cluster/node/IRSA roles
+# exercise in the smoke path (EKS control plane, node compute/networking, ECR
+# pulls, CNI, logs/metrics, SSM agent channels); deliberately NO iam:* or
+# sts:AssumeRole* — a bounded role stays inside the compute plane even if an
+# arbitrary inline policy is put on it. If a future smoke needs an action
+# outside the cap, the failure names it and this file is the tuning point.
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: eks-ci-smoke-boundary
+  namespace: aws
+  labels:
+    app.kubernetes.io/managed-by: ksail
+spec:
+  forProvider:
+    description: >-
+      Permissions boundary capping IAM roles created by the eks-ci GitHub
+      OIDC role for throwaway st-eks-* smoke clusters.
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "SmokeComputePlaneCap",
+            "Effect": "Allow",
+            "Action": [
+              "autoscaling:*",
+              "cloudwatch:*",
+              "ec2:*",
+              "ec2messages:*",
+              "ecr:BatchCheckLayerAvailability",
+              "ecr:BatchGetImage",
+              "ecr:GetAuthorizationToken",
+              "ecr:GetDownloadUrlForLayer",
+              "eks:*",
+              "eks-auth:AssumeRoleForPodIdentity",
+              "elasticloadbalancing:*",
+              "kms:CreateGrant",
+              "kms:DescribeKey",
+              "logs:*",
+              "ssm:GetParameter",
+              "ssm:GetParameters",
+              "ssmmessages:*",
+              "sts:GetCallerIdentity",
+              "sts:TagSession"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
+++ b/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
@@ -31,6 +31,15 @@
 # action is granted, so roles this principal creates (and can pass to EC2) are
 # capped at the smoke-test compute plane even if an arbitrary policy is written
 # to them.
+#
+# ROLLOUT GATE (#2631 review): the iam:CreateRole condition below makes every
+# eksctl-created role carry the boundary, but ksail's generated eks.yaml does not
+# yet set eksctl's iam.serviceRolePermissionsBoundary /
+# managedNodeGroups[].iam.instanceRolePermissionsBoundary — so CloudFormation's
+# first unbounded CreateRole would be DENIED and the smoke could not provision.
+# devantler-tech/ksail#6082 must land before the first System-Test-EKS dispatch.
+# This is a rollout-sequencing gate, not a defect in the condition: the cap is
+# correct, the caller just has to ask for it.
 apiVersion: iam.aws.m.upbound.io/v1beta1
 kind: Role
 metadata:
@@ -38,6 +47,11 @@ metadata:
   namespace: aws
   labels:
     app.kubernetes.io/managed-by: ksail
+  annotations:
+    # See policy-eks-ci-smoke-boundary.yaml: the `apps` Kustomization runs
+    # force: true, and a force-recreate of a Crossplane MR with the default
+    # deletionPolicy: Delete would DELETE the backing AWS IAM role. Opt out.
+    kustomize.toolkit.fluxcd.io/force: disabled
 spec:
   forProvider:
     description: >-

--- a/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
+++ b/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
@@ -134,7 +134,10 @@ spec:
               {
                 "Sid": "SsmAmiLookup",
                 "Effect": "Allow",
-                "Action": "ssm:GetParameter",
+                "Action": [
+                  "ssm:GetParameter",
+                  "ssm:GetParameters"
+                ],
                 "Resource": [
                   "arn:aws:ssm:*::parameter/aws/service/eks/optimized-ami/*",
                   "arn:aws:ssm:*::parameter/aws/service/bottlerocket/*"
@@ -234,6 +237,18 @@ spec:
                   "iam:GetPolicyVersion"
                 ],
                 "Resource": "*"
+              },
+              {
+                "Sid": "IamReadCallerIdentity",
+                "Effect": "Allow",
+                "Action": [
+                  "iam:GetRole",
+                  "iam:GetUser"
+                ],
+                "Resource": [
+                  "arn:aws:iam::939001610192:role/*",
+                  "arn:aws:iam::939001610192:user/*"
+                ]
               },
               {
                 "Sid": "StsIdentity",

--- a/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
+++ b/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
@@ -1,0 +1,221 @@
+---
+# The AWS-side identity the ksail "System Test - EKS" workflow assumes via
+# GitHub Actions OIDC (platform#2326 child 2). Trust is scoped to exactly one
+# GitHub environment — repo:devantler-tech/ksail:environment:ci — through the
+# account's GitHub OIDC provider (owned by the devantler-tech/aws artifact), so
+# no long-lived key exists anywhere. maxSessionDuration is 7200s because the
+# smoke job may run up to 120 min including cluster cleanup.
+#
+# PLATFORM-OWNED ON PURPOSE (#2631 review, codex P1). This Role — not just the
+# boundary Policy — must live on the platform side. The cap on what eks-ci may
+# mint is expressed as an iam:PermissionsBoundary CONDITION inside this Role's
+# own inlinePolicy, so whoever can edit the Role can delete the condition and
+# escape the cap without ever touching the Policy object. Moving only the Policy
+# to the platform (the first cut of #2631) therefore fixed nothing on its own:
+# the tenant Role RBAC still granted update/patch/delete on iam `roles`, and the
+# PUBLIC devantler-tech/aws artifact is applied as that ServiceAccount. Both the
+# boundary AND the role it constrains are now platform-owned, and the tenant SA
+# holds NO write verbs on iam roles or policies (see role.yaml) — it keeps only
+# the OIDC provider, which is what the aws artifact legitimately owns.
+#
+# Permissions are an INLINE policy (platform#2564: RolePolicyAttachment MRD is
+# deliberately not activated) modeled on eksctl's documented minimum policies,
+# name-scoped to the workflow's st-eks-*/eksctl-st-eks-* naming wherever IAM
+# supports resource-level scoping (CloudFormation stacks, IAM roles/instance
+# profiles, EKS clusters). EC2/autoscaling/SSM-AMI actions are account-wide
+# because eksctl drives them through CloudFormation with the caller's
+# credentials and their create-time actions do not support name scoping; the
+# blast radius remains bounded by the single-environment trust.
+# iam:CreateRole is conditioned on the eks-ci-smoke-boundary permissions
+# boundary (policy-eks-ci-smoke-boundary.yaml) and no *PermissionsBoundary
+# action is granted, so roles this principal creates (and can pass to EC2) are
+# capped at the smoke-test compute plane even if an arbitrary policy is written
+# to them.
+apiVersion: iam.aws.m.upbound.io/v1beta1
+kind: Role
+metadata:
+  name: eks-ci
+  namespace: aws
+  labels:
+    app.kubernetes.io/managed-by: ksail
+spec:
+  forProvider:
+    description: >-
+      GitHub OIDC role for the ksail System Test - EKS smoke workflow
+      (repo:devantler-tech/ksail:environment:ci). Creates and deletes
+      throwaway st-eks-* EKS clusters via eksctl.
+    maxSessionDuration: 7200
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Federated": "arn:aws:iam::939001610192:oidc-provider/token.actions.githubusercontent.com"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+              "StringEquals": {
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                "token.actions.githubusercontent.com:sub": "repo:devantler-tech/ksail:environment:ci"
+              }
+            }
+          }
+        ]
+      }
+    inlinePolicy:
+      - name: eks-ci-smoke
+        policy: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "CloudFormationScoped",
+                "Effect": "Allow",
+                "Action": "cloudformation:*",
+                "Resource": "arn:aws:cloudformation:*:939001610192:stack/eksctl-st-eks-*/*"
+              },
+              {
+                "Sid": "CloudFormationRead",
+                "Effect": "Allow",
+                "Action": [
+                  "cloudformation:ListStacks",
+                  "cloudformation:GetTemplateSummary"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "EksScoped",
+                "Effect": "Allow",
+                "Action": "eks:*",
+                "Resource": [
+                  "arn:aws:eks:*:939001610192:cluster/st-eks-*",
+                  "arn:aws:eks:*:939001610192:nodegroup/st-eks-*/*/*",
+                  "arn:aws:eks:*:939001610192:addon/st-eks-*/*/*",
+                  "arn:aws:eks:*:939001610192:access-entry/st-eks-*/*/*/*/*",
+                  "arn:aws:eks:*:939001610192:accessEntry/st-eks-*/*/*/*/*"
+                ]
+              },
+              {
+                "Sid": "EksRead",
+                "Effect": "Allow",
+                "Action": [
+                  "eks:DescribeAddonVersions",
+                  "eks:DescribeAddonConfiguration",
+                  "eks:ListClusters"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "Ec2AndAutoscaling",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:*",
+                  "autoscaling:*",
+                  "elasticloadbalancing:*"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "SsmAmiLookup",
+                "Effect": "Allow",
+                "Action": "ssm:GetParameter",
+                "Resource": [
+                  "arn:aws:ssm:*::parameter/aws/service/eks/optimized-ami/*",
+                  "arn:aws:ssm:*::parameter/aws/service/bottlerocket/*"
+                ]
+              },
+              {
+                "Sid": "IamCreateRoleBounded",
+                "Effect": "Allow",
+                "Action": "iam:CreateRole",
+                "Resource": "arn:aws:iam::939001610192:role/eksctl-st-eks-*",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:PermissionsBoundary": "arn:aws:iam::939001610192:policy/eks-ci-smoke-boundary"
+                  }
+                }
+              },
+              {
+                "Sid": "IamScopedRoleLifecycle",
+                "Effect": "Allow",
+                "Action": [
+                  "iam:DeleteRole",
+                  "iam:GetRole",
+                  "iam:TagRole",
+                  "iam:UntagRole",
+                  "iam:AttachRolePolicy",
+                  "iam:DetachRolePolicy",
+                  "iam:PutRolePolicy",
+                  "iam:GetRolePolicy",
+                  "iam:DeleteRolePolicy",
+                  "iam:ListRolePolicies",
+                  "iam:ListAttachedRolePolicies",
+                  "iam:ListInstanceProfilesForRole",
+                  "iam:PassRole"
+                ],
+                "Resource": "arn:aws:iam::939001610192:role/eksctl-st-eks-*"
+              },
+              {
+                "Sid": "IamScopedInstanceProfiles",
+                "Effect": "Allow",
+                "Action": [
+                  "iam:CreateInstanceProfile",
+                  "iam:DeleteInstanceProfile",
+                  "iam:GetInstanceProfile",
+                  "iam:TagInstanceProfile",
+                  "iam:AddRoleToInstanceProfile",
+                  "iam:RemoveRoleFromInstanceProfile"
+                ],
+                "Resource": "arn:aws:iam::939001610192:instance-profile/eksctl-st-eks-*"
+              },
+              {
+                "Sid": "IamServiceLinkedRoles",
+                "Effect": "Allow",
+                "Action": "iam:CreateServiceLinkedRole",
+                "Resource": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:AWSServiceName": [
+                      "eks.amazonaws.com",
+                      "eks-nodegroup.amazonaws.com",
+                      "autoscaling.amazonaws.com",
+                      "elasticloadbalancing.amazonaws.com"
+                    ]
+                  }
+                }
+              },
+              {
+                "Sid": "IamOidcProviderLifecycle",
+                "Effect": "Allow",
+                "Action": [
+                  "iam:CreateOpenIDConnectProvider",
+                  "iam:DeleteOpenIDConnectProvider",
+                  "iam:TagOpenIDConnectProvider",
+                  "iam:UntagOpenIDConnectProvider"
+                ],
+                "Resource": "arn:aws:iam::939001610192:oidc-provider/oidc.eks.*"
+              },
+              {
+                "Sid": "IamReadForEksctl",
+                "Effect": "Allow",
+                "Action": [
+                  "iam:GetOpenIDConnectProvider",
+                  "iam:ListPolicies",
+                  "iam:GetPolicy",
+                  "iam:GetPolicyVersion"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "StsIdentity",
+                "Effect": "Allow",
+                "Action": "sts:GetCallerIdentity",
+                "Resource": "*"
+              }
+            ]
+          }
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
+++ b/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
@@ -213,6 +213,18 @@ spec:
                 "Resource": "arn:aws:iam::939001610192:oidc-provider/oidc.eks.*"
               },
               {
+                "Sid": "IamScopedPolicyLifecycle",
+                "Effect": "Allow",
+                "Action": [
+                  "iam:CreatePolicy",
+                  "iam:DeletePolicy",
+                  "iam:CreatePolicyVersion",
+                  "iam:DeletePolicyVersion",
+                  "iam:ListPolicyVersions"
+                ],
+                "Resource": "arn:aws:iam::939001610192:policy/eksctl-*"
+              },
+              {
                 "Sid": "IamReadForEksctl",
                 "Effect": "Allow",
                 "Action": [

--- a/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
+++ b/k8s/providers/hetzner/apps/aws/role-eks-ci.yaml
@@ -159,6 +159,7 @@ spec:
                   "iam:GetRole",
                   "iam:TagRole",
                   "iam:UntagRole",
+                  "iam:UpdateAssumeRolePolicy",
                   "iam:AttachRolePolicy",
                   "iam:DetachRolePolicy",
                   "iam:PutRolePolicy",

--- a/k8s/providers/hetzner/apps/aws/role.yaml
+++ b/k8s/providers/hetzner/apps/aws/role.yaml
@@ -3,6 +3,15 @@
 # is applied as this ServiceAccount, so it receives namespace-local authority
 # over exactly the namespaced provider-aws-iam kinds activated for the EKS CI
 # identity. ProviderConfig and credential resources remain platform-owned.
+#
+# `policies` is deliberately NOT granted (#2612 review): the tenant artifact is
+# the PUBLIC devantler-tech/aws repo, so write access to iam Policy objects
+# would let that artifact create, rewrite or delete the very
+# eks-ci-smoke-boundary permissions boundary that is meant to cap the roles the
+# eks-ci principal mints — and the already-active Role kind can attach managed
+# policies via managedPolicyArns, so withholding RolePolicyAttachment does not
+# contain it. The boundary is therefore platform-owned
+# (policy-eks-ci-smoke-boundary.yaml) and the tenant only references it by ARN.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -15,7 +24,6 @@ rules:
       - iam.aws.m.upbound.io
     resources:
       - openidconnectproviders
-      - policies
       - roles
     verbs:
       - get

--- a/k8s/providers/hetzner/apps/aws/role.yaml
+++ b/k8s/providers/hetzner/apps/aws/role.yaml
@@ -4,14 +4,22 @@
 # over exactly the namespaced provider-aws-iam kinds activated for the EKS CI
 # identity. ProviderConfig and credential resources remain platform-owned.
 #
-# `policies` is deliberately NOT granted (#2612 review): the tenant artifact is
-# the PUBLIC devantler-tech/aws repo, so write access to iam Policy objects
-# would let that artifact create, rewrite or delete the very
-# eks-ci-smoke-boundary permissions boundary that is meant to cap the roles the
-# eks-ci principal mints — and the already-active Role kind can attach managed
-# policies via managedPolicyArns, so withholding RolePolicyAttachment does not
-# contain it. The boundary is therefore platform-owned
-# (policy-eks-ci-smoke-boundary.yaml) and the tenant only references it by ARN.
+# Neither `policies` NOR `roles` is granted (#2612 / #2631 review). The tenant
+# artifact is the PUBLIC devantler-tech/aws repo, applied as this ServiceAccount,
+# so every verb here is a capability handed to that artifact:
+#
+#   - write on `policies` would let it create, rewrite or delete the
+#     eks-ci-smoke-boundary permissions boundary itself;
+#   - write on `roles` would let it edit the eks-ci Role, whose inlinePolicy
+#     carries the iam:PermissionsBoundary CONDITION that IS the cap — deleting
+#     that condition escapes the boundary without ever touching the Policy
+#     object (and the Role kind can also attach managed policies via
+#     managedPolicyArns, so withholding RolePolicyAttachment does not contain it).
+#
+# A boundary the bounded party can edit caps nothing, so BOTH the boundary
+# (policy-eks-ci-smoke-boundary.yaml) and the role it constrains
+# (role-eks-ci.yaml) are platform-owned. The artifact keeps only the OIDC
+# provider, which is what it legitimately owns.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -24,7 +32,6 @@ rules:
       - iam.aws.m.upbound.io
     resources:
       - openidconnectproviders
-      - roles
     verbs:
       - get
       - list


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

**A boundary the bounded party can edit caps nothing.**

The EKS-CI setup let the **public** `devantler-tech/aws` repo administer its own security cap. The platform applies that repo's contents with a ServiceAccount that #2612 had granted write access to IAM roles and policies — so anything landing in that public repo could have removed the limit on what the CI identity may create in AWS, then created whatever it liked. **That grant is live in prod today**; this PR is what removes it.

Two things are worth being upfront about, because the review caught both and I had them wrong:

1. My first attempt moved only the *policy*. That fixed nothing — the limit is actually expressed **inside the role**, so editing the role removes it without touching the policy. Both had to move.
2. Moving them then put them under a Kustomization that force-replaces on conflict, which for these resources would have **deleted the real AWS role and boundary** (the failure that wiped `coroot-db` in June). Now explicitly opted out.

## What

The CI identity and its cap are **platform-owned**, where the public repo can't reach them — that repo keeps only the OIDC provider, which is genuinely its own. No capability is lost; the CI role simply can no longer rewrite its own limits.

Also closes two gaps in the cap that would have *broken* the smoke test rather than weakened it (load-balancer creation and SSM agent registration were being denied), and protects both resources from force-replace.

## Merge order

1. **This PR** (removes the live over-grant).
2. **`devantler-tech/aws#4`** — on hold; must drop its copies of the role and boundary. It then has no content left, so it likely closes.
3. **ksail#6082** — must land before the first System-Test-EKS dispatch: eksctl doesn't yet pass the boundary, so the first `CreateRole` would be denied. Nothing dispatches on merge, so landing this today breaks nothing.

**Known limitation, deliberately not fixed here:** on a DR rebuild this resource needs the real AWS credential restored before the apps layer goes healthy — a pre-existing property of the layer (#2626). I didn't want to bundle a delivery-layer redesign into a security fix.

Part of #2326.
