### PR TITLE
fix(alerting): page on failing HelmReleases; fix GHCR node-credential rotation docs

### DIFF
--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -487,6 +487,86 @@ gh secret set TALOS_CONFIG --env prod --repo devantler-tech/platform < ~/.talos/
 
 ---
 
+## Scenario 10 — GHCR pull-credential rotation
+
+The ghcr.io pull credential lives in **two places that behave very differently**,
+and the node one is the trap:
+
+| Copy | Consumer | Picks up a new token… |
+|---|---|---|
+| OpenBao `infrastructure/ghcr/auth` → `ghcr-auth` / `ksail-registry-credentials` Secrets | Flux (OCI artifacts), per-pod `imagePullSecrets`, Kyverno | automatically, on ExternalSecret re-sync |
+| Talos `machine.registries` / `RegistryAuthConfig` → containerd | **every node-level image pull** | **only when the node REBOOTS** |
+
+containerd loads registry auth from its static config **once, at process start**.
+Talos re-renders `/etc/cri/conf.d/01-registries.part` the moment the config
+changes, but it does not restart containerd — and it will not let you:
+
+```console
+$ talosctl service cri restart
+error: service "cri" doesn't support restart operation via API
+```
+
+So after a rotation the new token is on disk, correct and **inert**, while the
+running containerd keeps presenting the revoked one.
+
+**Why this is a silent, delayed outage.** A revoked credential is *worse than no
+credential*: ghcr.io answers bad basic-auth with `403 DENIED` on the token
+exchange instead of falling back to anonymous, so even **public** packages stop
+pulling. But images already cached on a node are never re-pulled — so every
+running workload stays up and the cluster looks green. Only a **fresh** pull
+fails, i.e. an upgrade, and Helm then times out and **rolls back**, deleting the
+failed pods. (2026-07-14: `ksail-operator` sat four releases behind for over a
+day, every ReplicaSet since v7.168.0 at 0 replicas, with no alert.)
+
+```bash
+# 1. Mint the new PAT (classic, scope: read:packages only). Do NOT revoke the
+#    old one yet -- both must work during the roll.
+
+# 2. Update the single source of truth + the org secret used by the deploy.
+kubectl -n openbao exec openbao-0 -- \
+  bao kv put secret/infrastructure/ghcr/auth username=<user> password=<new-pat>
+gh secret set GHCR_TOKEN --org devantler-tech --body '<new-pat>'
+
+# 3. Let the deploy (`ksail cluster update`) push the new token into each node's
+#    machine config, then confirm it actually landed on disk:
+talosctl --nodes <node-ip> read /etc/cri/conf.d/01-registries.part   # new token?
+
+# 4. THE OPERATIVE STEP -- roll a reboot so containerd reloads it. One node at a
+#    time; workers first, then control planes (watch etcd quorum between each).
+talosctl --nodes <node-ip> reboot
+kubectl get node <name> -w                       # wait Ready before the next
+talosctl --nodes <node-ip> service cri           # PID/uptime must have reset
+
+# 5. Verify a REAL pull end-to-end (static config being correct proves nothing --
+#    it was correct throughout the incident). Force a fresh pull of an image that
+#    is NOT cached on that node and confirm it starts:
+kubectl -n <ns> rollout restart deploy/<some-first-party-deploy>
+kubectl get pods -A | grep -E 'ImagePullBackOff|ErrImagePull'   # expect none
+
+# 6. Only now revoke the old PAT in GitHub.
+```
+
+**Verifying whether nodes are currently stale** (do this after any rotation, and
+first whenever an upgrade mysteriously rolls back):
+
+```bash
+# Does the token containerd actually holds still work?
+TOK=$(talosctl --nodes <node-ip> read /etc/cri/conf.d/01-registries.part \
+        | grep -oE 'ghp_[A-Za-z0-9]+' | head -1)
+curl -s -o /dev/null -w '%{http_code}\n' -u "<user>:$TOK" \
+  'https://ghcr.io/token?service=ghcr.io&scope=repository:devantler-tech/ksail:pull'
+# 200 = good. 403 = revoked credential -> that node cannot pull ANY ghcr.io image.
+
+# A containerd older than the last rotation is a stale node, by definition:
+talosctl --nodes <node-ip> service cri | grep Process   # started ... ago
+```
+
+> Node **creation** is unaffected: a freshly booted node (including an
+> autoscaled one) reads the current config at start, so scale-out and node
+> replacement always get the right token. Only **long-running** nodes go stale.
+
+---
+
 ## Related documents
 
 - [Cryptographic custody](./crypto-custody.md) — per-artifact threat model for SOPS keys, Talos PKI, OpenBao seal, cosign identity

--- a/k8s/providers/hetzner/infrastructure/flux-notifications/alert.yaml
+++ b/k8s/providers/hetzner/infrastructure/flux-notifications/alert.yaml
@@ -5,15 +5,31 @@
 # server-side apply, an unresolved dependency, or a child resource that never
 # goes Ready under a wait:true Kustomization.
 #
-# Watching every Kustomization at error severity catches the whole class: the
+# Watching every Kustomization at error severity catches most of the class: the
 # four top-level health gates (bootstrap → infrastructure-controllers →
-# infrastructure → apps) wait on their children, so a failed controller / app /
-# HelmRelease surfaces as its parent Kustomization going NotReady → an error
-# event here → Slack. Event-driven (no polling pod, so nothing for the kubescape
-# scan to flag) and posting to the same channel as the Coroot alerts.
+# infrastructure → apps) wait on their children, so a failed controller / app
+# surfaces as its parent Kustomization going NotReady → an error event here →
+# Slack. Event-driven (no polling pod, so nothing for the kubescape scan to
+# flag) and posting to the same channel as the Coroot alerts.
+#
+# HelmRelease is watched DIRECTLY, and not left to that parent-Kustomization
+# gate, because a failing HelmRelease can stay INVISIBLE to it. With Helm
+# remediation enabled, a failed upgrade is ROLLED BACK to the last-good release
+# — after which the HelmRelease is legitimately Ready again, its parent
+# Kustomization stays healthy, and nothing ever pages. The release simply stops
+# advancing, silently, forever.
+#
+# That is not hypothetical: on 2026-07-14 the ksail-operator HelmRelease failed
+# its upgrade and rolled back on every attempt for over a day (stuck four
+# releases behind, every ReplicaSet since v7.168.0 at 0 replicas, because the
+# nodes' ghcr.io credential was stale — see
+# talos/cluster/authenticate-ghcr-pulls.yaml). Prod looked green the whole time
+# and no alert fired. Watching HelmRelease routes helm-controller's own error
+# events (upgrade failed / retries exhausted / rollback) instead of depending on
+# a health gate that a successful rollback deliberately satisfies.
 #
 # notification-controller dedupes + rate-limits, so a persistently-failing
-# Kustomization pages once, not every reconcile.
+# resource pages once, not every reconcile.
 apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
@@ -25,5 +41,7 @@ spec:
   eventSeverity: error
   eventSources:
     - kind: Kustomization
+      name: "*"
+    - kind: HelmRelease
       name: "*"
   summary: "Flux reconciliation error — prod platform"

--- a/talos/cluster/authenticate-ghcr-pulls.yaml
+++ b/talos/cluster/authenticate-ghcr-pulls.yaml
@@ -31,15 +31,40 @@
 # ksail.prod.yaml; local/CI uses talos-local/, which carries no
 # ImageVerificationConfig.
 #
-# CAVEAT — applying to EXISTING nodes: ksail's `cluster update` diff only tracks
-# node count / Talos version / ISO, so a machine-config-only change like this is
-# NOT pushed to already-running nodes (it reports "No changes detected"). This
-# patch makes every node correct-by-construction on create/recreate (and the
-# autoscaler's rendered worker config); to apply it to nodes that are already up,
-# patch them once out-of-band, e.g.:
-#   talosctl --nodes <node-ips> patch mc --patch @<this file, ${GHCR_TOKEN} filled>
-# (registries is a no-reboot field), then restart any pod stuck in
-# ImagePullBackOff. See docs/dr/runbook.md.
+# CAVEAT — ROTATING this credential requires a ROLLING NODE REBOOT. Writing the
+# new token to a node's machine config is NOT enough, and patching pods is
+# useless. containerd reads registry auth
+# (plugins.'io.containerd.cri.v1.images'.registry.configs.'ghcr.io'.auth) from
+# its STATIC config, which it loads ONCE at process start. Talos re-renders that
+# file (/etc/cri/conf.d/01-registries.part) as soon as the config changes, but it
+# will NOT restart containerd for you — and it refuses to let you do it either:
+#   $ talosctl service cri restart
+#   error: service "cri" doesn't support restart operation via API
+# So a rotated token sits on disk, correct and inert, while the running containerd
+# keeps presenting the OLD one until the node reboots.
+#
+# This is worse than it sounds, because a REVOKED credential is worse than NO
+# credential: ghcr.io answers bad basic-auth with 403 DENIED on the token
+# exchange rather than falling back to anonymous, so a stale token breaks pulls of
+# PUBLIC packages too (ghcr.io/devantler-tech/ksail is public) — every ghcr.io
+# pull on that node fails:
+#   failed to authorize: failed to fetch oauth token: unexpected status from GET
+#   request to https://ghcr.io/token?...&service=ghcr.io: 403 Forbidden
+#
+# And it fails SILENTLY: images already cached on a node are never re-pulled, so
+# every running workload stays up and the cluster looks green. Only a FRESH pull
+# breaks — i.e. an upgrade — and Helm then times out and rolls back, restoring the
+# last-good release and deleting the evidence. The 2026-07-14 incident: the
+# ksail-operator sat four releases behind (v7.167.0 while v7.169.2 was current)
+# with every ReplicaSet since v7.168.0 at 0 replicas, for over a day, with no
+# alert.
+#
+# To rotate: see "Scenario 10 — GHCR pull-credential rotation" in
+# docs/dr/runbook.md. The short version is that the reboot is the operative step.
+#
+# NOTE — on create/recreate (and for the autoscaler's rendered worker config) a
+# node is correct-by-construction: it boots with the current token, so scale-out
+# and node replacement are unaffected. Only LONG-RUNNING nodes go stale.
 #
 # Reference:
 #   https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/registriesconfig/


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

The `ksail-operator` sat **four releases behind on prod for over a day** and nobody knew. Its image pulls were failing because the nodes' ghcr.io credential had been rotated, but a running node can only pick up a new registry credential by **rebooting** — so every node kept using the revoked one, and every ghcr.io pull failed.

Two things made this a silent, day-long outage rather than a five-minute fix:

1. **Nothing alerted.** A failed Helm upgrade rolls back and then looks perfectly healthy, so the health check we relied on to catch it can never fire for this class of failure.
2. **Our written remediation was wrong.** The note in the repo told an operator to patch the node config and restart the stuck pods. Neither does anything — following it would not have fixed this.

## What

- **Alerts now page on failing HelmReleases directly** instead of assuming a broken release drags its parent into an unhealthy state — a successful rollback deliberately hides exactly that.
- **Adds a real rotation procedure** for the node registry credential to the DR runbook, with the step that actually matters (a rolling node reboot) and a way to check whether nodes are currently stale.
- **Corrects the misleading note** that would have sent the next operator down a dead end. Comments only — the effective config is byte-identical.

Prod is **already recovered** (operator back on the current release, no failing pulls cluster-wide). This PR makes the failure *visible* next time and the fix *repeatable*.

Context: the credential having several sources of truth is tracked in #2613.