### PR TITLE
feat(headlamp): add default-off user namespace gate

### DIFF
--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -66,6 +66,22 @@ patches:
   # add-security-context Kyverno rule. Local/CI and stateful workloads stay
   # out; in mixed namespaces (umami, backstage) the rule itself excludes the
   # CNPG database pods via their cnpg.io/cluster label.
+  # Headlamp is a separately gated stateful pilot (#2650): its chart explicitly
+  # renders hostUsers: true, so the namespace-label Kyverno rule cannot override
+  # that authored value. Keep this exact-target values patch default-off until
+  # the concurrent node-auth rollout has settled and Headlamp/Longhorn are
+  # healthy. Activation uncomments the whole block; recovery re-comments/reverts
+  # it and never deletes the plugins PVC.
+  # - target:
+  #     group: helm.toolkit.fluxcd.io
+  #     version: v2
+  #     kind: HelmRelease
+  #     name: headlamp
+  #     namespace: headlamp
+  #   patch: |-
+  #     - op: add
+  #       path: /spec/values/hostUsers
+  #       value: false
   - path: whoami/patches/enable-user-namespaces.yaml
   - path: homepage/patches/enable-user-namespaces.yaml
   - path: umami/patches/enable-user-namespaces.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer (Codex instance)

## Why

Headlamp is the next stateful workload in the Kubernetes 1.36 user-namespace readiness program. Its chart explicitly renders `hostUsers: true`, so the namespace-label Kyverno rule cannot override the value. This adds a deliberately default-off, exact-target gate before the separately observed live rollout in #2651.

## What

- document the Headlamp/Longhorn safety boundary beside the active user-namespace pilots
- add a fully commented JSON6902 values patch targeting only the `headlamp/headlamp` HelmRelease
- make activation set `spec.values.hostUsers: false`; recovery re-comments the block and preserves the plugins PVC

The committed manifest is parse-identical to `main`, so this PR makes no runtime change.

## Validation

- `ksail workload validate`
- `ksail --config ksail.prod.yaml workload validate`
- `python3 scripts/validate-embedded-json.py`
- `python3 scripts/validate-naming.py`
- `go test ./scripts/generate-kubescape-exceptions`
- generated 21 Kubescape exception policies
- `ksail workload scan --framework nsa --exceptions /tmp/kubescape-exceptions-2650.json --compliance-threshold 95` — all controls passed
- local and production renders are byte-identical to `main` with the gate commented
- synthetic enabled render adds exactly one field, `spec.values.hostUsers: false`, to the Headlamp HelmRelease
- Headlamp chart `0.43.0` renders `hostUsers: true` by default and `false` with the proposed value
- independent Codex review: no actionable findings

## Rollout safety

Activation is intentionally deferred to #2651, after #2635 has settled and live node, Headlamp, and Longhorn health are verified. Recovery changes only this value and never deletes the existing `headlamp-plugins` PVC.

Fixes #2650
Part of #1807
