### PR TITLE
fix(vpa): cap kyverno controller CPU below the leader hot-loop level

### DIFF
--- a/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
@@ -123,6 +123,10 @@ patches:
   # as the 2026-06-30 DaemonSet ratchet above). CPU is compressible: capping
   # only throttles the degenerate loop, never correctness. Root-cause hunt for
   # the loop itself is tracked on the platform issue referenced in the PR.
+  # Memory keeps the shared 6Gi ceiling: `op: replace` swaps the whole
+  # maxAllowed object, and a tighter memory max would clamp an incompressible
+  # resource (the admission controller has a documented OOM history) — the
+  # cap here is deliberately CPU-only.
   - target:
       kind: VerticalPodAutoscaler
       name: kyverno-reports-controller
@@ -131,7 +135,7 @@ patches:
         path: /spec/resourcePolicy/containerPolicies/0/maxAllowed
         value:
           cpu: 500m
-          memory: 512Mi
+          memory: 6Gi
   - target:
       kind: VerticalPodAutoscaler
       name: kyverno-admission-controller
@@ -140,7 +144,7 @@ patches:
         path: /spec/resourcePolicy/containerPolicies/0/maxAllowed
         value:
           cpu: 800m
-          memory: 512Mi
+          memory: 6Gi
   # spire-server: singleton StatefulSet on an RWO volume — never evict.
   - target:
       kind: VerticalPodAutoscaler

--- a/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/vertical-pod-autoscalers/kustomization.yaml
@@ -112,6 +112,35 @@ patches:
         path: /spec/resourcePolicy/containerPolicies/0/maxAllowed
         value:
           cpu: "1"
+  # kyverno admission + reports controllers: cap CPU below the hot-loop level.
+  # Their leader replicas hot-loop (aggregate-report-controller measured at
+  # ~23 no-op reconciles/s, 1.6-2M cumulative; leader steadily burning ~1 CPU
+  # while the standby idles), so an uncapped VPA faithfully sizes the whole
+  # deployment for the pathology: reports hit 1836m and admission 1168m
+  # requests, ~6.2 requested cores across the pairs — which alone tipped the
+  # fleet past the static workers and ratcheted FOUR autoscale nodes into
+  # existence (the 2026-07-16 snapshot-slot deadlock's other half; same class
+  # as the 2026-06-30 DaemonSet ratchet above). CPU is compressible: capping
+  # only throttles the degenerate loop, never correctness. Root-cause hunt for
+  # the loop itself is tracked on the platform issue referenced in the PR.
+  - target:
+      kind: VerticalPodAutoscaler
+      name: kyverno-reports-controller
+    patch: |
+      - op: replace
+        path: /spec/resourcePolicy/containerPolicies/0/maxAllowed
+        value:
+          cpu: 500m
+          memory: 512Mi
+  - target:
+      kind: VerticalPodAutoscaler
+      name: kyverno-admission-controller
+    patch: |
+      - op: replace
+        path: /spec/resourcePolicy/containerPolicies/0/maxAllowed
+        value:
+          cpu: 800m
+          memory: 512Mi
   # spire-server: singleton StatefulSet on an RWO volume — never evict.
   - target:
       kind: VerticalPodAutoscaler


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Prod was holding four autoscale nodes for load that is ~80% request padding: the kyverno reports/admission leader replicas hot-loop (~23 no-op reconciles/s), the uncapped VPA faithfully sized both pairs for that pathology (~6.2 requested cores), and the fleet tipped past the three static workers — the capacity half of tonight's snapshot-slot deadlock.

## What

Caps the two kyverno VPAs' CPU (reports 500m, admission 800m) in the declarative VPA tier, mirroring the emergency values already applied and verified live (pods resized in place and rescheduled onto static workers). CPU is compressible — the cap throttles only the degenerate loop. The loop's root cause is tracked in the linked issue.
