### PR TITLE
fix(headlamp): revert chart to 0.42.0 and gate the broken 0.43.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -278,6 +278,16 @@
       "automerge": false
     },
     {
+      "description": "headlamp chart 0.43.0 is EXCLUDED (k8s/bases/apps/headlamp/helm-release.yaml, reverted to 0.42.0): its in-cluster OIDC login is broken in Safari — the sign-in popup's only close signal is a cross-window localStorage storage event, which Safari ITP suppresses after the popup's cross-site Dex/GitHub hops, so the popup hangs on 'Redirecting to main page…' forever (upstream kubernetes-sigs/headlamp#6353; fix PR #6355 unmerged; tracked in #2438). The negated regex blocks exactly 0.43.0 while letting the NEXT release (>= 0.43.1, minor or major) bump normally — on that bump, verify Safari login end-to-end per #2438 before considering the regression closed, then remove this rule.",
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "headlamp"
+      ],
+      "allowedVersions": "!/^v?0\\.43\\.0$/"
+    },
+    {
       "description": "KubeVirt and CDI ship as VENDORED upstream operator manifests (k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml, .../cdi/cdi-operator.yaml) — thousands of lines of CRDs, RBAC and the operator Deployment vendored as one unit from each release's published asset. The kubernetes manager only sees the `image:` lines inside them, so a Renovate bump rewrites the operator image alone and silently skews it against the CRDs/RBAC vendored next to it; the system-test would still pass bring-up (operators tolerate startup skew) so automerge would land the skew unseen. Keep the update PR as the new-release signal but require a maintainer to re-vendor the full manifest from the matching release before merging. automerge:false placed last so it overrides the major/minor/patch automerge defaults above.",
       "matchPackageNames": [
         "quay.io/kubevirt/**"

--- a/k8s/bases/apps/headlamp/helm-release.yaml
+++ b/k8s/bases/apps/headlamp/helm-release.yaml
@@ -12,7 +12,11 @@ spec:
   chart:
     spec:
       chart: headlamp
-      version: 0.43.0
+      # 0.43.0 is reverted: its OIDC popup never closes in Safari (ITP suppresses
+      # the cross-window storage event the opener waits for) — upstream
+      # kubernetes-sigs/headlamp#6353, tracked in #2438. Renovate is gated off
+      # exactly 0.43.0 (.github/renovate.json); >= 0.43.1 bumps normally.
+      version: 0.42.0
       sourceRef:
         kind: HelmRepository
         name: headlamp


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Signing in to Headlamp from Safari leaves the login popup stuck on "Redirecting to main page…" — Headlamp 0.43.0's popup-close mechanism is broken in Safari, and the upstream fix has been stalled unmerged for two weeks (kubernetes-sigs/headlamp#6355). The maintainer hit it again today.

## What

Reverts the Headlamp chart to 0.42.0 (the version confirmed working in Safari) and gates Renovate from re-proposing exactly 0.43.0. The next release — patch, minor or major (≥ 0.43.1) — bumps normally; per the tracking issue, that bump gets a Safari login verification before the regression is considered closed.

Part of #2438