### PR TITLE
feat(cilium): stage eBPF host-routing prerequisites for pod BBR

### DIFF
--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/components/ebpf-host-routing/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/components/ebpf-host-routing/kustomization.yaml
@@ -1,0 +1,64 @@
+# Default-off staging component for platform#2029 / platform#2609.
+#
+# Cilium's pod-scope BBR path (removing bandwidth-manager-bbr's
+# bbrHostNamespaceOnly guard) requires eBPF host routing, which in turn
+# requires BPF masquerading. This component stages the SMALLEST compatible
+# prerequisite set on the Hetzner/prod datapath:
+#
+#   bpf.masquerade: true   — moves pod->external SNAT from iptables to eBPF,
+#                            a hard prerequisite for eBPF host routing.
+#   bpf.hostLegacyRouting: false — asserts the eBPF host-routing fast path
+#                            explicitly (also the chart default when the
+#                            prerequisites hold) so a future chart-default
+#                            flip cannot silently fall back to the legacy
+#                            iptables path while this component claims
+#                            otherwise.
+#
+# COMPATIBILITY with the existing datapath (statically asserted here; the
+# activation soak proves it live):
+#   - kubeProxyReplacement: true (base values) — required by bpf.masquerade;
+#     already on.
+#   - Kernel: Talos 6.x ≥ Cilium's 5.10 minimum for eBPF host routing.
+#   - Tunnel (VXLAN) routing mode: supported with BPF masquerade for IPv4;
+#     this cluster is single-stack IPv4.
+#   - WireGuard + egress strict mode (hetzner patch): unchanged by this
+#     component — masquerade happens after encryption steering decisions
+#     (destinations outside the pod CIDR are not strict-mode-dropped, see
+#     enforce-wireguard-strict-mode.yaml). The WireGuard interplay is
+#     exactly what the activation soak must observe (Hubble drops,
+#     cilium status --verbose) before any production enable.
+#   - Private-NIC device pinning: NOT touched here; homogeneous device
+#     selection is #2610's slice.
+#
+# SAFETY: this component is staged, not activation-ready. Keep it
+# unreferenced until its own low-traffic activation + soak; it changes the
+# NAT path for ALL pod egress (Cloudflare-bound responses, registry pulls,
+# webhooks) and `rollOutCiliumPods: true` means enabling it rolls every
+# Cilium agent one node at a time. bandwidth-manager-bbr's
+# bbrHostNamespaceOnly guard stays `true` until THIS component has merged,
+# been activated, and passed its own live soak (that guard removal is a
+# further separate change). Roll back by removing the component reference,
+# which restores chart defaults on the next one-node-at-a-time roll.
+#
+# netkit device mode is deliberately out of scope (see #2029 "revisit
+# later"); no netkit keys appear here.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: cilium
+      namespace: kube-system
+    patch: |
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: cilium
+        namespace: kube-system
+      spec:
+        values:
+          bpf:
+            masquerade: true
+            hostLegacyRouting: false

--- a/k8s/providers/hetzner/infrastructure/controllers/cilium/components/ebpf-host-routing/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/cilium/components/ebpf-host-routing/kustomization.yaml
@@ -27,8 +27,19 @@
 #     enforce-wireguard-strict-mode.yaml). The WireGuard interplay is
 #     exactly what the activation soak must observe (Hubble drops,
 #     cilium status --verbose) before any production enable.
-#   - Private-NIC device pinning: NOT touched here; homogeneous device
-#     selection is #2610's slice.
+#   - Private-NIC device pinning: NOT touched here — and it is a HARD
+#     ACTIVATION BLOCKER, not just a naming concern. The hetzner strict-mode
+#     patch pins `devices: "enp7s0 eth1"` (private NICs, required so SPIRE
+#     mutual-auth dials private primary addresses), while the default route —
+#     and therefore pod->internet egress — leaves via the PUBLIC NICs
+#     (workers enp1s0 / control planes eth0). BPF masquerading only processes
+#     interfaces carrying Cilium's eBPF programs, so with today's device list
+#     the public egress NICs would get NO masquerade program while iptables
+#     masquerade is disabled: pod traffic would leave with an unroutable
+#     pod-CIDR source and external egress would break cluster-wide. #2610
+#     must FIRST extend device selection so the masquerade program attaches
+#     to the public default-route NICs while preserving the private-NIC
+#     primary-address behaviour; only then may this component be referenced.
 #
 # SAFETY: this component is staged, not activation-ready. Keep it
 # unreferenced until its own low-traffic activation + soak; it changes the

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -72,6 +72,12 @@ components:
   # Enabling replaces the node qdisc and rolls every Cilium agent; after both
   # guards close, use a separate low-traffic activation. Rollback = re-comment.
   # - cilium/components/bandwidth-manager-bbr/
+  # Default-off eBPF host-routing/masquerade prerequisite staging for pod BBR
+  # (#2609). Changes the NAT path for ALL pod egress and rolls every Cilium
+  # agent when enabled — activate on its own in a low-traffic window (before
+  # bandwidth-manager-bbr's host-only guard may be lifted), verify
+  # `cilium status --verbose` + Hubble for drops. Rollback = re-comment.
+  # - cilium/components/ebpf-host-routing/
 patches:
   - path: openbao/patches/store-data-on-hcloud.yaml
   # Prod-only fail-closed WireGuard encryption (egress strict mode) — see file.

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -74,9 +74,14 @@ components:
   # - cilium/components/bandwidth-manager-bbr/
   # Default-off eBPF host-routing/masquerade prerequisite staging for pod BBR
   # (#2609). Changes the NAT path for ALL pod egress and rolls every Cilium
-  # agent when enabled — activate on its own in a low-traffic window (before
-  # bandwidth-manager-bbr's host-only guard may be lifted), verify
-  # `cilium status --verbose` + Hubble for drops. Rollback = re-comment.
+  # agent when enabled. HARD BLOCKER: do NOT enable until #2610 extends the
+  # pinned device list to the public default-route NICs — today's private-only
+  # `devices: "enp7s0 eth1"` would leave public egress without a masquerade
+  # program while iptables masquerade is off, breaking external egress
+  # cluster-wide (see the component's DEVICE section). Then activate on its
+  # own in a low-traffic window (before bandwidth-manager-bbr's host-only
+  # guard may be lifted), verify `cilium status --verbose` + Hubble for
+  # drops. Rollback = re-comment.
   # - cilium/components/ebpf-host-routing/
 patches:
   - path: openbao/patches/store-data-on-hcloud.yaml


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
Pod-scope BBR (the point of the staged bandwidth-manager component) requires eBPF host routing, which today's datapath deliberately lacks — activating BBR without it would roll every Cilium agent for no benefit. This stages the missing prerequisite safely, without touching production.

## What
Adds a second default-off Cilium staging component (BPF masquerade + eBPF host routing) next to the bandwidth-manager one, wired as a commented opt-in. Production and local renders are proven unchanged; a temporary opt-in render proves the complete pod-BBR prerequisite set composes. Activation stays a separate, reversible low-traffic change after its own live soak.

Fixes #2609. Part of #2029.