### PR TITLE
fix(release): disable issue side effects

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,11 +9,11 @@ permissions: {}
 
 jobs:
   release:
-    uses: devantler-tech/actions/.github/workflows/create-release.yaml@0f27c13a9785608e0bbf9998777d27761b4de617 # v10.0.2
+    uses: devantler-tech/actions/.github/workflows/create-release.yaml@adbda4a7309c6879c75e307c9c417965e640907e # v10.0.3
+    with:
+      disable-issue-side-effects: true
     permissions:
       contents: write # create releases and tags
-      issues: write # comment on related issues
-      pull-requests: write # comment on related PRs
       id-token: write # provenance signing
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why

Platform can publish a valid release and then report a failed run when semantic-release interprets an upstream issue reference as local. Actions v10.0.3 provides an opt-in way to prevent those post-publication issue and pull-request hooks.

## What

- Pin the shared create-release workflow to Actions v10.0.3.
- Enable issue-side-effect suppression for Platform releases.
- Remove issue and pull-request write permissions while preserving release publication, provenance, and App secret wiring.

Part of #2681
Part of devantler-tech/actions#610