### PR TITLE
fix(wedding-app): scope backup R2 credentials

### DIFF
--- a/k8s/bases/apps/wedding-app/external-secret-db-backup.yaml
+++ b/k8s/bases/apps/wedding-app/external-secret-db-backup.yaml
@@ -1,17 +1,14 @@
 # R2 credentials for wedding-db's CNPG barmanObjectStore backup (the backup
 # block + ScheduledBackup live in the wedding-app tenant repo's deploy/). Projects
-# the shared backup R2 key/secret from OpenBao (infrastructure/backup/r2 — the
-# same path umami-db's backup and Velero's velero-r2-credentials read) into a
-# Secret in the wedding-app namespace, where CNPG's backup s3Credentials must
-# live (it can only reference a Secret in the Cluster's own namespace).
+# a wedding-db-scoped R2 key/secret from OpenBao into a Secret in the
+# wedding-app namespace, where CNPG's backup s3Credentials must live (it can
+# only reference a Secret in the Cluster's own namespace).
 #
-# This is a PLATFORM-side resource: reconciled by flux-system (the registration
-# dir), never by the tenant ServiceAccount. The shared bucket credential is
-# platform-owned, so it uses the cluster-scoped `openbao` ClusterSecretStore —
-# the `restrict-tenant-secret-stores` Kyverno policy carves out
-# flux-system-applied ExternalSecrets while still blocking a tenant from pointing
-# its OWN ExternalSecret at the ClusterSecretStore. Mirrors
-# external-secret-ghcr-auth.yaml and apps/umami/db-backup-external-secret.yaml.
+# This intentionally does NOT read infrastructure/backup/r2: that path contains
+# shared infrastructure backup credentials used by Velero and OpenBao snapshot
+# mirroring, and materializing it into a tenant namespace would cross the tenant
+# boundary. The OpenBao entry behind apps/wedding-app/backup/r2 must be a
+# dedicated R2 credential scoped to the wedding database backup destination.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -39,9 +36,9 @@ spec:
   data:
     - secretKey: ACCESS_KEY_ID
       remoteRef:
-        key: infrastructure/backup/r2
+        key: apps/wedding-app/backup/r2
         property: access_key_id
     - secretKey: SECRET_ACCESS_KEY
       remoteRef:
-        key: infrastructure/backup/r2
+        key: apps/wedding-app/backup/r2
         property: secret_access_key

--- a/k8s/bases/apps/wedding-app/kustomization.yaml
+++ b/k8s/bases/apps/wedding-app/kustomization.yaml
@@ -2,11 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # db-backup-external-secret stays platform-side: it projects the SHARED R2
-  # backup credential from the infra OpenBao path via the ClusterSecretStore
-  # (flux-system-applied), which a tenant SecretStore cannot reach. The tenant's
-  # own CiliumNetworkPolicy (networkpolicy.yaml) and namespaced SecretStore now
-  # live in the tenant repo's deploy/.
+  # db-backup-external-secret stays platform-side: it projects a dedicated
+  # wedding-db R2 backup credential via the ClusterSecretStore
+  # (flux-system-applied). Never point this at the shared infrastructure backup
+  # credential; the resulting Secret lives in the tenant namespace for CNPG.
   - external-secret-db-backup.yaml
   - object-store.yaml
   - external-secret-ghcr-auth.yaml

--- a/k8s/bases/apps/wedding-app/object-store.yaml
+++ b/k8s/bases/apps/wedding-app/object-store.yaml
@@ -4,13 +4,12 @@
 # 1.30; plugin installed in infrastructure/controllers/plugin-barman-cloud).
 #
 # PLATFORM-side (registration dir, reconciled by flux-system): the R2 destination
-# and the shared-bucket credentials are platform-owned, so they live here next to
-# the external-secret-db-backup.yaml that provisions `wedding-db-backup-r2` — the
-# tenant's own (namespaced) SecretStore cannot reach infrastructure/backup/r2, and
-# barmancloud.cnpg.io is outside the tenant's cnpg-tenant-edit RBAC anyway. The
+# and wedding-db-scoped credentials are platform-owned, so they live here next to
+# the external-secret-db-backup.yaml that provisions `wedding-db-backup-r2`. The
 # tenant's Cluster (wedding-app repo deploy/cluster.yaml) opts in by referencing
 # this ObjectStore by name via spec.plugins. r2_* are Flux-substituted from
-# variables-base. Same R2 store + creds + retention as the old inline block.
+# variables-base; the credential itself is dedicated to this backup destination
+# rather than the shared infrastructure backup key.
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:


### PR DESCRIPTION
### Motivation
- A platform-authored ExternalSecret was projecting the shared infrastructure R2 backup credential (`infrastructure/backup/r2`) into the `wedding-app` namespace, which allowed tenant-scoped workloads (the tenant's `wedding-app` ServiceAccount bound to `tenant-edit`) to read shared Velero/OpenBao backup keys and risk cross-tenant exposure or corruption. 
- The change aims to remove that tenant-to-infrastructure secret exposure by ensuring the secret materialized into the tenant namespace is a dedicated credential scoped to the wedding DB backup destination.

### Description
- The wedding DB backup `ExternalSecret` now reads from a dedicated OpenBao path `apps/wedding-app/backup/r2` instead of the shared `infrastructure/backup/r2`. 
- Comments in `k8s/bases/apps/wedding-app/kustomization.yaml` and `k8s/bases/apps/wedding-app/object-store.yaml` were updated to document the dedicated-credential requirement and to note that the shared infrastructure backup credential must never be projected into tenant namespaces. 
- Files changed: `k8s/bases/apps/wedding-app/external-secret-db-backup.yaml`, `k8s/bases/apps/wedding-app/kustomization.yaml`, and `k8s/bases/apps/wedding-app/object-store.yaml`, while preserving the ObjectStore references that consume the namespaced secret.

### Testing
- Ran `python3 scripts/validate-naming.py` and it succeeded. 
- Validated YAML parsing with `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_stream(File.read(f)); puts \"ok #{f}\" }"` against the modified files and it succeeded. 
- Ran `git diff --check` and repository checks reported no whitespace/patch issues. 
- `kubectl kustomize k8s/clusters/local/` and `kubectl kustomize k8s/clusters/prod/` could not be executed because `kubectl` is not available in the environment. 
- `ksail workload validate` (and `ksail --config ksail.prod.yaml workload validate`) could not be executed because `ksail` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b39ad50c832b9e1efcf4b01f17ba)