### PR TITLE
fix(security): scope tenant GHCR pull credentials

### DIFF
--- a/docs/TENANTS.md
+++ b/docs/TENANTS.md
@@ -114,17 +114,17 @@ and workloads consume the values **from OpenBao via `ExternalSecret`s**.
 
 ### The GHCR image-pull secret (`ghcr-auth`)
 
-A **platform-managed** credential, not a tenant secret. Every registration dir
-ships a `external-secret-ghcr-auth.yaml` that sources the shared org pull
-credential from OpenBao (`infrastructure/ghcr/auth`) via the cluster-scoped `openbao`
+A **platform-managed** credential, not an app secret, but it must be
+**tenant/repository-scoped**. Every registration dir ships an
+`external-secret-ghcr-auth.yaml` that sources only that tenant's pull credential
+from OpenBao (`apps/<tenant>/ghcr/auth`) via the cluster-scoped `openbao`
 **ClusterSecretStore** and materialises the `ghcr-auth` dockerconfigjson the
 `OCIRepository` and ServiceAccount consume. It is reconciled by flux-system (not
 your tenant SA) — which is why it may use the ClusterSecretStore where your own
 resources may not (the Kyverno policy carves out flux-system-applied resources).
-The value lives SOPS-encrypted as `ghcr_dockerconfigjson` in the shared
-`secret.enc.yaml` (the same org token both clusters use); the
-`seed-ghcr` PushSecret pushes it to `infrastructure/ghcr/auth` via the `openbao`
-ClusterSecretStore.
+Do not point tenant `ghcr-auth` ExternalSecrets at the shared platform
+`infrastructure/ghcr/auth` credential; that path is for platform-only consumers
+such as Kyverno image verification.
 
 - The release and template-sync workflows mint a **GitHub App token** from the
   org-level `APP_ID` variable and `APP_PRIVATE_KEY` secret — already available to
@@ -166,8 +166,8 @@ grants below) and rename — with:
 | `kustomization.yaml` | Kustomize entrypoint listing the resources in this directory |
 | `namespace.yaml` | Namespace, `pod-security.kubernetes.io/enforce: restricted` |
 | `service-account.yaml` | SA with `automountServiceAccountToken: false` + `imagePullSecrets: [ghcr-auth]` |
-| `role-binding.yaml` | Binds the SA to the `edit` ClusterRole in the namespace |
-| `external-secret-ghcr-auth.yaml` | OpenBao-backed `ExternalSecret` (shared `openbao` ClusterSecretStore, key `infrastructure/ghcr/auth`) producing the `ghcr-auth` pull secret (just `external-secret.yaml` when it is the tenant's only one) |
+| `role-binding.yaml` | Binds the SA to the scoped `tenant-edit` ClusterRole in the namespace |
+| `external-secret-ghcr-auth.yaml` | OpenBao-backed `ExternalSecret` (shared `openbao` ClusterSecretStore, tenant-scoped key `apps/<tenant>/ghcr/auth`) producing the `ghcr-auth` pull secret (just `external-secret.yaml` when it is the tenant's only one) |
 | `role-binding-external-dns*.yaml` + `cluster-role-binding.yaml` | *Only if the tenant runs its own external-dns for a tenant-owned domain* — bind the tenant's `external-dns` SA to the `tenant-external-dns(-global)` ClusterRoles (HTTPRoutes in its namespace, the shared Gateway in kube-system, namespaces) — mirror `ascoachingogvaner/` |
 | `oci-repository.yaml` + `flux-kustomization.yaml` | `OCIRepository` (semver `>=1.0.0`, cosign `verify`) + Flux `Kustomization` (prune, `serviceAccountName: <tenant>`) |
 

--- a/k8s/bases/apps/ascoachingogvaner/external-secret.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/external-secret.yaml
@@ -1,13 +1,12 @@
 # GHCR image-pull secret for ascoachingogvaner, sourced from OpenBao instead of
-# a SOPS-encrypted Secret. Produces the same `ghcr-auth` dockerconfigjson Secret
-# the tenant's OCIRepository (secretRef) and ServiceAccount (imagePullSecrets)
-# already consume.
+# a SOPS-encrypted Secret. This is a per-tenant/repository dockerconfigjson,
+# not the shared platform GHCR credential.
 #
 # ascoachingogvaner is a static site with NO app secrets, so it gets no
 # namespaced SecretStore / Vault role (a tenant "has a vault" only if it needs
 # one). This pull secret is platform-side — reconciled by flux-system, not the
-# tenant SA, and consumed platform-side — so it uses the shared cluster-scoped
-# `openbao` ClusterSecretStore reading the platform path infrastructure/ghcr/auth.
+# tenant SA — so it uses the shared cluster-scoped `openbao` ClusterSecretStore
+# to read only this tenant's scoped pull credential.
 # The `restrict-tenant-secret-stores` Kyverno policy carves out
 # flux-system-applied ExternalSecrets while still blocking tenant-authored ones.
 apiVersion: external-secrets.io/v1
@@ -33,5 +32,5 @@ spec:
   data:
     - secretKey: dockerconfigjson
       remoteRef:
-        key: infrastructure/ghcr/auth
+        key: apps/ascoachingogvaner/ghcr/auth
         property: dockerconfigjson

--- a/k8s/bases/apps/wedding-app/external-secret-ghcr-auth.yaml
+++ b/k8s/bases/apps/wedding-app/external-secret-ghcr-auth.yaml
@@ -1,13 +1,12 @@
 # GHCR image-pull secret for wedding-app, sourced from OpenBao instead of a
-# SOPS-encrypted Secret. Produces the same `ghcr-auth` dockerconfigjson Secret
-# the tenant's OCIRepository (secretRef) and ServiceAccount (imagePullSecrets)
-# already consume — no other registration changes needed.
+# SOPS-encrypted Secret. This is a per-tenant/repository dockerconfigjson,
+# not the shared platform GHCR credential.
 #
 # This is a PLATFORM-side resource: it is reconciled by flux-system (the
 # registration dir), never by the tenant ServiceAccount, and the pull
-# credential is platform-owned and consumed platform-side. It therefore uses
-# the shared cluster-scoped `openbao` ClusterSecretStore reading the platform
-# path infrastructure/ghcr/auth — the `restrict-tenant-secret-stores` Kyverno policy
+# credential is scoped to this tenant/repository. It therefore uses the shared
+# cluster-scoped `openbao` ClusterSecretStore reading only this tenant's GHCR
+# path — the `restrict-tenant-secret-stores` Kyverno policy
 # carves out flux-system-applied ExternalSecrets, while still blocking a tenant
 # from pointing its OWN ExternalSecret at the ClusterSecretStore.
 apiVersion: external-secrets.io/v1
@@ -33,5 +32,5 @@ spec:
   data:
     - secretKey: dockerconfigjson
       remoteRef:
-        key: infrastructure/ghcr/auth
+        key: apps/wedding-app/ghcr/auth
         property: dockerconfigjson

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-secret-stores.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-secret-stores.yaml
@@ -25,7 +25,7 @@
 # serviceAccountName and therefore applies as flux-system's own
 # kustomize-controller SA — excluded below. This lets the platform place a
 # trusted `ghcr-auth` ExternalSecret (backed by the shared ClusterSecretStore,
-# reading only infrastructure/ghcr/auth) in a tenant namespace for the image-pull
+# reading only apps/<tenant>/ghcr/auth) in a tenant namespace for the image-pull
 # credential, while a tenant still cannot point its OWN ExternalSecret/PushSecret
 # at the ClusterSecretStore. The discriminator is the applying identity, which a
 # tenant cannot forge (it cannot make flux-system's SA apply its manifests).

--- a/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
@@ -135,8 +135,8 @@ spec:
             name: ${serviceAccount.metadata.name}
             namespace: ${tenantNamespace.metadata.name}
     # GHCR image-pull secret, sourced from OpenBao (not a SOPS Secret) via the
-    # shared cluster-scoped `openbao` ClusterSecretStore reading the platform
-    # path infrastructure/ghcr/auth. Reconciled platform-side (flux-system), so
+    # shared cluster-scoped `openbao` ClusterSecretStore reading the tenant-scoped
+    # path apps/<tenant>/ghcr/auth. Reconciled platform-side (flux-system), so
     # the `restrict-tenant-secret-stores` Kyverno policy carve-out applies.
     # Produces the `ghcr-auth` dockerconfigjson the OCIRepository (secretRef) and
     # ServiceAccount (imagePullSecrets) consume.
@@ -165,7 +165,7 @@ spec:
           data:
             - secretKey: dockerconfigjson
               remoteRef:
-                key: infrastructure/ghcr/auth
+                key: apps/${schema.spec.name}/ghcr/auth
                 property: dockerconfigjson
     # Default-deny NetworkPolicy mirroring the runtime Kyverno-generated
     # CiliumNetworkPolicy, so the static Kubescape scan sees the namespace as

--- a/k8s/bases/infrastructure/vault-config/job.yaml
+++ b/k8s/bases/infrastructure/vault-config/job.yaml
@@ -626,12 +626,10 @@ spec:
               }
               POLICY
 
-              # Read the shared GHCR image-pull credential. Consumed by the
-              # platform-authored `ghcr-auth` ExternalSecrets in the tenant
-              # namespaces via the `external-secrets` ClusterSecretStore role, so
-              # tenants get their pull secret from OpenBao instead of a per-tenant
-              # SOPS file. Platform-side, not a tenant secret: those ExternalSecrets
-              # are reconciled by flux-system, never by a tenant ServiceAccount.
+              # Read the shared GHCR image-pull credential for platform-only
+              # consumers such as Kyverno image verification. Tenant namespace
+              # `ghcr-auth` ExternalSecrets must use the per-tenant app policies
+              # below (apps/<tenant>/ghcr/auth), never this shared path.
               bao policy write infra-ghcr-readonly - <<'POLICY'
               path "secret/data/infrastructure/ghcr/*" {
                 capabilities = ["read"]
@@ -674,6 +672,9 @@ spec:
               }
               POLICY
 
+              # Read-only view of wedding-app's app path for platform-authored
+              # ExternalSecrets in its namespace, including the tenant-scoped
+              # GHCR pull credential at apps/wedding-app/ghcr/auth.
               bao policy write app-wedding-readonly - <<'POLICY'
               path "secret/data/apps/wedding-app/*" {
                 capabilities = ["read"]
@@ -744,10 +745,11 @@ spec:
               POLICY
 
               # Read-only view of ascoachingogvaner's app path for the shared
-              # ClusterSecretStore bundle: the cert-manager simply.com DNS01
-              # solver consumes the tenant-owned simply.com API credentials
-              # (apps/ascoachingogvaner/simply) to issue the tenant's
-              # certificate on the shared Gateway.
+              # ClusterSecretStore bundle: the platform-authored ghcr-auth
+              # ExternalSecret reads apps/ascoachingogvaner/ghcr/auth, and the
+              # cert-manager simply.com DNS01 solver consumes the tenant-owned
+              # simply.com API credentials (apps/ascoachingogvaner/simply) to
+              # issue the tenant's certificate on the shared Gateway.
               bao policy write app-ascoachingogvaner-readonly - <<'POLICY'
               path "secret/data/apps/ascoachingogvaner/*" {
                 capabilities = ["read"]

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-ghcr.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-ghcr.yaml
@@ -2,15 +2,13 @@
 # Shared GHCR image-pull credential
 # ---------------------------------
 # Seeds the org-level GHCR pull credential (a docker config JSON) into OpenBao at
-# infrastructure/ghcr/auth so the platform-authored `ghcr-auth` ExternalSecrets in
-# the tenant namespaces (k8s/bases/apps/<tenant>/external-secret-ghcr-auth.yaml)
-# materialise the `ghcr-auth` pull Secret from OpenBao instead of a per-tenant
-# SOPS file. Read back via the `external-secrets` ClusterSecretStore role
-# (infra-ghcr-readonly) — a platform secret, not a tenant secret. Source key
-# `ghcr_dockerconfigjson` lives in secret.enc.yaml (shared,
-# cluster-independent — the same org token both clusters use) and holds the full
-# `{"auths":{"ghcr.io":{...}}}` document. Re-pushed hourly, so a rotated
-# token (or a re-initialized vault) converges without manual re-apply.
+# infrastructure/ghcr/auth for platform-only consumers such as Kyverno image
+# verification. Tenant namespaces must not materialise this shared credential;
+# their `ghcr-auth` ExternalSecrets read tenant/repository-scoped credentials
+# from apps/<tenant>/ghcr/auth instead. Source key `ghcr_dockerconfigjson` lives
+# in secret.enc.yaml and holds the full `{"auths":{"ghcr.io":{...}}}` document.
+# Re-pushed hourly, so a rotated token (or a re-initialized vault) converges
+# without manual re-apply.
 #
 # This one is deliberately SOPS-seeded, NOT user-fed, even though it is an
 # upstream token: the verify-image-signatures ClusterPolicy needs the kyverno

--- a/k8s/providers/docker/apps/tenant-ascoachingogvaner.yaml
+++ b/k8s/providers/docker/apps/tenant-ascoachingogvaner.yaml
@@ -3,7 +3,7 @@
 # that — once proven — replaces ascoachingogvaner's ~10-file control-plane
 # skeleton (k8s/bases/apps/ascoachingogvaner/). The KRO controller expands it
 # into the identical skeleton: Namespace (restricted PSS), Flux-impersonated
-# `edit` SA + RoleBinding, ghcr-auth ExternalSecret, default-deny
+# `tenant-edit` SA + RoleBinding, ghcr-auth ExternalSecret, default-deny
 # NetworkPolicy, cosign-verified OCIRepository, impersonating Kustomization,
 # and (externalDns: true) the three tenant-external-dns bindings.
 #
@@ -13,7 +13,7 @@
 # CRDs); it lives in flux-system as platform control-plane state, while its
 # children land in the tenant namespace via the RGD's explicit namespace
 # templating. The tenant's own app still needs GHCR credentials seeded in the
-# local OpenBao (infrastructure/ghcr/auth) before its OCIRepository can pull —
+# local OpenBao (apps/ascoachingogvaner/ghcr/auth) before its OCIRepository can pull —
 # without them the expansion itself still validates (the pilot's purpose), but
 # the tenant Kustomization stays not-ready and the apps layer reports Failed.
 apiVersion: kro.run/v1alpha1


### PR DESCRIPTION
### Motivation
- A shared org-level GHCR dockerconfigjson was being materialized into tenant namespaces, allowing a compromised tenant workload to exfiltrate the org-wide GHCR pull credential and widen the blast radius.
- Tenant ServiceAccounts have namespace-scoped privileges (imagePullSecrets, `tenant-edit`-style bindings) that permit mounting same-namespace Secrets, so the shared credential must not live where tenant workloads can access it.
- The platform still needs a cluster-scoped GHCR credential for platform-only consumers (eg. Kyverno image verification), so the fix must preserve that use while preventing tenant materialization of the org token.

### Description
- Point tenant `ExternalSecret` resources to tenant-scoped OpenBao keys by changing their remote keys from `infrastructure/ghcr/auth` to `apps/<tenant>/ghcr/auth` for the registration directories (examples: `k8s/bases/apps/ascoachingogvaner/external-secret.yaml` and `k8s/bases/apps/wedding-app/external-secret-ghcr-auth.yaml`).
- Update the tenant ResourceGraphDefinition so generated tenants use `apps/${schema.spec.name}/ghcr/auth` when producing `ghcr-auth` for a tenant namespace (`k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml`).
- Clarify and restrict the shared seed path so `infrastructure/ghcr/auth` is documented/seeded only for platform-only consumers (eg. Kyverno image verification) and not for tenant pull secrets (`k8s/bases/infrastructure/vault-seed/push-secret-seed-ghcr.yaml`, `k8s/bases/infrastructure/vault-config/job.yaml`).
- Update onboarding docs and a few text/role references to reflect tenant-scoped pull credentials and the scoped tenant admin role (`docs/TENANTS.md`, `k8s/providers/docker/apps/tenant-ascoachingogvaner.yaml`).

### Testing
- Ran `python3 scripts/validate-naming.py` and it succeeded (manifest naming conventions satisfied). 
- Ran `git diff --check` and local diffs were clean (no whitespace/merge errors). 
- Attempted `kubectl kustomize k8s/clusters/local/` and `kubectl kustomize k8s/clusters/prod/` but `kubectl` was not available in the execution environment so full kustomize render/`ksail` validation could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52c0ed8ac8832bb9d12e19c2f88f8f)