### PR TITLE
docs(tenants): point publish-app.yaml at devantler-tech/actions

### DIFF
--- a/docs/TENANTS.md
+++ b/docs/TENANTS.md
@@ -133,7 +133,7 @@ ClusterSecretStore.
 ## 4. How publishing & trust fit together
 
 On every `v*` tag, the tenant's `cd.yaml` calls the
-[`publish-app.yaml`](https://github.com/devantler-tech/reusable-workflows/blob/main/.github/workflows/publish-app.yaml)
+[`publish-app.yaml`](https://github.com/devantler-tech/actions/blob/main/.github/workflows/publish-app.yaml)
 reusable workflow, which builds and pushes the image, pins its digest into
 `deploy/deployment.yaml`, pushes the manifests as an OCI artifact, and
 **cosign-signs** both (keyless, via GitHub OIDC). The platform's `OCIRepository`


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Engineer

## Why
TENANTS.md pointed tenant authors at the archived `reusable-workflows` repo for the publish workflow, which misleads onboarding even though verification still accepts both identities today.

## What
The one citation now links `publish-app.yaml` in `devantler-tech/actions` (verified live to exist); no other doc in the repo cites the old path.

Fixes #2694