### PR TITLE
fix(ci): handle exception file close errors

### DIFF
--- a/scripts/generate-kubescape-exceptions/main.go
+++ b/scripts/generate-kubescape-exceptions/main.go
@@ -449,14 +449,16 @@ func generate(directory string) ([]policy, error) {
 }
 
 // decodeDocuments reads every YAML document in a multi-document file.
-func decodeDocuments(path string) ([]any, error) {
+func decodeDocuments(path string) (documents []any, err error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
-	defer file.Close()
-
-	var documents []any
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close %s: %w", path, closeErr)
+		}
+	}()
 
 	decoder := yaml.NewDecoder(file)
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The shared Go validation workflow now rejects the generator's unchecked deferred file close. This fails every current platform PR before its own change can be evaluated.

## What

Propagate a close failure when document decoding otherwise succeeded, while preserving the earlier decode error when one exists.

## Validation

- `go test ./...` (98 tests)
- `golangci-lint run ./scripts/generate-kubescape-exceptions/...`
- generated the current 21-policy Kubescape exceptions file through the CLI

Unblocks #2794.
