### PR TITLE
fix(ci): restore the EKS authorization gate and run it on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,10 @@ jobs:
               # cd.yaml carries the manual-deploy gate itself. Without it here, a PR
               # that deletes that gate does not run the job whose test guards it.
               - '.github/workflows/cd.yaml'
+              # Same reasoning for validate-main.yaml, which carries the
+              # push-to-main gate: TestAuthorizationGateRunsOnPushToMain guards it,
+              # and that test only runs when this filter matches.
+              - '.github/workflows/validate-main.yaml'
             bridge_validation:
               - 'scripts/refresh-flux-ghcr-auth.sh'
               - 'scripts/ghcr-auth-lib.sh'

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -1,0 +1,64 @@
+name: Validate Main
+
+# ci.yaml runs the authorization gate on `pull_request` and `merge_group` only,
+# and cd.yaml runs it on a manual dispatch. A DIRECT PUSH to main fires none of
+# those, so main could carry a broken authorization surface with every one of
+# its own checks green — which is exactly what happened in f89efff4: the break
+# stayed invisible on main for two days and surfaced only as an unexplained red
+# on unrelated PRs, because a PR's CI builds the merge result and so inherits
+# main's state.
+#
+# This workflow closes that hole: the same gate, on the push itself, so a
+# regression is reported where it is introduced.
+#
+# Deliberately NOT path-filtered. The gate reads the whole rendered
+# authorization surface, which a change anywhere in the overlays (or in the
+# validator itself) can move; a paths filter here would recreate a narrower
+# version of the same blind spot.
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: validate-main-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-eks-authorization:
+    name: 🔐 Validate EKS Authorization
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: ⚙️ Install pinned kubectl renderer
+        shell: bash
+        env:
+          KUBECTL_VERSION: "v1.36.2"
+          KUBECTL_SHA256: "1e9045ec32bea85da43de85f0065358529ea7c7a152eca78154fba5b58c27d82"
+        run: |
+          set -euo pipefail
+          kubectl_path="$RUNNER_TEMP/kubectl"
+          curl -fsSL \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+            -o "$kubectl_path"
+          printf '%s  %s\n' "$KUBECTL_SHA256" "$kubectl_path" | sha256sum --check
+          sudo install "$kubectl_path" /usr/local/bin/kubectl
+          kubectl version --client
+
+      - name: 🔐 Validate EKS authorization surface
+        run: |
+          go test ./scripts/validate-eks-ci-role-policy
+          go run ./scripts/validate-eks-ci-role-policy .

--- a/scripts/generate-kubescape-exceptions/main.go
+++ b/scripts/generate-kubescape-exceptions/main.go
@@ -454,8 +454,9 @@ func decodeDocuments(path string) ([]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
-	// Read-only handle: a failed Close cannot lose data, and the caller already
-	// has the decode result. Discard explicitly so errcheck sees the intent.
+	// The file is only ever read, so a close error says nothing about whether
+	// the documents below were decoded correctly — discard it explicitly rather
+	// than leaving it unchecked.
 	defer func() { _ = file.Close() }()
 
 	var documents []any

--- a/scripts/generate-kubescape-exceptions/main.go
+++ b/scripts/generate-kubescape-exceptions/main.go
@@ -454,7 +454,9 @@ func decodeDocuments(path string) ([]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
-	defer file.Close()
+	// Read-only handle: a failed Close cannot lose data, and the caller already
+	// has the decode result. Discard explicitly so errcheck sees the intent.
+	defer func() { _ = file.Close() }()
 
 	var documents []any
 

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// workflowsDir is where this repository's GitHub Actions live, relative to this
+// package.
+const workflowsDir = "../../.github/workflows"
+
+// validatorInvocation is the command that actually runs this gate. A workflow
+// only counts as covering a trigger if it runs THIS, not merely if it mentions
+// the gate by name.
+const validatorInvocation = "go run ./scripts/validate-eks-ci-role-policy"
+
+// workflow is the narrow slice of Actions schema this contract needs.
+//
+// It is parsed as YAML rather than string-matched on purpose: the workflow
+// files describe this very trigger in their comments, so a text search would
+// pass on prose alone and keep passing after the trigger itself was deleted.
+type workflow struct {
+	On   triggerSet `yaml:"on"`
+	Jobs map[string]struct {
+		Steps []struct {
+			Run string `yaml:"run"`
+		} `yaml:"steps"`
+	} `yaml:"jobs"`
+}
+
+// triggerSet is the `on:` block. GitHub accepts three spellings — a mapping
+// (`on: {push: {...}}`), a sequence (`on: [push]`) and a bare scalar
+// (`on: push`) — and every workflow in this repository currently uses the
+// mapping. Decoding all three anyway keeps this guard failing for the ONE
+// reason it exists: a genuinely missing push-to-main gate. A strict mapping-only
+// decode would instead abort with a parse error the day someone adds an
+// unrelated workflow in shorthand, which reads like the contract broke.
+//
+// The sequence and scalar forms carry no branch filter, so they yield a trigger
+// with no branches — correctly not counting as main coverage on their own.
+type triggerSet map[string]triggerSpec
+
+func (t *triggerSet) UnmarshalYAML(value *yaml.Node) error {
+	*t = make(triggerSet)
+	switch value.Kind {
+	case yaml.MappingNode:
+		return value.Decode((*map[string]triggerSpec)(t))
+	case yaml.SequenceNode:
+		var names []string
+		if err := value.Decode(&names); err != nil {
+			return err
+		}
+		for _, name := range names {
+			(*t)[name] = triggerSpec{}
+		}
+	case yaml.ScalarNode:
+		var name string
+		if err := value.Decode(&name); err != nil {
+			return err
+		}
+		(*t)[name] = triggerSpec{}
+	}
+	return nil
+}
+
+// triggerSpec captures a trigger's branch filter. `on:` values are heterogenous
+// (`merge_group:` is null, `push:` is a mapping), so unmarshalling is lenient
+// and a null trigger simply yields no branches.
+type triggerSpec struct {
+	Branches []string `yaml:"branches"`
+}
+
+func (t *triggerSpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return nil
+	}
+	type rawTrigger triggerSpec
+	return value.Decode((*rawTrigger)(t))
+}
+
+// runsValidator reports whether any job in the workflow actually executes the
+// gate.
+func (w workflow) runsValidator() bool {
+	for _, job := range w.Jobs {
+		for _, step := range job.Steps {
+			if strings.Contains(step.Run, validatorInvocation) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// coversPushToMain reports whether the workflow runs the gate on a direct push
+// to main.
+func (w workflow) coversPushToMain() bool {
+	push, ok := w.On["push"]
+	if !ok {
+		return false
+	}
+	onMain := false
+	for _, branch := range push.Branches {
+		if branch == "main" {
+			onMain = true
+			break
+		}
+	}
+	return onMain && w.runsValidator()
+}
+
+func loadWorkflows(t *testing.T) map[string]workflow {
+	t.Helper()
+
+	entries, err := os.ReadDir(workflowsDir)
+	if err != nil {
+		t.Fatalf("read workflows dir: %v", err)
+	}
+	loaded := make(map[string]workflow)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || (!strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml")) {
+			continue
+		}
+		contents, readErr := os.ReadFile(filepath.Join(workflowsDir, name)) //nolint:gosec // Fixed repository path.
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		var parsed workflow
+		if err := yaml.Unmarshal(contents, &parsed); err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		loaded[name] = parsed
+	}
+	if len(loaded) == 0 {
+		t.Fatal("no workflows parsed — the guard would pass vacuously")
+	}
+	return loaded
+}
+
+// TestAuthorizationGateRunsOnPushToMain pins the coverage gap that let
+// f89efff4 break main invisibly.
+//
+// ci.yaml gates on `pull_request` and `merge_group`; cd.yaml is
+// `workflow_dispatch`. A direct push to main fires none of them, so main's own
+// checks stayed green while the authorization surface was broken, and the
+// failure surfaced only on unrelated PRs (whose CI builds the merge result and
+// therefore inherits main).
+func TestAuthorizationGateRunsOnPushToMain(t *testing.T) {
+	workflows := loadWorkflows(t)
+
+	covering := make([]string, 0, 1)
+	for name, parsed := range workflows {
+		if parsed.coversPushToMain() {
+			covering = append(covering, name)
+		}
+	}
+
+	if len(covering) == 0 {
+		t.Fatalf("no workflow runs %q on push to main — a direct push to main can "+
+			"break the authorization surface with every check on main green. "+
+			"Restore a push-triggered workflow that runs the gate.", validatorInvocation)
+	}
+}
+
+// TestAuthorizationGateGuardIsNotVacuous proves the guard above can actually
+// fail. A coverage assertion that cannot go RED is worse than none: it reports
+// the hole as closed forever.
+//
+// The negative controls perturb exactly the two conditions the guard depends
+// on, so each must flip it to false on its own.
+func TestAuthorizationGateGuardIsNotVacuous(t *testing.T) {
+	covering := workflow{
+		On: triggerSet{"push": {Branches: []string{"main"}}},
+		Jobs: map[string]struct {
+			Steps []struct {
+				Run string `yaml:"run"`
+			} `yaml:"steps"`
+		}{
+			"gate": {Steps: []struct {
+				Run string `yaml:"run"`
+			}{{Run: validatorInvocation + " ."}}},
+		},
+	}
+	if !covering.coversPushToMain() {
+		t.Fatal("positive control failed: a push-to-main workflow that runs the gate must count")
+	}
+
+	t.Run("wrong branch does not count", func(t *testing.T) {
+		perturbed := covering
+		perturbed.On = triggerSet{"push": {Branches: []string{"release"}}}
+		if perturbed.coversPushToMain() {
+			t.Fatal("a push trigger on another branch must not satisfy main coverage")
+		}
+	})
+
+	t.Run("wrong trigger does not count", func(t *testing.T) {
+		perturbed := covering
+		perturbed.On = triggerSet{"pull_request": {Branches: []string{"main"}}}
+		if perturbed.coversPushToMain() {
+			t.Fatal("a pull_request trigger must not satisfy push-to-main coverage — " +
+				"that is precisely the gap f89efff4 slipped through")
+		}
+	})
+
+	t.Run("naming the gate without running it does not count", func(t *testing.T) {
+		perturbed := covering
+		perturbed.Jobs = map[string]struct {
+			Steps []struct {
+				Run string `yaml:"run"`
+			} `yaml:"steps"`
+		}{
+			"gate": {Steps: []struct {
+				Run string `yaml:"run"`
+			}{{Run: "echo validate-eks-ci-role-policy"}}},
+		}
+		if perturbed.coversPushToMain() {
+			t.Fatal("merely mentioning the validator must not count as running it")
+		}
+	})
+}

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -29,15 +29,38 @@ const (
 	rootProductionOverlayPath = "k8s/clusters/prod"
 	rendererCommandTimeout    = 2 * time.Minute
 
-	expectedKubectlVersion     = "v1.36.2"
-	expectedKustomizeVersion   = "v5.8.1"
-	expectedRoleManifestSHA    = "96a77d18160c450340e65b0953f44016a01a08429416f7a82142c3f90a61ca07"
-	expectedBoundarySHA        = "b96bfd8c96baa2e09f32a1cc05f76473ecc021fed554a2880ce8e3dd399902c7"
-	expectedTrustPolicySHA     = "85d5d45343f9eac5fdc35717c85c88c5b0f8fde9eddffb169c3a223617fd0a5e"
-	expectedInlinePolicySHA    = "60e3086a6d3dac0092ffe8264c04ebae783c0d38f19a3cf073ed8991085a4df8"
-	expectedBoundaryJSONSHA    = "e617004bce71a65f92934c4f7575d7559a290afe7a17363ce12db8ad7b519610"
-	expectedRenderedSurfaceSHA = "a7fc2f116afd6cc1e9595f6b61de85215c751d2cac033660befabc2c7e3fda61"
+	expectedKubectlVersion   = "v1.36.2"
+	expectedKustomizeVersion = "v5.8.1"
+	expectedRoleManifestSHA  = "96a77d18160c450340e65b0953f44016a01a08429416f7a82142c3f90a61ca07"
+	expectedBoundarySHA      = "b96bfd8c96baa2e09f32a1cc05f76473ecc021fed554a2880ce8e3dd399902c7"
+	expectedTrustPolicySHA   = "85d5d45343f9eac5fdc35717c85c88c5b0f8fde9eddffb169c3a223617fd0a5e"
+	expectedInlinePolicySHA  = "60e3086a6d3dac0092ffe8264c04ebae783c0d38f19a3cf073ed8991085a4df8"
+	expectedBoundaryJSONSHA  = "e617004bce71a65f92934c4f7575d7559a290afe7a17363ce12db8ad7b519610"
 )
+
+// expectedRenderedSurfaceSHA is the aggregate fingerprint of the whole selected
+// authorization surface.
+//
+// It sits outside the const block above so this rationale can travel with it
+// without re-aligning seven unrelated security constants.
+//
+// Re-approved 2026-07-25 after f89efff4 ("fix(secret): update alertmanager
+// webhook URL and metadata timestamps"). That commit re-encrypted
+// k8s/clusters/prod/bootstrap/secret.enc.yaml, and the Secret it renders to —
+// flux-system/variables-cluster — is a substituteFrom source, so its ciphertext
+// is part of the surface.
+//
+// Measured before re-approving, rather than assumed: exactly ONE of 159 surface
+// entries moved (that Secret), the Secret's plaintext KEY SET is unchanged, and
+// no pinned authorization resource moved. So the edit added, removed and
+// repointed no substitution variable — the change is authorization-inert.
+//
+// NOTE for whoever re-approves this next: an opaque ciphertext in the surface
+// moves on ANY re-encryption — this value also absorbed a SOPS version bump
+// (3.13.2 -> 3.13.3) — so a routine secret rotation reds this gate with no
+// authorization change at all. Do NOT treat a moved hash as self-evidently
+// benign: re-run the per-entry membership measurement above before re-approving.
+const expectedRenderedSurfaceSHA = "44cb60262b1fd052663855cb35b2ac60d202534586b7f586a5c1611ce840ada9"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The EKS authorization gate — a security control over who can act on the production
cluster — has been failing on `main` since 23 July. Every open PR that re-ran CI
inherited the failure and went red for reasons that had nothing to do with its own
change, which both blocked real work and trains reviewers to wave the gate through.

It stayed invisible for two days because the gate never ran on `main` itself: it was
wired to pull requests, the merge queue, and a manual deploy. The change that broke it
was pushed straight to `main`, which fires none of those, so `main`'s own checks stayed
green while it was broken.

## What

Two things, both needed to close it out:

**Re-approves the authorization baseline**, which unblocks `main` and every affected PR.
The break was a routine secret rotation: the production bootstrap secret feeds
configuration values into the cluster, and the gate pins its encrypted contents, so
re-encrypting it moved the fingerprint. Before re-approving I measured that the change
carries no authorization meaning — one of 159 tracked items moved, its set of
configuration keys is unchanged, and no pinned permission resource moved.

**Runs the gate on pushes to `main`**, so this class of break is reported where it
happens instead of surfacing days later on someone else's PR. A guard test fails if that
coverage is ever removed again.

⚠️ **Worth knowing:** the gate is sensitive to the encrypted file's raw bytes, so any
routine secret rotation will red it again with no permission change at all — it even
absorbed a SOPS version bump here. I've documented that in place and filed the
recurrence separately rather than widening the control silently in this PR.

Also fixes an unrelated unchecked-error lint failure in another script. It has been
red on `main` since a linter version bump and fails the lint job on *any* PR that
touches Go, so it had to go green here.

Fixes #2801
