### PR TITLE
fix(security): reject floating workflow refs in cosign subject matchers

### DIFF
--- a/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/oci-repository.yaml
@@ -16,12 +16,14 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # publish-app.yaml is moving from devantler-tech/reusable-workflows into
-      # devantler-tech/actions (actions#425 consumer repoint); both repo
-      # subjects are accepted via ONE regex-alternated entry — cosign's keyless
-      # attestation verification rejects MULTIPLE identity entries outright
-      # ("unsupported: multiple identities are not supported at this time").
-      # Narrow the alternation to actions-only once the first actions-signed
-      # artifact has been published and verified.
+      # Keyless-signed by the shared publish-app workflow this app's cd.yaml
+      # calls. The ref part accepts only a 40-hex commit SHA or a release tag,
+      # so an artifact signed from a floating ref (e.g. @main) does not verify.
+      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
+      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # cosign's keyless attestation verification rejects MULTIPLE identity
+      # entries outright ("unsupported: multiple identities are not supported at
+      # this time"), so any future alternation must stay inside one subject
+      # regex.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'

--- a/k8s/bases/apps/github-config/oci-repository.yaml
+++ b/k8s/bases/apps/github-config/oci-repository.yaml
@@ -24,17 +24,18 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Keyless-signed by the shared publish-manifests reusable workflow that
-      # .github's cd.yaml calls. Signing runs INSIDE that reusable workflow, so
-      # the cosign OIDC subject is the reusable workflow's path, NOT .github's
-      # own cd.yaml — same convention as the publish-app.yaml-signed app
-      # artifacts. The workflow is moving from devantler-tech/reusable-workflows
-      # into devantler-tech/actions (actions#425 consumer repoint); both repo
-      # subjects are accepted via ONE regex-alternated entry — cosign's keyless
-      # attestation verification rejects MULTIPLE identity entries outright
-      # ("unsupported: multiple identities are not supported at this time"), so
-      # the transition must be expressed inside a single subject regex. Narrow
-      # the alternation to actions-only once the first actions-signed artifact
-      # has been published and verified.
+      # Keyless-signed by the shared publish-manifests workflow that .github's
+      # cd.yaml calls. Signing runs INSIDE that workflow, so the cosign OIDC
+      # subject is that workflow's path, NOT .github's own cd.yaml — same
+      # convention as the publish-app.yaml-signed app artifacts.
+      #
+      # The ref part accepts only a 40-hex commit SHA or a release tag, so an
+      # artifact signed from a floating ref (e.g. @main) does not verify.
+      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
+      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # cosign's keyless attestation verification rejects MULTIPLE identity
+      # entries outright ("unsupported: multiple identities are not supported at
+      # this time"), so any future alternation must stay inside one subject
+      # regex.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-manifests\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'

--- a/k8s/bases/apps/wedding-app/oci-repository.yaml
+++ b/k8s/bases/apps/wedding-app/oci-repository.yaml
@@ -16,12 +16,14 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # publish-app.yaml is moving from devantler-tech/reusable-workflows into
-      # devantler-tech/actions (actions#425 consumer repoint); both repo
-      # subjects are accepted via ONE regex-alternated entry — cosign's keyless
-      # attestation verification rejects MULTIPLE identity entries outright
-      # ("unsupported: multiple identities are not supported at this time").
-      # Narrow the alternation to actions-only once the first actions-signed
-      # artifact has been published and verified.
+      # Keyless-signed by the shared publish-app workflow this app's cd.yaml
+      # calls. The ref part accepts only a 40-hex commit SHA or a release tag,
+      # so an artifact signed from a floating ref (e.g. @main) does not verify.
+      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
+      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # cosign's keyless attestation verification rejects MULTIPLE identity
+      # entries outright ("unsupported: multiple identities are not supported at
+      # this time"), so any future alternation must stay inside one subject
+      # regex.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/(reusable-workflows|actions)/\.github/workflows/publish-app\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'

--- a/k8s/providers/hetzner/apps/aws/oci-repository.yaml
+++ b/k8s/providers/hetzner/apps/aws/oci-repository.yaml
@@ -21,11 +21,13 @@ spec:
   verify:
     provider: cosign
     matchOIDCIdentity:
-      # Keyless-signed by the shared publish-manifests reusable workflow that
-      # aws's cd.yaml calls. Signing runs INSIDE that reusable workflow, so the
-      # cosign OIDC subject is the reusable workflow's path, NOT aws's own
-      # cd.yaml. Unlike the older tenants there is no reusable-workflows
-      # alternation here: the aws repo was scaffolded after the actions#425
-      # repoint, so every artifact it has ever published is actions-signed.
+      # Keyless-signed by the shared publish-manifests workflow that aws's
+      # cd.yaml calls. Signing runs INSIDE that workflow, so the cosign OIDC
+      # subject is that workflow's path, NOT aws's own cd.yaml.
+      #
+      # The ref part accepts only a 40-hex commit SHA or a release tag, so an
+      # artifact signed from a floating ref (e.g. @main) does not verify.
+      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
+      # today; the tag branch is kept so a tag-pinned caller also verifies.
       - issuer: '^https://token\.actions\.githubusercontent\.com$'
-        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@.+$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-manifests\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -56,21 +56,30 @@ const (
 // The approved surface includes the encrypted flux-system/variables-cluster
 // substitution source and the staged Cilium homogeneous-device activation.
 //
-// Measured against main b9f39bc before approving this value: both renders
-// contain 159 surface entries and exactly one entry moves, the kube-system
-// Cilium HelmRelease. Its canonical fingerprint changes from 4bfb70e9 to
-// 434560fd because values.devices, updateStrategy and the temporary Helm
-// disableWait handoff stage the intended operator-stepped Cilium rollout
-// without blocking Flux dependencies. No pinned authorization resource or
-// substitution source moves, so the change adds, removes and repoints no
-// grant-bearing object.
+// Measured against main 607ad877 before approving this value: rendering the
+// five authorization overlays for both trees yields 503 documents on each side
+// — no entry is added, removed or renamed — and the entire textual delta is
+// FOUR lines, each the cosign `subject:` matcher of an app OCIRepository
+// (github-config, wedding-app, ascoachingogvaner, aws). Each drops the dead
+// (reusable-workflows|actions) alternation and replaces the `@.+` ref part with
+// `@([0-9a-f]{40}|refs/tags/v.+)$`, so an artifact signed from a floating
+// workflow ref no longer verifies. The validator reported no per-resource
+// fingerprint mismatch, no missing and no duplicate resource, so no RBAC
+// object, ServiceAccount, pinned authorization resource or substitution source
+// moves: the change adds, removes and repoints no grant-bearing object. The
+// gate moved only because an OCIRepository carrying a ghcr-auth secretRef is
+// itself inside the selected surface, not because a privilege changed.
 //
 // NOTE for whoever re-approves this next: an opaque ciphertext in the surface
 // moves on ANY re-encryption — this value also absorbed a SOPS version bump
 // (3.13.2 -> 3.13.3) — so a routine secret rotation reds this gate with no
 // authorization change at all. Do NOT treat a moved hash as self-evidently
 // benign: re-run the per-entry membership measurement above before re-approving.
-const expectedRenderedSurfaceSHA = "9c50a90deac105597b57e0308e3d1f6d61b987dbabefc55af4ff2eaad80a9f43"
+// A Go toolchain is only needed to recompute the hash; MEMBERSHIP is a plain
+// kubectl render diff — render k8s/providers/hetzner/{apps,infrastructure,
+// infrastructure/controllers} plus k8s/clusters/prod/{bootstrap,} for both
+// trees and diff them.
+const expectedRenderedSurfaceSHA = "aba2c747530f3742b4fa2571e0c216c9722d7b9540bfea3dfc797d692e0b54f9"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Our apps only deploy artifacts that carry a valid signature from our own publishing workflow. Until now the rule checking that signature accepted the workflow signed from **any** ref of itself — including a moving branch like `main`. A moving branch is the weak link: what it points at can change after anyone last looked at it.

Three of the rules also still accepted a second, now-archived source repository, left over from a workflow move that finished a fortnight ago.

## What

The four live artifact trust rules now accept a signature only from a **fixed** ref — a commit or a release tag — and only from the one repository that still publishes. A signature produced from a moving branch no longer verifies.

To be precise about the limit: this rejects *moving* refs, it does not restrict which fixed revision is acceptable. Narrowing further to an approved revision list is a real hardening step, but it would need every workflow release to be shepherded across these files or verification breaks — so it is tracked separately rather than smuggled in here.

No change to what is deployed today — every currently-deployed artifact already satisfies the stricter rule, checked against the real signatures first.

**Security floor:** an artifact signed from a moving workflow ref is now rejected.
**Everyday path:** unchanged — the workflows are already pinned by commit, so nobody has to do anything differently.

## Operational note

This governs live verification: if the stricter rule were wrong, the affected sources would stop reconciling. The deployed artifacts were checked against their actual signatures first, and it is a single-commit revert.

Two deliberate exclusions, each tracked: the same matcher in the **tenant template** (#2817), and the same weakness at the **container-image layer** (#2815 — larger blast radius). Neither is a live rule today.

Fixes #2402
