### PR TITLE
feat(apps): onboard the doggy-countdown tenant

### DIFF
--- a/k8s/bases/apps/doggy-countdown/flux-kustomization.yaml
+++ b/k8s/bases/apps/doggy-countdown/flux-kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  annotations:
+    ksail.devantler.tech/reconcile-exclude: "true"
+  name: doggy-countdown
+  namespace: doggy-countdown
+spec:
+  interval: 1m
+  timeout: 5m
+  retryInterval: 2m
+  path: .
+  prune: true
+  wait: true
+  force: true
+  serviceAccountName: doggy-countdown
+  sourceRef:
+    kind: OCIRepository
+    name: doggy-countdown
+  targetNamespace: doggy-countdown

--- a/k8s/bases/apps/doggy-countdown/kustomization.yaml
+++ b/k8s/bases/apps/doggy-countdown/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Matches the other tenant skeletons: when the KRO Tenant-CR handover
+# (#1932/#2486) de-inventories these objects from the `apps` Kustomization, Flux
+# must not garbage-collect them — kro adopts them in place.
+commonAnnotations:
+  kustomize.toolkit.fluxcd.io/prune: disabled
+resources:
+  - namespace.yaml
+  - network-policy.yaml
+  - service-account.yaml
+  - role-binding-doggy-countdown.yaml
+  - oci-repository.yaml
+  - flux-kustomization.yaml

--- a/k8s/bases/apps/doggy-countdown/namespace.yaml
+++ b/k8s/bases/apps/doggy-countdown/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+  name: doggy-countdown

--- a/k8s/bases/apps/doggy-countdown/network-policy.yaml
+++ b/k8s/bases/apps/doggy-countdown/network-policy.yaml
@@ -1,0 +1,16 @@
+# Default-deny NetworkPolicy mirroring the runtime Kyverno-generated
+# CiliumNetworkPolicy (cluster-policies/best-practices/add-default-deny.yaml),
+# so the static Kubescape scan sees this namespace as network-restricted
+# (C-0054). Behaviourally redundant with the runtime default-deny this namespace
+# already runs under: the tenant's own allow CiliumNetworkPolicy still applies
+# (Cilium evaluates NetworkPolicy and CiliumNetworkPolicy allows additively).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: doggy-countdown
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/k8s/bases/apps/doggy-countdown/oci-repository.yaml
+++ b/k8s/bases/apps/doggy-countdown/oci-repository.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: doggy-countdown
+  namespace: doggy-countdown
+spec:
+  interval: 1m
+  ref:
+    semver: ">=1.0.0"
+  # No secretRef: the package is public, so it is pulled anonymously and the
+  # tenant needs no GHCR pull credential.
+  url: oci://ghcr.io/devantler-tech/doggy-countdown/manifests
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      # Keyless-signed by the shared publish-app workflow this app's cd.yaml
+      # calls. The ref part accepts only a 40-hex commit SHA or a release tag,
+      # so an artifact signed from a floating ref (e.g. @main) does not verify.
+      # Consumers pin the workflow by SHA, so only the SHA branch is exercised
+      # today; the tag branch is kept so a tag-pinned caller also verifies.
+      # cosign's keyless attestation verification rejects MULTIPLE identity
+      # entries outright ("unsupported: multiple identities are not supported at
+      # this time"), so any future alternation must stay inside one subject
+      # regex.
+      - issuer: '^https://token\.actions\.githubusercontent\.com$'
+        subject: '^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$'

--- a/k8s/bases/apps/doggy-countdown/role-binding-doggy-countdown.yaml
+++ b/k8s/bases/apps/doggy-countdown/role-binding-doggy-countdown.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: doggy-countdown
+  namespace: doggy-countdown
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tenant-edit
+subjects:
+  - kind: ServiceAccount
+    name: doggy-countdown
+    namespace: doggy-countdown

--- a/k8s/bases/apps/doggy-countdown/service-account.yaml
+++ b/k8s/bases/apps/doggy-countdown/service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: ksail
+  name: doggy-countdown
+  namespace: doggy-countdown
+automountServiceAccountToken: false

--- a/k8s/bases/apps/kustomization.yaml
+++ b/k8s/bases/apps/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
   # Crossplane CRDs, and Crossplane runs only on the Hetzner provider. The
   # docker provider deploys no apps, so it is naturally excluded from local.
   - crossview/
+  # Countdown to a puppy coming home — a single static page on
+  # simba.platform.devantler.tech, served by the shared platform gateway under
+  # its existing *.platform.devantler.tech certificate.
+  - doggy-countdown/
   # fleetdm disabled 2026-06-03 — not in use. The manifests under
   # bases/apps/fleetdm/ are retained; re-enable by uncommenting the line below.
   # The prod-only HelmRelease patch (providers/hetzner/apps/fleetdm/) was

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -56,19 +56,23 @@ const (
 // The approved surface includes the encrypted flux-system/variables-cluster
 // substitution source and the staged Cilium homogeneous-device activation.
 //
-// Measured against main 607ad877 before approving this value: rendering the
-// five authorization overlays for both trees yields 503 documents on each side
-// — no entry is added, removed or renamed — and the entire textual delta is
-// FOUR lines, each the cosign `subject:` matcher of an app OCIRepository
-// (github-config, wedding-app, ascoachingogvaner, aws). Each drops the dead
-// (reusable-workflows|actions) alternation and replaces the `@.+` ref part with
-// `@([0-9a-f]{40}|refs/tags/v.+)$`, so an artifact signed from a floating
-// workflow ref no longer verifies. The validator reported no per-resource
-// fingerprint mismatch, no missing and no duplicate resource, so no RBAC
-// object, ServiceAccount, pinned authorization resource or substitution source
-// moves: the change adds, removes and repoints no grant-bearing object. The
-// gate moved only because an OCIRepository carrying a ghcr-auth secretRef is
-// itself inside the selected surface, not because a privilege changed.
+// Measured against main e77fdb9c before approving this value: the render goes
+// from 503 to 509 documents and the delta is **purely additive** — 97 added
+// lines, ZERO removed — so no existing entry is modified, removed or renamed.
+// The six new documents are one tenant skeleton (`doggy-countdown`):
+// Namespace, NetworkPolicy, ServiceAccount, RoleBinding, OCIRepository and
+// Flux Kustomization. The validator reported no per-resource
+// fingerprint mismatch, no missing and no duplicate resource.
+//
+// The new RoleBinding grants the tenant's own ServiceAccount the existing
+// `tenant-edit` ClusterRole in its own namespace — the same scoped grant every
+// other tenant skeleton carries. Nothing is granted to the aws/aws service
+// account this validator exists to protect, and no existing grant is repointed.
+// The tenant pulls a PUBLIC package, so it carries no pull secret and no
+// ExternalSecret — it holds no credential at all.
+//
+// (The previous value covered the cosign matcher tightening: 503 documents on
+// both sides, four changed `subject:` lines, no grant-bearing object moved.)
 //
 // NOTE for whoever re-approves this next: an opaque ciphertext in the surface
 // moves on ANY re-encryption — this value also absorbed a SOPS version bump
@@ -79,7 +83,7 @@ const (
 // kubectl render diff — render k8s/providers/hetzner/{apps,infrastructure,
 // infrastructure/controllers} plus k8s/clusters/prod/{bootstrap,} for both
 // trees and diff them.
-const expectedRenderedSurfaceSHA = "aba2c747530f3742b4fa2571e0c216c9722d7b9540bfea3dfc797d692e0b54f9"
+const expectedRenderedSurfaceSHA = "5d11d1bf2f5989c3483dd528fb59306cc14ef71b44f87e804e1c3c905a4da406"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A small personal app — a countdown to the day a puppy comes home — needs somewhere to run. It is a single static page, so it should cost the platform as little as possible to host.

## What

Onboards it as an ordinary tenant at **https://simba.platform.devantler.tech**.

It reuses what the platform already provides rather than adding anything: the shared gateway's certificate already covers that whole domain, and DNS is created from the app's own route. So there is no certificate, no DNS resource, and no per-app ingress plumbing to maintain.

**It holds no credentials at all.** Both its image and its manifests are public, so it pulls anonymously — no pull secret, and no dependency on the secret store. That is one fewer thing to rotate and one fewer thing to break.

The only permission it gets is the standard one every tenant gets: its own service account, limited to its own namespace.

## Also in here

Re-approves the authorization fingerprint, which moves whenever a tenant is added. The measurement is recorded next to the value: the render grows by exactly this tenant's six resources with **nothing existing changed**, and the guard was RED/GREEN proved — it still fails if this tenant's permissions are widened.
