### PR TITLE
chore(renovate): disable the Dependency Dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "assigneesFromCodeOwners": true,
   "minimumReleaseAge": "7 days",
   "flux": {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

You asked for this directly, twice, on monorepo#2503 (16:44Z and 17:02Z today):

> I would also like us to disable this issue dashboard. I do not use it, and it confuses agents, so it should be disabled!

`platform` is the last repo still opting in. The monorepo already turned it off; this repo's dashboard is the issue that has been sitting open since August 2023, and it does confuse agents — it looks like the oldest open issue in the portfolio, so runs keep having to recognise and skip it.

## What

Turns the dashboard off in this repo's Renovate config, which is what makes Renovate retire the issue itself. Deliberately not done by closing the issue by hand: that issue belongs to the bot, and closing it manually changes Renovate's behaviour in a way nobody chose.

Nothing depends on it. No update in this repo waits for dashboard approval — every rule that mentions the dashboard says exactly that — so no approval step is lost.

Fixes nothing tracked; this implements your direction on monorepo#2503.
