### PR TITLE
feat(ci): publish Kubescape posture findings to Code Scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout repository
+      security-events: write # upload the Kubescape SARIF to Code Scanning
     steps:
       - name: 📑 Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -330,10 +331,56 @@ jobs:
         # (deliberate dev-only credential — tracked for a root-cause fix, not
         # an exception). Ratchet the floor up as genuine gaps close; never
         # lower it.
+        #
+        # --format sarif -o writes the findings to a file IN ADDITION to the
+        # human-readable posture table, which still goes to this log unchanged
+        # (verified on both a passing and a failing scan) — so the SARIF is a
+        # pure addition, not a swap. The upload step below turns those findings
+        # into Code Scanning alerts. The threshold flag is untouched and remains
+        # the merge gate; this step's pass/fail behaviour does not change.
         run: |
           go test ./scripts/generate-kubescape-exceptions
           go run ./scripts/generate-kubescape-exceptions -o /tmp/kubescape-exceptions.json
-          ksail workload scan --framework nsa --exceptions /tmp/kubescape-exceptions.json --compliance-threshold 95
+          ksail workload scan --framework nsa --exceptions /tmp/kubescape-exceptions.json --compliance-threshold 95 --format sarif -o "${RUNNER_TEMP}/kubescape.sarif"
+
+      - name: 🛡️ Upload Kubescape findings to Code Scanning
+        # The score gate above answers "did posture regress"; it cannot show
+        # WHICH control failed on WHICH file, and a finding that does not move
+        # the score is invisible in it entirely. Code Scanning gives each
+        # control an alert with file and line, dedupes it across runs, and
+        # closes it automatically when the finding is gone (#2829).
+        #
+        # `!cancelled()` rather than `success()`: the findings are wanted most
+        # precisely when the gate above FAILED. ksail writes the SARIF before it
+        # applies the threshold, so the file exists on that path too.
+        #
+        # Skipped on fork PRs — this job deliberately runs on them (it needs no
+        # secrets), but a fork's GITHUB_TOKEN cannot be granted
+        # security-events: write, so attempting the upload there would fail the
+        # build for a permission no fork can have.
+        #
+        # The fork check is the ONLY narrowing: the scan step above is
+        # unconditional within this job, so gating this step on a path filter
+        # would silently drop the findings for any run the scan still made.
+        #
+        # KNOWN CHARACTERISTIC: cluster-RBAC controls that are not backed by a
+        # manifest file (C-0002 is the one observed) emit a result with an EMPTY
+        # artifactLocation.uri. The scan as configured here — NSA framework with
+        # this repo's exceptions — produces none of them (measured: 0 of 4
+        # findings; the same scan with exceptions removed produces 1 of 70). If
+        # a future exception or framework change surfaces one and this upload
+        # starts failing on it, that empty uri is the thing to look at first,
+        # not the SARIF as a whole.
+        if: >-
+          !cancelled() &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: ${{ runner.temp }}/kubescape.sarif
+          # Distinguishes these alerts from the CodeQL and zizmor analyses that
+          # already publish to this repository's Security tab, so each tool's
+          # results are tracked and closed independently.
+          category: kubescape-nsa
 
   naming:
     name: 🏷️ Validate Naming Conventions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
               - 'scripts/validate-naming.py'
               - 'scripts/validate-embedded-json.py'
               - 'scripts/generate-kubescape-exceptions/**'
+              - 'scripts/normalize-sarif-paths.sh'
               - 'go.mod'
               - 'go.sum'
               - 'scripts/tests/test-cilium-bandwidth-manager-component.sh'
@@ -343,15 +344,22 @@ jobs:
           go run ./scripts/generate-kubescape-exceptions -o /tmp/kubescape-exceptions.json
           ksail workload scan --framework nsa --exceptions /tmp/kubescape-exceptions.json --compliance-threshold 95 --format sarif -o "${RUNNER_TEMP}/kubescape.sarif"
 
-      - name: 🔬 TEMPORARY — report SARIF URI shape
-        # Diagnostic only: the alerts from the first run of this PR anchored
-        # to bases/... while the files live at k8s/bases/..., so this prints
-        # what was actually uploaded. Removed before this PR leaves draft.
+      - name: 🧭 Make the SARIF paths repo-root-relative
+        # Kubescape reports paths relative to the directory it scanned, so a
+        # finding in k8s/bases/... arrives as bases/... . Code Scanning resolves
+        # an alert against the REPO ROOT, so uploading those unchanged creates
+        # alerts pointing at files that do not exist — measured on this PR's
+        # first run: the upload was green, four alerts existed, all four dead.
+        #
+        # The same scan run locally emitted the k8s/ prefix, so the shape is not
+        # stable across ksail versions. The script resolves each path against
+        # the working tree rather than assuming either shape, so it is a no-op
+        # if ksail later emits root-relative paths, and it hard-fails rather
+        # than uploading a path it cannot resolve.
         if: "!cancelled()"
         run: |
-          jq -r '[.runs[].results[].locations[].physicalLocation.artifactLocation.uri]|unique[]' "${RUNNER_TEMP}/kubescape.sarif"
-          echo "--- workspace check ---"
-          ls -d k8s bases 2>&1 || true
+          shellcheck scripts/normalize-sarif-paths.sh
+          bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
 
       - name: 🛡️ Upload Kubescape findings to Code Scanning
         # The score gate above answers "did posture regress"; it cannot show
@@ -375,12 +383,10 @@ jobs:
         #
         # KNOWN CHARACTERISTIC: cluster-RBAC controls that are not backed by a
         # manifest file (C-0002 is the one observed) emit a result with an EMPTY
-        # artifactLocation.uri. The scan as configured here — NSA framework with
-        # this repo's exceptions — produces none of them (measured: 0 of 4
-        # findings; the same scan with exceptions removed produces 1 of 70). If
-        # a future exception or framework change surfaces one and this upload
-        # starts failing on it, that empty uri is the thing to look at first,
-        # not the SARIF as a whole.
+        # artifactLocation.uri — there is no file for such a finding to anchor
+        # to. The step above drops those; with this repo's exceptions applied
+        # the scan produces none anyway (measured: 0 of 4 findings; the same
+        # scan with exceptions removed produces 1 of 70).
         if: >-
           !cancelled() &&
           github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -356,6 +356,7 @@ jobs:
         # the working tree rather than assuming either shape, so it is a no-op
         # if ksail later emits root-relative paths, and it hard-fails rather
         # than uploading a path it cannot resolve.
+        id: normalize-sarif
         if: "!cancelled()"
         run: |
           shellcheck scripts/normalize-sarif-paths.sh
@@ -365,9 +366,17 @@ jobs:
           # loudest error in the log and bury the one that actually matters.
           if [ ! -f "${RUNNER_TEMP}/kubescape.sarif" ]; then
             echo "::notice::No SARIF written — the scan step failed before producing one. Leaving its error as the visible failure."
+            echo "sarif=absent" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
           bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
+          # Only now is the file both PRESENT and root-relative. The upload gates
+          # on this output, so a normalizer hard-failure (an unresolvable path)
+          # cannot fall through to publishing the un-normalized SARIF — which
+          # would create exactly the dead-path alerts this step exists to
+          # prevent. `exit 0` above deliberately leaves it `absent` instead:
+          # a missing SARIF is the scan's failure to report, not this step's.
+          echo "sarif=ready" >> "${GITHUB_OUTPUT}"
 
       - name: 🛡️ Upload Kubescape findings to Code Scanning
         # The score gate above answers "did posture regress"; it cannot show
@@ -395,8 +404,18 @@ jobs:
         # to. The step above drops those; with this repo's exceptions applied
         # the scan produces none anyway (measured: 0 of 4 findings; the same
         # scan with exceptions removed produces 1 of 70).
+        # Gated on the normalize step's OUTPUT, not merely on `!cancelled()`.
+        # `!cancelled()` stays true when normalization FAILS, which would upload
+        # the un-normalized SARIF and recreate the dead-path alerts that step
+        # exists to prevent; it is also true when no SARIF was written at all,
+        # which would invoke the uploader on a missing file. `sarif == 'ready'`
+        # is reached only after the file exists AND normalization succeeded.
+        # Note this deliberately still uploads when the SCAN step failed: a
+        # compliance-threshold failure exits non-zero but writes a valid SARIF,
+        # and those findings are precisely the ones worth publishing.
         if: >-
           !cancelled() &&
+          steps.normalize-sarif.outputs.sarif == 'ready' &&
           github.event.pull_request.head.repo.full_name == github.repository
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -359,6 +359,14 @@ jobs:
         if: "!cancelled()"
         run: |
           shellcheck scripts/normalize-sarif-paths.sh
+          # `!cancelled()` also covers the scan step failing BEFORE ksail writes
+          # the SARIF — a failing `go test`, or a ksail crash. There is nothing to
+          # normalize then, and exiting 2 with "no such file" would make this the
+          # loudest error in the log and bury the one that actually matters.
+          if [ ! -f "${RUNNER_TEMP}/kubescape.sarif" ]; then
+            echo "::notice::No SARIF written — the scan step failed before producing one. Leaving its error as the visible failure."
+            exit 0
+          fi
           bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
 
       - name: 🛡️ Upload Kubescape findings to Code Scanning

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -343,6 +343,16 @@ jobs:
           go run ./scripts/generate-kubescape-exceptions -o /tmp/kubescape-exceptions.json
           ksail workload scan --framework nsa --exceptions /tmp/kubescape-exceptions.json --compliance-threshold 95 --format sarif -o "${RUNNER_TEMP}/kubescape.sarif"
 
+      - name: 🔬 TEMPORARY — report SARIF URI shape
+        # Diagnostic only: the alerts from the first run of this PR anchored
+        # to bases/... while the files live at k8s/bases/..., so this prints
+        # what was actually uploaded. Removed before this PR leaves draft.
+        if: "!cancelled()"
+        run: |
+          jq -r '[.runs[].results[].locations[].physicalLocation.artifactLocation.uri]|unique[]' "${RUNNER_TEMP}/kubescape.sarif"
+          echo "--- workspace check ---"
+          ls -d k8s bases 2>&1 || true
+
       - name: 🛡️ Upload Kubescape findings to Code Scanning
         # The score gate above answers "did posture regress"; it cannot show
         # WHICH control failed on WHICH file, and a finding that does not move

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -62,3 +62,89 @@ jobs:
         run: |
           go test ./scripts/validate-eks-ci-role-policy
           go run ./scripts/validate-eks-ci-role-policy .
+
+  kubescape-baseline:
+    name: 🛡️ Publish Kubescape Baseline
+    runs-on: ubuntu-latest
+    # ci.yaml scans and uploads on `pull_request` only, so every Kubescape
+    # analysis lands on an ephemeral `refs/pull/<n>/merge` ref. Code Scanning
+    # tracks alerts per (tool, category, ref): with no analysis for the default
+    # branch there is nothing for those findings to dedupe against and nothing
+    # to close, so the deployed tree has no durable posture baseline. Measured
+    # on 2026-07-28 — six kubescape analyses, all on PR refs, and ZERO
+    # default-branch kubescape alerts.
+    #
+    # This job publishes that baseline from main itself. It is the same scan
+    # ci.yaml runs, so a finding fixed on a PR closes here on merge, and a
+    # finding introduced by a direct push is reported where it is introduced.
+    permissions:
+      contents: read # checkout repository
+      security-events: write # publish the Kubescape SARIF to Code Scanning
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: ⚙️ Setup KSail
+        # Kept at the version ci.yaml pins, so the baseline is produced by the
+        # same renderer as the PR-ref analyses it is the baseline for. Renovate
+        # updates both together (group 'ksail').
+        shell: bash
+        env:
+          # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
+          KSAIL_VERSION: "7.176.4"
+        run: |
+          curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
+          tar -xzf /tmp/ksail.tar.gz -C /tmp
+          sudo install /tmp/ksail /usr/local/bin/ksail
+          ksail --version
+
+      - name: 🔎 Scan manifests (Kubescape NSA)
+        # Same invocation and same justified exceptions as ci.yaml's gate, so
+        # the two analyses are comparable. The threshold is kept: main can only
+        # receive gated content, so a failure here means posture moved without
+        # a PR — which this workflow exists to report.
+        run: |
+          go test ./scripts/generate-kubescape-exceptions
+          go run ./scripts/generate-kubescape-exceptions -o /tmp/kubescape-exceptions.json
+          ksail workload scan --framework nsa --exceptions /tmp/kubescape-exceptions.json --compliance-threshold 95 --format sarif -o "${RUNNER_TEMP}/kubescape.sarif"
+
+      - name: 🧭 Make the SARIF paths repo-root-relative
+        # Kubescape reports paths relative to the directory it scanned; Code
+        # Scanning resolves them against the repo root. Uploading them unchanged
+        # creates alerts pointing at files that do not exist.
+        id: normalize-sarif
+        if: "!cancelled()"
+        run: |
+          if [ ! -f "${RUNNER_TEMP}/kubescape.sarif" ]; then
+            echo "::notice::No SARIF written — the scan failed before producing one. Leaving its error as the visible failure."
+            echo "sarif=absent" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
+          echo "sarif=ready" >> "${GITHUB_OUTPUT}"
+
+      - name: 🛡️ Upload Kubescape findings to Code Scanning
+        # `!cancelled()` rather than `success()`: the findings are wanted most
+        # when the scan's threshold FAILED, and ksail writes the SARIF before
+        # applying it. Gated on the normalize OUTPUT so a normalizer failure
+        # cannot fall through to publishing dead paths. No fork check is needed
+        # — this runs on a push to main, which is never a fork.
+        if: >-
+          !cancelled() &&
+          steps.normalize-sarif.outputs.sarif == 'ready'
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: ${{ runner.temp }}/kubescape.sarif
+          # MUST match ci.yaml's category: Code Scanning dedupes and closes per
+          # (tool, category, ref), so a different category here would create a
+          # parallel alert set instead of a baseline the PR findings resolve
+          # against.
+          category: kubescape-nsa

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -101,7 +101,40 @@ jobs:
           # renovate: datasource=github-releases depName=devantler-tech/ksail extractVersion=^v(?<version>.+)$
           KSAIL_VERSION: "7.176.4"
         run: |
-          curl -fsSL "https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}/ksail_${KSAIL_VERSION}_linux_amd64.tar.gz" -o /tmp/ksail.tar.gz
+          set -euo pipefail
+          BASE="https://github.com/devantler-tech/ksail/releases/download/v${KSAIL_VERSION}"
+          ASSET="ksail_${KSAIL_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL "${BASE}/${ASSET}" -o /tmp/ksail.tar.gz
+          # A version-pinned URL is not an integrity check: this archive is
+          # `sudo install`ed and executed on a trusted `main` workflow, so a
+          # replaced release asset would run here. Verify against the release's
+          # published checksums before extracting.
+          #
+          # Checked against the published list rather than a literal SHA pinned
+          # in this file: Renovate bumps KSAIL_VERSION and cannot update an
+          # opaque digest beside it, so a pinned SHA would break every bump
+          # until a human hand-edited it — a control people end up removing.
+          # This costs nothing per bump. Its LIMIT, stated plainly: the archive
+          # and the checksum list come from the same origin, so this detects a
+          # corrupted, truncated or individually-substituted asset, not a fully
+          # compromised release. Provenance attestations would close that and
+          # are tracked separately.
+          curl -fsSL "${BASE}/ksail_${KSAIL_VERSION}_checksums.txt" -o /tmp/ksail_checksums.txt
+          # `|| true` is load-bearing under `set -e -o pipefail`: grep exits 1
+          # when the asset is absent, which would abort the step before the
+          # explicit check below and fail with no explanation of what to do.
+          expected=$(grep -E "  ${ASSET}\$" /tmp/ksail_checksums.txt | cut -d' ' -f1 || true)
+          # Fail closed on a MISSING entry too — otherwise a renamed asset
+          # silently skips verification instead of failing.
+          if [ -z "$expected" ]; then
+            echo "::error::no published checksum for ${ASSET} — refusing to install unverified"
+            exit 1
+          fi
+          actual=$(sha256sum /tmp/ksail.tar.gz | cut -d' ' -f1)
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::checksum mismatch for ${ASSET}: expected ${expected}, got ${actual}"
+            exit 1
+          fi
           tar -xzf /tmp/ksail.tar.gz -C /tmp
           sudo install /tmp/ksail /usr/local/bin/ksail
           ksail --version

--- a/scripts/normalize-sarif-paths.sh
+++ b/scripts/normalize-sarif-paths.sh
@@ -33,8 +33,14 @@ SARIF="${1:?usage: normalize-sarif-paths.sh <sarif-file> <prefix> [repo-root]}"
 PREFIX="${2:?usage: normalize-sarif-paths.sh <sarif-file> <prefix> [repo-root]}"
 ROOT="${3:-.}"
 
-[ -f "$SARIF" ] || { echo "normalize-sarif-paths: no such file: $SARIF" >&2; exit 2; }
-[ -d "$ROOT/$PREFIX" ] || { echo "normalize-sarif-paths: prefix dir not found: $ROOT/$PREFIX" >&2; exit 2; }
+[ -f "$SARIF" ] || {
+  echo "normalize-sarif-paths: no such file: $SARIF" >&2
+  exit 2
+}
+[ -d "$ROOT/$PREFIX" ] || {
+  echo "normalize-sarif-paths: prefix dir not found: $ROOT/$PREFIX" >&2
+  exit 2
+}
 
 PREFIX="${PREFIX%/}"
 
@@ -86,7 +92,7 @@ jq --arg prefix "$PREFIX" --argjson rewrite "$(printf '%s\n' "${rewrite_args[@]+
         )
       )
   )
-' "$SARIF" > "$tmp"
+' "$SARIF" >"$tmp"
 mv "$tmp" "$SARIF"
 
 dropped=$(printf '%s\n' "${uris[@]+"${uris[@]}"}" | grep -c '^$' || true)
@@ -100,6 +106,9 @@ while IFS= read -r line; do after+=("$line"); done < <(jq -r '
 bad=0
 for uri in "${after[@]}"; do
   [ -n "$uri" ] || continue
-  [ -e "$ROOT/$uri" ] || { echo "::error::normalize-sarif-paths: still unresolved after rewrite: $uri" >&2; bad=1; }
+  [ -e "$ROOT/$uri" ] || {
+    echo "::error::normalize-sarif-paths: still unresolved after rewrite: $uri" >&2
+    bad=1
+  }
 done
 [ "$bad" -eq 0 ] || exit 1

--- a/scripts/normalize-sarif-paths.sh
+++ b/scripts/normalize-sarif-paths.sh
@@ -56,7 +56,11 @@ unresolved=()
 kept=0
 prefixed=0
 
-for uri in "${uris[@]}"; do
+# `${arr[@]+"${arr[@]}"}` rather than a bare `"${arr[@]}"`: under `set -u`, bash
+# 3.2 treats an empty array as unset and aborts with `uris[@]: unbound variable`.
+# A SARIF with zero results is the normal clean-scan case, so the unguarded form
+# fails exactly when there is nothing wrong.
+for uri in ${uris[@]+"${uris[@]}"}; do
   if [ -z "$uri" ]; then
     continue
   elif [ -e "$ROOT/$uri" ]; then
@@ -95,7 +99,13 @@ jq --arg prefix "$PREFIX" --argjson rewrite "$(printf '%s\n' "${rewrite_args[@]+
 ' "$SARIF" >"$tmp"
 mv "$tmp" "$SARIF"
 
-dropped=$(printf '%s\n' "${uris[@]+"${uris[@]}"}" | grep -c '^$' || true)
+# Counted from the array length, not from `printf | grep -c '^$'`: with no uris at
+# all, printf still emits one newline, so the grep form reports 1 dropped group on
+# a clean scan that had none.
+dropped=0
+for uri in ${uris[@]+"${uris[@]}"}; do
+  [ -n "$uri" ] || dropped=$((dropped + 1))
+done
 echo "normalize-sarif-paths: ${kept} already root-relative, ${prefixed} prefixed with '${PREFIX}/', ${dropped} empty-uri group(s) dropped."
 
 # Fail-closed re-check: every surviving path must now resolve.
@@ -104,7 +114,7 @@ while IFS= read -r line; do after+=("$line"); done < <(jq -r '
   [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty] | unique[]
 ' "$SARIF")
 bad=0
-for uri in "${after[@]}"; do
+for uri in ${after[@]+"${after[@]}"}; do
   [ -n "$uri" ] || continue
   [ -e "$ROOT/$uri" ] || {
     echo "::error::normalize-sarif-paths: still unresolved after rewrite: $uri" >&2

--- a/scripts/normalize-sarif-paths.sh
+++ b/scripts/normalize-sarif-paths.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Make a SARIF file's result paths repo-root-relative, so Code Scanning alerts
+# anchor to real files.
+#
+# WHY THIS EXISTS. Kubescape reports paths relative to the directory it scanned,
+# not to the repository root: a finding in k8s/bases/apps/umami/cron-job.yaml
+# arrives as bases/apps/umami/cron-job.yaml. Code Scanning resolves an alert's
+# location against the repository root, so an un-prefixed uri produces an alert
+# pointing at a path that does not exist — the alert is created, looks correct in
+# the API, and is unclickable. Measured on devantler-tech/platform#2830: the
+# upload step was green, four alerts existed, and every one of them was dead.
+#
+# The same scan run locally emitted the k8s/ prefix, so the shape is not stable
+# across ksail versions. This script therefore does not assume either shape: it
+# resolves each uri against the working tree and only rewrites the ones that
+# need it, which makes it correct before and after any upstream change.
+#
+# CONTRACT
+#   - A uri that already resolves to a file is left ALONE (idempotent, and a
+#     re-run or a future ksail that emits root-relative paths is a no-op).
+#   - A uri that does not resolve, but does resolve under <prefix>/, is
+#     rewritten to <prefix>/<uri>.
+#   - A uri that resolves under NEITHER is a hard error naming the uri, because
+#     silently uploading it recreates exactly the dead-alert bug this prevents.
+#   - An EMPTY uri is dropped with a warning, not an error: Kubescape emits one
+#     for cluster-RBAC controls that have no backing manifest (C-0002), and there
+#     is no file for such a finding to anchor to.
+#
+# Usage: normalize-sarif-paths.sh <sarif-file> <prefix> [repo-root]
+set -euo pipefail
+
+SARIF="${1:?usage: normalize-sarif-paths.sh <sarif-file> <prefix> [repo-root]}"
+PREFIX="${2:?usage: normalize-sarif-paths.sh <sarif-file> <prefix> [repo-root]}"
+ROOT="${3:-.}"
+
+[ -f "$SARIF" ] || { echo "normalize-sarif-paths: no such file: $SARIF" >&2; exit 2; }
+[ -d "$ROOT/$PREFIX" ] || { echo "normalize-sarif-paths: prefix dir not found: $ROOT/$PREFIX" >&2; exit 2; }
+
+PREFIX="${PREFIX%/}"
+
+# `while read` rather than `mapfile`, which is bash 4+ and so unavailable on the
+# macOS bash 3.2 a maintainer may run this under locally.
+uris=()
+while IFS= read -r line; do uris+=("$line"); done < <(jq -r '
+  [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty] | unique[]
+' "$SARIF")
+
+rewrite_args=()
+unresolved=()
+kept=0
+prefixed=0
+
+for uri in "${uris[@]}"; do
+  if [ -z "$uri" ]; then
+    continue
+  elif [ -e "$ROOT/$uri" ]; then
+    kept=$((kept + 1))
+  elif [ -e "$ROOT/$PREFIX/$uri" ]; then
+    prefixed=$((prefixed + 1))
+    rewrite_args+=("$uri")
+  else
+    unresolved+=("$uri")
+  fi
+done
+
+if [ ${#unresolved[@]} -gt 0 ]; then
+  echo "::error::normalize-sarif-paths: these SARIF paths resolve neither at the repo root nor under '$PREFIX/':" >&2
+  printf '  %s\n' "${unresolved[@]}" >&2
+  echo "Uploading them would create Code Scanning alerts that point at files which do not exist." >&2
+  echo "Check what path base the scanner is emitting before changing this script's prefix." >&2
+  exit 1
+fi
+
+# Rewrite in one pass. Empty-uri results are dropped here too — see CONTRACT.
+tmp="$(mktemp)"
+jq --arg prefix "$PREFIX" --argjson rewrite "$(printf '%s\n' "${rewrite_args[@]+"${rewrite_args[@]}"}" | jq -R . | jq -s 'map(select(. != ""))')" '
+  def fix(u): if (u == "") then u
+              elif (u as $x | $rewrite | index($x)) then ($prefix + "/" + u)
+              else u end;
+  .runs |= map(
+    (.results //= [])
+    | .results |= map(select((.locations[0].physicalLocation.artifactLocation.uri // "") != ""))
+    | .results |= map(
+        .locations |= map(
+          .physicalLocation.artifactLocation.uri |= fix(.)
+        )
+      )
+  )
+' "$SARIF" > "$tmp"
+mv "$tmp" "$SARIF"
+
+dropped=$(printf '%s\n' "${uris[@]+"${uris[@]}"}" | grep -c '^$' || true)
+echo "normalize-sarif-paths: ${kept} already root-relative, ${prefixed} prefixed with '${PREFIX}/', ${dropped} empty-uri group(s) dropped."
+
+# Fail-closed re-check: every surviving path must now resolve.
+after=()
+while IFS= read -r line; do after+=("$line"); done < <(jq -r '
+  [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty] | unique[]
+' "$SARIF")
+bad=0
+for uri in "${after[@]}"; do
+  [ -n "$uri" ] || continue
+  [ -e "$ROOT/$uri" ] || { echo "::error::normalize-sarif-paths: still unresolved after rewrite: $uri" >&2; bad=1; }
+done
+[ "$bad" -eq 0 ] || exit 1

--- a/scripts/validate-eks-ci-role-policy/coverage_test.go
+++ b/scripts/validate-eks-ci-role-policy/coverage_test.go
@@ -24,12 +24,29 @@ const validatorInvocation = "go run ./scripts/validate-eks-ci-role-policy"
 // files describe this very trigger in their comments, so a text search would
 // pass on prose alone and keep passing after the trigger itself was deleted.
 type workflow struct {
-	On   triggerSet `yaml:"on"`
-	Jobs map[string]struct {
-		Steps []struct {
-			Run string `yaml:"run"`
-		} `yaml:"steps"`
-	} `yaml:"jobs"`
+	On   triggerSet     `yaml:"on"`
+	Jobs map[string]job `yaml:"jobs"`
+}
+
+// job and step are named rather than inlined so the workflow-coverage guards in
+// this package share ONE parser. The kubescape baseline guard needs `uses:` and
+// `with:` as well as `run:`; giving it a second, near-identical loader would
+// duplicate this file's parsing logic and trip the repository's duplication
+// gate for no benefit.
+type job struct {
+	Steps []step `yaml:"steps"`
+}
+
+type step struct {
+	Run  string     `yaml:"run"`
+	Uses string     `yaml:"uses"`
+	With stepInputs `yaml:"with"`
+}
+
+// stepInputs is the slice of an action's `with:` block these contracts read.
+// Actions inputs are heterogenous, so unknown keys are simply ignored.
+type stepInputs struct {
+	Category string `yaml:"category"`
 }
 
 // triggerSet is the `on:` block. GitHub accepts three spellings — a mapping
@@ -95,21 +112,25 @@ func (w workflow) runsValidator() bool {
 	return false
 }
 
-// coversPushToMain reports whether the workflow runs the gate on a direct push
-// to main.
-func (w workflow) coversPushToMain() bool {
+// triggersOnPushToMain reports whether the workflow fires on a direct push to
+// main. Shared by every push-to-main coverage guard in this package.
+func (w workflow) triggersOnPushToMain() bool {
 	push, ok := w.On["push"]
 	if !ok {
 		return false
 	}
-	onMain := false
 	for _, branch := range push.Branches {
 		if branch == "main" {
-			onMain = true
-			break
+			return true
 		}
 	}
-	return onMain && w.runsValidator()
+	return false
+}
+
+// coversPushToMain reports whether the workflow runs the gate on a direct push
+// to main.
+func (w workflow) coversPushToMain() bool {
+	return w.triggersOnPushToMain() && w.runsValidator()
 }
 
 func loadWorkflows(t *testing.T) map[string]workflow {
@@ -175,14 +196,8 @@ func TestAuthorizationGateRunsOnPushToMain(t *testing.T) {
 func TestAuthorizationGateGuardIsNotVacuous(t *testing.T) {
 	covering := workflow{
 		On: triggerSet{"push": {Branches: []string{"main"}}},
-		Jobs: map[string]struct {
-			Steps []struct {
-				Run string `yaml:"run"`
-			} `yaml:"steps"`
-		}{
-			"gate": {Steps: []struct {
-				Run string `yaml:"run"`
-			}{{Run: validatorInvocation + " ."}}},
+		Jobs: map[string]job{
+			"gate": {Steps: []step{{Run: validatorInvocation + " ."}}},
 		},
 	}
 	if !covering.coversPushToMain() {
@@ -208,14 +223,8 @@ func TestAuthorizationGateGuardIsNotVacuous(t *testing.T) {
 
 	t.Run("naming the gate without running it does not count", func(t *testing.T) {
 		perturbed := covering
-		perturbed.Jobs = map[string]struct {
-			Steps []struct {
-				Run string `yaml:"run"`
-			} `yaml:"steps"`
-		}{
-			"gate": {Steps: []struct {
-				Run string `yaml:"run"`
-			}{{Run: "echo validate-eks-ci-role-policy"}}},
+		perturbed.Jobs = map[string]job{
+			"gate": {Steps: []step{{Run: "echo validate-eks-ci-role-policy"}}},
 		}
 		if perturbed.coversPushToMain() {
 			t.Fatal("merely mentioning the validator must not count as running it")

--- a/scripts/validate-eks-ci-role-policy/kubescape_baseline_test.go
+++ b/scripts/validate-eks-ci-role-policy/kubescape_baseline_test.go
@@ -24,14 +24,60 @@ const (
 
 // scansKubescapeToSarif reports whether this job runs the scan in the
 // SARIF-producing mode.
+//
+// Matched per LINE, and only on a line that actually executes the scan. A
+// whole-script `strings.Contains` counts `# ksail workload scan --format sarif`
+// in a comment, or an `echo` of the same text, as a scan — so a workflow could
+// stop scanning while this guard stayed green, which is the false-green it
+// exists to prevent. The file header already claims naming the command in a
+// comment is not enough; this is what makes that true.
 func (j job) scansKubescapeToSarif() bool {
 	for _, s := range j.Steps {
-		if strings.Contains(s.Run, kubescapeScanCommand) &&
-			strings.Contains(s.Run, kubescapeScanSarifFlag) {
-			return true
+		for _, line := range strings.Split(s.Run, "\n") {
+			if isKubescapeScanCommand(line) {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+// isKubescapeScanCommand reports whether ONE script line executes the scan in
+// SARIF mode. Deliberately conservative: it rejects rather than guesses, since
+// a false positive here re-opens the false-green.
+func isKubescapeScanCommand(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	// A comment executes nothing. This also covers a trailing-comment line whose
+	// command half is a comment, which is the shape CodeRabbit raised.
+	if strings.HasPrefix(trimmed, "#") {
+		return false
+	}
+	// `echo`/`printf` merely PRINT the command text. Strip any leading
+	// `VAR=x` assignments and shell prefixes before testing the verb, so
+	// `echo ksail workload scan --format sarif` cannot masquerade as a run.
+	verb := trimmed
+	if i := strings.IndexAny(verb, "|;&"); i >= 0 {
+		// Only the segment that would actually invoke ksail matters; check each.
+		for _, seg := range strings.FieldsFunc(trimmed, func(r rune) bool {
+			return r == '|' || r == ';' || r == '&'
+		}) {
+			if isKubescapeScanCommand(seg) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, w := range strings.Fields(verb) {
+		if strings.Contains(w, "=") && !strings.HasPrefix(w, "-") {
+			continue // leading VAR=value assignment
+		}
+		if w == "echo" || w == "printf" || w == ":" {
+			return false
+		}
+		break
+	}
+	return strings.Contains(trimmed, kubescapeScanCommand) &&
+		strings.Contains(trimmed, kubescapeScanSarifFlag)
 }
 
 // uploadsKubescapeSarif reports whether this job uploads that SARIF to Code
@@ -182,6 +228,54 @@ func TestKubescapeBaselineGuardIsNotVacuous(t *testing.T) {
 		if perturbed.publishesKubescapeBaselineOnPushToMain() {
 			t.Fatal("an upload under a different category creates a parallel alert set, " +
 				"not a baseline the PR-ref findings can close against")
+		}
+	})
+
+	// A step's script can NAME the scan without running it. Both shapes below
+	// keep every other condition satisfied, so each isolates the executes-vs-
+	// mentions distinction alone. Without them the guard reports the baseline as
+	// published by a workflow that scans nothing.
+	t.Run("a commented-out scan does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"baseline": {Steps: []step{
+				{Run: "# " + kubescapeScanCommand + " --framework nsa " + kubescapeScanSarifFlag},
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: kubescapeCategory}},
+			}},
+		}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("a scan named only in a COMMENT executes nothing and must not count")
+		}
+	})
+
+	t.Run("an echoed scan command does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"baseline": {Steps: []step{
+				{Run: "echo " + kubescapeScanCommand + " --framework nsa " + kubescapeScanSarifFlag},
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: kubescapeCategory}},
+			}},
+		}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("an echoed scan command only PRINTS the text and must not count")
+		}
+	})
+
+	// The complement: a real invocation surrounded by noise must still count, or
+	// the tightening above would be a false-negative in the other direction.
+	t.Run("a real scan among other lines still counts", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"baseline": {Steps: []step{
+				{Run: "# run the scan\n" +
+					"echo starting\n" +
+					kubescapeScanCommand + " --framework nsa " + kubescapeScanSarifFlag + " -o out.sarif\n"},
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: kubescapeCategory}},
+			}},
+		}
+		if !perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("a genuine scan invocation must still count when a comment and an echo " +
+				"of similar text sit beside it")
 		}
 	})
 

--- a/scripts/validate-eks-ci-role-policy/kubescape_baseline_test.go
+++ b/scripts/validate-eks-ci-role-policy/kubescape_baseline_test.go
@@ -22,28 +22,24 @@ const (
 	kubescapeCategory = "kubescape-nsa"
 )
 
-// scansKubescapeToSarif reports whether any job actually runs the scan in the
+// scansKubescapeToSarif reports whether this job runs the scan in the
 // SARIF-producing mode.
-func (w workflow) scansKubescapeToSarif() bool {
-	for _, j := range w.Jobs {
-		for _, s := range j.Steps {
-			if strings.Contains(s.Run, kubescapeScanCommand) &&
-				strings.Contains(s.Run, kubescapeScanSarifFlag) {
-				return true
-			}
+func (j job) scansKubescapeToSarif() bool {
+	for _, s := range j.Steps {
+		if strings.Contains(s.Run, kubescapeScanCommand) &&
+			strings.Contains(s.Run, kubescapeScanSarifFlag) {
+			return true
 		}
 	}
 	return false
 }
 
-// uploadsKubescapeSarif reports whether any job uploads that SARIF to Code
+// uploadsKubescapeSarif reports whether this job uploads that SARIF to Code
 // Scanning under the kubescape category.
-func (w workflow) uploadsKubescapeSarif() bool {
-	for _, j := range w.Jobs {
-		for _, s := range j.Steps {
-			if strings.Contains(s.Uses, uploadSarifAction) && s.With.Category == kubescapeCategory {
-				return true
-			}
+func (j job) uploadsKubescapeSarif() bool {
+	for _, s := range j.Steps {
+		if strings.Contains(s.Uses, uploadSarifAction) && s.With.Category == kubescapeCategory {
+			return true
 		}
 	}
 	return false
@@ -51,8 +47,25 @@ func (w workflow) uploadsKubescapeSarif() bool {
 
 // publishesKubescapeBaselineOnPushToMain reports whether the workflow produces a
 // default-branch Kubescape analysis.
+//
+// Both halves are required of a SINGLE job, not of the workflow as a whole.
+// Every job gets its own fresh runner and its own ${RUNNER_TEMP}, so a scan in
+// one job and an uploader in another share no filesystem: the uploader would
+// have no SARIF to read and no analysis would be published. Matching the two
+// halves independently would let exactly that arrangement report the gap as
+// closed — the same false-green this guard exists to prevent. A future split
+// across jobs is legitimate only with an explicit artifact handoff, which is a
+// different shape and should have to update this guard deliberately.
 func (w workflow) publishesKubescapeBaselineOnPushToMain() bool {
-	return w.triggersOnPushToMain() && w.scansKubescapeToSarif() && w.uploadsKubescapeSarif()
+	if !w.triggersOnPushToMain() {
+		return false
+	}
+	for _, j := range w.Jobs {
+		if j.scansKubescapeToSarif() && j.uploadsKubescapeSarif() {
+			return true
+		}
+	}
+	return false
 }
 
 // TestKubescapeBaselineIsPublishedForTheDefaultBranch pins the gap measured on
@@ -169,6 +182,24 @@ func TestKubescapeBaselineGuardIsNotVacuous(t *testing.T) {
 		if perturbed.publishesKubescapeBaselineOnPushToMain() {
 			t.Fatal("an upload under a different category creates a parallel alert set, " +
 				"not a baseline the PR-ref findings can close against")
+		}
+	})
+
+	t.Run("scan and upload split across jobs does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"scan": {Steps: []step{
+				{Run: kubescapeScanCommand + " --framework nsa " + kubescapeScanSarifFlag + " -o out.sarif"},
+			}},
+			"upload": {Steps: []step{
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: kubescapeCategory}},
+			}},
+		}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("a scan and an upload in SEPARATE jobs must not count: each job gets a " +
+				"fresh runner, so the uploader cannot read the scanner's ${RUNNER_TEMP} " +
+				"SARIF and no baseline is published — the guard must not report the gap " +
+				"closed on a workflow that only names both halves somewhere")
 		}
 	})
 }

--- a/scripts/validate-eks-ci-role-policy/kubescape_baseline_test.go
+++ b/scripts/validate-eks-ci-role-policy/kubescape_baseline_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The kubescape SARIF chain, named by what each half actually does. A workflow
+// only counts as publishing the baseline if it RUNS the scan and UPLOADS the
+// result — naming either one in a comment is not enough.
+const (
+	kubescapeScanCommand   = "ksail workload scan"
+	kubescapeScanSarifFlag = "--format sarif"
+	uploadSarifAction      = "github/codeql-action/upload-sarif"
+
+	// kubescapeCategory is the Code Scanning category the findings are
+	// published under. It is part of the contract, not an implementation
+	// detail: alerts dedupe and auto-close per (tool, category, ref), so a
+	// default-branch upload under a DIFFERENT category would create a second,
+	// parallel alert set instead of giving the PR-ref findings a baseline to
+	// close against.
+	kubescapeCategory = "kubescape-nsa"
+)
+
+// scansKubescapeToSarif reports whether any job actually runs the scan in the
+// SARIF-producing mode.
+func (w workflow) scansKubescapeToSarif() bool {
+	for _, j := range w.Jobs {
+		for _, s := range j.Steps {
+			if strings.Contains(s.Run, kubescapeScanCommand) &&
+				strings.Contains(s.Run, kubescapeScanSarifFlag) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// uploadsKubescapeSarif reports whether any job uploads that SARIF to Code
+// Scanning under the kubescape category.
+func (w workflow) uploadsKubescapeSarif() bool {
+	for _, j := range w.Jobs {
+		for _, s := range j.Steps {
+			if strings.Contains(s.Uses, uploadSarifAction) && s.With.Category == kubescapeCategory {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// publishesKubescapeBaselineOnPushToMain reports whether the workflow produces a
+// default-branch Kubescape analysis.
+func (w workflow) publishesKubescapeBaselineOnPushToMain() bool {
+	return w.triggersOnPushToMain() && w.scansKubescapeToSarif() && w.uploadsKubescapeSarif()
+}
+
+// TestKubescapeBaselineIsPublishedForTheDefaultBranch pins the gap measured on
+// this repository on 2026-07-28: every Kubescape analysis lived on an ephemeral
+// `refs/pull/<n>/merge` ref and the repository had ZERO default-branch
+// kubescape alerts.
+//
+// ci.yaml's `validate` job is `pull_request`-only, so merged manifests never
+// produced an analysis for the deployed tree. Without a default-branch
+// baseline, Code Scanning has nothing to dedupe against and nothing to close:
+// the findings exist only for as long as the PR ref does, which defeats the
+// automatic-closing behaviour the upload was added to provide (#2829).
+func TestKubescapeBaselineIsPublishedForTheDefaultBranch(t *testing.T) {
+	workflows := loadWorkflows(t)
+
+	publishing := make([]string, 0, 1)
+	for name, parsed := range workflows {
+		if parsed.publishesKubescapeBaselineOnPushToMain() {
+			publishing = append(publishing, name)
+		}
+	}
+
+	if len(publishing) == 0 {
+		t.Fatalf("no workflow scans manifests and uploads the Kubescape SARIF under "+
+			"category %q on push to main — merged manifests produce no default-branch "+
+			"analysis, so findings live only on temporary PR refs and can never be "+
+			"closed on main. Restore a push-to-main scan-and-upload path.",
+			kubescapeCategory)
+	}
+}
+
+// TestKubescapeBaselineGuardIsNotVacuous proves the guard above can go RED.
+//
+// Each negative control perturbs exactly ONE of the three conditions the guard
+// depends on, so each must flip it to false on its own. Without this, a guard
+// that silently stopped matching would report the hole as closed forever —
+// which is the same class of failure the baseline gap itself was.
+func TestKubescapeBaselineGuardIsNotVacuous(t *testing.T) {
+	publishing := workflow{
+		On: triggerSet{"push": {Branches: []string{"main"}}},
+		Jobs: map[string]job{
+			"baseline": {Steps: []step{
+				{Run: kubescapeScanCommand + " --framework nsa " + kubescapeScanSarifFlag + " -o out.sarif"},
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: kubescapeCategory}},
+			}},
+		},
+	}
+	if !publishing.publishesKubescapeBaselineOnPushToMain() {
+		t.Fatal("positive control failed: a push-to-main workflow that scans and uploads must count")
+	}
+
+	t.Run("wrong branch does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.On = triggerSet{"push": {Branches: []string{"release"}}}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("a push trigger on another branch must not satisfy default-branch coverage")
+		}
+	})
+
+	t.Run("pull_request alone does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.On = triggerSet{"pull_request": {Branches: []string{"main"}}}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("a pull_request trigger must not satisfy default-branch coverage — " +
+				"that is exactly the gap this guard exists to close")
+		}
+	})
+
+	t.Run("uploading without scanning does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"baseline": {Steps: []step{
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: kubescapeCategory}},
+			}},
+		}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("an upload with no scan producing the SARIF must not count")
+		}
+	})
+
+	t.Run("scanning without uploading does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"baseline": {Steps: []step{
+				{Run: kubescapeScanCommand + " --framework nsa " + kubescapeScanSarifFlag},
+			}},
+		}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("a scan whose SARIF is never uploaded must not count — it produces no analysis")
+		}
+	})
+
+	t.Run("scanning without the SARIF flag does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"baseline": {Steps: []step{
+				{Run: kubescapeScanCommand + " --framework nsa"},
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: kubescapeCategory}},
+			}},
+		}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("a scan that writes no SARIF must not count as producing one")
+		}
+	})
+
+	t.Run("uploading under another category does not count", func(t *testing.T) {
+		perturbed := publishing
+		perturbed.Jobs = map[string]job{
+			"baseline": {Steps: []step{
+				{Run: kubescapeScanCommand + " --framework nsa " + kubescapeScanSarifFlag},
+				{Uses: uploadSarifAction + "@v4", With: stepInputs{Category: "some-other-tool"}},
+			}},
+		}
+		if perturbed.publishesKubescapeBaselineOnPushToMain() {
+			t.Fatal("an upload under a different category creates a parallel alert set, " +
+				"not a baseline the PR-ref findings can close against")
+		}
+	})
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Our manifest security scan is a **score gate**, not a finding surface. It fails a pull request when the overall compliance score drops below the floor — and that number, in a CI log, is the only trace a finding ever leaves.

Two things follow, and both are true today. A finding that does not move the score is **invisible**: nobody sees it, so nobody triages it, so it never becomes work. And because the log is the only record, there is no history, no deduplication, and nothing that notices when a finding has been fixed. Answering "what is failing right now, and since when" means reading CI logs by hand.

Measured on this repo while preparing the change: the scan as CI runs it prints **"All controls passed. No issues found"** — and produces **four findings**, with file and line, in its machine-readable output. Those four are exactly the ones nobody can currently see.

## What

The findings now also go to GitHub Code Scanning, so each one becomes an alert in the Security tab with a file, a line, and a remediation — deduplicated across runs and closed automatically when it is fixed.

Deliberately additive. The scan still runs once, its readable table still goes to the CI log unchanged, and the score gate keeps exactly its current pass/fail behaviour. This changes what a person can **see**, not what blocks a merge; turning findings into blocking enforcement is a later step, not this one.

Uploads are skipped for pull requests from forks, which cannot be granted the permission the upload needs — those builds are unaffected rather than failing.

Fixes #2829
Part of #2451
