### PR TITLE
fix(security): enforce the tenant ClusterIssuer boundary at admission

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-issuer-refs.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-issuer-refs.yaml
@@ -1,0 +1,145 @@
+# Confines self-service tenants to their OWN namespaced Issuer and blocks any
+# reference to a cluster-scoped issuer from a tenant namespace.
+#
+# Why: tenants are granted edit on Certificate/Issuer (see
+# cluster-roles/cert-manager-tenant-edit.yaml) so they can manage their own
+# certificates. Referencing a ClusterIssuer needs no RBAC on the issuer object —
+# `spec.issuerRef` is resolved by cert-manager's controller under ITS identity,
+# not the tenant's — so RBAC cannot enforce the stated boundary ("ClusterIssuer
+# remains platform territory"). Without this guard a tenant could point a
+# Certificate at the shared `letsencrypt-prod` ClusterIssuer and mint
+# certificates for ANY domain the platform's ACME account controls, including
+# other tenants' hostnames. A tenant must instead create its own namespaced
+# Issuer, which is scoped to credentials the platform grants it.
+#
+# Scope: only ksail-generated tenant namespaces (labelled
+# app.kubernetes.io/managed-by: ksail), so platform/infra namespaces that
+# legitimately use a ClusterIssuer (kube-system's gateway-certificate,
+# cert-manager, cnpg-system, …) are unaffected.
+#
+# Allow-list, not deny-list: the rules deny any issuerRef.kind that is not in
+# the allowed set, rather than denying `ClusterIssuer` by name. External issuer
+# projects conventionally ship BOTH a namespaced and a cluster-scoped kind
+# (AWSPCAIssuer/AWSPCAClusterIssuer, step-issuer, google-cas, …), so a
+# name-based deny silently misses every cluster-scoped kind except
+# cert-manager's own. Extending the boundary later means adding the namespaced
+# kind to `value:` below — a visible, reviewable edit.
+#
+# `kind` is OPTIONAL and defaults to `Issuer` when omitted, so both rules
+# default the empty case to `Issuer` before comparing. This is not theoretical:
+# 2 of the 9 Certificates live on prod omit `kind` entirely. A naive
+# `NotEquals Issuer` on the raw field would deny every one of them.
+#
+# Platform carve-out: the deny targets only resources applied by a TENANT — i.e.
+# by the impersonated tenant ServiceAccount (the tenant's deploy/ Kustomization
+# sets spec.serviceAccountName: <tenant>). Resources the PLATFORM ships into a
+# tenant namespace are reconciled by the apps-layer Flux Kustomization, which
+# sets NO serviceAccountName and therefore applies as flux-system's own
+# kustomize-controller SA — excluded below. The discriminator is the applying
+# identity, which a tenant cannot forge. This mirrors
+# restrict-tenant-secret-stores.yaml so both tenant boundaries share one rule.
+#
+# CertificateRequests are additionally excluded for cert-manager's own SA:
+# cert-manager MINTS a CertificateRequest from each Certificate under its own
+# identity, copying the issuerRef verbatim. Without that exclusion, a
+# platform-authored ClusterIssuer-backed Certificate in a tenant namespace would
+# be admitted (flux-system carve-out) and then have its derived
+# CertificateRequest rejected — breaking issuance in a way that points at the
+# wrong object. Tenants cannot create CertificateRequests directly (the
+# ClusterRole grants read only), so this rule is defense-in-depth that holds if
+# that RBAC ever regresses.
+#
+# Because both excludes match on request.userInfo, the policy is admission-only
+# (background: false); every escalation is a create/update that passes through
+# admission, so enforcement is unaffected.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-tenant-issuer-refs
+  annotations:
+    policies.kyverno.io/title: Restrict Tenant Issuer References
+    policies.kyverno.io/category: Security, cert-manager
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Certificate, CertificateRequest
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      Blocks tenant-applied Certificate and CertificateRequest resources in
+      ksail tenant namespaces from referencing a cluster-scoped issuer via
+      spec.issuerRef.kind. Tenants must use their own namespaced Issuer, so a
+      tenant cannot mint certificates through the platform's shared ACME
+      account. Platform-authored resources (applied by flux-system's
+      kustomize-controller) and cert-manager's own derived CertificateRequests
+      are excluded.
+spec:
+  validationFailureAction: Enforce
+  # Admission-only: the excludes match on request.userInfo (the applying
+  # ServiceAccount), which is unavailable during background scans. Every
+  # escalation path is a create/update that passes through admission, so
+  # enforcement is fully preserved.
+  background: false
+  rules:
+    - name: certificate-no-cluster-scoped-issuer
+      match:
+        any:
+          - resources:
+              kinds:
+                - Certificate
+              namespaceSelector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: ksail
+      # Exclude platform-authored resources: the tenant registration dir is
+      # reconciled by the apps-layer Flux Kustomization as flux-system's own
+      # kustomize-controller SA (no impersonation). A tenant's deploy/ artifact
+      # is applied as its impersonated tenant SA, so it stays subject to the deny.
+      exclude:
+        any:
+          - subjects:
+              - kind: ServiceAccount
+                name: kustomize-controller
+                namespace: flux-system
+      validate:
+        message: >-
+          Tenant Certificates must reference a namespaced Issuer
+          (kind: Issuer), not a cluster-scoped issuer such as ClusterIssuer.
+          Create an Issuer in this namespace and point spec.issuerRef at it.
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec.issuerRef.kind || 'Issuer' }}"
+                operator: AnyNotIn
+                value:
+                  - Issuer
+    - name: certificaterequest-no-cluster-scoped-issuer
+      match:
+        any:
+          - resources:
+              kinds:
+                - CertificateRequest
+              namespaceSelector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: ksail
+      # Same platform carve-out as the Certificate rule above, plus cert-manager
+      # itself: it derives a CertificateRequest from every Certificate under its
+      # own identity and copies the issuerRef, so denying it here would break
+      # issuance for any Certificate the flux-system carve-out admitted.
+      exclude:
+        any:
+          - subjects:
+              - kind: ServiceAccount
+                name: kustomize-controller
+                namespace: flux-system
+          - subjects:
+              - kind: ServiceAccount
+                name: cert-manager
+                namespace: cert-manager
+      validate:
+        message: >-
+          Tenant CertificateRequests must reference a namespaced Issuer
+          (kind: Issuer), not a cluster-scoped issuer such as ClusterIssuer.
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec.issuerRef.kind || 'Issuer' }}"
+                operator: AnyNotIn
+                value:
+                  - Issuer

--- a/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - best-practices/disable-default-sa-automount.yaml
   - best-practices/disallow-latest-tag.yaml
   - best-practices/propagate-reloader-to-flagger-primary.yaml
+  - best-practices/restrict-tenant-issuer-refs.yaml
   - best-practices/restrict-tenant-secret-stores.yaml
   - best-practices/validate-host-restrictions.yaml
   - best-practices/validate-pdb-drain-safe.yaml

--- a/k8s/bases/infrastructure/cluster-roles/cert-manager-tenant-edit.yaml
+++ b/k8s/bases/infrastructure/cluster-roles/cert-manager-tenant-edit.yaml
@@ -14,8 +14,10 @@
 # controller mints them from a tenant's Certificate under its own identity, so a
 # tenant never creates them directly — read access covers issuance debugging.
 # NOTE: RBAC alone cannot stop a tenant Certificate from *referencing* a
-# ClusterIssuer via `spec.issuerRef.kind` — that boundary needs admission
-# enforcement, tracked separately.
+# ClusterIssuer via `spec.issuerRef.kind` — cert-manager's controller resolves
+# that reference under its own identity, not the tenant's. That half of the
+# boundary is enforced at admission by the
+# `restrict-tenant-issuer-refs` ClusterPolicy.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/tests/restrict-tenant-issuer-refs/kyverno-test.yaml
+++ b/tests/restrict-tenant-issuer-refs/kyverno-test.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-tenant-issuer-refs
+policies:
+  - >-
+    ../../k8s/bases/infrastructure/cluster-policies/best-practices/restrict-tenant-issuer-refs.yaml
+resources:
+  - resources.yaml
+# Declares the namespace labels the namespaceSelector matches on. Without it the
+# CLI reports every resource "Excluded" and the fixture passes vacuously.
+variables: values.yaml
+results:
+  # The escalation the boundary exists to stop.
+  - policy: restrict-tenant-issuer-refs
+    rule: certificate-no-cluster-scoped-issuer
+    resources:
+      - tenant-ns/tenant-cert-clusterissuer
+      - tenant-ns/tenant-cert-external-clusterissuer
+    kind: Certificate
+    result: fail
+  # The paved road, and the omitted-kind default that must not be caught.
+  - policy: restrict-tenant-issuer-refs
+    rule: certificate-no-cluster-scoped-issuer
+    resources:
+      - tenant-ns/tenant-cert-namespaced-issuer
+      - tenant-ns/tenant-cert-kind-omitted
+    kind: Certificate
+    result: pass
+  # Out of scope: platform namespaces keep their ClusterIssuer.
+  - policy: restrict-tenant-issuer-refs
+    rule: certificate-no-cluster-scoped-issuer
+    resources:
+      - kube-system/gateway-certificate
+    kind: Certificate
+    result: skip
+  # Defense-in-depth on directly-created CertificateRequests.
+  - policy: restrict-tenant-issuer-refs
+    rule: certificaterequest-no-cluster-scoped-issuer
+    resources:
+      - tenant-ns/tenant-cr-clusterissuer
+    kind: CertificateRequest
+    result: fail
+  - policy: restrict-tenant-issuer-refs
+    rule: certificaterequest-no-cluster-scoped-issuer
+    resources:
+      - tenant-ns/tenant-cr-namespaced-issuer
+    kind: CertificateRequest
+    result: pass

--- a/tests/restrict-tenant-issuer-refs/resources.yaml
+++ b/tests/restrict-tenant-issuer-refs/resources.yaml
@@ -1,0 +1,106 @@
+---
+# The escalation the boundary exists to stop: a tenant Certificate pointing at
+# the platform's shared cluster-scoped issuer.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tenant-cert-clusterissuer
+  namespace: tenant-ns
+spec:
+  secretName: tenant-tls
+  dnsNames:
+    - tenant.example.com
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+---
+# An external project's cluster-scoped issuer kind. A deny-list naming only
+# "ClusterIssuer" would let this through; the allow-list catches it.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tenant-cert-external-clusterissuer
+  namespace: tenant-ns
+spec:
+  secretName: tenant-tls-ext
+  dnsNames:
+    - ext.example.com
+  issuerRef:
+    group: awspca.cert-manager.io
+    kind: AWSPCAClusterIssuer
+    name: aws-pca
+---
+# The paved road: a tenant's own namespaced Issuer. This is what
+# ascoachingogvaner actually does on prod today.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tenant-cert-namespaced-issuer
+  namespace: tenant-ns
+spec:
+  secretName: tenant-tls-ok
+  dnsNames:
+    - ok.example.com
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: letsencrypt-prod
+---
+# `kind` omitted entirely — cert-manager defaults it to Issuer. 2 of the 9
+# Certificates live on prod look like this, so denying them would be a real
+# outage. Must PASS.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tenant-cert-kind-omitted
+  namespace: tenant-ns
+spec:
+  secretName: tenant-tls-default
+  dnsNames:
+    - default.example.com
+  issuerRef:
+    name: in-namespace-issuer
+---
+# Out of scope: a platform namespace legitimately using a ClusterIssuer. This
+# mirrors the real kube-system/gateway-certificate, which must keep working.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-certificate
+  namespace: kube-system
+spec:
+  secretName: gateway-tls
+  dnsNames:
+    - example.com
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+---
+# Defense-in-depth: a directly-created tenant CertificateRequest pointing at a
+# cluster-scoped issuer. RBAC forbids this today; the rule holds if that regresses.
+apiVersion: cert-manager.io/v1
+kind: CertificateRequest
+metadata:
+  name: tenant-cr-clusterissuer
+  namespace: tenant-ns
+spec:
+  request: dGVzdA==
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+---
+# The derived CertificateRequest for a compliant tenant Certificate. Must PASS.
+apiVersion: cert-manager.io/v1
+kind: CertificateRequest
+metadata:
+  name: tenant-cr-namespaced-issuer
+  namespace: tenant-ns
+spec:
+  request: dGVzdA==
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: letsencrypt-prod

--- a/tests/restrict-tenant-issuer-refs/values.yaml
+++ b/tests/restrict-tenant-issuer-refs/values.yaml
@@ -1,0 +1,18 @@
+---
+# The Kyverno CLI does not read namespace labels from the Namespace objects in
+# resources.yaml — a rule matched by namespaceSelector is reported "Excluded"
+# for every resource unless the namespace labels are declared here. Without
+# this file the whole fixture passes vacuously, including the fail cases.
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+metadata:
+  name: values
+namespaceSelector:
+  # A ksail-generated tenant namespace — in scope.
+  - name: tenant-ns
+    labels:
+      app.kubernetes.io/managed-by: ksail
+  # A platform/infra namespace — out of scope, so a ClusterIssuer ref here is
+  # legitimate (this is where the real gateway-certificate lives).
+  - name: kube-system
+    labels: {}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Tenants can manage their own certificates, and the intended boundary is that
cluster-wide issuers stay platform territory. Today that boundary is a comment,
not a rule. Permissions can stop a tenant from *editing* the shared issuer, but
not from *pointing at* it — that reference is resolved by cert-manager on the
tenant's behalf, under cert-manager's own identity.

The consequence is that any tenant could request certificates through the
platform's shared Let's Encrypt account, including for hostnames belonging to
other tenants. Nothing would reject it and nothing would flag it.

## What

Adds an admission rule that requires certificates in tenant namespaces to use an
issuer from their own namespace. Platform namespaces are untouched, and so is
anything the platform itself installs into a tenant namespace.

**Security floor gained:** a tenant can no longer obtain a certificate for a name
it does not own via the shared issuer. **Everyday cost:** none — the supported
path already works and is what the one existing tenant certificate does today.

Two details worth flagging, both of which would have been silent bugs:

- It allows an approved list of issuer types rather than blocking one by name.
  Add-on issuer projects ship both a namespaced and a cluster-wide variant, so
  blocking only the obvious name would have missed every other cluster-wide type.
- Leaving the issuer type unset is legal and means "my own namespace". Two of the
  nine certificates running in production do exactly that, so treating unset as a
  violation would have been an outage.

Checked against production before choosing to enforce rather than warn: there are
no violating certificates today, so nothing currently running is affected.

Fixes #2470
