### PR TITLE
fix(kubescape): stop the Headlamp mirror granting exceptions the CRs never granted

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -175,13 +175,6 @@ data:
               "kind": "^RoleBinding$",
               "name": "^(ascoachingogvaner|kyverno:admission-controller|kyverno:cleanup-controller|longhorn|tf-runner|velero-server|wedding-app)$"
             }
-          },
-          {
-            "designatorType": "Attributes",
-            "attributes": {
-              "kind": "^Group$",
-              "name": "^crossplane-masters$"
-            }
           }
         ],
         "posturePolicies": [
@@ -463,9 +456,6 @@ data:
           },
           {
             "controlID": "^C-0016$"
-          },
-          {
-            "controlID": "^C-0017$"
           },
           {
             "controlID": "^C-0055$"
@@ -1045,6 +1035,86 @@ data:
         "posturePolicies": [
           {
             "controlID": "^C-0015$"
+          }
+        ]
+      },
+      {
+        "name": "kubescape-privileged",
+        "policyType": "postureExceptionPolicy",
+        "actions": [
+          "alertOnly"
+        ],
+        "reason": "The kubescape node-agent DaemonSet and storage Deployment require privileged host access to scan the node; matched by kind+name so no other workload inherits it.",
+        "resources": [
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^DaemonSet$",
+              "name": "^node-agent$"
+            }
+          },
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "kind": "^Deployment$",
+              "name": "^storage$"
+            }
+          }
+        ],
+        "posturePolicies": [
+          {
+            "controlID": "^C-0057$"
+          },
+          {
+            "controlID": "^C-0048$"
+          },
+          {
+            "controlID": "^C-0045$"
+          },
+          {
+            "controlID": "^C-0041$"
+          },
+          {
+            "controlID": "^C-0038$"
+          },
+          {
+            "controlID": "^C-0044$"
+          },
+          {
+            "controlID": "^C-0046$"
+          },
+          {
+            "controlID": "^C-0016$"
+          },
+          {
+            "controlID": "^C-0013$"
+          },
+          {
+            "controlID": "^C-0017$"
+          },
+          {
+            "controlID": "^C-0055$"
+          }
+        ]
+      },
+      {
+        "name": "readonly-rootfs-pending",
+        "policyType": "postureExceptionPolicy",
+        "actions": [
+          "alertOnly"
+        ],
+        "reason": "C-0017 exceptions for the few NON-privileged workloads that still write to their root filesystem, scoped by namespace so it never suppresses C-0017 for the workloads that DO pass it.",
+        "resources": [
+          {
+            "designatorType": "Attributes",
+            "attributes": {
+              "namespace": "^(opencost|wedding-app)$"
+            }
+          }
+        ],
+        "posturePolicies": [
+          {
+            "controlID": "^C-0017$"
           }
         ]
       }

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -1044,7 +1044,7 @@ data:
         "actions": [
           "alertOnly"
         ],
-        "reason": "The kubescape node-agent DaemonSet and storage Deployment require privileged host access to scan the node; matched by kind+name so no other workload inherits it.",
+        "reason": "node-agent needs privileged host access for eBPF runtime detection, and the storage aggregated APIserver writes its backing store at runtime; scoped to those two workloads so the operator, kubevuln and scheduler in the same namespace stay subject to these controls.",
         "resources": [
           {
             "designatorType": "Attributes",
@@ -1103,7 +1103,7 @@ data:
         "actions": [
           "alertOnly"
         ],
-        "reason": "C-0017 exceptions for the few NON-privileged workloads that still write to their root filesystem, scoped by namespace so it never suppresses C-0017 for the workloads that DO pass it.",
+        "reason": "opencost-UI (nginx) rewrites its baked /var/www assets in place at boot so it cannot run a read-only root; wedding-app is hardened in a follow-up app release. Scoped by namespace so C-0017 is never suppressed for the workloads that DO pass it.",
         "resources": [
           {
             "designatorType": "Attributes",


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Headlamp dashboard is how we read the platform's security posture. Its exception list is a
hand-maintained copy of the `ClusterSecurityException` CRs, and the copy had drifted — in the
direction that **hides findings**.

The worst entry excepted "immutable container filesystem" (C-0017) for *every workload in the
cluster*. The CRs never say that: they except C-0017 in three narrow, deliberate places, and one of
them carries a comment saying it is scoped precisely so it never suppresses C-0017 for the workloads
that do pass it. The dashboard was overriding that decision. A second entry excepted a group that no
CR mentions — it had been copied out of a trailing code comment.

Two real exceptions were missing at the same time, so the dashboard also reported legitimately-excepted
workloads as failing. The mirror was wrong in both directions at once.

Nothing is being actively hidden today — sampled workloads outside the excepted scopes pass C-0017
anyway — so this closes a latent suppression rather than an active incident.

## What

Makes the mirror faithful to the CRs: removes the two exceptions that have no source, and adds the two
that were missing. Control sets now match the CRs exactly across all 19 shared policies. The two
host/CIS exceptions stay deliberately unmirrored, as the file header already documents — those
controls never attach to a workload.

This is the first slice of #2586. Ending the hand-maintenance itself (generating this file and gating
drift in CI) is the follow-up; the notes for it are on the issue.

Part of #2586