### PR TITLE
feat(security): give the DR rebuild a signed-artifact publication path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,11 @@ jobs:
           go test ./scripts/validate-merge-group-heal
           go run ./scripts/validate-merge-group-heal .github/workflows/ci.yaml
 
+      - name: 🖋️ Validate DR signing contract
+        run: |
+          go test ./scripts/validate-dr-signing
+          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml
+
       - name: 🔍 Filter paths
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter

--- a/.github/workflows/dr-rebuild.yaml
+++ b/.github/workflows/dr-rebuild.yaml
@@ -61,6 +61,7 @@ jobs:
     permissions:
       contents: read # checkout repository
       packages: write # push OCI artifacts to GHCR
+      id-token: write # keyless cosign signing (Fulcio OIDC)
     steps:
       - name: 🛑 Verify confirmation phrase
         env:
@@ -178,6 +179,41 @@ jobs:
             exit 1
           fi
           echo "digest=${DIGEST}" >>"${GITHUB_OUTPUT}"
+
+      - name: ⚙️ Install cosign
+        # Same installer and pinned release as the deploy-prod composite, so a
+        # DR-published artifact is signed by the identical toolchain a normal
+        # deploy uses. Renovate bumps COSIGN_VERSION via the custom regex
+        # manager in .github/renovate.json.
+        env:
+          # renovate: datasource=github-releases depName=sigstore/cosign extractVersion=^v(?<version>.+)$
+          COSIGN_VERSION: "3.1.2"
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v${{ env.COSIGN_VERSION }}"
+
+      - name: 🖋️ Sign OCI manifest with cosign (keyless)
+        # A DR rebuild writes the same mutable tag as a normal deploy, so it
+        # must produce the same supply-chain evidence — otherwise enabling
+        # verification on the root source turns every recovery into a rejected
+        # artifact at the exact moment manual repair is hardest.
+        #
+        # Signs the digest resolved by the step above rather than the tag: a
+        # concurrent deploy could move `latest` between resolve and sign, and
+        # signing the tag would then attest bytes we never published. The
+        # signing identity is this workflow at its dispatch ref
+        # (dr-rebuild.yaml@refs/heads/main), which ksail.prod.yaml's
+        # matchOIDCIdentity allow-list names explicitly.
+        env:
+          # Keyless is the default when --key is omitted (COSIGN_EXPERIMENTAL
+          # was retired in cosign 2.x). GHCR credentials come from
+          # ~/.docker/config.json written by the auth step above.
+          COSIGN_YES: "true"
+          DIGEST: ${{ steps.platform_manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"
+          cosign sign --yes --recursive "${REF}"
 
       - name: 🔎 Verify Flux GHCR pull credential after publish
         id: verify_flux_ghcr_auth_after_push

--- a/docs/dr/runbook.md
+++ b/docs/dr/runbook.md
@@ -554,7 +554,12 @@ The production deploy closes the bootstrap loop in this order:
    `--allow-incomplete-fanout` mode stages `variables-base` and repairs root auth
    so the first reconcile can create the chain. Normal mode fails closed on any
    missing fan-out resource.
-4. Push and sign the artifact with `GHCR_TOKEN`, revalidate the newly-published
+4. Push the artifact with `GHCR_TOKEN`, then cosign-sign the resolved digest
+   keyless: Fulcio mints the certificate from the workflow's OIDC identity
+   (`dr-rebuild.yaml@refs/heads/main`), and `GHCR_TOKEN` only pushes the
+   resulting signature. That identity must stay listed in `ksail.prod.yaml`'s
+   `matchOIDCIdentity`, or a recovery publishes an artifact a verifying cluster
+   refuses. Revalidate the newly-published
    artifact with `--check-only`, and only then explicitly reconcile Flux. DR
    runs the full bridge again after every Flux Kustomization is Ready, proving
    that bootstrap mode completed the entire fan-out, and once more after an

--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -180,6 +180,14 @@ spec:
         # Manual prod deploy: cd.yaml is workflow_dispatch, run from main.
         - issuer: '^https://token\.actions\.githubusercontent\.com$'
           subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/cd\.yaml@refs/heads/main$'
+        # Disaster recovery: dr-rebuild.yaml is workflow_dispatch, run from main,
+        # and republishes this same artifact while rebuilding prod from zero.
+        # Without this entry a recovery produces a correctly-signed artifact that
+        # Flux still refuses — the one situation where a manual workaround is
+        # least available. Pinned to refs/heads/main, like cd.yaml above, so a DR
+        # run dispatched from any other ref is not trusted.
+        - issuer: '^https://token\.actions\.githubusercontent\.com$'
+          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/dr-rebuild\.yaml@refs/heads/main$'
   provider:
     hetzner:
       # Hetzner account hard cap: at most 10 servers total. This mirrors the

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -1,0 +1,177 @@
+// Command validate-dr-signing checks that the disaster-recovery rebuild can
+// publish an artifact production is allowed to trust.
+//
+// Production's root Flux source is the whole platform: every controller, every
+// tenant binding, every policy arrives through it. Signature verification on
+// that source is only worth switching on if EVERY writer to the mutable tag
+// signs, because Flux rejects what it cannot verify — and a disaster recovery
+// rebuild is exactly the moment a rejected artifact is unrecoverable by hand.
+//
+// The DR rebuild pushes to the same tag as a normal deploy, so it needs four
+// things to be true: the job must hold `id-token: write`, or Fulcio cannot mint
+// the short-lived certificate keyless signing depends on; it must actually sign
+// what it pushed; it must sign the resolved digest rather than the mutable tag,
+// or a concurrent deploy can move the tag between resolve and sign; and its
+// workflow identity must appear in the cluster's verification allow-list, or a
+// perfectly signed artifact is still refused.
+//
+// None of the four fails loudly when it is wrong. With verification off they
+// fail silently forever; with verification on they fail during an incident, at
+// the one moment nobody can afford to debug a supply-chain policy. Pinning all
+// four here turns that into a CI failure on the pull request that breaks one.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// drIdentitySubject is the Fulcio certificate subject the DR rebuild signs
+// under: the reusable workflow path at the ref it is dispatched from. It must
+// be present in the cluster's matchOIDCIdentity allow-list for Flux to accept a
+// DR-published artifact.
+const drIdentitySubject = `^https://github\.com/devantler-tech/platform/\.github/workflows/dr-rebuild\.yaml@refs/heads/main$`
+
+func validateDRWorkflow(workflow string) error {
+	job, ok := extractJob(workflow, "  rebuild:")
+	if !ok {
+		return errors.New("missing rebuild job")
+	}
+
+	if !containsExactLine(job, "      id-token: write # keyless cosign signing (Fulcio OIDC)") {
+		return errors.New(
+			"rebuild job is missing `id-token: write`, so keyless cosign signing cannot mint a Fulcio certificate",
+		)
+	}
+
+	pushIdx, ok := lineIndexContaining(job, "workload push")
+	if !ok {
+		return errors.New("rebuild job no longer pushes the workload artifact")
+	}
+
+	signIdx, ok := lineIndexContaining(job, "cosign sign ")
+	if !ok {
+		return errors.New(
+			"rebuild job publishes the mutable tag without signing it, so a verifying cluster would reject the DR artifact",
+		)
+	}
+
+	if signIdx < pushIdx {
+		return errors.New("rebuild job signs before it pushes, so it signs the previous artifact")
+	}
+
+	if !containsLine(job, `cosign sign --yes --recursive "${REF}"`) {
+		return errors.New("rebuild job must sign the resolved digest reference (REF), not a mutable tag")
+	}
+
+	if !containsLine(job, `REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`) {
+		return errors.New(
+			"rebuild job must build its sign reference from the resolved digest, or a concurrent deploy can move the tag between resolve and sign",
+		)
+	}
+
+	return nil
+}
+
+func validateVerifyAllowList(config string) error {
+	if !containsLine(config, drIdentitySubject) {
+		return errors.New(
+			"cosign matchOIDCIdentity does not allow the DR rebuild identity, so a DR-published artifact stays unverifiable",
+		)
+	}
+	return nil
+}
+
+func extractJob(workflow string, header string) (string, bool) {
+	lines := strings.Split(workflow, "\n")
+	start := -1
+	for i, line := range lines {
+		if line == header {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+
+	end := len(lines)
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if strings.HasPrefix(line, "  ") &&
+			!strings.HasPrefix(line, "   ") &&
+			strings.HasSuffix(line, ":") {
+			end = i
+			break
+		}
+	}
+
+	return strings.Join(lines[start:end], "\n"), true
+}
+
+func containsExactLine(block string, want string) bool {
+	for _, line := range strings.Split(block, "\n") {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsLine(block string, want string) bool {
+	for _, line := range strings.Split(block, "\n") {
+		if strings.Contains(line, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func lineIndexContaining(block string, want string) (int, bool) {
+	for i, line := range strings.Split(block, "\n") {
+		if strings.Contains(line, want) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func run(workflowPath string, configPath string, stdout io.Writer, stderr io.Writer) int {
+	workflow, err := os.ReadFile(workflowPath) //nolint:gosec // The explicit CLI path is the validator input.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr signing contract: read workflow: %v\n", err)
+		return 1
+	}
+	config, err := os.ReadFile(configPath) //nolint:gosec // The explicit CLI path is the validator input.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr signing contract: read cluster config: %v\n", err)
+		return 1
+	}
+
+	if err := validateDRWorkflow(string(workflow)); err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr signing contract: %v\n", err)
+		return 1
+	}
+	if err := validateVerifyAllowList(string(config)); err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr signing contract: %v\n", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintln(stdout, "DR signing contract passed.")
+	return 0
+}
+
+func runCLI(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) != 2 {
+		_, _ = fmt.Fprintln(stderr, "usage: validate-dr-signing <dr-workflow-path> <cluster-config-path>")
+		return 2
+	}
+	return run(args[0], args[1], stdout, stderr)
+}
+
+func main() {
+	os.Exit(runCLI(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// repoFile reads a file from the repository root so the negative controls below
+// ablate the REAL production workflow rather than a fixture that only resembles
+// it. A fixture can drift into agreeing with the validator while the shipped
+// workflow does not.
+func repoFile(t *testing.T, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(data)
+}
+
+func TestRealDRWorkflowSatisfiesTheSigningContract(t *testing.T) {
+	t.Parallel()
+
+	if err := validateDRWorkflow(repoFile(t, ".github/workflows/dr-rebuild.yaml")); err != nil {
+		t.Fatalf("shipped dr-rebuild.yaml violates the signing contract: %v", err)
+	}
+}
+
+func TestRealClusterConfigAllowsTheDRIdentity(t *testing.T) {
+	t.Parallel()
+
+	if err := validateVerifyAllowList(repoFile(t, "ksail.prod.yaml")); err != nil {
+		t.Fatalf("shipped ksail.prod.yaml violates the allow-list contract: %v", err)
+	}
+}
+
+// TestDRWorkflowContractRejectsEachAblation removes exactly ONE guarantee from
+// the real workflow per case. Each must fail, and each must fail for its OWN
+// reason — a case that passes means the validator never depended on the line it
+// claims to pin.
+func TestDRWorkflowContractRejectsEachAblation(t *testing.T) {
+	t.Parallel()
+
+	workflow := repoFile(t, ".github/workflows/dr-rebuild.yaml")
+
+	cases := []struct {
+		name    string
+		mutate  func(string) string
+		wantErr string
+	}{
+		{
+			name: "without id-token the job cannot mint a Fulcio certificate",
+			mutate: func(w string) string {
+				return strings.ReplaceAll(w,
+					"      id-token: write # keyless cosign signing (Fulcio OIDC)\n", "")
+			},
+			wantErr: "id-token: write",
+		},
+		{
+			name: "without a sign step DR publishes an unverifiable artifact",
+			mutate: func(w string) string {
+				return strings.ReplaceAll(w,
+					`cosign sign --yes --recursive "${REF}"`, `echo skip-signing`)
+			},
+			wantErr: "without signing it",
+		},
+		{
+			name: "signing a mutable tag reintroduces the resolve/sign race",
+			mutate: func(w string) string {
+				return strings.ReplaceAll(w,
+					`REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`,
+					`REF="ghcr.io/devantler-tech/platform/manifests:latest"`)
+			},
+			wantErr: "resolved digest",
+		},
+		{
+			name: "a renamed rebuild job hides the whole contract",
+			mutate: func(w string) string {
+				return strings.ReplaceAll(w, "\n  rebuild:\n", "\n  rebuild-renamed:\n")
+			},
+			wantErr: "missing rebuild job",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ablated := testCase.mutate(workflow)
+			if ablated == workflow {
+				t.Fatalf("ablation changed nothing — the control does not target a real line")
+			}
+
+			err := validateDRWorkflow(ablated)
+			if err == nil {
+				t.Fatalf("ablated workflow passed; the validator does not depend on this line")
+			}
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("failed for the wrong reason: got %q, want it to mention %q",
+					err.Error(), testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestSigningBeforePushingIsRejected(t *testing.T) {
+	t.Parallel()
+
+	// Ordering matters independently of presence: a sign step that runs before
+	// the push signs whatever the PREVIOUS deploy left on the tag, which
+	// verifies green while shipping stale bytes.
+	job := strings.Join([]string{
+		"    permissions:",
+		"      id-token: write # keyless cosign signing (Fulcio OIDC)",
+		"    steps:",
+		`          REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`,
+		`          cosign sign --yes --recursive "${REF}"`,
+		"      - name: push",
+		"        run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push",
+	}, "\n")
+	workflow := "jobs:\n  rebuild:\n" + job + "\n  other:\n"
+
+	err := validateDRWorkflow(workflow)
+	if err == nil {
+		t.Fatal("signing before pushing was accepted")
+	}
+	if !strings.Contains(err.Error(), "signs before it pushes") {
+		t.Fatalf("wrong reason: %v", err)
+	}
+}
+
+func TestVerifyAllowListRejectsAMissingDRIdentity(t *testing.T) {
+	t.Parallel()
+
+	config := repoFile(t, "ksail.prod.yaml")
+	ablated := strings.ReplaceAll(config, drIdentitySubject, `^https://example\.invalid$`)
+	if ablated == config {
+		t.Fatal("ablation changed nothing — the DR identity is not present to remove")
+	}
+
+	if err := validateVerifyAllowList(ablated); err == nil {
+		t.Fatal("allow-list without the DR identity was accepted")
+	}
+}
+
+func TestRunReportsSuccessAndFailure(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := filepath.Join("..", "..", ".github", "workflows", "dr-rebuild.yaml")
+	configPath := filepath.Join("..", "..", "ksail.prod.yaml")
+
+	var stdout, stderr bytes.Buffer
+	if code := run(workflowPath, configPath, &stdout, &stderr); code != 0 {
+		t.Fatalf("run on the real repository failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "DR signing contract passed.") {
+		t.Fatalf("missing success line: %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+	if code := run(missing, configPath, &stdout, &stderr); code != 1 {
+		t.Fatalf("unreadable workflow should exit 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "read workflow") {
+		t.Fatalf("missing read-failure diagnostic: %q", stderr.String())
+	}
+}
+
+func TestRunCLIRequiresBothPaths(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	if code := runCLI([]string{"only-one"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("expected usage exit 2, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: validate-dr-signing") {
+		t.Fatalf("missing usage line: %q", stderr.String())
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production's root Flux source delivers the entire platform — every controller, tenant binding and policy arrives through it. Today it is the **only** source with no signature verification, while every tenant source has it:

| Source | `spec.verify` |
|---|---|
| **`flux-system/flux-system` (root)** | **null** |
| ascoachingogvaner, aws, doggy-countdown, github-config, wedding-app | `cosign` |

Turning verification on is blocked by the disaster-recovery rebuild: it publishes to the same tag as a normal deploy, but never signs what it pushes and cannot sign, because its job holds no `id-token` permission. Enabling verification first would mean the next recovery publishes an artifact Flux refuses — during an incident, when manual repair is least available.

## What

Gives DR the signing path a normal deploy already has, and names its identity in the allow-list so a signed DR artifact is actually accepted. A CI contract pins all four guarantees so none can silently regress.

**Verification stays off in this change.** Signing an artifact nothing yet verifies is inert, which is what makes this safe to land ahead of the publication-atomicity and config-nesting work the parent still needs. No production reconcile behaviour changes.

Fixes #2839
Part of #2627