### PR TITLE
feat(headlamp): run inside a user namespace

### DIFF
--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -66,22 +66,27 @@ patches:
   # add-security-context Kyverno rule. Local/CI and stateful workloads stay
   # out; in mixed namespaces (umami, backstage) the rule itself excludes the
   # CNPG database pods via their cnpg.io/cluster label.
-  # Headlamp is a separately gated stateful pilot (#2650): its chart explicitly
-  # renders hostUsers: true, so the namespace-label Kyverno rule cannot override
-  # that authored value. Keep this exact-target values patch default-off until
-  # the concurrent node-auth rollout has settled and Headlamp/Longhorn are
-  # healthy. Activation uncomments the whole block; recovery re-comments/reverts
-  # it and never deletes the plugins PVC.
-  # - target:
-  #     group: helm.toolkit.fluxcd.io
-  #     version: v2
-  #     kind: HelmRelease
-  #     name: headlamp
-  #     namespace: headlamp
-  #   patch: |-
-  #     - op: add
-  #       path: /spec/values/hostUsers
-  #       value: false
+  # Headlamp takes an exact-target values patch instead of a namespace label
+  # (#2651). Its chart renders `hostUsers: {{ .Values.hostUsers }}` from a
+  # values.yaml default of true, so the value is authored rather than absent and
+  # the add-security-context rule's +(hostUsers) conditional anchor — which only
+  # fills in a MISSING value — cannot reach it. Setting the chart value is what
+  # actually changes the rendered Deployment.
+  # Headlamp is the first Longhorn-backed workload here: its plugin sidecar
+  # writes to the `headlamp` PVC and the main container reads those files. That
+  # cross-container round trip under a user namespace is the property the
+  # disposable userns-longhorn-smoke Job proved on this cluster (#2619).
+  # Recovery re-comments this block and never deletes the plugins PVC.
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: headlamp
+      namespace: headlamp
+    patch: |-
+      - op: add
+        path: /spec/values/hostUsers
+        value: false
   - path: whoami/patches/enable-user-namespaces.yaml
   - path: homepage/patches/enable-user-namespaces.yaml
   - path: umami/patches/enable-user-namespaces.yaml

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -56,10 +56,29 @@ const (
 // The approved surface includes the encrypted flux-system/variables-cluster
 // substitution source and the staged Cilium homogeneous-device activation.
 //
-// Measured against main fa041449 before approving this value: the production
-// infrastructure overlay moves from 204 -> 210 documents, with exactly six
-// additive OpenCost usage-scraper resources and no existing document modified
-// or removed. The authorization delta is one dedicated ServiceAccount, one
+// Measured against main 6e011890 before approving this value: 515 documents on
+// both sides, membership IDENTICAL — proven by set difference in BOTH
+// directions over apiVersion|kind|namespace|name across all five rendered
+// trees, not by count alone, which cannot see a rename. Exactly ONE entry's
+// content moved:
+//
+//	helm.toolkit.fluxcd.io/v2  HelmRelease  headlamp/headlamp
+//
+// Its rendered delta is a single line — `hostUsers: false` — activating the
+// user-namespace pilot gated since #2650. That field places the pod in its own
+// user namespace; it constrains the workload and grants nothing.
+//
+// No grant-bearing object moved: 64 Role / ClusterRole / RoleBinding /
+// ClusterRoleBinding / ServiceAccount documents on BOTH sides, none of them in
+// the moved set. All 116 `aws`-bearing lines are byte-identical across the two
+// trees, so nothing granted to the aws/aws service account this validator
+// exists to protect is touched.
+//
+// Measured against main fa041449 before approving the previous value: the
+// production infrastructure overlay moves from 204 -> 210 documents, with
+// exactly six additive OpenCost usage-scraper resources and no existing
+// document modified or removed. The authorization delta is one dedicated
+// ServiceAccount, one
 // ClusterRole limited to get/list/watch on nodes plus get on nodes/metrics, and
 // one binding between exactly those identities. The ConfigMap, Deployment, and
 // scraper-scoped CiliumNetworkPolicy carry the bounded scrape/remote-write path
@@ -117,7 +136,7 @@ const (
 // kubectl render diff — render k8s/providers/hetzner/{apps,infrastructure,
 // infrastructure/controllers} plus k8s/clusters/prod/{bootstrap,} for both
 // trees and diff them.
-const expectedRenderedSurfaceSHA = "b1b8547b7a4826c100cbbbea860fc9688fc8b0f3472148a52f63bfeb27969e29"
+const expectedRenderedSurfaceSHA = "a00f3c5d3e5a1ab7418f543d52c15640c7a8777349d6ead63a25646e67c7c374"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Headlamp is the last app on the cluster still sharing the host's user namespace. Every other opted-in workload already runs isolated, so a container break-out from Headlamp lands as a real host UID where the others land as an unprivileged mapped one. It was held back deliberately: it is the first one that stores anything, so activation waited until the node rollout settled and its storage was known-good. Both conditions are now met.

## What

Turns on the Headlamp user-namespace switch that has been sitting ready and default-off since #2650. One value changes; nothing else in the cluster render moves.

Headlamp needs its own switch rather than the namespace label the other apps use, because its chart writes the setting out explicitly and the cluster-wide rule only fills in a value that is missing.

**Verification follows the merge, not this PR** — the point of a pilot is the live observation, so this uses `Part of` and leaves #2651 open until the evidence is recorded there.

**Rollback** is re-commenting the block. The plugins volume is never deleted, on any path.

Part of #2651