### PR TITLE
fix(ci): report what the Kubescape scan actually found

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
               - 'scripts/validate-embedded-json.py'
               - 'scripts/generate-kubescape-exceptions/**'
               - 'scripts/normalize-sarif-paths.sh'
+              - 'scripts/summarize-sarif-findings.sh'
               - 'go.mod'
               - 'go.sum'
               - 'scripts/tests/test-cilium-bandwidth-manager-component.sh'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
               - 'scripts/generate-kubescape-exceptions/**'
               - 'scripts/normalize-sarif-paths.sh'
               - 'scripts/summarize-sarif-findings.sh'
+              - 'scripts/tests/test-summarize-sarif-findings.sh'
               - 'go.mod'
               - 'go.sum'
               - 'scripts/tests/test-cilium-bandwidth-manager-component.sh'
@@ -247,6 +248,15 @@ jobs:
         # Render the full component contract so the cAdvisor scrape and its
         # least-privilege delivery path cannot silently disappear.
         run: bash scripts/tests/test-opencost-usage-scraper.sh
+
+      - name: 📋 Validate Kubescape finding summary
+        if: needs.changes.outputs.k8s == 'true'
+        # The summary is what makes the CI log and the Security tab agree (#2846),
+        # and it fails by under-reporting rather than by crashing — a dropped
+        # control looks exactly like a clean scan. Pin the grouping, the counts and
+        # the two SARIF shapes that turn into hard jq errors if indexed naively: a
+        # result with no ruleId, and a ruleId absent from the rule table.
+        run: bash scripts/tests/test-summarize-sarif-findings.sh
 
       - name: 📢 Validate reconciliation-Alert namespace coverage
         if: needs.changes.outputs.k8s == 'true'
@@ -472,7 +482,17 @@ jobs:
         # assert that an upload happened.
         #
         # Informational only. The compliance threshold on the scan step remains
-        # the sole merge gate; this step cannot fail the build over findings.
+        # the sole merge gate.
+        #
+        # The script exits non-zero on a usage error or a SARIF it cannot parse,
+        # and leaves it to the caller whether that is fatal. This caller says no:
+        # a summary that cannot be built says nothing about posture, and the gate
+        # that does — the compliance threshold — has already run against the same
+        # file. `continue-on-error` keeps the failure loud (the step is still
+        # marked failed and annotated on the run) without blocking a merge on a
+        # reporting bug. Without it, this step silently becomes a second gate,
+        # contradicting the sentence above it.
+        continue-on-error: true
         if: >-
           !cancelled() &&
           steps.normalize-sarif.outputs.sarif == 'ready'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -408,6 +408,15 @@ jobs:
             echo "sarif=absent" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
+          # Keep the scan's own output before normalization touches it. The
+          # normalizer DROPS results with an empty artifactLocation.uri (see its
+          # CONTRACT) because Code Scanning cannot anchor an alert without a
+          # file. That is right for the upload and wrong for the summary: a
+          # cluster-level control with no manifest behind it is exactly the kind
+          # of finding that is otherwise invisible, so summarizing the
+          # normalized file would under-report the very case this reporting
+          # exists for. Upload reads the normalized file; the summary reads this.
+          cp "${RUNNER_TEMP}/kubescape.sarif" "${RUNNER_TEMP}/kubescape.raw.sarif"
           bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
           # Only now is the file both PRESENT and root-relative. The upload gates
           # on this output, so a normalizer hard-failure (an unresolvable path)
@@ -498,7 +507,7 @@ jobs:
           steps.normalize-sarif.outputs.sarif == 'ready'
         run: |
           shellcheck scripts/summarize-sarif-findings.sh
-          bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.sarif"
+          bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.raw.sarif"
 
   naming:
     name: 🏷️ Validate Naming Conventions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -453,6 +453,32 @@ jobs:
           # results are tracked and closed independently.
           category: kubescape-nsa
 
+      - name: 📋 Summarize Kubescape findings
+        # Kubescape's own console table shows only a subset of what it finds:
+        # measured on this repository, a scan whose SARIF carried 4 findings
+        # printed "All controls passed. No issues found". Since the upload above
+        # turns those findings into alerts, the log and the Security tab
+        # disagreed — and the log is what a developer reads on a PR (#2846).
+        #
+        # This reports from the SARIF the run already produced, so the two
+        # surfaces cannot drift: same file, same findings.
+        #
+        # Gated on the normalizer's output rather than `!cancelled()` alone, for
+        # the same reason the upload is: that output is the only signal that the
+        # file both exists and is well-formed. It runs even when the upload step
+        # did not — a fork PR cannot upload, but its author still benefits from
+        # seeing what the scan found, which is why the script's wording does not
+        # assert that an upload happened.
+        #
+        # Informational only. The compliance threshold on the scan step remains
+        # the sole merge gate; this step cannot fail the build over findings.
+        if: >-
+          !cancelled() &&
+          steps.normalize-sarif.outputs.sarif == 'ready'
+        run: |
+          shellcheck scripts/summarize-sarif-findings.sh
+          bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.sarif"
+
   naming:
     name: 🏷️ Validate Naming Conventions
     needs: [changes]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -417,6 +417,13 @@ jobs:
           # normalized file would under-report the very case this reporting
           # exists for. Upload reads the normalized file; the summary reads this.
           cp "${RUNNER_TEMP}/kubescape.sarif" "${RUNNER_TEMP}/kubescape.raw.sarif"
+          # Emitted BEFORE the normalizer runs, because it is the summary's gate
+          # and the summary must survive a normalizer failure. An unresolvable
+          # path aborts the step, so anything echoed after that line never
+          # happens — and gating the summary on `sarif=ready` would skip it
+          # exactly when an upstream path-shape change made the findings most
+          # worth reading.
+          echo "raw=ready" >> "${GITHUB_OUTPUT}"
           bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
           # Only now is the file both PRESENT and root-relative. The upload gates
           # on this output, so a normalizer hard-failure (an unresolvable path)
@@ -504,7 +511,7 @@ jobs:
         continue-on-error: true
         if: >-
           !cancelled() &&
-          steps.normalize-sarif.outputs.sarif == 'ready'
+          steps.normalize-sarif.outputs.raw == 'ready'
         run: |
           shellcheck scripts/summarize-sarif-findings.sh
           bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.raw.sarif"

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -161,6 +161,10 @@ jobs:
             echo "sarif=absent" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
+          # Same split as ci.yaml: the normalizer drops empty-uri results because
+          # Code Scanning cannot anchor them, so the upload reads the normalized
+          # file and the summary below reads this untouched copy.
+          cp "${RUNNER_TEMP}/kubescape.sarif" "${RUNNER_TEMP}/kubescape.raw.sarif"
           bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
           echo "sarif=ready" >> "${GITHUB_OUTPUT}"
 
@@ -181,3 +185,23 @@ jobs:
           # parallel alert set instead of a baseline the PR findings resolve
           # against.
           category: kubescape-nsa
+
+      - name: 📋 Summarize Kubescape findings
+        # This job exists because ci.yaml scans on `pull_request` only, so a
+        # posture change that arrived without a PR is invisible until this run
+        # publishes it. That argument applies to the LOG as much as to the alert
+        # set: without this step the push-to-main log can still read as a clean
+        # scan while the same run uploads findings — the exact contradiction
+        # #2846 is about, on the one path nobody opens a PR to look at.
+        #
+        # Reads the pre-normalization copy for the same reason ci.yaml does.
+        # Informational only: this job's gate is the compliance threshold on the
+        # scan step, and a summary that cannot be built says nothing about
+        # posture, so it annotates rather than failing the baseline.
+        continue-on-error: true
+        if: >-
+          !cancelled() &&
+          steps.normalize-sarif.outputs.sarif == 'ready'
+        run: |
+          shellcheck scripts/summarize-sarif-findings.sh
+          bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.raw.sarif"

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -165,6 +165,10 @@ jobs:
           # Code Scanning cannot anchor them, so the upload reads the normalized
           # file and the summary below reads this untouched copy.
           cp "${RUNNER_TEMP}/kubescape.sarif" "${RUNNER_TEMP}/kubescape.raw.sarif"
+          # Emitted before the normalizer: an unresolvable path aborts the step,
+          # so the summary would otherwise be skipped exactly when a path-shape
+          # change made the findings most worth reading.
+          echo "raw=ready" >> "${GITHUB_OUTPUT}"
           bash scripts/normalize-sarif-paths.sh "${RUNNER_TEMP}/kubescape.sarif" k8s .
           echo "sarif=ready" >> "${GITHUB_OUTPUT}"
 
@@ -201,7 +205,7 @@ jobs:
         continue-on-error: true
         if: >-
           !cancelled() &&
-          steps.normalize-sarif.outputs.sarif == 'ready'
+          steps.normalize-sarif.outputs.raw == 'ready'
         run: |
           shellcheck scripts/summarize-sarif-findings.sh
           bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.raw.sarif"

--- a/scripts/summarize-sarif-findings.sh
+++ b/scripts/summarize-sarif-findings.sh
@@ -47,21 +47,44 @@ fi
 # files is one thing to fix, and a per-result list would bury that.
 report="$(
   jq -r '
-    [.runs[]? ] as $runs
+    # A SARIF document MUST carry .runs as an array. Without this check `{}`,
+    # `{"version":"2.1.0"}` and `{"runs":null}` all flow through the optional
+    # iteration below and report "0 findings" — a structurally unusable file
+    # reported as a clean scan, which is the exact ambiguity this script exists
+    # to remove. `"runs": []` is a different thing and stays a legitimate zero.
+    if (.runs | type) != "array" then
+      error("not a SARIF document: .runs is absent or not an array")
+    else . end
+    | [.runs[]] as $runs
     | ( [ $runs[].tool.driver.rules[]? ] | map({key: .id, value: .}) | from_entries ) as $rules
-    | [ $runs[].results[]? ] as $results
-    | ($results | length) as $total
+    # SARIF lets a result name its rule EITHER by .ruleId or by .ruleIndex into
+    # its own run.tool.driver.rules. Resolving only .ruleId collapses every
+    # ruleIndex result into one "<no rule id>" bucket and throws the metadata
+    # away, so resolve per run — the index is run-scoped and meaningless across
+    # a concatenated list. The bounds check keeps an out-of-range index a miss
+    # rather than a wrong attribution (jq would index backwards from -1).
+    | [ $runs[]
+        | ( .tool.driver.rules // [] ) as $runRules
+        | ( .results // [] )[]
+        | ( .ruleId
+            // ( if (.ruleIndex | type) == "number"
+                   and .ruleIndex >= 0
+                   and .ruleIndex < ( $runRules | length )
+                 then $runRules[.ruleIndex].id
+                 else null end ) )
+      ] as $ids
+    | ( $ids | length ) as $total
     | if $total == 0 then
         "Kubescape: 0 findings in this scan."
       else
-        ( $results
-          | group_by(.ruleId)
+        ( $ids
+          | group_by(.)
           | map(
-              # A result is not required to carry a ruleId, and indexing the rule
-              # table with null is an error rather than a miss — so resolve the id
-              # once and look the rule up only when there is one. A finding with no
-              # id stays counted and visible instead of aborting the summary.
-              ( .[0].ruleId ) as $id
+              # A result is not required to identify its rule at all, and indexing
+              # the rule table with null is an error rather than a miss — so look
+              # the rule up only when there is an id. A finding with none stays
+              # counted and visible instead of aborting the summary.
+              ( .[0] ) as $id
               | ( if $id == null then null else $rules[$id] end ) as $rule
               | {
                   id:    ( $id // "<no rule id>" ),

--- a/scripts/summarize-sarif-findings.sh
+++ b/scripts/summarize-sarif-findings.sh
@@ -95,5 +95,5 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo '```text'
     printf '%s\n' "$report"
     echo '```'
-  } >> "$GITHUB_STEP_SUMMARY"
+  } >>"$GITHUB_STEP_SUMMARY"
 fi

--- a/scripts/summarize-sarif-findings.sh
+++ b/scripts/summarize-sarif-findings.sh
@@ -41,10 +41,12 @@ if [ ! -f "$sarif_file" ]; then
 fi
 
 # One jq pass builds the whole report. Rule metadata lives in
-# .runs[].tool.driver.rules and the findings in .runs[].results, so the rule
-# table is indexed by id first and each result counted against it. Results are
-# grouped by control rather than listed one per line: the same control on twenty
-# files is one thing to fix, and a per-result list would bury that.
+# .runs[].tool.driver.rules and the findings in .runs[].results, and both are
+# scoped to their run — so each result resolves its rule against its OWN run and
+# carries the answer forward, rather than against a table flattened across runs.
+# Results are then grouped by control rather than listed one per line: the same
+# control on twenty files is one thing to fix, and a per-result list would bury
+# that.
 report="$(
   jq -r '
     # A SARIF document MUST carry .runs as an array. Without this check `{}`,
@@ -56,43 +58,46 @@ report="$(
       error("not a SARIF document: .runs is absent or not an array")
     else . end
     | [.runs[]] as $runs
-    | ( [ $runs[].tool.driver.rules[]? ] | map({key: .id, value: .}) | from_entries ) as $rules
     # SARIF lets a result name its rule EITHER by .ruleId or by .ruleIndex into
-    # its own run.tool.driver.rules. Resolving only .ruleId collapses every
-    # ruleIndex result into one "<no rule id>" bucket and throws the metadata
-    # away, so resolve per run — the index is run-scoped and meaningless across
-    # a concatenated list. The bounds check keeps an out-of-range index a miss
-    # rather than a wrong attribution (jq would index backwards from -1).
+    # its OWN run.tool.driver.rules, and two runs may define the same rule id
+    # with different metadata. Both facts make rule resolution run-scoped, so
+    # each result is resolved against its own run and carries the answer with it.
+    #
+    # A global id-keyed table cannot do this: `from_entries` keeps the LAST
+    # definition of a duplicate key, so every finding for that id would be
+    # reported with the level and description from the LAST run — a wrong attribution,
+    # which is worse than an absent one. Same reason the index is bounds-checked:
+    # jq indexes backwards from -1, so an out-of-range index would silently
+    # borrow the last rule in the table.
     | [ $runs[]
         | ( .tool.driver.rules // [] ) as $runRules
+        | ( $runRules | map({key: .id, value: .}) | from_entries ) as $runRuleTable
         | ( .results // [] )[]
         | ( .ruleId
             // ( if (.ruleIndex | type) == "number"
                    and .ruleIndex >= 0
                    and .ruleIndex < ( $runRules | length )
                  then $runRules[.ruleIndex].id
-                 else null end ) )
-      ] as $ids
-    | ( $ids | length ) as $total
+                 else null end ) ) as $id
+        | ( if $id == null then null else $runRuleTable[$id] end ) as $rule
+        | {
+            id:    ( $id // "<no rule id>" ),
+            level: ( $rule.defaultConfiguration.level // "unknown" ),
+            desc:  ( $rule.shortDescription.text // "" )
+          }
+      ] as $findings
+    | ( $findings | length ) as $total
     | if $total == 0 then
         "Kubescape: 0 findings in this scan."
       else
-        ( $ids
-          | group_by(.)
-          | map(
-              # A result is not required to identify its rule at all, and indexing
-              # the rule table with null is an error rather than a miss — so look
-              # the rule up only when there is an id. A finding with none stays
-              # counted and visible instead of aborting the summary.
-              ( .[0] ) as $id
-              | ( if $id == null then null else $rules[$id] end ) as $rule
-              | {
-                  id:    ( $id // "<no rule id>" ),
-                  count: length,
-                  level: ( $rule.defaultConfiguration.level // "unknown" ),
-                  desc:  ( $rule.shortDescription.text // "" )
-                }
-            )
+        # Grouped on the resolved triple, not on the id alone. Runs that agree
+        # about a rule still merge into one control (the ordinary case, and the
+        # only one the single-run scans in this repository produce); runs that
+        # disagree are reported separately rather than one silently overwriting
+        # the other.
+        ( $findings
+          | group_by([.id, .level, .desc])
+          | map( .[0] + { count: length } )
           | sort_by(-.count)
         ) as $byControl
         | ( "Kubescape: \($total) finding(s) across \($byControl | length) control(s)."

--- a/scripts/summarize-sarif-findings.sh
+++ b/scripts/summarize-sarif-findings.sh
@@ -56,12 +56,20 @@ report="$(
       else
         ( $results
           | group_by(.ruleId)
-          | map({
-              id:    .[0].ruleId,
-              count: length,
-              level: ( $rules[.[0].ruleId].defaultConfiguration.level // "unknown" ),
-              desc:  ( $rules[.[0].ruleId].shortDescription.text // "" )
-            })
+          | map(
+              # A result is not required to carry a ruleId, and indexing the rule
+              # table with null is an error rather than a miss — so resolve the id
+              # once and look the rule up only when there is one. A finding with no
+              # id stays counted and visible instead of aborting the summary.
+              ( .[0].ruleId ) as $id
+              | ( if $id == null then null else $rules[$id] end ) as $rule
+              | {
+                  id:    ( $id // "<no rule id>" ),
+                  count: length,
+                  level: ( $rule.defaultConfiguration.level // "unknown" ),
+                  desc:  ( $rule.shortDescription.text // "" )
+                }
+            )
           | sort_by(-.count)
         ) as $byControl
         | ( "Kubescape: \($total) finding(s) across \($byControl | length) control(s)."

--- a/scripts/summarize-sarif-findings.sh
+++ b/scripts/summarize-sarif-findings.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Print a human-readable summary of the findings in a SARIF file.
+#
+# WHY THIS EXISTS. Kubescape's own console table shows only a subset of what it
+# finds: measured on this repository, a scan whose SARIF carried 4 findings
+# printed "All controls passed. No issues found", and a scan whose SARIF carried
+# 70 findings listed a single control. The compliance-score gate is orthogonal —
+# it answers "did posture regress", not "what was found" — so a finding that does
+# not move the score below the floor is invisible in the log entirely.
+#
+# Since the SARIF is uploaded to Code Scanning (#2829), that silence became a
+# contradiction: the CI log says there is nothing to fix while the Security tab
+# raises alerts for the same run. A developer reading the log — which is what a
+# developer actually reads on a PR — draws the wrong conclusion. This script
+# closes that gap by reporting from the SARIF itself, so the log and the alerts
+# always agree because they come from one source. See #2846.
+#
+# CONTRACT
+#   - Reports what is IN the file; it never re-scans and never filters.
+#   - Zero findings is stated explicitly, so "no findings" and "the summary did
+#     not run" can never look alike in a log.
+#   - Purely informational: it does NOT gate. The compliance threshold remains
+#     the only merge gate, and this script's exit status never fails a build for
+#     the content of a scan.
+#   - Exits non-zero ONLY on a usage error or a file it cannot parse — a broken
+#     summary is worth surfacing, but the caller decides whether that is fatal.
+#   - Writes to $GITHUB_STEP_SUMMARY as well when that variable is set, so the
+#     result is visible on the run page without opening the log.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: ${0##*/} <sarif-file>" >&2
+  exit 2
+fi
+
+sarif_file="$1"
+
+if [ ! -f "$sarif_file" ]; then
+  echo "${0##*/}: no such file: $sarif_file" >&2
+  exit 2
+fi
+
+# One jq pass builds the whole report. Rule metadata lives in
+# .runs[].tool.driver.rules and the findings in .runs[].results, so the rule
+# table is indexed by id first and each result counted against it. Results are
+# grouped by control rather than listed one per line: the same control on twenty
+# files is one thing to fix, and a per-result list would bury that.
+report="$(
+  jq -r '
+    [.runs[]? ] as $runs
+    | ( [ $runs[].tool.driver.rules[]? ] | map({key: .id, value: .}) | from_entries ) as $rules
+    | [ $runs[].results[]? ] as $results
+    | ($results | length) as $total
+    | if $total == 0 then
+        "Kubescape: 0 findings in this scan."
+      else
+        ( $results
+          | group_by(.ruleId)
+          | map({
+              id:    .[0].ruleId,
+              count: length,
+              level: ( $rules[.[0].ruleId].defaultConfiguration.level // "unknown" ),
+              desc:  ( $rules[.[0].ruleId].shortDescription.text // "" )
+            })
+          | sort_by(-.count)
+        ) as $byControl
+        | ( "Kubescape: \($total) finding(s) across \($byControl | length) control(s)."
+          , ( $byControl[]
+              | "  \(.id)  \(.level)  \(.desc)  — \(.count) finding(s)" )
+          , "Where these are uploaded, they appear under Security -> Code scanning -> kubescape-nsa, with file and line."
+          )
+      end
+  ' "$sarif_file"
+)" || {
+  echo "${0##*/}: could not parse SARIF: $sarif_file" >&2
+  exit 2
+}
+
+printf '%s\n' "$report"
+
+# The step summary renders Markdown, so the body goes in a fenced block to keep
+# the alignment the plain-text report relies on.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Kubescape findings"
+    echo ''
+    echo '```text'
+    printf '%s\n' "$report"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/tests/test-summarize-sarif-findings.sh
+++ b/scripts/tests/test-summarize-sarif-findings.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Pin the report that scripts/summarize-sarif-findings.sh builds from a SARIF file.
+#
+# WHY THIS EXISTS. That script is the only thing standing between a scan's real
+# findings and a CI log that says nothing was found (#2846), so a silent
+# regression in its jq pipeline restores exactly the contradiction it was written
+# to remove — and it restores it invisibly, because a summary that under-reports
+# still looks like a healthy run. The failure mode is a missing line, never a
+# crash, which is why this pins counts and grouping rather than just exit status.
+#
+# The SARIF shapes below are the ones measured on this repository: a result may
+# carry no `ruleId` at all, and a `ruleId` may reference a rule absent from the
+# driver's rule table. Both are misses that jq turns into hard errors if indexed
+# naively, so each has its own case here.
+#
+# Bash plus the runner's jq; no cluster, no secrets, no network.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly script="${root_dir}/scripts/summarize-sarif-findings.sh"
+readonly ci_workflow="${root_dir}/.github/workflows/ci.yaml"
+
+work_dir="$(mktemp -d)"
+readonly work_dir
+cleanup() {
+  rm -rf "${work_dir}"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+require_text() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "$needle" <<<"${haystack}"; then
+    printf 'FAIL: %s\n--- actual output ---\n%s\n---\n' "${description}" "${haystack}" >&2
+    exit 1
+  fi
+}
+
+# Writes $2 to a SARIF file named $1 and echoes its path.
+write_sarif() {
+  local name="$1"
+  local body="$2"
+  local path="${work_dir}/${name}"
+
+  printf '%s\n' "${body}" >"${path}"
+  printf '%s' "${path}"
+}
+
+# Runs the script under test, capturing combined output and exit status without
+# tripping `set -e`. Sets the globals `run_output` and `run_status`.
+run_summary() {
+  run_status=0
+  run_output="$(bash "${script}" "$@" 2>&1)" || run_status=$?
+}
+
+# The 1-based line number of the first line matching $2 in $1, or empty.
+line_of() {
+  local haystack="$1"
+  local needle="$2"
+
+  grep -nF -- "${needle}" <<<"${haystack}" | head -1 | cut -d: -f1
+}
+
+# ---------------------------------------------------------------------------
+# A scan that found nothing says so explicitly.
+#
+# This is the case that must never be silent: "no findings" and "the summary did
+# not run" have to be distinguishable in a log, or a broken step reads as a clean
+# scan.
+# ---------------------------------------------------------------------------
+empty_sarif="$(write_sarif empty.sarif '{"runs":[{"tool":{"driver":{"rules":[]}},"results":[]}]}')"
+run_summary "${empty_sarif}"
+[ "${run_status}" -eq 0 ] || fail "an empty SARIF must exit 0, got ${run_status}"
+require_text "${run_output}" 'Kubescape: 0 findings in this scan.' \
+  'an empty SARIF must state zero findings explicitly'
+
+# A SARIF with no runs at all is the same story, and reaches a different jq path
+# (`.runs[]?` yields nothing rather than an empty results array).
+no_runs_sarif="$(write_sarif no-runs.sarif '{"version":"2.1.0"}')"
+run_summary "${no_runs_sarif}"
+[ "${run_status}" -eq 0 ] || fail "a SARIF with no runs must exit 0, got ${run_status}"
+require_text "${run_output}" 'Kubescape: 0 findings in this scan.' \
+  'a SARIF with no runs must state zero findings explicitly'
+
+# ---------------------------------------------------------------------------
+# Findings are grouped by control, counted, and ordered by count descending.
+#
+# Grouping is the whole point of the report: the same control on twenty files is
+# one thing to fix. Ordering matters because the log is read top-down and the
+# biggest group is the one worth acting on first.
+# ---------------------------------------------------------------------------
+multi_sarif="$(write_sarif multi.sarif '{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "rules": [
+            {
+              "id": "C-0016",
+              "shortDescription": { "text": "Allow privilege escalation" },
+              "defaultConfiguration": { "level": "warning" }
+            },
+            {
+              "id": "C-0009",
+              "shortDescription": { "text": "Resource limits" },
+              "defaultConfiguration": { "level": "error" }
+            }
+          ]
+        }
+      },
+      "results": [
+        { "ruleId": "C-0009" },
+        { "ruleId": "C-0016" },
+        { "ruleId": "C-0016" },
+        { "ruleId": "C-0016" }
+      ]
+    }
+  ]
+}')"
+run_summary "${multi_sarif}"
+[ "${run_status}" -eq 0 ] || fail "a well-formed SARIF must exit 0, got ${run_status}"
+require_text "${run_output}" 'Kubescape: 4 finding(s) across 2 control(s).' \
+  'the header must carry the total finding count and the control count'
+require_text "${run_output}" 'C-0016  warning  Allow privilege escalation  — 3 finding(s)' \
+  'a control must report its level, description and grouped count from the rule table'
+require_text "${run_output}" 'C-0009  error  Resource limits  — 1 finding(s)' \
+  'every control must be reported, not only the largest'
+
+busiest_line="$(line_of "${run_output}" 'C-0016')"
+quietest_line="$(line_of "${run_output}" 'C-0009')"
+[ -n "${busiest_line}" ] && [ -n "${quietest_line}" ] ||
+  fail 'both controls must appear in the report'
+[ "${busiest_line}" -lt "${quietest_line}" ] ||
+  fail "controls must be ordered by descending count (C-0016 at line ${busiest_line}, C-0009 at line ${quietest_line})"
+
+require_text "${run_output}" 'Security -> Code scanning -> kubescape-nsa' \
+  'the report must say where the uploaded findings appear'
+
+# ---------------------------------------------------------------------------
+# A result carrying no ruleId stays counted instead of aborting the summary.
+#
+# jq raises "Cannot index object with null" if the rule table is indexed with a
+# null id, which would take the whole report down over one malformed result —
+# turning a partial scan into a silent one.
+# ---------------------------------------------------------------------------
+no_id_sarif="$(write_sarif no-rule-id.sarif '{
+  "runs": [
+    {
+      "tool": { "driver": { "rules": [ { "id": "C-0009" } ] } },
+      "results": [ { "ruleId": "C-0009" }, { "message": { "text": "orphan" } } ]
+    }
+  ]
+}')"
+run_summary "${no_id_sarif}"
+[ "${run_status}" -eq 0 ] ||
+  fail "a result with no ruleId must not abort the summary, got exit ${run_status}"
+require_text "${run_output}" 'Kubescape: 2 finding(s) across 2 control(s).' \
+  'a result with no ruleId must still be counted in the total'
+require_text "${run_output}" '<no rule id>' \
+  'a result with no ruleId must be visible in the report rather than dropped'
+
+# ---------------------------------------------------------------------------
+# A ruleId with no matching rule reports as unknown rather than blank-crashing.
+# ---------------------------------------------------------------------------
+orphan_rule_sarif="$(write_sarif orphan-rule.sarif '{
+  "runs": [
+    {
+      "tool": { "driver": { "rules": [] } },
+      "results": [ { "ruleId": "C-9999" } ]
+    }
+  ]
+}')"
+run_summary "${orphan_rule_sarif}"
+[ "${run_status}" -eq 0 ] ||
+  fail "a ruleId absent from the rule table must not abort the summary, got exit ${run_status}"
+require_text "${run_output}" 'Kubescape: 1 finding(s) across 1 control(s).' \
+  'a finding whose rule is missing from the table must still be counted'
+require_text "${run_output}" 'C-9999  unknown' \
+  'a finding whose rule is missing from the table must report an unknown level'
+
+# ---------------------------------------------------------------------------
+# The step summary carries the same report as the log.
+#
+# Two surfaces built from one file is the property this whole script exists for;
+# if they can diverge, the summary is just another place to be wrong.
+# ---------------------------------------------------------------------------
+step_summary="${work_dir}/step-summary.md"
+: >"${step_summary}"
+summary_status=0
+summary_stdout="$(GITHUB_STEP_SUMMARY="${step_summary}" bash "${script}" "${multi_sarif}" 2>&1)" ||
+  summary_status=$?
+[ "${summary_status}" -eq 0 ] || fail "writing a step summary must exit 0, got ${summary_status}"
+summary_body="$(cat "${step_summary}")"
+require_text "${summary_body}" '### Kubescape findings' \
+  'the step summary must carry a heading'
+require_text "${summary_body}" 'Kubescape: 4 finding(s) across 2 control(s).' \
+  'the step summary must carry the same totals as the log'
+require_text "${summary_body}" 'C-0016  warning  Allow privilege escalation  — 3 finding(s)' \
+  'the step summary must carry the same per-control detail as the log'
+require_text "${summary_body}" '```text' \
+  'the step summary must fence the report so its alignment survives Markdown'
+require_text "${summary_stdout}" 'Kubescape: 4 finding(s) across 2 control(s).' \
+  'writing a step summary must not suppress the log output'
+
+# Absent GITHUB_STEP_SUMMARY, nothing is written anywhere — the script must not
+# assume it runs under Actions.
+stray_before="$(find "${work_dir}" -type f | wc -l | tr -d ' ')"
+run_summary "${multi_sarif}"
+stray_after="$(find "${work_dir}" -type f | wc -l | tr -d ' ')"
+[ "${stray_before}" -eq "${stray_after}" ] ||
+  fail 'running without GITHUB_STEP_SUMMARY must not create files'
+
+# ---------------------------------------------------------------------------
+# Failure modes exit 2 and say why. The caller decides whether that is fatal,
+# so the status has to be distinguishable from "scan was clean".
+# ---------------------------------------------------------------------------
+malformed_sarif="$(write_sarif malformed.sarif '{"runs": [ this is not json')"
+run_summary "${malformed_sarif}"
+[ "${run_status}" -eq 2 ] || fail "unparseable SARIF must exit 2, got ${run_status}"
+require_text "${run_output}" 'could not parse SARIF' \
+  'unparseable SARIF must name the failure'
+
+run_summary "${work_dir}/does-not-exist.sarif"
+[ "${run_status}" -eq 2 ] || fail "a missing file must exit 2, got ${run_status}"
+require_text "${run_output}" 'no such file' \
+  'a missing file must name the failure'
+
+run_summary
+[ "${run_status}" -eq 2 ] || fail "no argument must exit 2, got ${run_status}"
+require_text "${run_output}" 'usage:' 'no argument must print usage'
+
+run_summary "${multi_sarif}" "${empty_sarif}"
+[ "${run_status}" -eq 2 ] || fail "too many arguments must exit 2, got ${run_status}"
+
+# ---------------------------------------------------------------------------
+# The wiring. A guard nothing runs is not a guard, and a guard whose own edits do
+# not trigger it decays silently — so both the invocation and this file's
+# presence in the path filter are pinned here.
+# ---------------------------------------------------------------------------
+workflow_body="$(cat "${ci_workflow}")"
+require_text "${workflow_body}" 'bash scripts/tests/test-summarize-sarif-findings.sh' \
+  'CI must invoke this test, or it never runs'
+require_text "${workflow_body}" "- 'scripts/tests/test-summarize-sarif-findings.sh'" \
+  'this test must be in the k8s path filter, or editing it alone never runs it'
+require_text "${workflow_body}" "- 'scripts/summarize-sarif-findings.sh'" \
+  'the script under test must be in the k8s path filter'
+
+printf 'PASS: %s\n' "${BASH_SOURCE[0]##*/}"

--- a/scripts/tests/test-summarize-sarif-findings.sh
+++ b/scripts/tests/test-summarize-sarif-findings.sh
@@ -82,13 +82,31 @@ run_summary "${empty_sarif}"
 require_text "${run_output}" 'Kubescape: 0 findings in this scan.' \
   'an empty SARIF must state zero findings explicitly'
 
-# A SARIF with no runs at all is the same story, and reaches a different jq path
-# (`.runs[]?` yields nothing rather than an empty results array).
-no_runs_sarif="$(write_sarif no-runs.sarif '{"version":"2.1.0"}')"
-run_summary "${no_runs_sarif}"
-[ "${run_status}" -eq 0 ] || fail "a SARIF with no runs must exit 0, got ${run_status}"
+# An EMPTY runs array is still a well-formed SARIF, so it is a legitimate zero.
+empty_runs_sarif="$(write_sarif empty-runs.sarif '{"version":"2.1.0","runs":[]}')"
+run_summary "${empty_runs_sarif}"
+[ "${run_status}" -eq 0 ] || fail "a SARIF with an empty runs array must exit 0, got ${run_status}"
 require_text "${run_output}" 'Kubescape: 0 findings in this scan.' \
-  'a SARIF with no runs must state zero findings explicitly'
+  'a SARIF with an empty runs array must state zero findings explicitly'
+
+# ---------------------------------------------------------------------------
+# A file that is valid JSON but NOT a SARIF document must fail, never read clean.
+#
+# This is the one that matters most and the easiest to get backwards: `.runs[]?`
+# happily yields nothing for `{}`, so without an explicit shape check a
+# structurally unusable file reports "0 findings" and a broken scan is
+# indistinguishable from a clean one — precisely the ambiguity this script
+# exists to remove. An earlier revision of this test asserted the WRONG
+# behaviour here (exit 0); it was corrected after review.
+# ---------------------------------------------------------------------------
+for not_sarif in '{}' '{"version":"2.1.0"}' '{"runs":null}' '{"runs":{}}'; do
+  probe="$(write_sarif "not-sarif.sarif" "${not_sarif}")"
+  run_summary "${probe}"
+  [ "${run_status}" -eq 2 ] ||
+    fail "a non-SARIF document ${not_sarif} must exit 2, got ${run_status}"
+  require_text "${run_output}" 'not a SARIF document' \
+    "a non-SARIF document ${not_sarif} must name the reason"
+done
 
 # ---------------------------------------------------------------------------
 # Findings are grouped by control, counted, and ordered by count descending.
@@ -254,6 +272,56 @@ require_text "${workflow_body}" "- 'scripts/summarize-sarif-findings.sh'" \
   'the script under test must be in the k8s path filter'
 
 # ---------------------------------------------------------------------------
+# A result may name its rule by ruleIndex instead of ruleId.
+#
+# SARIF allows either. Grouping on .ruleId alone buckets every such result under
+# "<no rule id>" and discards the rule metadata, so two distinct controls report
+# as one unknown one — an under-report dressed as a finding. The index is scoped
+# to its OWN run, so it must be resolved per run, not against a concatenated
+# rule list.
+# ---------------------------------------------------------------------------
+rule_index_sarif="$(write_sarif rule-index.sarif '{
+  "runs": [
+    {
+      "tool": { "driver": { "rules": [
+        { "id": "C-0001", "shortDescription": { "text": "first" },
+          "defaultConfiguration": { "level": "warning" } },
+        { "id": "C-0002", "shortDescription": { "text": "second" },
+          "defaultConfiguration": { "level": "error" } }
+      ] } },
+      "results": [ { "ruleIndex": 0 }, { "ruleIndex": 1 }, { "ruleIndex": 1 } ]
+    }
+  ]
+}')"
+run_summary "${rule_index_sarif}"
+[ "${run_status}" -eq 0 ] || fail "a ruleIndex SARIF must exit 0, got ${run_status}"
+require_text "${run_output}" 'Kubescape: 3 finding(s) across 2 control(s).' \
+  'ruleIndex results must resolve to distinct controls, not collapse into one'
+require_text "${run_output}" 'C-0002  error  second  — 2 finding(s)' \
+  'a ruleIndex-identified control must carry its resolved level and description'
+require_text "${run_output}" 'C-0001  warning  first  — 1 finding(s)' \
+  'every ruleIndex-identified control must be reported'
+
+# An out-of-range ruleIndex is a miss, not a wrong attribution: jq indexes
+# backwards from -1, so an unguarded lookup would silently label the finding
+# with the LAST rule in the table.
+bad_index_sarif="$(write_sarif bad-index.sarif '{
+  "runs": [
+    {
+      "tool": { "driver": { "rules": [ { "id": "C-0001" }, { "id": "C-0002" } ] } },
+      "results": [ { "ruleIndex": -1 }, { "ruleIndex": 99 } ]
+    }
+  ]
+}')"
+run_summary "${bad_index_sarif}"
+[ "${run_status}" -eq 0 ] || fail "an out-of-range ruleIndex must not abort, got ${run_status}"
+require_text "${run_output}" '<no rule id>' \
+  'an out-of-range ruleIndex must report as unidentified rather than mis-attributed'
+if grep -Fq 'C-0002' <<<"${run_output}"; then
+  fail 'an out-of-range ruleIndex must not be attributed to a real control'
+fi
+
+# ---------------------------------------------------------------------------
 # The summary must read the PRE-NORMALIZATION scan output, on BOTH paths.
 #
 # normalize-sarif-paths.sh drops results with an empty artifactLocation.uri —
@@ -287,6 +355,22 @@ for wf_name in ci validate-main; do
   reject_normalized="$(grep -F 'summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.sarif"' <<<"${body}" || true)"
   [ -z "${reject_normalized}" ] ||
     fail "${wf_name}.yaml must not summarize the normalized SARIF (found: ${reject_normalized})"
+
+  # The summary's gate must be the raw copy's existence, NOT the normalizer's
+  # success. Gating it on `sarif=ready` skips the summary exactly when an
+  # unresolvable path aborts normalization — the moment the findings are most
+  # worth reading.
+  require_text "${body}" "steps.normalize-sarif.outputs.raw == 'ready'" \
+    "${wf_name}.yaml must gate the summary on the raw copy, not on normalization succeeding"
+
+  # And `raw=ready` must be emitted BEFORE the normalizer runs, or the abort
+  # takes the output with it and the gate above can never be true.
+  raw_line="$(grep -nF 'echo "raw=ready"' <<<"${body}" | head -1 | cut -d: -f1)"
+  norm_line="$(grep -nF 'bash scripts/normalize-sarif-paths.sh' <<<"${body}" | head -1 | cut -d: -f1)"
+  [ -n "${raw_line}" ] && [ -n "${norm_line}" ] ||
+    fail "${wf_name}.yaml must both emit raw=ready and call the normalizer"
+  [ "${raw_line}" -lt "${norm_line}" ] ||
+    fail "${wf_name}.yaml must emit raw=ready BEFORE the normalizer (raw at ${raw_line}, normalizer at ${norm_line})"
 done
 
 # The differential that makes the split load-bearing: the normalizer really does

--- a/scripts/tests/test-summarize-sarif-findings.sh
+++ b/scripts/tests/test-summarize-sarif-findings.sh
@@ -54,11 +54,28 @@ write_sarif() {
   printf '%s' "${path}"
 }
 
+# Under Actions, GITHUB_STEP_SUMMARY is set for every step and inherited by child
+# processes — so an unguarded fixture run appends its output to the REAL job
+# summary. That is not cosmetic here: the fixtures print lines like
+# "Kubescape: 4 finding(s) across 2 control(s)", which are indistinguishable from
+# the genuine scan's report on the same run page. A test for a findings reporter
+# must not publish fabricated findings.
+#
+# This file therefore points the ambient variable at a sentinel that must stay
+# EMPTY, and every fixture run below clears the variable for the child. The
+# single case that exercises the step-summary output sets its own path
+# explicitly. The sentinel is asserted empty at the end, so the isolation is
+# proven rather than assumed.
+ambient_summary="${work_dir}/ambient-step-summary.md"
+readonly ambient_summary
+: >"${ambient_summary}"
+export GITHUB_STEP_SUMMARY="${ambient_summary}"
+
 # Runs the script under test, capturing combined output and exit status without
 # tripping `set -e`. Sets the globals `run_output` and `run_status`.
 run_summary() {
   run_status=0
-  run_output="$(bash "${script}" "$@" 2>&1)" || run_status=$?
+  run_output="$(env -u GITHUB_STEP_SUMMARY bash "${script}" "$@" 2>&1)" || run_status=$?
 }
 
 # The 1-based line number of the first line matching $2 in $1, or empty.
@@ -469,5 +486,20 @@ require_text "${run_output}" 'Kubescape: 2 finding(s) across 2 control(s).' \
   'the summary over the RAW scan output must keep the locationless finding'
 require_text "${run_output}" 'C-0002' \
   'the locationless control must be named in the report, not just counted'
+
+# ---------------------------------------------------------------------------
+# Nothing above may have written to the ambient step summary.
+#
+# Asserted last so it covers every case in the file. Under Actions this sentinel
+# stands in for the real job summary, so a failure here means the suite would
+# have published fixture output — fabricated Kubescape findings — onto the run
+# page of the very PR that adds trustworthy findings reporting.
+# ---------------------------------------------------------------------------
+ambient_bytes="$(wc -c <"${ambient_summary}" | tr -d ' ')"
+[ "${ambient_bytes}" -eq 0 ] || {
+  printf 'FAIL: the fixtures wrote %s bytes to the ambient GITHUB_STEP_SUMMARY\n--- leaked ---\n%s\n---\n' \
+    "${ambient_bytes}" "$(head -20 "${ambient_summary}")" >&2
+  exit 1
+}
 
 printf 'PASS: %s\n' "${BASH_SOURCE[0]##*/}"

--- a/scripts/tests/test-summarize-sarif-findings.sh
+++ b/scripts/tests/test-summarize-sarif-findings.sh
@@ -322,6 +322,64 @@ if grep -Fq 'C-0002' <<<"${run_output}"; then
 fi
 
 # ---------------------------------------------------------------------------
+# Two runs may define the SAME rule id with different metadata.
+#
+# A rule table flattened across runs cannot represent that: `from_entries` keeps
+# the last definition of a duplicate key, so every finding for that id would be
+# reported with the last run's level and description — a confident, wrong
+# attribution rather than a visible gap. Resolution is per run for the same
+# reason ruleIndex is.
+# ---------------------------------------------------------------------------
+conflicting_runs_sarif="$(write_sarif conflicting-runs.sarif '{
+  "runs": [
+    {
+      "tool": { "driver": { "rules": [ { "id": "C-0001",
+        "shortDescription": { "text": "first-run-text" },
+        "defaultConfiguration": { "level": "error" } } ] } },
+      "results": [ { "ruleId": "C-0001" } ]
+    },
+    {
+      "tool": { "driver": { "rules": [ { "id": "C-0001",
+        "shortDescription": { "text": "second-run-text" },
+        "defaultConfiguration": { "level": "note" } } ] } },
+      "results": [ { "ruleId": "C-0001" } ]
+    }
+  ]
+}')"
+run_summary "${conflicting_runs_sarif}"
+[ "${run_status}" -eq 0 ] || fail "conflicting run metadata must not abort, got ${run_status}"
+require_text "${run_output}" 'Kubescape: 2 finding(s) across 2 control(s).' \
+  'runs disagreeing about a rule must report separately, not collapse onto the last definition'
+require_text "${run_output}" 'C-0001  error  first-run-text' \
+  "the first run's finding must keep the first run's metadata"
+require_text "${run_output}" 'C-0001  note  second-run-text' \
+  "the second run's finding must keep the second run's metadata"
+
+# The other half of that rule: runs that AGREE must still merge, or the fix
+# above would fragment every ordinary multi-run report.
+agreeing_runs_sarif="$(write_sarif agreeing-runs.sarif '{
+  "runs": [
+    {
+      "tool": { "driver": { "rules": [ { "id": "C-0009",
+        "shortDescription": { "text": "same-text" },
+        "defaultConfiguration": { "level": "error" } } ] } },
+      "results": [ { "ruleId": "C-0009" } ]
+    },
+    {
+      "tool": { "driver": { "rules": [ { "id": "C-0009",
+        "shortDescription": { "text": "same-text" },
+        "defaultConfiguration": { "level": "error" } } ] } },
+      "results": [ { "ruleId": "C-0009" } ]
+    }
+  ]
+}')"
+run_summary "${agreeing_runs_sarif}"
+require_text "${run_output}" 'Kubescape: 2 finding(s) across 1 control(s).' \
+  'runs agreeing about a rule must still merge into one control'
+require_text "${run_output}" 'C-0009  error  same-text  — 2 finding(s)' \
+  'a merged control must carry the shared metadata and the combined count'
+
+# ---------------------------------------------------------------------------
 # The summary must read the PRE-NORMALIZATION scan output, on BOTH paths.
 #
 # normalize-sarif-paths.sh drops results with an empty artifactLocation.uri —

--- a/scripts/tests/test-summarize-sarif-findings.sh
+++ b/scripts/tests/test-summarize-sarif-findings.sh
@@ -253,4 +253,79 @@ require_text "${workflow_body}" "- 'scripts/tests/test-summarize-sarif-findings.
 require_text "${workflow_body}" "- 'scripts/summarize-sarif-findings.sh'" \
   'the script under test must be in the k8s path filter'
 
+# ---------------------------------------------------------------------------
+# The summary must read the PRE-NORMALIZATION scan output, on BOTH paths.
+#
+# normalize-sarif-paths.sh drops results with an empty artifactLocation.uri —
+# correct for Code Scanning, which cannot anchor an alert without a file, and
+# wrong for a report whose entire purpose is that no finding goes unmentioned.
+# Summarizing the normalized file would silently under-report exactly the
+# cluster-level controls that have no manifest behind them.
+#
+# ci.yaml scans on pull_request only, so validate-main.yaml is the sole
+# push-to-main scan; a summary missing there leaves the log/alert contradiction
+# standing on the one path nobody opens a PR to read.
+# ---------------------------------------------------------------------------
+validate_main_workflow="${root_dir}/.github/workflows/validate-main.yaml"
+validate_main_body="$(cat "${validate_main_workflow}")"
+
+for wf_name in ci validate-main; do
+  case "${wf_name}" in
+    ci) body="${workflow_body}" ;;
+    *) body="${validate_main_body}" ;;
+  esac
+  # SC2016 is the point here, not a mistake: these are literal YAML fragments to
+  # find in the workflow, where `${RUNNER_TEMP}` is expanded by Actions at run
+  # time. Expanding it in this shell would search for the runner's path instead.
+  # shellcheck disable=SC2016
+  require_text "${body}" 'cp "${RUNNER_TEMP}/kubescape.sarif" "${RUNNER_TEMP}/kubescape.raw.sarif"' \
+    "${wf_name}.yaml must copy the scan output before normalization"
+  # shellcheck disable=SC2016
+  require_text "${body}" 'bash scripts/summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.raw.sarif"' \
+    "${wf_name}.yaml must summarize the raw copy, not the normalized file"
+  # shellcheck disable=SC2016
+  reject_normalized="$(grep -F 'summarize-sarif-findings.sh "${RUNNER_TEMP}/kubescape.sarif"' <<<"${body}" || true)"
+  [ -z "${reject_normalized}" ] ||
+    fail "${wf_name}.yaml must not summarize the normalized SARIF (found: ${reject_normalized})"
+done
+
+# The differential that makes the split load-bearing: the normalizer really does
+# drop a locationless finding, and the summary really does keep it. If either
+# half stops being true, the two-file dance above is cargo cult and should go.
+locationless='{
+  "runs": [
+    {
+      "tool": { "driver": { "rules": [ { "id": "C-0002" }, { "id": "C-0009" } ] } },
+      "results": [
+        { "ruleId": "C-0009",
+          "locations": [ { "physicalLocation": { "artifactLocation": { "uri": "k8s/app.yaml" } } } ] },
+        { "ruleId": "C-0002",
+          "locations": [ { "physicalLocation": { "artifactLocation": { "uri": "" } } } ] }
+      ]
+    }
+  ]
+}'
+raw_fixture="$(write_sarif raw-locationless.sarif "${locationless}")"
+normalized_fixture="${work_dir}/normalized-locationless.sarif"
+cp "${raw_fixture}" "${normalized_fixture}"
+
+# Give the normalizer a tree its one real uri resolves against.
+mkdir -p "${work_dir}/tree/k8s"
+: >"${work_dir}/tree/k8s/app.yaml"
+norm_status=0
+bash "${root_dir}/scripts/normalize-sarif-paths.sh" "${normalized_fixture}" k8s "${work_dir}/tree" \
+  >/dev/null 2>&1 || norm_status=$?
+[ "${norm_status}" -eq 0 ] ||
+  fail "the normalizer must accept this fixture, got exit ${norm_status}"
+
+run_summary "${normalized_fixture}"
+require_text "${run_output}" 'Kubescape: 1 finding(s) across 1 control(s).' \
+  'PRECONDITION: the normalizer must drop the locationless finding (if this fails, the raw copy is no longer needed)'
+
+run_summary "${raw_fixture}"
+require_text "${run_output}" 'Kubescape: 2 finding(s) across 2 control(s).' \
+  'the summary over the RAW scan output must keep the locationless finding'
+require_text "${run_output}" 'C-0002' \
+  'the locationless control must be named in the report, not just counted'
+
 printf 'PASS: %s\n' "${BASH_SOURCE[0]##*/}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Kubescape's console table shows only part of what it finds. Measured on this repository: a scan whose SARIF carried 4 findings printed `All controls passed. No issues found`, and one carrying 70 findings listed a single control. Since those findings are now uploaded as Code Scanning alerts, the CI log and the Security tab actively contradict each other — and the log is what a developer reads on a PR.

## What

Reports the findings from the SARIF the scan already produces, so the log and the alerts cannot disagree. Covers pull requests and pushes to `main` (the latter is the only default-branch scan). Purely informational — the compliance threshold stays the sole merge gate, and a summary that cannot be built annotates rather than blocking a merge.

Fixes #2846
Part of #2451
