### PR TITLE
test(ci): pin the prod publication ordering so evidence precedes release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,14 @@ jobs:
           go test ./scripts/validate-dr-signing
           go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml
 
+      # The deploy path's counterpart to the DR signing contract above: that one
+      # pins that DR signs at all, this pins that no step advances what
+      # production can see before the evidence exists.
+      - name: 🔏 Validate publication ordering
+        run: |
+          go test ./scripts/validate-publication-order
+          go run ./scripts/validate-publication-order .github/actions/deploy-prod/action.yml
+
       - name: 🔍 Filter paths
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/devantler-tech/platform
 go 1.25.12
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require mvdan.cc/sh/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,16 @@
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+mvdan.cc/sh/v3 v3.13.1 h1:DP3TfgZhDkT7lerUdnp6PTGKyxxzz6T+cOlY/xEvfWk=
+mvdan.cc/sh/v3 v3.13.1/go.mod h1:lXJ8SexMvEVcHCoDvAGLZgFJ9Wsm2sulmoNEXGhYZD0=

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -1732,6 +1732,13 @@ func mustNotSkipIndependently(steps []step, m marker, idx []int, releaseIdx []in
 // evidence step while reading as if it required success. The spellings that are genuinely safe —
 // `success()` alone, or `success() && <expr>` — are exactly the ones the implicit gate already
 // provides, so rejecting them costs nothing: the remedy is to drop the call and keep `<expr>`.
+//
+// The entries are lowercase and the condition is lowercased before matching, so a case variant
+// (`ALWAYS()`, `Always()`) is caught too. That holds under either reading of GitHub's expression
+// parser: if function names resolve case-insensitively then a case variant is a working bypass and
+// has to be rejected; if they do not, it is not a spelling any legitimate condition uses, so
+// rejecting it costs nothing. Matching only the lowercase spelling is the one choice that is wrong
+// in the dangerous direction.
 var statusChecks = []string{"always(", "failure(", "cancelled(", "success("}
 
 // mustNotReleaseAfterFailure rejects a release whose condition survives a failed evidence step.
@@ -1748,9 +1755,10 @@ var statusChecks = []string{"always(", "failure(", "cancelled(", "success("}
 func mustNotReleaseAfterFailure(steps []step, releaseIdx []int) error {
 	for _, at := range releaseIdx {
 		condition := strings.TrimSpace(steps[at].If)
+		normalized := strings.ToLower(strings.ReplaceAll(condition, " ", ""))
 
 		for _, check := range statusChecks {
-			if !strings.Contains(strings.ReplaceAll(condition, " ", ""), check) {
+			if !strings.Contains(normalized, check) {
 				continue
 			}
 

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -176,6 +176,20 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 
 		cmd := newExecutedCommand(run, call)
 
+		// An unconditional `exit` or `exec` at the top level ends this shell, so nothing written
+		// after it runs at all. Continuing to scan credited a later `cosign sign` as executed even
+		// though control never reached it: the step still exits zero, the digest output is already
+		// exported, and both attestations plus reconciliation advance over an artifact that was
+		// never signed. Stop here rather than skipping the statement — every subsequent command is
+		// equally unreachable.
+		//
+		// Only the unconditional top-level form terminates. A negated or backgrounded one was
+		// already skipped above, and one nested inside an if/loop/function is not reached by this
+		// walk, which iterates top-level statements only.
+		if terminatesShell(cmd) {
+			break
+		}
+
 		// `set` changes how the shell treats a later failure, so it has to be tracked as state
 		// rather than matched as a shape. Applied before the errexit test so `set -e` enables
 		// itself, which is what makes an explicit re-enable after `set +e` work.
@@ -293,6 +307,40 @@ func declaredFunctions(file *syntax.File) map[string]bool {
 // A `set` whose flags are not statically known (`set "${OPTS}"`) yields "errexit off", the
 // conservative direction: the guard then cannot prove any later operation gates the step, and says
 // so, rather than assuming the safe case.
+// terminatesShell reports whether a command ends this shell, so nothing written after it executes.
+//
+// `exit` returns from the script and `exec <cmd>` replaces the shell image, and in both cases every
+// later top-level statement is unreachable. Crediting those statements as executed was a bypass with
+// a clean-looking step: `digest=${DIGEST} >> "$GITHUB_OUTPUT"; exit 0; cosign sign …` exports the
+// correct digest, exits zero, and satisfied a scan that then recorded the unreachable `cosign sign`
+// as having run — so the attestations covered the right digest while the artifact was released
+// unsigned.
+//
+// `exec` with NO command is deliberately excluded: that form only applies redirections to the
+// current shell and execution continues past it, so treating it as terminating would blind the guard
+// to everything after an ordinary `exec >log`.
+//
+// The wrapper prefix is stripped first, because `builtin exit 0` and `command exec …` terminate
+// exactly as the bare forms do. An unreadable command word yields no termination, which keeps this
+// from swallowing the rest of a script the guard cannot actually read.
+func terminatesShell(cmd executedCommand) bool {
+	start, executes := commandStart(cmd.lits, cmd.litOK)
+	if !executes || start >= len(cmd.lits) || !cmd.litOK[start] {
+		return false
+	}
+
+	switch cmd.lits[start] {
+	case "exit":
+		return true
+	case "exec":
+		// Only a form that names a program replaces the shell; a bare `exec` (or one carrying just
+		// redirections, which contribute no words) leaves execution to continue.
+		return len(cmd.lits)-start > 1
+	default:
+		return false
+	}
+}
+
 func errexitToggle(cmd executedCommand) (bool, bool) {
 	// `builtin set +e` and `command set +e` run `set` exactly as a bare `set` does, so the wrapper
 	// must be stripped before the name is compared. Reading only the first word credited errexit as
@@ -443,6 +491,22 @@ func assignmentsTo(run, name string) []assignment {
 			if declaresNamerefTo(typed, name) {
 				out = append(out, assignment{text: "", consumesPublishedTag: false})
 			}
+
+		// A `for`/`select` clause BINDS its loop variable, and bash leaves the final value in scope
+		// after the loop ends. `for REF in <stale-reference>; do :; done` therefore overwrites REF as
+		// surely as an assignment does, but the parser models the binding as a WordIter rather than
+		// an Assign or a DeclClause, so neither collector above saw it: the validator read only the
+		// one correct assignment while cosign signed the stale value the loop left behind.
+		//
+		// Recorded as an unprovable write, like a builtin destination. The loop's last value depends
+		// on the word list and on whether the body runs at all, so there is no single text this could
+		// honestly attribute — and both consumers require EVERY assignment to qualify, so an opaque
+		// entry makes the guard report that it cannot prove this rather than guess.
+		case *syntax.ForClause:
+			if iter, isWordIter := typed.Loop.(*syntax.WordIter); isWordIter &&
+				iter.Name != nil && iter.Name.Value == name {
+				out = append(out, assignment{text: "", consumesPublishedTag: false})
+			}
 		}
 
 		return true
@@ -587,6 +651,14 @@ func commandStart(lits []string, litOK []bool) (int, bool) {
 		switch lits[i] {
 		case "builtin":
 			i++
+
+			// `builtin -- set +e` runs `set` exactly as `builtin set +e` does. Advancing only past
+			// the wrapper left `--` standing as the apparent command name, so `set` was never
+			// recognised and errexit stayed tracked as enabled across a step that had disabled it.
+			// `command` already skipped its terminator below; this is the same rule for `builtin`.
+			if i < len(lits) && litOK[i] && lits[i] == "--" {
+				i++
+			}
 		case "command":
 			i++
 
@@ -684,11 +756,11 @@ func printfWritesTo(args []*syntax.Word, name string) bool {
 
 			target, targetReadable := literalOf(args[i+1])
 
-			return !targetReadable || target == name
+			return !targetReadable || namerefBase(target) == name
 		}
 
 		if strings.HasPrefix(word, "-v") && len(word) > 2 {
-			return word[2:] == name
+			return namerefBase(word[2:]) == name
 		}
 	}
 
@@ -722,7 +794,7 @@ func readLikeWritesTo(args []*syntax.Word, name, valueOpts string) bool {
 			// `read -a NAME` names its destination in the option's own argument.
 			if word == "-a" && i+1 < len(args) {
 				target, targetReadable := literalOf(args[i+1])
-				if !targetReadable || target == name {
+				if !targetReadable || namerefBase(target) == name {
 					return true
 				}
 			}
@@ -744,7 +816,7 @@ func operandWritesTo(args []*syntax.Word, name string, skip int) bool {
 		}
 
 		word, readable := literalOf(arg)
-		if !readable || word == name {
+		if !readable || namerefBase(word) == name {
 			return true
 		}
 	}

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -51,6 +51,9 @@ type step struct {
 	// and action reference together still leave the subject free, and an attestation of the wrong
 	// subject is evidence that looks complete and covers nothing this run published.
 	With map[string]string `yaml:"with"`
+	// Env is read because two of its names change the shell BEFORE the run block's first line, so a
+	// step can shadow a required command without the script containing anything unusual.
+	Env map[string]string `yaml:"env"`
 }
 
 type action struct {
@@ -237,6 +240,144 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 // any rebinding of a required name as disqualifying is the conservative direction and matches how
 // functions are already handled: the remedy, given in the error message, is to name the wrapper
 // something else.
+// unmodeledShellState reports a construct that changes how the shell RESOLVES a command or
+// PROPAGATES its failure and that this guard does not interpret, naming it for the error message.
+//
+// This is the state axis of the rule executedCommand already applies to the grammar axis. That one
+// asks the parser what RUNS instead of enumerating the ways a line can fail to run; this one bounds
+// what can change the MEANING of what runs. The guard models a fixed set — errexit, aliases, shell
+// functions, namerefs — and previously skipped every other construct, so each unmodeled one was a
+// silent bypass rather than a failure: `hash -p /usr/bin/true cosign` rebinds the lookup,
+// `trap 'exit 0' ERR` swallows the failure, `set -n` stops execution entirely, and `source`/`eval`
+// run text this file never sees. Each was reported separately, and the list did not end.
+//
+// So the direction is inverted: a construct is allowed here only because it has been reasoned about,
+// and anything else fails closed with its name in the message. The remedy is always the same —
+// express the step without it, or extend the model deliberately.
+//
+// The walk DESCENDS into nested constructs, unlike the top-level statement iteration that decides
+// which commands run. The two questions differ: a command nested in a conditional may never execute,
+// but a block, loop or branch body runs in the CURRENT shell, so `{ trap 'exit 0' ERR; }` changes
+// exactly as much state as the bare form does. Depth is what this walk must not stop at.
+func unmodeledShellState(file *syntax.File) (string, bool) {
+	found := ""
+
+	syntax.Walk(file, func(node syntax.Node) bool {
+		if found != "" {
+			return false
+		}
+
+		if assign, isAssign := node.(*syntax.Assign); isAssign && assign.Name != nil {
+			// PATH decides where every unqualified name resolves, and BASH_ENV/ENV name a file the
+			// shell reads before the script. None of the three is interpreted here.
+			switch assign.Name.Value {
+			case "PATH", "BASH_ENV", "ENV":
+				found = "an assignment to " + assign.Name.Value
+
+				return false
+			}
+		}
+
+		call, isCall := node.(*syntax.CallExpr)
+		if !isCall || len(call.Args) == 0 {
+			return true
+		}
+
+		lits, litOK := wordsOf(call.Args)
+
+		start, executes := commandStart(lits, litOK)
+		if !executes || start >= len(lits) || !litOK[start] {
+			return true
+		}
+
+		switch name := lits[start]; name {
+		case "hash", "trap", "shopt", "enable", "unalias", "eval", "source", ".":
+			found = "`" + name + "`"
+
+			return false
+		case "bash", "sh", "dash", "ksh", "zsh":
+			// An interpreter given inline code runs text this file never parses, exactly as `eval`
+			// does. One naming a SCRIPT is ordinary and is resolved through by scriptTarget.
+			for _, arg := range lits[start+1:] {
+				if strings.HasPrefix(arg, "-") && strings.Contains(arg, "c") {
+					found = "`" + name + " " + arg + "`"
+
+					return false
+				}
+			}
+		case "set":
+			if opt, ok := unmodeledSetOption(lits[start+1:], litOK[start+1:]); ok {
+				found = "`set " + opt + "`"
+
+				return false
+			}
+		}
+
+		return true
+	})
+
+	return found, found != ""
+}
+
+// unmodeledSetOption reports a `set` option outside the modeled set.
+//
+// `set` is the one builtin here that must stay usable — the real signing block opens with
+// `set -euo pipefail` — so it is filtered by option rather than rejected outright. Only the options
+// this guard reasons about are accepted: errexit is tracked, and nounset/xtrace/pipefail cannot
+// affect whether a command runs or what it resolves to. Everything else fails closed, which is what
+// catches `-n` (read commands without executing them) and `-t` (exit after one command) without
+// having to know in advance that those two were the dangerous ones.
+func unmodeledSetOption(lits []string, litOK []bool) (string, bool) {
+	const modeledFlags = "eux"
+
+	modeledLong := map[string]bool{
+		"errexit": true, "nounset": true, "xtrace": true, "pipefail": true,
+	}
+
+	for i := 0; i < len(lits); i++ {
+		if !litOK[i] {
+			return "", false
+		}
+
+		word := lits[i]
+
+		// `--` and `-` end option parsing; every later word is a positional parameter.
+		if word == "--" || word == "-" {
+			return "", false
+		}
+
+		if !strings.HasPrefix(word, "-") && !strings.HasPrefix(word, "+") {
+			// A non-option word is a positional parameter, not a mode change.
+			return "", false
+		}
+
+		flags := word[1:]
+
+		// `o` takes the NEXT word as its long option name, and it may be bundled — `set -euo pipefail`
+		// is `-e -u -o pipefail`. Only a trailing `o` consumes the argument; `set -o` with nothing
+		// after it lists the options rather than setting one.
+		if strings.HasSuffix(flags, "o") {
+			flags = flags[:len(flags)-1]
+
+			if i+1 < len(lits) {
+				if !litOK[i+1] || !modeledLong[lits[i+1]] {
+					return word + " " + lits[i+1], true
+				}
+
+				i++
+			}
+		}
+
+		for _, flag := range flags {
+			if !strings.ContainsRune(modeledFlags, flag) {
+				return word, true
+			}
+		}
+	}
+
+	return "", false
+}
+
 func declaredNames(file *syntax.File) map[string]bool {
 	out := declaredFunctions(file)
 
@@ -1012,6 +1153,49 @@ func viaKsail(exec string) bool {
 	return exec == "ksail" || strings.HasSuffix(exec, ".sh")
 }
 
+// interpreters run a script named as their ARGUMENT, so the executable is not what executes.
+var interpreters = map[string]bool{
+	"bash": true, "sh": true, "dash": true, "ksh": true, "zsh": true,
+}
+
+// scriptTarget returns the program a command actually runs, looking through an interpreter, and the
+// index its own arguments start at.
+//
+// `bash ./scripts/run-ksail-prod-with-pull-auth.sh workload push` publishes exactly as the direct
+// invocation does, but the executable reads as `bash`, so a matcher keyed on the executable omitted
+// the operation entirely. That omission is fail-OPEN in the direction that matters most: the extra
+// push it hides is the one this guard exists to reject, since a second publish AFTER the evidence
+// steps releases bytes nothing covers.
+//
+// Only the leading interpreter is stripped, and only when it names a script. An interpreter carrying
+// inline code (`bash -c …`) names no script and runs text this file never parses, so it is rejected
+// by unmodeledShellState rather than guessed at here.
+func scriptTarget(cmd executedCommand) (string, bool, int) {
+	exec, known := cmd.name()
+	if !known {
+		return "", false, 0
+	}
+
+	if !interpreters[exec] {
+		return exec, true, 0
+	}
+
+	// Skip the interpreter's own options to reach the script operand.
+	for i := 1; i < len(cmd.lits); i++ {
+		if !cmd.litOK[i] {
+			return "", false, 0
+		}
+
+		if strings.HasPrefix(cmd.lits[i], "-") {
+			continue
+		}
+
+		return cmd.lits[i], true, i
+	}
+
+	return "", false, 0
+}
+
 // ksailWorkload matches a step that runs `workload <op>` through that wrapper.
 //
 // The executable matters as much as the words: `ksail workload push` and `echo workload push` have
@@ -1020,12 +1204,12 @@ func viaKsail(exec string) bool {
 func ksailWorkload(op string) func(step) bool {
 	return func(s step) bool {
 		for _, cmd := range parseExecuted(s.Run, errexitAtStart(s)) {
-			exec, known := cmd.name()
+			exec, known, from := scriptTarget(cmd)
 			if !known || !viaKsail(exec) {
 				continue
 			}
 
-			for i := 1; i+1 < len(cmd.lits); i++ {
+			for i := from + 1; i+1 < len(cmd.lits); i++ {
 				if cmd.litOK[i] && cmd.lits[i] == "workload" && cmd.litOK[i+1] && cmd.lits[i+1] == op {
 					return true
 				}
@@ -1386,6 +1570,62 @@ func mustNotReleaseAfterFailure(steps []step, releaseIdx []int) error {
 	return nil
 }
 
+// shellStartupEnv are the step-level names that change the shell before the run block's first line.
+//
+// Bash expands BASH_ENV in a non-interactive shell and reads the resulting file before executing the
+// script, so `BASH_ENV: ./setup.sh` with `cosign() { true; }` inside it shadows the required command
+// while the run block stays textually perfect. ENV is the same mechanism under POSIX mode, and
+// SHELLOPTS/BASHOPTS set shell options — including noexec — from outside the script.
+var shellStartupEnv = []string{"BASH_ENV", "ENV", "SHELLOPTS", "BASHOPTS"}
+
+// mustModelEveryRunStep rejects an action carrying a construct this guard cannot interpret.
+//
+// Scope is every run step of the action rather than only the ones matching a marker, because which
+// steps match is itself decided by the analysis this protects: a step made unreadable stops matching,
+// and "no step appears to sign" would then be reported as a missing step rather than as an
+// unreadable one. Both are failures, but only the second names the actual cause.
+func mustModelEveryRunStep(steps []step) error {
+	for i, s := range steps {
+		if s.Run == "" {
+			continue
+		}
+
+		label := s.Name
+		if label == "" {
+			label = fmt.Sprintf("position %d", i+1)
+		}
+
+		for _, name := range shellStartupEnv {
+			if _, set := s.Env[name]; set {
+				return fmt.Errorf(
+					"step %q sets %s, which changes the shell before the step's first line runs.\n"+
+						"Bash reads that file (or applies those options) ahead of the script, so a required"+
+						" command can be shadowed by something this check never sees. Configure the step"+
+						" without it",
+					label, name)
+			}
+		}
+
+		file, err := syntax.NewParser().Parse(strings.NewReader(s.Run), "")
+		if err != nil {
+			continue
+		}
+
+		if construct, unmodeled := unmodeledShellState(file); unmodeled {
+			return fmt.Errorf(
+				"step %q uses %s, which changes how the shell resolves a command or propagates its"+
+					" failure in a way this check does not model.\n"+
+					"That makes both halves of the check unreliable: a required operation can look"+
+					" executed when it was not, and an extra one can go unseen. This is deliberately"+
+					" fail-closed — express the step without that construct, or extend the model in"+
+					" unmodeledShellState deliberately",
+				label, construct)
+		}
+	}
+
+	return nil
+}
+
 func validate(source []byte) error {
 	var parsed action
 	if err := yaml.Unmarshal(source, &parsed); err != nil {
@@ -1395,6 +1635,14 @@ func validate(source []byte) error {
 	steps := parsed.Runs.Steps
 	if len(steps) == 0 {
 		return errors.New("no runs.steps; this does not look like a composite action")
+	}
+
+	// Established before any ordering question, because an unmodeled state change makes every later
+	// answer unreliable in BOTH directions: a required operation can be credited when it never ran,
+	// and an extra one can go unseen. Reporting it as an error rather than as "this step matches
+	// nothing" is what keeps the second half from failing open.
+	if err := mustModelEveryRunStep(steps); err != nil {
+		return err
 	}
 
 	locate := func(m marker) ([]int, error) {

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -343,32 +343,61 @@ func valueResolvedFrom(word *syntax.Word, name string) bool {
 // Cosign and both attestations then cover that constant in full while the tag this run published
 // ships unsigned — a bypass with a GREEN result, which is the worst shape a security guard can have.
 //
-// It recurses to any depth WITHIN that statement rather than demanding a bare call, because a
-// pipeline, a retry loop, a subshell or a redirection around the resolver is ordinary correct code
-// and the output still terminates in the digest. That is the deliberate split: the accepted SHAPE is
-// narrowed to one statement, and the freedom inside it is kept — narrowing what is accepted, rather
-// than enumerating what is forbidden, which is what left this guard bypassable for five rounds.
+// The accepted shape is ENUMERATED rather than searched. Recursing through every nested call was
+// still too loose: a branch that never runs is part of the last statement, so
+//
+//	DIGEST="$( if false; then crane digest "${REF_TAG}"; else printf '%s' 'sha256:…'; fi )"
+//
+// contained a consuming call while bash returned the constant. Anything whose output depends on
+// which branch or iteration executes cannot be bound without evaluating it, so it is rejected
+// outright — that is the conservative direction, and it is what makes this terminal instead of one
+// more round.
+//
+// A pipeline stays accepted because it has no branches: every stage runs, and the first stage is the
+// one that reads the tag and produces the data the rest transforms. A retry belongs around the
+// ASSIGNMENT (`for … do DIGEST=$(…) && break; done`), which is unaffected — assignmentsTo already
+// finds it at any depth — so the idiomatic spelling still passes.
 func consumes(stmt *syntax.Stmt, name string) bool {
-	found := false
+	stages, simple := pipelineStages(stmt.Cmd)
+	if !simple || len(stages) == 0 {
+		return false
+	}
 
-	syntax.Walk(stmt, func(node syntax.Node) bool {
-		call, isCall := node.(*syntax.CallExpr)
-		if !isCall {
-			return !found
+	// The first stage is the resolver; later stages only reshape what it emitted.
+	for _, arg := range stages[0].Args {
+		if expands(arg, name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// pipelineStages flattens a plain command or a pipeline of plain commands into its stages, in order.
+//
+// simple is false for every other construct — `if`, `for`, `while`, `case`, a subshell, a block, a
+// function body, and the `&&`/`||` operators — because each of those can produce its output from a
+// command that did not run, which is precisely the gap consumes exists to close.
+func pipelineStages(cmd syntax.Command) (stages []*syntax.CallExpr, simple bool) {
+	switch typed := cmd.(type) {
+	case *syntax.CallExpr:
+		return []*syntax.CallExpr{typed}, true
+	case *syntax.BinaryCmd:
+		if typed.Op != syntax.Pipe && typed.Op != syntax.PipeAll {
+			return nil, false
 		}
 
-		for _, arg := range call.Args {
-			if expands(arg, name) {
-				found = true
+		left, leftOK := pipelineStages(typed.X.Cmd)
+		right, rightOK := pipelineStages(typed.Y.Cmd)
 
-				return false
-			}
+		if !leftOK || !rightOK {
+			return nil, false
 		}
 
-		return !found
-	})
-
-	return found
+		return append(left, right...), true
+	default:
+		return nil, false
+	}
 }
 
 // expands reports whether a word contains a parameter expansion of name.

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -311,12 +311,8 @@ func sourceOf(src string, from, to syntax.Pos) string {
 // spelling it has no stake in: `$REF_TAG` is the same expansion, and rejecting it would fail correct
 // code.
 //
-// BOUNDARY, stated rather than implied: this proves the published tag is CONSUMED by a command the
-// resolution runs. It does not prove that command's output is what the substitution returns — that
-// is dataflow through the shell, not a property of the syntax, so a command given the tag and then
-// discarded (`: "${REF_TAG}"; printf '%s' 'sha256:…'`) satisfies this check. Chasing that with
-// another shape rule is what made this guard a blocklist five rounds running; the structural
-// boundary is deliberate, and closing it needs reachability analysis rather than a sixth pattern.
+// The tag must be read by the statement whose output BECOMES the value, not merely by something
+// somewhere inside the substitution — see consumes for why that distinction is load-bearing.
 func valueResolvedFrom(word *syntax.Word, name string) bool {
 	resolved := false
 
@@ -326,30 +322,53 @@ func valueResolvedFrom(word *syntax.Word, name string) bool {
 			return !resolved
 		}
 
-		// Any depth inside the substitution: a pipeline, a subshell, a loop or a redirection around
-		// the resolution is ordinary scripting, and the expansion still reaches the program that
-		// resolves the digest.
-		syntax.Walk(subst, func(inner syntax.Node) bool {
-			call, isCall := inner.(*syntax.CallExpr)
-			if !isCall {
-				return !resolved
-			}
-
-			for _, arg := range call.Args {
-				if expands(arg, name) {
-					resolved = true
-
-					return false
-				}
-			}
-
-			return !resolved
-		})
+		if len(subst.Stmts) > 0 && consumes(subst.Stmts[len(subst.Stmts)-1], name) {
+			resolved = true
+		}
 
 		return !resolved
 	})
 
 	return resolved
+}
+
+// consumes reports whether the statement whose output becomes the substitution's value reads name.
+//
+// Scoping this to the LAST statement is what ties the resolution to the RESULT. Accepting the tag
+// anywhere inside the substitution let a no-op consume it while a later command printed the value
+// that actually became the digest:
+//
+//	DIGEST="$( : "${REF_TAG}"; printf '%s' 'sha256:…' )"
+//
+// Cosign and both attestations then cover that constant in full while the tag this run published
+// ships unsigned — a bypass with a GREEN result, which is the worst shape a security guard can have.
+//
+// It recurses to any depth WITHIN that statement rather than demanding a bare call, because a
+// pipeline, a retry loop, a subshell or a redirection around the resolver is ordinary correct code
+// and the output still terminates in the digest. That is the deliberate split: the accepted SHAPE is
+// narrowed to one statement, and the freedom inside it is kept — narrowing what is accepted, rather
+// than enumerating what is forbidden, which is what left this guard bypassable for five rounds.
+func consumes(stmt *syntax.Stmt, name string) bool {
+	found := false
+
+	syntax.Walk(stmt, func(node syntax.Node) bool {
+		call, isCall := node.(*syntax.CallExpr)
+		if !isCall {
+			return !found
+		}
+
+		for _, arg := range call.Args {
+			if expands(arg, name) {
+				found = true
+
+				return false
+			}
+		}
+
+		return !found
+	})
+
+	return found
 }
 
 // expands reports whether a word contains a parameter expansion of name.

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -107,6 +107,7 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 	}
 
 	out := make([]executedCommand, 0, len(file.Stmts))
+	shadowed := declaredFunctions(file)
 
 	for _, stmt := range file.Stmts {
 		call, isCall := stmt.Cmd.(*syntax.CallExpr)
@@ -138,8 +139,41 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 			continue
 		}
 
+		// ...and name resolution says the words actually reach the program they name. Bash looks up
+		// functions before PATH, so `cosign() { true; }` turns the required invocation into a no-op
+		// that is otherwise indistinguishable from the real thing.
+		if len(cmd.words) > 0 && shadowed[cmd.words[0]] {
+			continue
+		}
+
 		out = append(out, cmd)
 	}
+
+	return out
+}
+
+// declaredFunctions returns every name the script defines as a shell function.
+//
+// This is a third axis, after "does it run" (grammar) and "does its failure matter" (errexit): what
+// the words actually resolve to. Bash looks up functions before PATH, so a script can define
+// `cosign() { true; }` and then issue a textually perfect, failure-propagating, top-level
+// `cosign sign … "${REF}"` that produces no signature.
+//
+// The whole script is searched rather than the statements before the call, and a declaration nested
+// inside a conditional counts too. Deciding whether a nested declaration executed is the reachability
+// analysis this guard deliberately does not attempt, so it fails closed: a required operation whose
+// name is defined as a function anywhere in the same block is not provably the real program. The
+// remedy is in the error message — name the wrapper something else, or invoke the real command.
+func declaredFunctions(file *syntax.File) map[string]bool {
+	out := map[string]bool{}
+
+	syntax.Walk(file, func(node syntax.Node) bool {
+		if decl, isDecl := node.(*syntax.FuncDecl); isDecl && decl.Name != nil {
+			out[decl.Name.Value] = true
+		}
+
+		return true
+	})
 
 	return out
 }
@@ -495,8 +529,14 @@ func validate(source []byte) error {
 		if len(at) == 0 {
 			return nil, fmt.Errorf(
 				"no step appears to %s.\n"+
-					"If that step was renamed, this check follows what a step does rather than what it is called — "+
-					"restore the command or action it matches on, or update the marker here deliberately",
+					"This check follows what a step does rather than what it is called, so it also reports"+
+					" a command that is present but will not take effect. Check, in order: the command or"+
+					" action it matches on is still there; it runs unconditionally at the top level (not"+
+					" inside `if`/`&&`/`||`/a pipeline/a function body/a here-document);"+
+					" its failure can still fail the step (no `set +e`, no trailing `|| true`, no `&`,"+
+					" and `shell: bash`); and its name is not shadowed by a shell function defined in the"+
+					" same step, which bash resolves before PATH.\n"+
+					"If the step was genuinely renamed or restructured, update the marker here deliberately",
 				m.label)
 		}
 

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -160,25 +160,55 @@ func executable(run string) string {
 // match is not itself the command being run.
 var commandPrefix = regexp.MustCompile(`^\s*[A-Za-z0-9_./-]*\s*$`)
 
-// isPlainCommand reports whether substr occurs on line as part of a plain top-level command.
+// carriedBy reports whether a given executable may carry a required operation. The empty string
+// means the operation began the line, i.e. the matched text names the executable itself.
+type carriedBy func(exec string) bool
+
+// directly accepts only a line that starts with the operation, for matches that already name their
+// own executable (`cosign sign`).
+func directly(exec string) bool { return exec == "" }
+
+// viaKsail accepts the authenticated wrapper the composite publishes through. `workload push` is a
+// SUBCOMMAND, so it is legitimately preceded by a command — the real step runs
+// `./scripts/run-ksail-prod-with-pull-auth.sh workload push` — which is why the prefix cannot simply
+// be banned the way it can for cosign. It is restricted to ksail or a script rather than pinned to
+// one path, so renaming the wrapper stays a legal refactor.
+func viaKsail(exec string) bool {
+	return exec == "ksail" || strings.HasSuffix(exec, ".sh")
+}
+
+// isInvocation reports whether substr occurs on line as a plain top-level command carried by an
+// executable ok accepts.
 //
-// This inverts the question the earlier versions asked. Enumerating the ways an invocation can fail
-// to run — a comment, a step condition, a block, `&&`, `||`, a pipeline, a string literal, a command
-// substitution, an uninvoked function — is a list that keeps growing, and each omission is a silent
-// bypass. Requiring the match to BE a command closes the class instead of another instance of it.
-func isPlainCommand(line, substr string) bool {
+// The plain-command half inverts the question earlier versions asked. Enumerating the ways an
+// invocation can fail to run — a comment, a step condition, a block, `&&`, `||`, a pipeline, a
+// string literal, a command substitution, an uninvoked function — is a list that keeps growing, and
+// each omission is a silent bypass. Requiring the match to BE a command closes that class.
+//
+// The executable half closes what remained: being a command is not enough when the match is only
+// part of one. Allowing any plain word in front accepted `echo cosign sign --yes "${REF}"`, which
+// bash merely prints. That distinction is not syntactic — `ksail workload push` and
+// `echo workload push` have identical shape — so the rule has to know which executable each
+// operation actually belongs to rather than reasoning about the line alone.
+func isInvocation(line, substr string, ok carriedBy) bool {
 	idx := strings.Index(line, substr)
 	if idx < 0 {
 		return false
 	}
 
-	return commandPrefix.MatchString(line[:idx])
+	prefix := line[:idx]
+	if !commandPrefix.MatchString(prefix) {
+		return false
+	}
+
+	return ok(strings.TrimSpace(prefix))
 }
 
-// containsCommand reports whether any executable line of run invokes substr as a plain command.
-func containsCommand(run, substr string) bool {
+// containsCommand reports whether any executable line of run invokes substr as a plain command
+// carried by an accepted executable.
+func containsCommand(run, substr string, ok carriedBy) bool {
 	for _, line := range strings.Split(executable(run), "\n") {
-		if isPlainCommand(line, substr) {
+		if isInvocation(line, substr, ok) {
 			return true
 		}
 	}
@@ -186,8 +216,8 @@ func containsCommand(run, substr string) bool {
 	return false
 }
 
-func runContains(substr string) func(step) bool {
-	return func(s step) bool { return containsCommand(s.Run, substr) }
+func runContains(substr string, ok carriedBy) func(step) bool {
+	return func(s step) bool { return containsCommand(s.Run, substr, ok) }
 }
 
 func usesPrefix(prefix string) func(step) bool {
@@ -205,12 +235,12 @@ func usesPrefix(prefix string) func(step) bool {
 var (
 	// publish makes new bytes reachable and must come first — signing or
 	// attesting before it would cover the previous artifact.
-	publish = marker{"publish the manifests (`workload push`)", runContains("workload push")}
+	publish = marker{"publish the manifests (`workload push`)", runContains("workload push", viaKsail)}
 
 	// sign is named separately because its step is inspected again below, for
 	// the digest reference. Locating it by value rather than by matching its
 	// label keeps that second lookup correct when the wording changes.
-	sign = marker{"sign the published digest (`cosign sign`)", runContains("cosign sign ")}
+	sign = marker{"sign the published digest (`cosign sign`)", runContains("cosign sign ", directly)}
 
 	// evidence is what must exist before production may look. Order among
 	// these is unconstrained.
@@ -221,7 +251,7 @@ var (
 	}
 
 	// release is the step that advances what production can see.
-	release = marker{"tell Flux to reconcile (`workload reconcile`)", runContains("workload reconcile")}
+	release = marker{"tell Flux to reconcile (`workload reconcile`)", runContains("workload reconcile", viaKsail)}
 )
 
 // digestRef is the form the signing step must use. Signing the mutable tag
@@ -260,7 +290,7 @@ func signsTheResolvedDigest(run string) bool {
 	signed := false
 
 	for _, line := range strings.Split(executable(run), "\n") {
-		if !isPlainCommand(line, "cosign sign ") {
+		if !isInvocation(line, "cosign sign ", directly) {
 			continue
 		}
 

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -38,6 +38,9 @@ type step struct {
 	ID   string `yaml:"id"`
 	Uses string `yaml:"uses"`
 	Run  string `yaml:"run"`
+	// If is read because ordering is positional: a step keeps its position while carrying a
+	// condition that never fires, so the sequence can be satisfied by steps that do not run.
+	If string `yaml:"if"`
 }
 
 type action struct {
@@ -57,8 +60,33 @@ type marker struct {
 	match func(step) bool
 }
 
+// executable drops comment-only lines from a shell script before it is matched.
+//
+// Every matcher here works on raw script text, so without this a `#` in front of the invocation
+// satisfies them all: the comment still contains the command AND the reference. The deploy would
+// publish and reconcile an artifact nothing signed while this check stayed green — a guard that a
+// single character disables is not a guard.
+//
+// Only whole-line comments are removed. A trailing `#` is left alone deliberately: deciding whether
+// one opens a comment or sits inside a string literal needs a shell parser, and guessing wrong would
+// silently drop a real invocation.
+func executable(run string) string {
+	lines := strings.Split(run, "\n")
+	kept := make([]string, 0, len(lines))
+
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+
+		kept = append(kept, line)
+	}
+
+	return strings.Join(kept, "\n")
+}
+
 func runContains(substr string) func(step) bool {
-	return func(s step) bool { return strings.Contains(s.Run, substr) }
+	return func(s step) bool { return strings.Contains(executable(s.Run), substr) }
 }
 
 func usesPrefix(prefix string) func(step) bool {
@@ -128,7 +156,7 @@ const signRefArg = `"${REF}"`
 // signsTheResolvedDigest reports whether every cosign invocation in run signs
 // the reference built from the resolved digest.
 func signsTheResolvedDigest(run string) bool {
-	for _, line := range strings.Split(run, "\n") {
+	for _, line := range strings.Split(executable(run), "\n") {
 		if !strings.Contains(line, "cosign sign ") {
 			continue
 		}
@@ -139,6 +167,29 @@ func signsTheResolvedDigest(run string) bool {
 	}
 
 	return true
+}
+
+// mustNotSkipIndependently rejects a required step whose condition lets it be skipped while the
+// release still runs. releaseIdx[0] is the binding release for ordering, so its condition is the one
+// a required step must share to stand or fall with it.
+func mustNotSkipIndependently(steps []step, m marker, idx []int, releaseIdx []int) error {
+	releaseIf := strings.TrimSpace(steps[releaseIdx[0]].If)
+
+	for _, at := range idx {
+		stepIf := strings.TrimSpace(steps[at].If)
+		if stepIf == "" || stepIf == releaseIf {
+			continue
+		}
+
+		return fmt.Errorf(
+			"the step that must %s carries `if: %s`, which does not match the release step's"+
+				" condition (%q), so it can be skipped while the release still runs.\n"+
+				"GitHub skips a false-conditioned step without failing the composite, so the ordering"+
+				" above would still hold while production is released without that evidence",
+			m.label, stepIf, releaseIf)
+	}
+
+	return nil
 }
 
 func validate(source []byte) error {
@@ -209,6 +260,28 @@ func validate(source []byte) error {
 		}
 	}
 
+	// Ordering is positional, so a step satisfies every comparison while carrying a condition that
+	// never fires. GitHub then skips it WITHOUT failing the composite and runs the unconditional
+	// release anyway, publishing without evidence the sequence claims is there.
+	//
+	// The test is not "may it have a condition" but "may it skip while the release still runs". A
+	// step guarded by the SAME condition as the release stands or falls with it, so that stays legal;
+	// anything else can vanish on its own.
+	if err := mustNotSkipIndependently(steps, publish, publishAt, releaseAt); err != nil {
+		return err
+	}
+
+	for _, m := range evidence {
+		at, err := locate(m)
+		if err != nil {
+			return err
+		}
+
+		if err := mustNotSkipIndependently(steps, m, at, releaseAt); err != nil {
+			return err
+		}
+	}
+
 	// sign is in evidence, so the loop above has already proved it resolves.
 	signAt, err := locate(sign)
 	if err != nil {
@@ -216,7 +289,7 @@ func validate(source []byte) error {
 	}
 
 	for _, at := range signAt {
-		if !strings.Contains(steps[at].Run, digestRef) {
+		if !strings.Contains(executable(steps[at].Run), digestRef) {
 			return fmt.Errorf(
 				"the signing step must build its reference from the resolved digest (%s); "+
 					"signing the mutable tag lets a concurrent deploy move it between resolve and sign",

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -105,11 +105,31 @@ func executable(run string) string {
 	kept := make([]string, 0, len(lines))
 	depth := 0
 
+	var heredocs []string
+
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
+
+		// A here-document body is INPUT to a command, not a sequence of commands. Without this the
+		// body reads as ordinary top-level lines, so `: <<'X'` followed by the real invocation
+		// satisfies every rule while bash only feeds those words to `:`. Checked before the comment
+		// and block logic because a body line may itself look like `#`, `}` or `fi`, and letting one
+		// close a block would mis-track nesting for every line after it.
+		if len(heredocs) > 0 {
+			if trimmed == heredocs[0] {
+				heredocs = heredocs[1:]
+			}
+
+			continue
+		}
+
 		if strings.HasPrefix(trimmed, "#") {
 			continue
 		}
+
+		// Registered before this line is classified, so a redirection on a line that also opens a
+		// block still hides its body. The opener itself stays a candidate: it is a real command.
+		heredocs = append(heredocs, heredocDelimiters(line)...)
 
 		word := firstWord(trimmed)
 		opens := slices.Contains(opensBlock, word)
@@ -153,6 +173,31 @@ func executable(run string) string {
 	}
 
 	return strings.Join(kept, "\n")
+}
+
+// heredocOpener matches a here-document redirection and captures its delimiter, quoted or bare.
+//
+// A here-STRING (`<<<`) is deliberately not matched: its operand is a value on the same line rather
+// than a body, so treating it as an opener would swallow every following line until something
+// happened to equal it. The bare form requires an identifier start, which also keeps an arithmetic
+// shift such as `$((1 << 2))` from registering a delimiter.
+var heredocOpener = regexp.MustCompile(`<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+
+// heredocDelimiters returns the delimiters a line opens, in the order bash will close them.
+func heredocDelimiters(line string) []string {
+	var out []string
+
+	for _, match := range heredocOpener.FindAllStringSubmatch(line, -1) {
+		for _, group := range match[1:] {
+			if group != "" {
+				out = append(out, group)
+
+				break
+			}
+		}
+	}
+
+	return out
 }
 
 // commandPrefix is what may precede a required match on its line: whitespace and at most a plain

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -47,6 +47,10 @@ type step struct {
 	// If is read because ordering is positional: a step keeps its position while carrying a
 	// condition that never fires, so the sequence can be satisfied by steps that do not run.
 	If string `yaml:"if"`
+	// With carries an action's inputs, which is where an attestation says WHAT it attests. Position
+	// and action reference together still leave the subject free, and an attestation of the wrong
+	// subject is evidence that looks complete and covers nothing this run published.
+	With map[string]string `yaml:"with"`
 }
 
 type action struct {
@@ -64,6 +68,11 @@ type marker struct {
 	label string
 	// match reports whether a step is this one.
 	match func(step) bool
+	// hint replaces the generic "why did my step stop matching" guidance when this marker needs
+	// different advice. The default text is about shell commands, which is useless for a step that
+	// runs no shell: an attestation stops matching because of its INPUTS, and being told to check
+	// for `set +e` sends the reader looking in the wrong place entirely.
+	hint string
 }
 
 // executedCommand is one command the shell will actually run, reduced to what the markers ask
@@ -84,6 +93,49 @@ type executedCommand struct {
 	// words is argv as written in the source, quoting included, so an argument can be compared
 	// against the exact form the contract requires (`"${REF}"`) rather than against its expansion.
 	words []string
+	// lits is argv after QUOTE REMOVAL, for the questions that are about what bash will do rather
+	// than about how the contract is spelled. The two differ, and reading the source form for a
+	// shell decision is a bypass: `set '+e'` disables errexit, because bash strips the quotes before
+	// interpreting the word, while the source form `'+e'` matches no flag pattern at all.
+	//
+	// A word whose value is not statically known — it expands a parameter or runs a substitution —
+	// has no entry here, which is what litOK records. Callers must fail closed on that rather than
+	// silently comparing against an empty string.
+	lits  []string
+	litOK []bool
+}
+
+// literalOf returns a word's value after quote removal, and whether that value is static.
+//
+// Single quotes, double quotes and backslash escapes all disappear before bash interprets a word, so
+// `+e`, `'+e'`, `"+e"` and `\+e` are the same argument. Anything whose value depends on the
+// environment — a parameter expansion, a command substitution, arithmetic — is NOT static, and is
+// reported as such so a caller can refuse to guess.
+func literalOf(w *syntax.Word) (string, bool) {
+	var sb strings.Builder
+
+	for _, part := range w.Parts {
+		switch p := part.(type) {
+		case *syntax.SglQuoted:
+			sb.WriteString(p.Value)
+		case *syntax.Lit:
+			// A backslash escape survives into Lit.Value; bash removes it.
+			sb.WriteString(strings.ReplaceAll(p.Value, "\\", ""))
+		case *syntax.DblQuoted:
+			for _, inner := range p.Parts {
+				lit, isLit := inner.(*syntax.Lit)
+				if !isLit {
+					return "", false
+				}
+
+				sb.WriteString(lit.Value)
+			}
+		default:
+			return "", false
+		}
+	}
+
+	return sb.String(), true
 }
 
 // assignment is one variable assignment, kept with enough provenance to tell a resolved value from a
@@ -108,7 +160,7 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 	}
 
 	out := make([]executedCommand, 0, len(file.Stmts))
-	shadowed := declaredFunctions(file)
+	shadowed := declaredNames(file)
 
 	for _, stmt := range file.Stmts {
 		call, isCall := stmt.Cmd.(*syntax.CallExpr)
@@ -127,7 +179,7 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 		// `set` changes how the shell treats a later failure, so it has to be tracked as state
 		// rather than matched as a shape. Applied before the errexit test so `set -e` enables
 		// itself, which is what makes an explicit re-enable after `set +e` work.
-		if toggled, ok := errexitToggle(cmd.words); ok {
+		if toggled, ok := errexitToggle(cmd); ok {
 			errexit = toggled
 
 			continue
@@ -141,14 +193,63 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 		}
 
 		// ...and name resolution says the words actually reach the program they name. Bash looks up
-		// functions before PATH, so `cosign() { true; }` turns the required invocation into a no-op
-		// that is otherwise indistinguishable from the real thing.
-		if len(cmd.words) > 0 && shadowed[cmd.words[0]] {
+		// aliases, then functions, before PATH, so either `cosign() { true; }` or
+		// `alias cosign=true` turns the required invocation into a no-op that is otherwise
+		// indistinguishable from the real thing.
+		//
+		// A command whose executable is not statically known (`"${SIGNER}" sign …`) cannot be proved
+		// to reach the real program either, so it does not count as one.
+		exec, known := cmd.name()
+		if !known || shadowed[exec] {
 			continue
 		}
 
 		out = append(out, cmd)
 	}
+
+	return out
+}
+
+// declaredNames returns every name the script rebinds ahead of PATH — as a function or as an alias.
+//
+// Bash resolves an alias first, a function next, and only then searches PATH, so both rebindings
+// have the same consequence for this guard: the words of a required operation stop reaching the
+// program they name. `alias cosign=true` combined with `shopt -s expand_aliases` (which a run block
+// may set, and which the parser does not apply) expands a textually perfect, failure-propagating,
+// top-level `cosign sign … "${REF}"` to `true`, producing no signature.
+//
+// Aliases expand at READ time rather than at execution time, so an alias defined and used inside the
+// same compound command does not take effect — but that distinction is not worth encoding. Treating
+// any rebinding of a required name as disqualifying is the conservative direction and matches how
+// functions are already handled: the remedy, given in the error message, is to name the wrapper
+// something else.
+func declaredNames(file *syntax.File) map[string]bool {
+	out := declaredFunctions(file)
+
+	syntax.Walk(file, func(node syntax.Node) bool {
+		call, isCall := node.(*syntax.CallExpr)
+		if !isCall || len(call.Args) < 2 {
+			return true
+		}
+
+		if name, ok := literalOf(call.Args[0]); !ok || name != "alias" {
+			return true
+		}
+
+		for _, arg := range call.Args[1:] {
+			definition, ok := literalOf(arg)
+			if !ok {
+				continue
+			}
+
+			// `alias -p` lists aliases rather than defining one; only a NAME=VALUE word binds.
+			if name, _, isBinding := strings.Cut(definition, "="); isBinding && name != "" {
+				out[name] = true
+			}
+		}
+
+		return true
+	})
 
 	return out
 }
@@ -183,22 +284,38 @@ func declaredFunctions(file *syntax.File) map[string]bool {
 //
 // Both spellings count (`set -e` / `set -o errexit`), in either direction, and a combined form such
 // as `set -euo pipefail` carries the flag among others.
-func errexitToggle(words []string) (bool, bool) {
-	if len(words) < 2 || words[0] != "set" {
+//
+// The words are read AFTER quote removal, because that is the form bash interprets. `set '+e'`,
+// `set "+e"` and `set \+e` all disable errexit exactly as `set +e` does, while their source spellings
+// match no flag pattern — so comparing source text here silently left errexit tracked as enabled and
+// accepted a required operation whose failure could no longer fail the step.
+//
+// A `set` whose flags are not statically known (`set "${OPTS}"`) yields "errexit off", the
+// conservative direction: the guard then cannot prove any later operation gates the step, and says
+// so, rather than assuming the safe case.
+func errexitToggle(cmd executedCommand) (bool, bool) {
+	exec, known := cmd.name()
+	if !known || exec != "set" || len(cmd.lits) < 2 {
 		return false, false
+	}
+
+	for i := 1; i < len(cmd.lits); i++ {
+		if !cmd.litOK[i] {
+			return false, true
+		}
 	}
 
 	state, found := false, false
 
-	for i := 1; i < len(words); i++ {
-		word := words[i]
+	for i := 1; i < len(cmd.lits); i++ {
+		word := cmd.lits[i]
 
 		switch {
 		case strings.HasPrefix(word, "-") && !strings.HasPrefix(word, "--") && strings.Contains(word, "e"):
 			state, found = true, true
 		case strings.HasPrefix(word, "+") && strings.Contains(word, "e"):
 			state, found = false, true
-		case (word == "-o" || word == "+o") && i+1 < len(words) && words[i+1] == "errexit":
+		case (word == "-o" || word == "+o") && i+1 < len(cmd.lits) && cmd.lits[i+1] == "errexit":
 			state, found = word == "-o", true
 			i++
 		}
@@ -218,13 +335,34 @@ func errexitAtStart(s step) bool {
 }
 
 func newExecutedCommand(src string, call *syntax.CallExpr) executedCommand {
-	cmd := executedCommand{words: make([]string, 0, len(call.Args))}
+	cmd := executedCommand{
+		words: make([]string, 0, len(call.Args)),
+		lits:  make([]string, 0, len(call.Args)),
+		litOK: make([]bool, 0, len(call.Args)),
+	}
 
 	for _, arg := range call.Args {
 		cmd.words = append(cmd.words, sourceOf(src, arg.Pos(), arg.End()))
+
+		lit, ok := literalOf(arg)
+		cmd.lits = append(cmd.lits, lit)
+		cmd.litOK = append(cmd.litOK, ok)
 	}
 
 	return cmd
+}
+
+// name returns the command's executable as bash resolves it, after quote removal.
+//
+// Reading the source form here would let `'cosign' sign …` — a perfectly ordinary invocation of the
+// real program — fail to match, which is the over-tightening direction of the same defect that makes
+// `set '+e'` slip through.
+func (c executedCommand) name() (string, bool) {
+	if len(c.lits) == 0 || !c.litOK[0] {
+		return "", false
+	}
+
+	return c.lits[0], true
 }
 
 // assignmentsTo returns every assignment to name anywhere in run, at any nesting depth.
@@ -368,17 +506,52 @@ func valueResolvedFrom(word *syntax.Word, name string) bool {
 // assignmentsTo finds it at any depth, so the idiomatic spelling still passes.
 func consumes(stmt *syntax.Stmt, name string) bool {
 	call, isCall := stmt.Cmd.(*syntax.CallExpr)
-	if !isCall {
+	if !isCall || len(call.Args) == 0 {
 		return false
 	}
 
-	for _, arg := range call.Args {
+	// Taking the tag as an argument does not mean the output depends on it. `printf` accepts extra
+	// arguments and ignores every one of them when the format string carries no conversion, so
+	//
+	//	DIGEST=$(printf 'sha256:<old-digest>' "${REF_TAG}")
+	//
+	// is a single direct call that reads the published tag and returns a constant — the same bypass
+	// as the pipeline and the untaken branch, in the one shape that survived narrowing the
+	// STRUCTURE. Structure alone cannot distinguish them: what separates a resolver from `printf` is
+	// what the program does, not how the call is written.
+	//
+	// So the executable is pinned to the small set whose documented contract is "resolve a reference
+	// to a digest". This is an allowlist and it is deliberately not exhaustive — a tool missing from
+	// it fails loudly with the list in the message, which is a one-line, reviewed edit. The
+	// alternative direction, rejecting known no-ops, has been tried on this predicate five times and
+	// each round found another one.
+	exec, known := literalOf(call.Args[0])
+	if !known || !digestResolvers[exec] {
+		return false
+	}
+
+	for _, arg := range call.Args[1:] {
 		if expands(arg, name) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// digestResolvers are the executables accepted as resolving a reference to a digest.
+//
+// Membership is about the program's contract, not about which one this repo happens to use: the
+// deploy runs `docker buildx imagetools inspect`, and switching to crane, skopeo, oras, regctl or
+// cosign is a legitimate refactor that must not fail CI. What is excluded is everything whose output
+// is unrelated to its arguments — `printf`, `echo`, `cat`, `true` — which is the whole bypass.
+var digestResolvers = map[string]bool{
+	"cosign": true,
+	"crane":  true,
+	"docker": true,
+	"oras":   true,
+	"regctl": true,
+	"skopeo": true,
 }
 
 // expands reports whether a word contains a parameter expansion of name.
@@ -418,12 +591,13 @@ func viaKsail(exec string) bool {
 func ksailWorkload(op string) func(step) bool {
 	return func(s step) bool {
 		for _, cmd := range parseExecuted(s.Run, errexitAtStart(s)) {
-			if len(cmd.words) == 0 || !viaKsail(cmd.words[0]) {
+			exec, known := cmd.name()
+			if !known || !viaKsail(exec) {
 				continue
 			}
 
-			for i := 1; i+1 < len(cmd.words); i++ {
-				if cmd.words[i] == "workload" && cmd.words[i+1] == op {
+			for i := 1; i+1 < len(cmd.lits); i++ {
+				if cmd.litOK[i] && cmd.lits[i] == "workload" && cmd.litOK[i+1] && cmd.lits[i+1] == op {
 					return true
 				}
 			}
@@ -438,12 +612,69 @@ func cosignSignCommands(s step) []executedCommand {
 	var out []executedCommand
 
 	for _, cmd := range parseExecuted(s.Run, errexitAtStart(s)) {
-		if len(cmd.words) >= 2 && cmd.words[0] == "cosign" && cmd.words[1] == "sign" {
+		exec, known := cmd.name()
+		if known && exec == "cosign" && len(cmd.lits) >= 2 && cmd.lits[1] == "sign" {
 			out = append(out, cmd)
 		}
 	}
 
 	return out
+}
+
+// signFlags are the options `cosign sign` may carry here, as an ALLOWLIST.
+//
+// Cosign has options that make a successful, correctly-referenced signing command publish nothing:
+// `--upload=false` generates the signature and never writes it to the registry, so the invocation
+// contains the exact required reference, exits zero, and leaves the artifact unsigned. Rejecting
+// that one flag would be a blocklist over an interface this repo does not control — the next option
+// with the same effect arrives with the next cosign release and is silently accepted.
+//
+// So the accepted set is enumerated instead: the two flags the deploy actually uses. An unfamiliar
+// flag fails with the list in the message, which is a deliberate, reviewed one-line edit here rather
+// than a silent change in what the evidence means.
+var signFlags = map[string]bool{
+	"--yes":       true,
+	"-y":          true,
+	"--recursive": true,
+	"-r":          true,
+}
+
+// unexpectedSignFlag returns the first option in the invocation that is not on the allowlist.
+//
+// The reference argument is exempt: it is required to be `"${REF}"` and is asserted separately, and
+// it is the one word here that is legitimately not statically known.
+//
+// Any OTHER word whose value is not statically known is reported, because a word that expands at run
+// time can supply an option this allowlist would otherwise reject — `cosign sign ${EXTRA} "${REF}"`
+// must not be a way around the list. A literal positional is left alone; it is not an option, and
+// cosign's own argument handling is not this guard's business.
+func unexpectedSignFlag(cmd executedCommand) (string, bool) {
+	// Skip the executable and the `sign` subcommand.
+	for i := 2; i < len(cmd.lits); i++ {
+		if cmd.words[i] == signRefArg {
+			continue
+		}
+
+		if !cmd.litOK[i] {
+			return cmd.words[i], true
+		}
+
+		word := cmd.lits[i]
+		if !strings.HasPrefix(word, "-") {
+			continue
+		}
+
+		// `--flag=value` and `--flag` are the same option.
+		if name, _, hasValue := strings.Cut(word, "="); hasValue {
+			word = name
+		}
+
+		if !signFlags[word] {
+			return word, true
+		}
+	}
+
+	return "", false
 }
 
 func runsCosignSign(s step) bool {
@@ -465,24 +696,77 @@ func usesPrefix(prefix string) func(step) bool {
 var (
 	// publish makes new bytes reachable and must come first — signing or
 	// attesting before it would cover the previous artifact.
-	publish = marker{"publish the manifests (`workload push`)", ksailWorkload("push")}
+	publish = marker{label: "publish the manifests (`workload push`)", match: ksailWorkload("push")}
 
 	// sign is named separately because its step is inspected again below, for
 	// the digest reference. Locating it by value rather than by matching its
 	// label keeps that second lookup correct when the wording changes.
-	sign = marker{"sign the published digest (`cosign sign`)", runsCosignSign}
-
-	// evidence is what must exist before production may look. Order among
-	// these is unconstrained.
-	evidence = []marker{
-		sign,
-		{"attest the SBOM (`actions/attest`)", usesPrefix("actions/attest@")},
-		{"attest build provenance (`actions/attest-build-provenance`)", usesPrefix("actions/attest-build-provenance@")},
-	}
+	sign = marker{label: "sign the published digest (`cosign sign`)", match: runsCosignSign}
 
 	// release is the step that advances what production can see.
-	release = marker{"tell Flux to reconcile (`workload reconcile`)", ksailWorkload("reconcile")}
+	release = marker{label: "tell Flux to reconcile (`workload reconcile`)", match: ksailWorkload("reconcile")}
 )
+
+// evidenceMarkers is what must exist before production may look. Order among these is unconstrained.
+//
+// The attestation markers are built from the signing step's id rather than declared as constants,
+// because what makes an attestation evidence is that its subject is the digest THIS run resolved and
+// signed. Pinning the subject to a literal would break the moment the step is renamed; binding it to
+// the signing step's output keeps the two moving together.
+func evidenceMarkers(signStepID string) []marker {
+	coversSubject := attestsSignedDigest(signStepID)
+
+	attests := func(label, prefix string) marker {
+		return marker{
+			label: label,
+			match: func(s step) bool { return usesPrefix(prefix)(s) && coversSubject(s) },
+			hint: fmt.Sprintf(
+				"This step is matched on its action reference AND on what it attests, because the"+
+					" reference alone does not say which artifact the evidence covers. Check that it"+
+					" still uses `%s…`, that `subject-digest` is `${{ steps.%s.outputs.digest }}`"+
+					" (the digest this run resolved and signed — a literal or an older digest"+
+					" produces real evidence about the wrong artifact), and that"+
+					" `push-to-registry` is `true`, without which the attestation is generated but"+
+					" never reaches the registry",
+				prefix, signStepID),
+		}
+	}
+
+	return []marker{
+		sign,
+		attests("attest the SBOM (`actions/attest`)", "actions/attest@"),
+		attests(
+			"attest build provenance (`actions/attest-build-provenance`)",
+			"actions/attest-build-provenance@",
+		),
+	}
+}
+
+// attestsSignedDigest reports whether an attestation step covers the digest this run resolved and
+// publishes the result where a consumer can find it.
+//
+// The action reference alone says only which program runs. `subject-digest` is a free input, so an
+// attestation step can keep its position, its pinned `uses:`, and its green result while covering an
+// OLDER digest — evidence that is genuine, verifiable, and about the wrong artifact. That is the
+// same failure the DIGEST provenance check exists to prevent, one layer up.
+//
+// `push-to-registry` matters for the same reason `--upload` does on the signature: an attestation
+// that is generated but never pushed leaves the registry with no evidence attached, while the step
+// succeeds.
+//
+// The subject must be bound to the signing step's OUTPUT rather than to any particular text, so
+// renaming the step is a legal refactor as long as the binding follows it.
+func attestsSignedDigest(signStepID string) func(step) bool {
+	wantDigest := fmt.Sprintf("${{ steps.%s.outputs.digest }}", signStepID)
+
+	return func(s step) bool {
+		if strings.TrimSpace(s.With["subject-digest"]) != wantDigest {
+			return false
+		}
+
+		return strings.TrimSpace(s.With["push-to-registry"]) == "true"
+	}
+}
 
 // digestRef is the form the signing step must use. Signing the mutable tag
 // instead would let a concurrent deploy move it between resolve and sign, so
@@ -629,6 +913,50 @@ func mustNotSkipIndependently(steps []step, m marker, idx []int, releaseIdx []in
 	return nil
 }
 
+// statusChecks are the GitHub expression functions that decouple a step from earlier failures.
+//
+// A step's `if:` is implicitly `success() && <expr>` — UNLESS the expression itself calls a status
+// check function, which replaces that default. So `if: github.ref == 'refs/heads/main'` still
+// requires every earlier step to have succeeded, while `if: always()` does not, and neither does
+// `if: !cancelled()`.
+var statusChecks = []string{"always(", "failure(", "cancelled("}
+
+// mustNotReleaseAfterFailure rejects a release whose condition survives a failed evidence step.
+//
+// Every ordering guarantee in this file assumes that a failing signature or attestation stops the
+// deploy before reconciliation. GitHub provides that for free — but only while the release step
+// keeps its implicit `success()`. Add `if: always()` and the sequence still reads correctly, every
+// evidence step still precedes the release, and production is released precisely when the evidence
+// FAILED, which is the one case all of this exists to prevent.
+//
+// The condition is rejected outright rather than compared against the evidence steps' conditions:
+// matching conditions couple the steps' SKIPPING, not their success, so evidence and release both
+// running under `always()` is equally broken.
+func mustNotReleaseAfterFailure(steps []step, releaseIdx []int) error {
+	for _, at := range releaseIdx {
+		condition := strings.TrimSpace(steps[at].If)
+
+		for _, check := range statusChecks {
+			if !strings.Contains(strings.ReplaceAll(condition, " ", ""), check) {
+				continue
+			}
+
+			return fmt.Errorf(
+				"the step that must %s carries `if: %s` at position %d, which calls a status check"+
+					" function and so replaces the implicit `success()` that couples it to the"+
+					" evidence above it.\n"+
+					"GitHub skips the remaining evidence steps when signing or attestation fails, but"+
+					" a release conditioned this way still runs — releasing production at exactly the"+
+					" moment the evidence is known to be missing.\n"+
+					"Gate the release on success instead: drop the condition, or express it without"+
+					" always()/failure()/cancelled()",
+				release.label, condition, at+1)
+		}
+	}
+
+	return nil
+}
+
 func validate(source []byte) error {
 	var parsed action
 	if err := yaml.Unmarshal(source, &parsed); err != nil {
@@ -643,6 +971,10 @@ func validate(source []byte) error {
 	locate := func(m marker) ([]int, error) {
 		at := indicesOf(steps, m)
 		if len(at) == 0 {
+			if m.hint != "" {
+				return nil, fmt.Errorf("no step appears to %s.\n%s", m.label, m.hint)
+			}
+
 			return nil, fmt.Errorf(
 				"no step appears to %s.\n"+
 					"This check follows what a step does rather than what it is called, so it also reports"+
@@ -688,6 +1020,20 @@ func validate(source []byte) error {
 		return err
 	}
 
+	// Every ordering comparison below assumes a failed evidence step stops the deploy. That is
+	// GitHub's default and a condition on the release can remove it, so it is established first —
+	// otherwise the whole sequence can hold while production is released from a failed run.
+	if err := mustNotReleaseAfterFailure(steps, releaseAt); err != nil {
+		return err
+	}
+
+	signAt, err := locate(sign)
+	if err != nil {
+		return err
+	}
+
+	evidence := evidenceMarkers(steps[signAt[0]].ID)
+
 	for _, m := range evidence {
 		at, err := locate(m)
 		if err != nil {
@@ -725,12 +1071,6 @@ func validate(source []byte) error {
 		}
 	}
 
-	// sign is in evidence, so the loop above has already proved it resolves.
-	signAt, err := locate(sign)
-	if err != nil {
-		return err
-	}
-
 	for _, at := range signAt {
 		if !assignsResolvedRef(steps[at].Run) {
 			return fmt.Errorf(
@@ -761,6 +1101,26 @@ func validate(source []byte) error {
 					"the assignment is dead and the signature would cover whatever the mutable tag "+
 					"resolves to at sign time",
 				digestRef, signRefArg)
+		}
+
+		// Checked after the reference contract above, deliberately. Until `"${REF}"` is known to be
+		// present, a stray expansion is more likely to be a wrong reference than a smuggled option,
+		// and reporting it as an unrecognised OPTION would name the wrong defect.
+		for _, cmd := range cosignSignCommands(steps[at]) {
+			flag, unexpected := unexpectedSignFlag(cmd)
+			if !unexpected {
+				continue
+			}
+
+			return fmt.Errorf(
+				"`cosign sign` carries the unrecognised option %q.\n"+
+					"Options are allow-listed here because some of them make a successful signing "+
+					"command publish nothing — `--upload=false` produces the signature and never "+
+					"writes it to the registry, leaving the artifact unsigned while this step and "+
+					"every ordering check pass.\n"+
+					"Accepted today: --yes/-y, --recursive/-r. If this option is intended, add it to "+
+					"signFlags in %s with a note on why it does not affect what reaches the registry",
+				flag, "scripts/validate-publication-order/main.go")
 		}
 	}
 

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -353,51 +353,32 @@ func valueResolvedFrom(word *syntax.Word, name string) bool {
 // outright — that is the conservative direction, and it is what makes this terminal instead of one
 // more round.
 //
-// A pipeline stays accepted because it has no branches: every stage runs, and the first stage is the
-// one that reads the tag and produces the data the rest transforms. A retry belongs around the
-// ASSIGNMENT (`for … do DIGEST=$(…) && break; done`), which is unaffected — assignmentsTo already
-// finds it at any depth — so the idiomatic spelling still passes.
+// A single call is the ONLY construct whose output can be bound without evaluating the script, which
+// is why it is the whole accepted set. Everything else was tried and each admitted a bypass:
+//
+//   - a compound (`if`/`for`/`while`/`case`/subshell/`&&`) emits the output of whichever branch or
+//     iteration ran, so a resolver in an untaken branch satisfied a search while bash returned a
+//     constant;
+//   - a PIPELINE is no better, though it looks it. `crane digest "${REF_TAG}" | printf '%s' 'sha256:…'`
+//     is a pipeline of plain calls whose first stage reads the tag — and `printf` never reads stdin,
+//     so the constant is what becomes DIGEST. "Later stages only reshape the resolver's output" reads
+//     as obviously true and is not a property shell syntax enforces.
+//
+// A retry belongs around the ASSIGNMENT (`for … do DIGEST=$(…) && break; done`), which is unaffected:
+// assignmentsTo finds it at any depth, so the idiomatic spelling still passes.
 func consumes(stmt *syntax.Stmt, name string) bool {
-	stages, simple := pipelineStages(stmt.Cmd)
-	if !simple || len(stages) == 0 {
+	call, isCall := stmt.Cmd.(*syntax.CallExpr)
+	if !isCall {
 		return false
 	}
 
-	// The first stage is the resolver; later stages only reshape what it emitted.
-	for _, arg := range stages[0].Args {
+	for _, arg := range call.Args {
 		if expands(arg, name) {
 			return true
 		}
 	}
 
 	return false
-}
-
-// pipelineStages flattens a plain command or a pipeline of plain commands into its stages, in order.
-//
-// simple is false for every other construct — `if`, `for`, `while`, `case`, a subshell, a block, a
-// function body, and the `&&`/`||` operators — because each of those can produce its output from a
-// command that did not run, which is precisely the gap consumes exists to close.
-func pipelineStages(cmd syntax.Command) (stages []*syntax.CallExpr, simple bool) {
-	switch typed := cmd.(type) {
-	case *syntax.CallExpr:
-		return []*syntax.CallExpr{typed}, true
-	case *syntax.BinaryCmd:
-		if typed.Op != syntax.Pipe && typed.Op != syntax.PipeAll {
-			return nil, false
-		}
-
-		left, leftOK := pipelineStages(typed.X.Cmd)
-		right, rightOK := pipelineStages(typed.Y.Cmd)
-
-		if !leftOK || !rightOK {
-			return nil, false
-		}
-
-		return append(left, right...), true
-	default:
-		return nil, false
-	}
 }
 
 // expands reports whether a word contains a parameter expansion of name.
@@ -760,11 +741,18 @@ func validate(source []byte) error {
 
 		if !resolvesDigestFromPublishedTag(steps[at].Run) {
 			return fmt.Errorf(
-				"the signing step must resolve DIGEST from the tag it just published (a command "+
-					"substitution reading %s); a digest that is written down rather than resolved "+
-					"lets cosign and both attestations cover an older artifact in full while the "+
-					"newly pushed tag is released unsigned",
-				publishedTagRef)
+				"the signing step must resolve DIGEST from the tag it just published; a digest that "+
+					"is written down rather than resolved lets cosign and both attestations cover an "+
+					"older artifact in full while the newly pushed tag is released unsigned.\n"+
+					"Required shape: DIGEST=$(<command> … %s …) — a command substitution whose LAST "+
+					"statement is a single command taking %s as an argument, for example\n"+
+					"  DIGEST=$(docker buildx imagetools inspect \"%s\" --format '{{.Manifest.Digest}}')\n"+
+					"Any tool may resolve it. What is not accepted is a pipeline, an if/for/while/case, "+
+					"a subshell or a && chain as that last statement: each of those can emit a value "+
+					"the tag-reading command never produced, which is the exact substitution this "+
+					"check exists to catch. Retry around the assignment instead "+
+					"(for … do DIGEST=$(…) && break; done), which is supported",
+				publishedTagRef, publishedTagRef, publishedTagRef)
 		}
 
 		if !signsTheResolvedDigest(steps[at]) {

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -1606,9 +1606,17 @@ func mustModelEveryRunStep(steps []step) error {
 			}
 		}
 
+		// A parse failure is the same fail-open shape as an unmodeled construct, for the same reason:
+		// parseExecuted yields no commands, which correctly refuses to CREDIT a required operation but
+		// silently hides a forbidden one. An unparseable step could therefore carry a second
+		// `workload push` after the evidence steps and be reported as satisfying the contract.
 		file, err := syntax.NewParser().Parse(strings.NewReader(s.Run), "")
 		if err != nil {
-			continue
+			return fmt.Errorf(
+				"step %q is not parseable as shell: %w.\n"+
+					"Nothing in it can be checked, including whether it publishes again after the"+
+					" evidence steps, so it is rejected rather than skipped",
+				label, err)
 		}
 
 		if construct, unmodeled := unmodeledShellState(file); unmodeled {

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"unicode"
 
 	"gopkg.in/yaml.v3"
 	"mvdan.cc/sh/v3/syntax"
@@ -1755,7 +1756,17 @@ var statusChecks = []string{"always(", "failure(", "cancelled(", "success("}
 func mustNotReleaseAfterFailure(steps []step, releaseIdx []int) error {
 	for _, at := range releaseIdx {
 		condition := strings.TrimSpace(steps[at].If)
-		normalized := strings.ToLower(strings.ReplaceAll(condition, " ", ""))
+		// Strip EVERY whitespace rune, not just U+0020. A YAML literal block scalar keeps its
+		// newlines verbatim and a double-quoted scalar resolves `\t`, so `always\n()` and
+		// `always\t()` both reach here intact — GitHub evaluates them as calls, while a space-only
+		// strip left them unmatched and released production on failed evidence.
+		normalized := strings.ToLower(strings.Map(func(r rune) rune {
+			if unicode.IsSpace(r) {
+				return -1
+			}
+
+			return r
+		}, condition))
 
 		for _, check := range statusChecks {
 			if !strings.Contains(normalized, check) {

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -243,13 +243,8 @@ func assignmentsTo(run, name string) []assignment {
 
 	var out []assignment
 
-	syntax.Walk(file, func(node syntax.Node) bool {
-		call, isCall := node.(*syntax.CallExpr)
-		if !isCall {
-			return true
-		}
-
-		for _, assign := range call.Assigns {
+	collect := func(assigns []*syntax.Assign) {
+		for _, assign := range assigns {
 			if assign.Name == nil || assign.Value == nil || assign.Name.Value != name {
 				continue
 			}
@@ -258,6 +253,20 @@ func assignmentsTo(run, name string) []assignment {
 				text:        sourceOf(run, assign.Value.Pos(), assign.Value.End()),
 				fromCommand: valueFromCommand(assign.Value),
 			})
+		}
+	}
+
+	syntax.Walk(file, func(node syntax.Node) bool {
+		switch typed := node.(type) {
+		case *syntax.CallExpr:
+			collect(typed.Assigns)
+		// `export`, `declare`, `local`, `readonly` and `typeset` assign too, and the parser models
+		// them as a DeclClause rather than a CallExpr. Reading only CallExpr made
+		// `declare -g DIGEST="sha256:…"` invisible, so a constant could silently override a correct
+		// resolution — and an action that legitimately exported REF would have been rejected for
+		// having no assignment at all.
+		case *syntax.DeclClause:
+			collect(typed.Args)
 		}
 
 		return true
@@ -278,15 +287,24 @@ func sourceOf(src string, from, to syntax.Pos) string {
 	return src[start:end]
 }
 
-// valueFromCommand reports whether any part of a value is a command substitution.
+// valueFromCommand reports whether a value contains a command substitution, at any nesting depth.
+//
+// Depth matters because `DIGEST="$(…)"` wraps the substitution in a *syntax.DblQuoted, so scanning
+// only the word's top-level parts sees a plain quoted string. Quoting a command substitution is
+// BETTER practice than leaving it bare, so a shallow scan rejected the more careful spelling of
+// correct code — the exact way a guard earns itself a suppression.
 func valueFromCommand(word *syntax.Word) bool {
-	for _, part := range word.Parts {
-		if _, ok := part.(*syntax.CmdSubst); ok {
-			return true
-		}
-	}
+	found := false
 
-	return false
+	syntax.Walk(word, func(node syntax.Node) bool {
+		if _, isSubst := node.(*syntax.CmdSubst); isSubst {
+			found = true
+		}
+
+		return !found
+	})
+
+	return found
 }
 
 // viaKsail accepts the authenticated wrapper the composite publishes through. `workload push` is a

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -78,10 +78,15 @@ var (
 	// attesting before it would cover the previous artifact.
 	publish = marker{"publish the manifests (`workload push`)", runContains("workload push")}
 
+	// sign is named separately because its step is inspected again below, for
+	// the digest reference. Locating it by value rather than by matching its
+	// label keeps that second lookup correct when the wording changes.
+	sign = marker{"sign the published digest (`cosign sign`)", runContains("cosign sign ")}
+
 	// evidence is what must exist before production may look. Order among
 	// these is unconstrained.
 	evidence = []marker{
-		{"sign the published digest (`cosign sign`)", runContains("cosign sign ")},
+		sign,
 		{"attest the SBOM (`actions/attest`)", usesPrefix("actions/attest@")},
 		{"attest build provenance (`actions/attest-build-provenance`)", usesPrefix("actions/attest-build-provenance@")},
 	}
@@ -153,8 +158,6 @@ func validate(source []byte) error {
 		return err
 	}
 
-	signAt := -1
-
 	for _, m := range evidence {
 		at, err := locate(m)
 		if err != nil {
@@ -168,10 +171,12 @@ func validate(source []byte) error {
 		if err := mustPrecede(m, at, release, releaseAt); err != nil {
 			return err
 		}
+	}
 
-		if strings.Contains(m.label, "cosign sign") {
-			signAt = at
-		}
+	// sign is in evidence, so the loop above has already proved it resolves.
+	signAt, err := locate(sign)
+	if err != nil {
+		return err
 	}
 
 	if !strings.Contains(steps[signAt].Run, digestRef) {

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -100,15 +100,45 @@ var (
 // the signature would cover bytes this run never published.
 const digestRef = `REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`
 
-// indexOf returns the position of the first step matching m.
-func indexOf(steps []step, m marker) (int, bool) {
+// indicesOf returns the position of EVERY step matching m, in file order.
+//
+// Every occurrence matters, not just the first. A composite that pushes, signs,
+// reconciles and then pushes again satisfies the contract on its first push
+// while republishing bytes nothing signed or attested — so locating one step of
+// each kind and stopping would validate exactly the window this guard exists to
+// close.
+func indicesOf(steps []step, m marker) []int {
+	var at []int
+
 	for i, s := range steps {
 		if m.match(s) {
-			return i, true
+			at = append(at, i)
 		}
 	}
 
-	return 0, false
+	return at
+}
+
+// signRefArg is the argument the cosign invocation must consume. Asserting the
+// assignment of digestRef alone is not enough: a step can resolve the digest
+// into REF and still sign "${REF_TAG}", leaving the assignment dead and the
+// signature covering whatever the mutable tag resolves to at sign time.
+const signRefArg = `"${REF}"`
+
+// signsTheResolvedDigest reports whether every cosign invocation in run signs
+// the reference built from the resolved digest.
+func signsTheResolvedDigest(run string) bool {
+	for _, line := range strings.Split(run, "\n") {
+		if !strings.Contains(line, "cosign sign ") {
+			continue
+		}
+
+		if !strings.Contains(line, signRefArg) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func validate(source []byte) error {
@@ -122,10 +152,10 @@ func validate(source []byte) error {
 		return errors.New("no runs.steps; this does not look like a composite action")
 	}
 
-	locate := func(m marker) (int, error) {
-		at, ok := indexOf(steps, m)
-		if !ok {
-			return 0, fmt.Errorf(
+	locate := func(m marker) ([]int, error) {
+		at := indicesOf(steps, m)
+		if len(at) == 0 {
+			return nil, fmt.Errorf(
 				"no step appears to %s.\n"+
 					"If that step was renamed, this check follows what a step does rather than what it is called — "+
 					"restore the command or action it matches on, or update the marker here deliberately",
@@ -135,7 +165,13 @@ func validate(source []byte) error {
 		return at, nil
 	}
 
-	mustPrecede := func(earlier marker, earlierAt int, later marker, laterAt int) error {
+	// Comparing the LAST occurrence of the earlier kind against the FIRST of the
+	// later kind is what makes this hold across every pair: if even the latest
+	// publish precedes the earliest piece of evidence, all of them do.
+	mustPrecede := func(earlier marker, earlierIdx []int, later marker, laterIdx []int) error {
+		earlierAt := earlierIdx[len(earlierIdx)-1]
+		laterAt := laterIdx[0]
+
 		if earlierAt < laterAt {
 			return nil
 		}
@@ -179,11 +215,21 @@ func validate(source []byte) error {
 		return err
 	}
 
-	if !strings.Contains(steps[signAt].Run, digestRef) {
-		return fmt.Errorf(
-			"the signing step must build its reference from the resolved digest (%s); "+
-				"signing the mutable tag lets a concurrent deploy move it between resolve and sign",
-			digestRef)
+	for _, at := range signAt {
+		if !strings.Contains(steps[at].Run, digestRef) {
+			return fmt.Errorf(
+				"the signing step must build its reference from the resolved digest (%s); "+
+					"signing the mutable tag lets a concurrent deploy move it between resolve and sign",
+				digestRef)
+		}
+
+		if !signsTheResolvedDigest(steps[at].Run) {
+			return fmt.Errorf(
+				"the signing step resolves the digest into %s but does not pass %s to `cosign sign`; "+
+					"the assignment is dead and the signature would cover whatever the mutable tag "+
+					"resolves to at sign time",
+				digestRef, signRefArg)
+		}
 	}
 
 	return nil

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -1551,7 +1551,14 @@ func mustNotSkipIndependently(steps []step, m marker, idx []int, releaseIdx []in
 // check function, which replaces that default. So `if: github.ref == 'refs/heads/main'` still
 // requires every earlier step to have succeeded, while `if: always()` does not, and neither does
 // `if: !cancelled()`.
-var statusChecks = []string{"always(", "failure(", "cancelled("}
+//
+// `success(` is on this list even though it reads as the safe one, because the rule above keys on
+// the CALL, not on which function is called: writing `success()` explicitly replaces the implicit
+// gate just as `always()` does, and `success() || true` is then a release that survives a failed
+// evidence step while reading as if it required success. The spellings that are genuinely safe —
+// `success()` alone, or `success() && <expr>` — are exactly the ones the implicit gate already
+// provides, so rejecting them costs nothing: the remedy is to drop the call and keep `<expr>`.
+var statusChecks = []string{"always(", "failure(", "cancelled(", "success("}
 
 // mustNotReleaseAfterFailure rejects a release whose condition survives a failed evidence step.
 //
@@ -1581,7 +1588,9 @@ func mustNotReleaseAfterFailure(steps []step, releaseIdx []int) error {
 					" a release conditioned this way still runs — releasing production at exactly the"+
 					" moment the evidence is known to be missing.\n"+
 					"Gate the release on success instead: drop the condition, or express it without"+
-					" always()/failure()/cancelled()",
+					" always()/failure()/cancelled()/success() — an explicit success() call is"+
+					" redundant with the implicit gate when it stands alone, so removing it keeps the"+
+					" coupling the release needs",
 				release.label, condition, at+1)
 		}
 	}

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -60,22 +61,76 @@ type marker struct {
 	match func(step) bool
 }
 
-// executable drops comment-only lines from a shell script before it is matched.
+// opensBlock and closesBlock are the shell keywords that make a line conditional on something.
+// Matching the first WORD keeps `iffy=1` or a path ending in `done` from being read as control flow.
+var (
+	opensBlock  = []string{"if", "elif", "else", "while", "until", "for", "case", "then", "do"}
+	closesBlock = []string{"fi", "done", "esac"}
+)
+
+func firstWord(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return ""
+	}
+
+	return strings.TrimSuffix(fields[0], ";")
+}
+
+// executable reduces a shell script to the lines that are matched: whole-line comments are dropped,
+// and so is anything a control-flow construct could stop from running.
 //
-// Every matcher here works on raw script text, so without this a `#` in front of the invocation
-// satisfies them all: the comment still contains the command AND the reference. The deploy would
-// publish and reconcile an artifact nothing signed while this check stayed green — a guard that a
-// single character disables is not a guard.
+// Comments matter because every matcher works on raw text, so a `#` in front of the invocation
+// satisfies them all at once — the comment still contains the command AND the reference. Only
+// whole-line comments are removed; a trailing `#` is left alone, because separating one from a `#`
+// inside a string literal needs a shell parser and guessing wrong would drop a real invocation.
 //
-// Only whole-line comments are removed. A trailing `#` is left alone deliberately: deciding whether
-// one opens a comment or sits inside a string literal needs a shell parser, and guessing wrong would
-// silently drop a real invocation.
+// Nesting matters for the same reason at one remove. A step can carry no `if:`, keep its position,
+// build REF from the resolved digest, and still produce no signature:
+//
+//	if false; then
+//	  cosign sign --yes --recursive "${REF}"
+//	fi
+//
+// Every check above is satisfied while the deploy attests and reconciles an unsigned artifact.
+//
+// This is a deliberately CONSERVATIVE structural check, not a shell parser: it does not decide
+// whether a branch is reachable, it declines to treat anything inside one as an executed command.
+// Required operations on this path are unconditional by design, so rejecting a conditional one is
+// the intended answer rather than a limitation. Control flow around other work in the same step is
+// untouched — only the lines the matchers read are filtered.
 func executable(run string) string {
 	lines := strings.Split(run, "\n")
 	kept := make([]string, 0, len(lines))
+	depth := 0
 
 	for _, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		word := firstWord(trimmed)
+		opens := slices.Contains(opensBlock, word)
+
+		if slices.Contains(closesBlock, word) && depth > 0 {
+			depth--
+
+			continue
+		}
+
+		// A line that OPENS a block is skipped whatever else it carries. That is what catches the
+		// one-line form `if false; then cosign sign ...; fi`, where a depth counter alone would be
+		// back at zero by the end of the line and read it as unnested.
+		if opens {
+			if word == "if" || word == "while" || word == "until" || word == "for" || word == "case" {
+				depth++
+			}
+
+			continue
+		}
+
+		if depth > 0 {
 			continue
 		}
 

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -294,12 +294,17 @@ func declaredFunctions(file *syntax.File) map[string]bool {
 // conservative direction: the guard then cannot prove any later operation gates the step, and says
 // so, rather than assuming the safe case.
 func errexitToggle(cmd executedCommand) (bool, bool) {
-	exec, known := cmd.name()
-	if !known || exec != "set" || len(cmd.lits) < 2 {
+	// `builtin set +e` and `command set +e` run `set` exactly as a bare `set` does, so the wrapper
+	// must be stripped before the name is compared. Reading only the first word credited errexit as
+	// still ENABLED across a prefixed `set +e` — the dangerous direction, since the guard then
+	// believes a later failure would fail the step when it no longer does.
+	start, executes := commandStart(cmd.lits, cmd.litOK)
+	if !executes || start >= len(cmd.lits) || !cmd.litOK[start] ||
+		cmd.lits[start] != "set" || len(cmd.lits)-start < 2 {
 		return false, false
 	}
 
-	for i := 1; i < len(cmd.lits); i++ {
+	for i := start + 1; i < len(cmd.lits); i++ {
 		if !cmd.litOK[i] {
 			return false, true
 		}
@@ -307,7 +312,7 @@ func errexitToggle(cmd executedCommand) (bool, bool) {
 
 	state, found := false, false
 
-	for i := 1; i < len(cmd.lits); i++ {
+	for i := start + 1; i < len(cmd.lits); i++ {
 		word := cmd.lits[i]
 
 		// `--` and a bare `-` end option parsing and assign every remaining word to the positional
@@ -446,6 +451,41 @@ func assignmentsTo(run, name string) []assignment {
 	return out
 }
 
+// declarationWordsWriteTo decodes a declaration whose leading word carried a `builtin`/`command`
+// wrapper, which stops the parser modelling it as a DeclClause. It covers both shapes the unprefixed
+// path already handles: a direct assignment (`export REF=…`) and a nameref alias (`declare -n
+// target=REF`), and it errs toward reporting a write when a word is unreadable.
+func declarationWordsWriteTo(lits []string, litOK []bool, name string) bool {
+	nameref := false
+
+	for i, word := range lits {
+		if !litOK[i] {
+			return true
+		}
+
+		if strings.HasPrefix(word, "-") && word != "--" {
+			if strings.Contains(word, "n") {
+				nameref = true
+			}
+
+			continue
+		}
+
+		lhs, rhs, isAssign := strings.Cut(word, "=")
+		if !isAssign {
+			continue
+		}
+
+		// `export REF=…` writes REF directly; `declare -n target=REF` makes target an alias FOR REF,
+		// so there the protected name appears on the right.
+		if lhs == name || (nameref && rhs == name) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // declaresNamerefTo reports whether decl creates a nameref aliasing the protected variable.
 //
 // It does not try to follow the alias. Tracking every later write through an arbitrary alias name is
@@ -507,17 +547,85 @@ func declaresNamerefTo(decl *syntax.DeclClause, name string) bool {
 // would reject correct workflows, and a guard people cannot ship past gets deleted, not obeyed. The
 // conservative direction is reserved for the destination position, where an unreadable word really
 // could be the name being written.
+// commandStart returns the index of the word that names the command actually run, after stripping
+// any `builtin` / `command` wrappers, and whether that command is EXECUTED at all.
+//
+// Bash accepts both wrappers in front of a builtin, so `builtin printf -v REF …` and
+// `command printf -v REF …` write REF exactly as the bare form does. Every check that keyed on the
+// first word — the errexit toggle, builtin write detection, nameref detection — was defeated by a
+// single prefix. Stripping in one place is what keeps the three consistent.
+//
+// `command -v` / `-V` only LOOK UP a command, so they execute nothing and must not be read as a
+// write; `command -p` still executes, merely with a default PATH. An unreadable word ends the strip:
+// the guard cannot see what it wraps, so the caller's own conservative handling takes over.
+func commandStart(lits []string, litOK []bool) (int, bool) {
+	i := 0
+
+	for i < len(lits) {
+		if !litOK[i] {
+			return i, true
+		}
+
+		switch lits[i] {
+		case "builtin":
+			i++
+		case "command":
+			i++
+
+			for i < len(lits) && litOK[i] && strings.HasPrefix(lits[i], "-") && lits[i] != "--" {
+				if strings.ContainsAny(lits[i], "vV") {
+					return i, false
+				}
+
+				i++
+			}
+
+			if i < len(lits) && litOK[i] && lits[i] == "--" {
+				i++
+			}
+		default:
+			return i, true
+		}
+	}
+
+	return i, true
+}
+
+// wordsOf flattens a call's arguments into the literal/readable pair commandStart consumes.
+func wordsOf(args []*syntax.Word) ([]string, []bool) {
+	lits := make([]string, 0, len(args))
+	ok := make([]bool, 0, len(args))
+
+	for _, arg := range args {
+		word, readable := literalOf(arg)
+		lits = append(lits, word)
+		ok = append(ok, readable)
+	}
+
+	return lits, ok
+}
+
 func builtinWritesTo(call *syntax.CallExpr, name string) bool {
 	if len(call.Args) == 0 {
 		return false
 	}
 
-	command, ok := literalOf(call.Args[0])
-	if !ok {
+	lits, litOK := wordsOf(call.Args)
+
+	start, executes := commandStart(lits, litOK)
+	if !executes || start >= len(call.Args) || !litOK[start] {
 		return false
 	}
 
-	args := call.Args[1:]
+	command := lits[start]
+	args := call.Args[start+1:]
+
+	// A prefixed declaration is not parsed as a DeclClause — `builtin declare -n target=REF` is an
+	// ordinary CallExpr — so the declaration family is decoded here from words as well.
+	switch command {
+	case "declare", "typeset", "local", "export", "readonly":
+		return declarationWordsWriteTo(lits[start+1:], litOK[start+1:], name)
+	}
 
 	switch command {
 	case "printf":
@@ -1263,7 +1371,21 @@ func validate(source []byte) error {
 		return err
 	}
 
-	evidence := evidenceMarkers(steps[signAt[0]].ID)
+	// Report a missing `id:` as itself. Without this the marker becomes
+	// `${{ steps..outputs.digest }}`, which no attestation can match, and the failure then points at
+	// the attestation steps and tells the reader to write that empty expression into them — sending
+	// them to the wrong file and the wrong fix. A guard that misnames the defect costs more than one
+	// that stays silent.
+	signStepID := strings.TrimSpace(steps[signAt[0]].ID)
+	if signStepID == "" {
+		return fmt.Errorf(
+			"the step that must %s has no `id:`, so no attestation can bind its `subject-digest`"+
+				" to the digest this run resolved.\nGive the signing step an `id:` and reference it"+
+				" as `${{ steps.<id>.outputs.digest }}` in both attestation steps",
+			sign.label)
+	}
+
+	evidence := evidenceMarkers(signStepID)
 
 	for _, m := range evidence {
 		at, err := locate(m)

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -288,6 +288,19 @@ func unmodeledShellState(file *syntax.File) (string, bool) {
 			return true
 		}
 
+		// The Assign check above only sees `PATH=…`. A builtin can write the same variable while
+		// naming it as an ARGUMENT — `printf -v PATH …`, `read PATH` — which produces no Assign
+		// node at all, so the walk waved it through and a shadowed `cosign` was credited as the
+		// real signature. Same destinations, same consequence, different spelling; reuse the
+		// existing detector rather than a second, differently-wrong one.
+		for _, protected := range [...]string{"PATH", "BASH_ENV", "ENV"} {
+			if builtinWritesTo(call, protected) {
+				found = "a builtin write to " + protected
+
+				return false
+			}
+		}
+
 		lits, litOK := wordsOf(call.Args)
 
 		start, executes := commandStart(lits, litOK)
@@ -568,12 +581,47 @@ func terminatesShell(cmd executedCommand) bool {
 	case "exit":
 		return true
 	case "exec":
-		// Only a form that names a program replaces the shell; a bare `exec` (or one carrying just
-		// redirections, which contribute no words) leaves execution to continue.
-		return len(cmd.lits)-start > 1
+		// Only a form that names a PROGRAM replaces the shell. Counting words was not the same
+		// question: `exec -c` carries a word but names nothing, so bash continues — and treating
+		// it as terminating stopped the scan and hid every later command, including an extra
+		// `workload push`. Options are skipped; anything unreadable returns false, which keeps the
+		// rest of the step visible rather than trusting it.
+		return execNamesProgram(cmd, start)
 	default:
 		return false
 	}
+}
+
+// execNamesProgram reports whether an `exec` call names a program to replace the shell with.
+//
+// Fail-closed direction matters here and is the opposite of the usual one: claiming the shell ends
+// SUPPRESSES the remainder of the scan, so an unreadable word must mean "keep looking", never
+// "stop". Options (`-c`, `-l`, `-a NAME`) are skipped; `--` ends them.
+func execNamesProgram(cmd executedCommand, start int) bool {
+	for i := start + 1; i < len(cmd.lits); i++ {
+		if !cmd.litOK[i] {
+			return false
+		}
+
+		word := cmd.lits[i]
+
+		if word == "--" {
+			return i+1 < len(cmd.lits) && cmd.litOK[i+1]
+		}
+
+		if strings.HasPrefix(word, "-") {
+			// `-a` takes the replacement argv[0] as a separate word; skip that too.
+			if word == "-a" {
+				i++
+			}
+
+			continue
+		}
+
+		return true
+	}
+
+	return false
 }
 
 func errexitToggle(cmd executedCommand) (bool, bool) {
@@ -702,6 +750,10 @@ func assignmentsTo(run, name string) []assignment {
 			// was therefore invisible here: a correct resolution could be followed by an unseen
 			// overwrite, and both consumers — which require EVERY assignment to qualify — passed
 			// while cosign signed the overwritten value.
+			if paramExpAssignsTo(typed, name) {
+				out = append(out, assignment{text: "", consumesPublishedTag: false})
+			}
+
 			if builtinWritesTo(typed, name) {
 				out = append(out, assignment{
 					// Deliberately opaque. Both consumers compare against an exact required form or
@@ -848,6 +900,39 @@ func declaresNamerefTo(decl *syntax.DeclClause, name string) bool {
 	}
 
 	return false
+}
+
+// paramExpAssignsTo reports whether the call contains an assignment-form parameter expansion that
+// writes name — `${DIGEST:=<stale>}` or `${DIGEST=<stale>}`.
+//
+// These assign as a SIDE EFFECT of expanding, so they produce no Assign, no DeclClause and no
+// builtin destination; `unset DIGEST; : "${DIGEST:=sha256:<old>}"` left the collector seeing only
+// the earlier valid resolution while bash signed the fallback. Recorded as an opaque write for the
+// same reason builtin writes are: both consumers demand a resolved value, so "cannot prove this"
+// fails them rather than guessing.
+func paramExpAssignsTo(call *syntax.CallExpr, name string) bool {
+	assigns := false
+
+	syntax.Walk(call, func(node syntax.Node) bool {
+		if assigns {
+			return false
+		}
+
+		exp, isExp := node.(*syntax.ParamExp)
+		if !isExp || exp.Param == nil || exp.Param.Value != name || exp.Exp == nil {
+			return true
+		}
+
+		if exp.Exp.Op == syntax.AssignUnset || exp.Exp.Op == syntax.AssignUnsetOrNull {
+			assigns = true
+
+			return false
+		}
+
+		return true
+	})
+
+	return assigns
 }
 
 // builtinWritesTo reports whether call writes the shell variable name through a builtin that takes

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -177,11 +177,17 @@ func executable(run string) string {
 
 // heredocOpener matches a here-document redirection and captures its delimiter, quoted or bare.
 //
-// A here-STRING (`<<<`) is deliberately not matched: its operand is a value on the same line rather
-// than a body, so treating it as an opener would swallow every following line until something
-// happened to equal it. The bare form requires an identifier start, which also keeps an arithmetic
-// shift such as `$((1 << 2))` from registering a delimiter.
-var heredocOpener = regexp.MustCompile(`<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`)
+// A here-STRING (`<<<`) must NOT match: its operand is a value on the same line rather than a body,
+// so treating it as an opener swallows every following line until one happens to equal it — hiding
+// the real invocation and failing a valid action. Excluding it needs the leading `[^<]`, because
+// `<<<` contains two overlapping `<<` pairs: without it the match simply starts one character later
+// and `<<<"sentinel"` registers `sentinel` as a delimiter.
+//
+// The bare form requires an identifier start, which also keeps an arithmetic shift such as
+// `$((1 << 2))` from registering a delimiter.
+var heredocOpener = regexp.MustCompile(
+	`(?:^|[^<])<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`,
+)
 
 // heredocDelimiters returns the delimiters a line opens, in the order bash will close them.
 func heredocDelimiters(line string) []string {

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -430,12 +430,67 @@ func assignmentsTo(run, name string) []assignment {
 		// having no assignment at all.
 		case *syntax.DeclClause:
 			collect(typed.Args)
+
+			// A NAMEREF is the same overwrite one level of indirection out. `declare -n target=REF`
+			// makes every later `target=…` write REF, but the collector above only matches
+			// assignments whose literal name is REF — so the one correct assignment satisfied the
+			// validator while cosign signed whatever was written through the alias.
+			if declaresNamerefTo(typed, name) {
+				out = append(out, assignment{text: "", consumesPublishedTag: false})
+			}
 		}
 
 		return true
 	})
 
 	return out
+}
+
+// declaresNamerefTo reports whether decl creates a nameref aliasing the protected variable.
+//
+// It does not try to follow the alias. Tracking every later write through an arbitrary alias name is
+// a dataflow problem, and getting it subtly wrong here is worse than refusing: the whole point of
+// this collector is that the CONSUMERS require every assignment to qualify, so recording the
+// aliasing itself as an unprovable write is both sound and small.
+//
+// The alias TARGET is what matters, not the alias name — `declare -n anything=REF` is a handle on
+// REF whatever it is called. A nameref whose target is not readable is also refused, since it could
+// be the protected name assembled at run time.
+func declaresNamerefTo(decl *syntax.DeclClause, name string) bool {
+	if decl.Variant == nil {
+		return false
+	}
+
+	switch decl.Variant.Value {
+	case "declare", "typeset", "local":
+	default:
+		return false
+	}
+
+	nameref := false
+
+	for _, assign := range decl.Args {
+		// Options arrive as valueless Args, e.g. the `-n` of `declare -n target=REF`.
+		if assign.Name == nil && assign.Value != nil {
+			if word, readable := literalOf(assign.Value); readable &&
+				strings.HasPrefix(word, "-") && strings.Contains(word, "n") {
+				nameref = true
+			}
+
+			continue
+		}
+
+		if !nameref || assign.Value == nil {
+			continue
+		}
+
+		target, readable := literalOf(assign.Value)
+		if !readable || target == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 // builtinWritesTo reports whether call writes the shell variable name through a builtin that takes

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -27,11 +27,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 // step is one entry of runs.steps, reduced to what identifies it here.
@@ -62,204 +62,132 @@ type marker struct {
 	match func(step) bool
 }
 
-// opensBlock and closesBlock are the shell keywords that make a line conditional on something.
-// Matching the first WORD keeps `iffy=1` or a path ending in `done` from being read as control flow.
-var (
-	opensBlock  = []string{"if", "elif", "else", "while", "until", "for", "case", "then", "do"}
-	closesBlock = []string{"fi", "done", "esac"}
-)
-
-func firstWord(line string) string {
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return ""
-	}
-
-	return strings.TrimSuffix(fields[0], ";")
+// executedCommand is one command the shell will actually run, reduced to what the markers ask
+// about: its words exactly as written.
+//
+// Deciding "actually run" from the shell GRAMMAR rather than from the text is what collapses a whole
+// family of bypasses into one rule. A comment is not a word; a here-document body is an argument to
+// the command that opened it, whatever quoting the delimiter uses; and `||`, `&&`, pipelines,
+// subshells, function bodies, backgrounding, negation and every conditional construct produce a
+// statement that is not a plain call. None of them can therefore present a required operation as an
+// executed command.
+//
+// Earlier revisions enumerated those shapes one at a time — a comment, then a step condition, then a
+// block, then a one-line `if`, then `&&`, then `echo`, then a here-document — and each omission was a
+// silent bypass rather than a failure. That is a blocklist, and the list never ended. Asking the
+// parser what runs is the allowlist equivalent.
+type executedCommand struct {
+	// words is argv as written in the source, quoting included, so an argument can be compared
+	// against the exact form the contract requires (`"${REF}"`) rather than against its expansion.
+	words []string
 }
 
-// executable reduces a shell script to the lines that are matched: whole-line comments are dropped,
-// and so is anything a control-flow construct could stop from running.
-//
-// Comments matter because every matcher works on raw text, so a `#` in front of the invocation
-// satisfies them all at once — the comment still contains the command AND the reference. Only
-// whole-line comments are removed; a trailing `#` is left alone, because separating one from a `#`
-// inside a string literal needs a shell parser and guessing wrong would drop a real invocation.
-//
-// Nesting matters for the same reason at one remove. A step can carry no `if:`, keep its position,
-// build REF from the resolved digest, and still produce no signature:
-//
-//	if false; then
-//	  cosign sign --yes --recursive "${REF}"
-//	fi
-//
-// Every check above is satisfied while the deploy attests and reconciles an unsigned artifact.
-//
-// This is a deliberately CONSERVATIVE structural check, not a shell parser: it does not decide
-// whether a branch is reachable, it declines to treat anything inside one as an executed command.
-// Required operations on this path are unconditional by design, so rejecting a conditional one is
-// the intended answer rather than a limitation. Control flow around other work in the same step is
-// untouched — only the lines the matchers read are filtered.
-func executable(run string) string {
-	lines := strings.Split(run, "\n")
-	kept := make([]string, 0, len(lines))
-	depth := 0
-
-	var heredocs []string
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-
-		// A here-document body is INPUT to a command, not a sequence of commands. Without this the
-		// body reads as ordinary top-level lines, so `: <<'X'` followed by the real invocation
-		// satisfies every rule while bash only feeds those words to `:`. Checked before the comment
-		// and block logic because a body line may itself look like `#`, `}` or `fi`, and letting one
-		// close a block would mis-track nesting for every line after it.
-		if len(heredocs) > 0 {
-			if trimmed == heredocs[0] {
-				heredocs = heredocs[1:]
-			}
-
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-
-		// Registered before this line is classified, so a redirection on a line that also opens a
-		// block still hides its body. The opener itself stays a candidate: it is a real command.
-		heredocs = append(heredocs, heredocDelimiters(line)...)
-
-		word := firstWord(trimmed)
-		opens := slices.Contains(opensBlock, word)
-
-		// A line ending in `{` opens a function body or a group. Its contents are only reached if
-		// something invokes it, which this check cannot know, so they are not executed commands.
-		if strings.HasSuffix(trimmed, "{") {
-			depth++
-
-			continue
-		}
-
-		if trimmed == "}" && depth > 0 {
-			depth--
-
-			continue
-		}
-
-		if slices.Contains(closesBlock, word) && depth > 0 {
-			depth--
-
-			continue
-		}
-
-		// A line that OPENS a block is skipped whatever else it carries. That is what catches the
-		// one-line form `if false; then cosign sign ...; fi`, where a depth counter alone would be
-		// back at zero by the end of the line and read it as unnested.
-		if opens {
-			if word == "if" || word == "while" || word == "until" || word == "for" || word == "case" {
-				depth++
-			}
-
-			continue
-		}
-
-		if depth > 0 {
-			continue
-		}
-
-		kept = append(kept, line)
-	}
-
-	return strings.Join(kept, "\n")
+// assignment is one variable assignment, kept with enough provenance to tell a resolved value from a
+// written-down one.
+type assignment struct {
+	// text is the value's source, so an exact required form can be compared.
+	text string
+	// fromCommand reports whether the value came from a command substitution. A digest that was
+	// typed is not a digest that was resolved, and only the second binds a signature to this run.
+	fromCommand bool
 }
 
-// heredocOpener matches a here-document redirection and captures its delimiter, quoted or bare.
+// parseExecuted returns the commands a run block executes at top level.
 //
-// A here-STRING (`<<<`) must NOT match: its operand is a value on the same line rather than a body,
-// so treating it as an opener swallows every following line until one happens to equal it — hiding
-// the real invocation and failing a valid action. Excluding it needs the leading `[^<]`, because
-// `<<<` contains two overlapping `<<` pairs: without it the match simply starts one character later
-// and `<<<"sentinel"` registers `sentinel` as a delimiter.
-//
-// The bare form requires an identifier start, which also keeps an arithmetic shift such as
-// `$((1 << 2))` from registering a delimiter.
-var heredocOpener = regexp.MustCompile(
-	`(?:^|[^<])<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_][A-Za-z0-9_]*))`,
-)
+// A parse failure yields none, so an unparseable script can never satisfy a required marker: the
+// guard fails closed rather than falling back to matching text.
+func parseExecuted(run string) []executedCommand {
+	file, err := syntax.NewParser().Parse(strings.NewReader(run), "")
+	if err != nil {
+		return nil
+	}
 
-// heredocDelimiters returns the delimiters a line opens, in the order bash will close them.
-func heredocDelimiters(line string) []string {
-	var out []string
+	out := make([]executedCommand, 0, len(file.Stmts))
 
-	for _, match := range heredocOpener.FindAllStringSubmatch(line, -1) {
-		for _, group := range match[1:] {
-			if group != "" {
-				out = append(out, group)
-
-				break
-			}
+	for _, stmt := range file.Stmts {
+		call, isCall := stmt.Cmd.(*syntax.CallExpr)
+		if !isCall {
+			continue
 		}
+
+		// `! cmd` inverts the exit status and `cmd &` detaches it. Neither lets the step fail when
+		// the operation does, which is the only reason requiring the operation means anything.
+		if stmt.Negated || stmt.Background {
+			continue
+		}
+
+		out = append(out, newExecutedCommand(run, call))
 	}
 
 	return out
 }
 
-// commandPrefix is what may precede a required match on its line: whitespace and at most a plain
-// command path. Anything else — an operator, a quote, an assignment, a substitution — means the
-// match is not itself the command being run.
-var commandPrefix = regexp.MustCompile(`^\s*[A-Za-z0-9_./-]*\s*$`)
+func newExecutedCommand(src string, call *syntax.CallExpr) executedCommand {
+	cmd := executedCommand{words: make([]string, 0, len(call.Args))}
 
-// carriedBy reports whether a given executable may carry a required operation. The empty string
-// means the operation began the line, i.e. the matched text names the executable itself.
-type carriedBy func(exec string) bool
-
-// directly accepts only a line that starts with the operation, for matches that already name their
-// own executable (`cosign sign`).
-func directly(exec string) bool { return exec == "" }
-
-// viaKsail accepts the authenticated wrapper the composite publishes through. `workload push` is a
-// SUBCOMMAND, so it is legitimately preceded by a command — the real step runs
-// `./scripts/run-ksail-prod-with-pull-auth.sh workload push` — which is why the prefix cannot simply
-// be banned the way it can for cosign. It is restricted to ksail or a script rather than pinned to
-// one path, so renaming the wrapper stays a legal refactor.
-func viaKsail(exec string) bool {
-	return exec == "ksail" || strings.HasSuffix(exec, ".sh")
-}
-
-// isInvocation reports whether substr occurs on line as a plain top-level command carried by an
-// executable ok accepts.
-//
-// The plain-command half inverts the question earlier versions asked. Enumerating the ways an
-// invocation can fail to run — a comment, a step condition, a block, `&&`, `||`, a pipeline, a
-// string literal, a command substitution, an uninvoked function — is a list that keeps growing, and
-// each omission is a silent bypass. Requiring the match to BE a command closes that class.
-//
-// The executable half closes what remained: being a command is not enough when the match is only
-// part of one. Allowing any plain word in front accepted `echo cosign sign --yes "${REF}"`, which
-// bash merely prints. That distinction is not syntactic — `ksail workload push` and
-// `echo workload push` have identical shape — so the rule has to know which executable each
-// operation actually belongs to rather than reasoning about the line alone.
-func isInvocation(line, substr string, ok carriedBy) bool {
-	idx := strings.Index(line, substr)
-	if idx < 0 {
-		return false
+	for _, arg := range call.Args {
+		cmd.words = append(cmd.words, sourceOf(src, arg.Pos(), arg.End()))
 	}
 
-	prefix := line[:idx]
-	if !commandPrefix.MatchString(prefix) {
-		return false
-	}
-
-	return ok(strings.TrimSpace(prefix))
+	return cmd
 }
 
-// containsCommand reports whether any executable line of run invokes substr as a plain command
-// carried by an accepted executable.
-func containsCommand(run, substr string, ok carriedBy) bool {
-	for _, line := range strings.Split(executable(run), "\n") {
-		if isInvocation(line, substr, ok) {
+// assignmentsTo returns every assignment to name anywhere in run, at any nesting depth.
+//
+// Depth is deliberately ignored here, unlike for the required OPERATIONS. Those must be top-level
+// because a conditional one may simply not run; an assignment is different — what matters is that no
+// value of this variable can come from somewhere untrustworthy. Restricting it to the top level
+// would reject a plain retry loop around the digest resolution, which is correct code, and a guard
+// that fails correct input gets suppressed rather than fixed.
+//
+// Here-document bodies contain no commands, so a resolution "found" inside one is not found at all.
+func assignmentsTo(run, name string) []assignment {
+	file, err := syntax.NewParser().Parse(strings.NewReader(run), "")
+	if err != nil {
+		return nil
+	}
+
+	var out []assignment
+
+	syntax.Walk(file, func(node syntax.Node) bool {
+		call, isCall := node.(*syntax.CallExpr)
+		if !isCall {
+			return true
+		}
+
+		for _, assign := range call.Assigns {
+			if assign.Name == nil || assign.Value == nil || assign.Name.Value != name {
+				continue
+			}
+
+			out = append(out, assignment{
+				text:        sourceOf(run, assign.Value.Pos(), assign.Value.End()),
+				fromCommand: valueFromCommand(assign.Value),
+			})
+		}
+
+		return true
+	})
+
+	return out
+}
+
+// sourceOf returns the source text a node spans. Comparing what was WRITTEN keeps the required
+// argument checks exact: `"${REF}"` and `"${REF_TAG}"` expand to different things at run time, and
+// the guard has to distinguish them without expanding anything.
+func sourceOf(src string, from, to syntax.Pos) string {
+	start, end := int(from.Offset()), int(to.Offset())
+	if start < 0 || end > len(src) || start > end {
+		return ""
+	}
+
+	return src[start:end]
+}
+
+// valueFromCommand reports whether any part of a value is a command substitution.
+func valueFromCommand(word *syntax.Word) bool {
+	for _, part := range word.Parts {
+		if _, ok := part.(*syntax.CmdSubst); ok {
 			return true
 		}
 	}
@@ -267,8 +195,53 @@ func containsCommand(run, substr string, ok carriedBy) bool {
 	return false
 }
 
-func runContains(substr string, ok carriedBy) func(step) bool {
-	return func(s step) bool { return containsCommand(s.Run, substr, ok) }
+// viaKsail accepts the authenticated wrapper the composite publishes through. `workload push` is a
+// SUBCOMMAND, so it is legitimately preceded by a command — the real step runs
+// `./scripts/run-ksail-prod-with-pull-auth.sh workload push` — which is why the executable cannot
+// simply be required to be the operation itself, the way it can for cosign. It is restricted to
+// ksail or a script rather than pinned to one path, so renaming the wrapper stays a legal refactor.
+func viaKsail(exec string) bool {
+	return exec == "ksail" || strings.HasSuffix(exec, ".sh")
+}
+
+// ksailWorkload matches a step that runs `workload <op>` through that wrapper.
+//
+// The executable matters as much as the words: `ksail workload push` and `echo workload push` have
+// identical shape, so a rule reading only the operation's words would accept a step that merely
+// prints it.
+func ksailWorkload(op string) func(step) bool {
+	return func(s step) bool {
+		for _, cmd := range parseExecuted(s.Run) {
+			if len(cmd.words) == 0 || !viaKsail(cmd.words[0]) {
+				continue
+			}
+
+			for i := 1; i+1 < len(cmd.words); i++ {
+				if cmd.words[i] == "workload" && cmd.words[i+1] == op {
+					return true
+				}
+			}
+		}
+
+		return false
+	}
+}
+
+// cosignSignCommands returns every executed `cosign sign` invocation in run.
+func cosignSignCommands(run string) []executedCommand {
+	var out []executedCommand
+
+	for _, cmd := range parseExecuted(run) {
+		if len(cmd.words) >= 2 && cmd.words[0] == "cosign" && cmd.words[1] == "sign" {
+			out = append(out, cmd)
+		}
+	}
+
+	return out
+}
+
+func runsCosignSign(s step) bool {
+	return len(cosignSignCommands(s.Run)) > 0
 }
 
 func usesPrefix(prefix string) func(step) bool {
@@ -286,12 +259,12 @@ func usesPrefix(prefix string) func(step) bool {
 var (
 	// publish makes new bytes reachable and must come first — signing or
 	// attesting before it would cover the previous artifact.
-	publish = marker{"publish the manifests (`workload push`)", runContains("workload push", viaKsail)}
+	publish = marker{"publish the manifests (`workload push`)", ksailWorkload("push")}
 
 	// sign is named separately because its step is inspected again below, for
 	// the digest reference. Locating it by value rather than by matching its
 	// label keeps that second lookup correct when the wording changes.
-	sign = marker{"sign the published digest (`cosign sign`)", runContains("cosign sign ", directly)}
+	sign = marker{"sign the published digest (`cosign sign`)", runsCosignSign}
 
 	// evidence is what must exist before production may look. Order among
 	// these is unconstrained.
@@ -302,13 +275,20 @@ var (
 	}
 
 	// release is the step that advances what production can see.
-	release = marker{"tell Flux to reconcile (`workload reconcile`)", runContains("workload reconcile", viaKsail)}
+	release = marker{"tell Flux to reconcile (`workload reconcile`)", ksailWorkload("reconcile")}
 )
 
 // digestRef is the form the signing step must use. Signing the mutable tag
 // instead would let a concurrent deploy move it between resolve and sign, so
 // the signature would cover bytes this run never published.
-const digestRef = `REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`
+const (
+	// digestRefValue is the value REF must be assigned, as written.
+	digestRefValue = `"ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`
+	// digestRef is the whole assignment, used in error messages.
+	digestRef = `REF=` + digestRefValue
+	// publishedTagRef is the tag this run just pushed. DIGEST must be derived from it.
+	publishedTagRef = `${REF_TAG}`
+)
 
 // indicesOf returns the position of EVERY step matching m, in file order.
 //
@@ -337,43 +317,103 @@ const signRefArg = `"${REF}"`
 
 // signsTheResolvedDigest reports whether every cosign invocation in run signs
 // the reference built from the resolved digest.
+//
+// The reference must be an ARGUMENT, which is why this reads parsed words rather than the line. A
+// substring test cannot tell an argument from a comment, so
+// `cosign sign --yes --recursive "${REF_TAG}" # "${REF}"` satisfied it while bash passed only the
+// mutable tag — restoring the exact tag-resolution race the check exists to prevent.
 func signsTheResolvedDigest(run string) bool {
-	signed := false
+	signing := cosignSignCommands(run)
 
-	for _, line := range strings.Split(executable(run), "\n") {
-		if !isInvocation(line, "cosign sign ", directly) {
-			continue
-		}
-
-		if !strings.Contains(line, signRefArg) {
-			return false
-		}
-
-		signed = true
+	// No executed invocation at all means nothing signs, whatever the text contains.
+	if len(signing) == 0 {
+		return false
 	}
 
-	// No plain invocation at all means nothing signs, whatever the text contains.
-	return signed
+	for _, cmd := range signing {
+		if !slices.Contains(cmd.words, signRefArg) {
+			return false
+		}
+	}
+
+	return true
 }
 
-// mustNotSkipIndependently rejects a required step whose condition lets it be skipped while the
-// release still runs. releaseIdx[0] is the binding release for ordering, so its condition is the one
-// a required step must share to stand or fall with it.
-func mustNotSkipIndependently(steps []step, m marker, idx []int, releaseIdx []int) error {
-	releaseIf := strings.TrimSpace(steps[releaseIdx[0]].If)
+// assignsResolvedRef reports whether EVERY assignment to REF builds it from the resolved digest.
+//
+// "Every" rather than "some": a later assignment overwrites an earlier one, so accepting the
+// presence of one correct assignment would let a second, wrong one decide what cosign actually
+// signs.
+func assignsResolvedRef(run string) bool {
+	refs := assignmentsTo(run, "REF")
+	if len(refs) == 0 {
+		return false
+	}
 
-	for _, at := range idx {
-		stepIf := strings.TrimSpace(steps[at].If)
-		if stepIf == "" || stepIf == releaseIf {
-			continue
+	for _, assigned := range refs {
+		if assigned.text != digestRefValue {
+			return false
 		}
+	}
 
-		return fmt.Errorf(
-			"the step that must %s carries `if: %s`, which does not match the release step's"+
-				" condition (%q), so it can be skipped while the release still runs.\n"+
-				"GitHub skips a false-conditioned step without failing the composite, so the ordering"+
-				" above would still hold while production is released without that evidence",
-			m.label, stepIf, releaseIf)
+	return true
+}
+
+// resolvesDigestFromPublishedTag reports whether run derives DIGEST by inspecting the tag it just
+// published, rather than naming a digest outright.
+//
+// Without this, DIGEST's provenance was unbound: every ordering check still held while a constant
+// digest for an OLDER manifest was signed and attested in full, and reconciliation released the
+// newly pushed — and unsigned — `latest`. That is the most dangerous shape the guard can miss,
+// because the evidence it produces is genuine, just about the wrong artifact.
+//
+// The requirement is that the value is RESOLVED from the published tag, not that one specific tool
+// resolves it: `docker buildx imagetools`, `crane` and a cosign equivalent are all legitimate, and a
+// guard that failed a correct switch between them would be suppressed rather than fixed.
+// EVERY assignment must qualify, for the same reason as REF: one resolved assignment sitting beside
+// a constant one proves nothing about which value cosign ends up signing.
+func resolvesDigestFromPublishedTag(run string) bool {
+	digests := assignmentsTo(run, "DIGEST")
+	if len(digests) == 0 {
+		return false
+	}
+
+	for _, assigned := range digests {
+		if !assigned.fromCommand || !strings.Contains(assigned.text, publishedTagRef) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// mustNotSkipIndependently rejects a required step whose condition lets it be skipped while a
+// release still runs.
+//
+// The comparison is against EVERY release, not just the binding one for ordering. Checking only the
+// first left a gap with the same shape as the one indicesOf closes for ordering: evidence guarded by
+// the same never-firing condition as a first reconcile looked correctly coupled, while a second,
+// unconditional reconcile released the artifact with all of that evidence skipped. A required step
+// has to stand or fall with each release, so one it cannot gate is a failure.
+func mustNotSkipIndependently(steps []step, m marker, idx []int, releaseIdx []int) error {
+	for _, releaseAt := range releaseIdx {
+		releaseIf := strings.TrimSpace(steps[releaseAt].If)
+
+		for _, at := range idx {
+			stepIf := strings.TrimSpace(steps[at].If)
+			if stepIf == "" || stepIf == releaseIf {
+				continue
+			}
+
+			return fmt.Errorf(
+				"the step that must %s carries `if: %s`, which does not match the release step's"+
+					" condition (%q) at position %d, so it can be skipped while that release still"+
+					" runs.\n"+
+					"GitHub skips a false-conditioned step without failing the composite, so the"+
+					" ordering above would still hold while production is released without that"+
+					" evidence",
+				m.label, stepIf, releaseIf, releaseAt+1)
+		}
 	}
 
 	return nil
@@ -476,11 +516,20 @@ func validate(source []byte) error {
 	}
 
 	for _, at := range signAt {
-		if !strings.Contains(executable(steps[at].Run), digestRef) {
+		if !assignsResolvedRef(steps[at].Run) {
 			return fmt.Errorf(
 				"the signing step must build its reference from the resolved digest (%s); "+
 					"signing the mutable tag lets a concurrent deploy move it between resolve and sign",
 				digestRef)
+		}
+
+		if !resolvesDigestFromPublishedTag(steps[at].Run) {
+			return fmt.Errorf(
+				"the signing step must resolve DIGEST from the tag it just published (a command "+
+					"substitution reading %s); a digest that is written down rather than resolved "+
+					"lets cosign and both attestations cover an older artifact in full while the "+
+					"newly pushed tag is released unsigned",
+				publishedTagRef)
 		}
 
 		if !signsTheResolvedDigest(steps[at].Run) {

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -1598,13 +1598,21 @@ func mustNotReleaseAfterFailure(steps []step, releaseIdx []int) error {
 	return nil
 }
 
-// shellStartupEnv are the step-level names that change the shell before the run block's first line.
+// shellStartupEnv are the step-level names that decide how the run block is interpreted or resolved,
+// before and while it executes — set from outside the script, so the run block stays textually
+// perfect either way.
 //
 // Bash expands BASH_ENV in a non-interactive shell and reads the resulting file before executing the
-// script, so `BASH_ENV: ./setup.sh` with `cosign() { true; }` inside it shadows the required command
-// while the run block stays textually perfect. ENV is the same mechanism under POSIX mode, and
-// SHELLOPTS/BASHOPTS set shell options — including noexec — from outside the script.
-var shellStartupEnv = []string{"BASH_ENV", "ENV", "SHELLOPTS", "BASHOPTS"}
+// script, so `BASH_ENV: ./setup.sh` with `cosign() { true; }` inside it shadows the required command.
+// ENV is the same mechanism under POSIX mode, and SHELLOPTS/BASHOPTS set shell options — including
+// noexec — from outside the script.
+//
+// PATH belongs here for the same reason it is already rejected as an in-script assignment above
+// ("PATH decides where every unqualified name resolves"): `env: PATH: /tmp/fake` resolves the
+// textually perfect `cosign sign …` to whatever `cosign` sits in that directory. The script-level
+// spellings were covered while the step-level one was not, which left the same shadowing reachable
+// without touching the script at all.
+var shellStartupEnv = []string{"BASH_ENV", "ENV", "SHELLOPTS", "BASHOPTS", "PATH"}
 
 // mustModelEveryRunStep rejects an action carrying a construct this guard cannot interpret.
 //
@@ -1626,9 +1634,11 @@ func mustModelEveryRunStep(steps []step) error {
 		for _, name := range shellStartupEnv {
 			if _, set := s.Env[name]; set {
 				return fmt.Errorf(
-					"step %q sets %s, which changes the shell before the step's first line runs.\n"+
-						"Bash reads that file (or applies those options) ahead of the script, so a required"+
-						" command can be shadowed by something this check never sees. Configure the step"+
+					"step %q sets %s, which decides how the run block is interpreted or resolved from"+
+						" outside the script.\n"+
+						"Bash reads that startup file, applies those options, or resolves unqualified names"+
+						" through that PATH, so a required command can be shadowed by something this check"+
+						" never sees while the run block stays textually correct. Configure the step"+
 						" without it",
 					label, name)
 			}

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -91,9 +91,10 @@ type executedCommand struct {
 type assignment struct {
 	// text is the value's source, so an exact required form can be compared.
 	text string
-	// fromCommand reports whether the value came from a command substitution. A digest that was
-	// typed is not a digest that was resolved, and only the second binds a signature to this run.
-	fromCommand bool
+	// consumesPublishedTag reports whether the value was RESOLVED by running something that reads
+	// the tag this run just published. A digest that was typed is not a digest that was resolved,
+	// and only the second binds a signature to this run.
+	consumesPublishedTag bool
 }
 
 // parseExecuted returns the commands a run block executes at top level.
@@ -250,8 +251,8 @@ func assignmentsTo(run, name string) []assignment {
 			}
 
 			out = append(out, assignment{
-				text:        sourceOf(run, assign.Value.Pos(), assign.Value.End()),
-				fromCommand: valueFromCommand(assign.Value),
+				text:                 sourceOf(run, assign.Value.Pos(), assign.Value.End()),
+				consumesPublishedTag: valueResolvedFrom(assign.Value, publishedTagVar),
 			})
 		}
 	}
@@ -287,17 +288,81 @@ func sourceOf(src string, from, to syntax.Pos) string {
 	return src[start:end]
 }
 
-// valueFromCommand reports whether a value contains a command substitution, at any nesting depth.
+// valueResolvedFrom reports whether a value is produced by RUNNING something that reads name.
 //
-// Depth matters because `DIGEST="$(…)"` wraps the substitution in a *syntax.DblQuoted, so scanning
-// only the word's top-level parts sees a plain quoted string. Quoting a command substitution is
-// BETTER practice than leaving it bare, so a shallow scan rejected the more careful spelling of
-// correct code — the exact way a guard earns itself a suppression.
-func valueFromCommand(word *syntax.Word) bool {
+// Both halves are load-bearing, and each closes a different bypass:
+//
+//   - The value must come from a command substitution, so a digest that was written down cannot
+//     pass as one that was resolved. Depth matters here because `DIGEST="$(…)"` wraps the
+//     substitution in a *syntax.DblQuoted; quoting one is BETTER practice than leaving it bare, so
+//     a shallow scan rejected the more careful spelling of correct code.
+//   - name must be EXPANDED as an argument of a command that substitution runs — not merely
+//     present in its source text. A source span covers the comments inside the substitution, so
+//     `DIGEST="$(printf '%s' 'sha256:…'  # ${REF_TAG}
+//     )"` satisfied a substring test while bash expanded nothing: cosign and both attestations then
+//     cover an OLDER manifest in full while the tag this run published ships unsigned. Requiring an
+//     argument also settles the neighbouring shape, `"${REF_TAG}$(…constant…)"`, where the tag is
+//     genuinely expanded but the substitution that decides the value never sees it.
+//
+// This is the same distinction the parser already draws for the required OPERATIONS — a mention is
+// not an execution — applied one level down to the values they consume.
+//
+// Reading the parsed expansion rather than the written `${REF_TAG}` also stops the guard enforcing a
+// spelling it has no stake in: `$REF_TAG` is the same expansion, and rejecting it would fail correct
+// code.
+//
+// BOUNDARY, stated rather than implied: this proves the published tag is CONSUMED by a command the
+// resolution runs. It does not prove that command's output is what the substitution returns — that
+// is dataflow through the shell, not a property of the syntax, so a command given the tag and then
+// discarded (`: "${REF_TAG}"; printf '%s' 'sha256:…'`) satisfies this check. Chasing that with
+// another shape rule is what made this guard a blocklist five rounds running; the structural
+// boundary is deliberate, and closing it needs reachability analysis rather than a sixth pattern.
+func valueResolvedFrom(word *syntax.Word, name string) bool {
+	resolved := false
+
+	syntax.Walk(word, func(node syntax.Node) bool {
+		subst, isSubst := node.(*syntax.CmdSubst)
+		if !isSubst {
+			return !resolved
+		}
+
+		// Any depth inside the substitution: a pipeline, a subshell, a loop or a redirection around
+		// the resolution is ordinary scripting, and the expansion still reaches the program that
+		// resolves the digest.
+		syntax.Walk(subst, func(inner syntax.Node) bool {
+			call, isCall := inner.(*syntax.CallExpr)
+			if !isCall {
+				return !resolved
+			}
+
+			for _, arg := range call.Args {
+				if expands(arg, name) {
+					resolved = true
+
+					return false
+				}
+			}
+
+			return !resolved
+		})
+
+		return !resolved
+	})
+
+	return resolved
+}
+
+// expands reports whether a word contains a parameter expansion of name.
+//
+// A comment's text is never parsed into an expansion node, and neither is a single-quoted string, so
+// walking the tree distinguishes what bash will substitute from what merely reads that way. Both
+// spellings are the same expansion: `$REF_TAG` is a short ParamExp, `${REF_TAG}` a braced one.
+func expands(word *syntax.Word, name string) bool {
 	found := false
 
 	syntax.Walk(word, func(node syntax.Node) bool {
-		if _, isSubst := node.(*syntax.CmdSubst); isSubst {
+		param, isParam := node.(*syntax.ParamExp)
+		if isParam && param.Param != nil && param.Param.Value == name {
 			found = true
 		}
 
@@ -398,8 +463,12 @@ const (
 	digestRefValue = `"ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`
 	// digestRef is the whole assignment, used in error messages.
 	digestRef = `REF=` + digestRefValue
-	// publishedTagRef is the tag this run just pushed. DIGEST must be derived from it.
-	publishedTagRef = `${REF_TAG}`
+	// publishedTagVar is the variable holding the tag this run just pushed. DIGEST must be derived
+	// from it. This is the NAME, not a spelling of the expansion: the check reads the parsed
+	// expansion, so `$REF_TAG` and `${REF_TAG}` both qualify.
+	publishedTagVar = `REF_TAG`
+	// publishedTagRef is that expansion as an operator would write it, for error messages.
+	publishedTagRef = `${` + publishedTagVar + `}`
 )
 
 // indicesOf returns the position of EVERY step matching m, in file order.
@@ -491,7 +560,7 @@ func resolvesDigestFromPublishedTag(run string) bool {
 	}
 
 	for _, assigned := range digests {
-		if !assigned.fromCommand || !strings.Contains(assigned.text, publishedTagRef) {
+		if !assigned.consumesPublishedTag {
 			return false
 		}
 	}

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -307,7 +307,11 @@ func unmodeledShellState(file *syntax.File) (string, bool) {
 			}
 		case "set":
 			if opt, ok := unmodeledSetOption(lits[start+1:], litOK[start+1:]); ok {
-				found = "`set " + opt + "`"
+				if opt == nonLiteralOption {
+					found = "`set` with an option whose value is not statically known"
+				} else {
+					found = "`set " + opt + "`"
+				}
 
 				return false
 			}
@@ -318,6 +322,10 @@ func unmodeledShellState(file *syntax.File) (string, bool) {
 
 	return found, found != ""
 }
+
+// nonLiteralOption marks a `set` word whose value is not statically known, so the allowlist cannot
+// read it at all. It is a distinct sentinel because it needs different wording in the error.
+const nonLiteralOption = "\x00non-literal"
 
 // unmodeledSetOption reports a `set` option outside the modeled set.
 //
@@ -335,8 +343,13 @@ func unmodeledSetOption(lits []string, litOK []bool) (string, bool) {
 	}
 
 	for i := 0; i < len(lits); i++ {
+		// A word whose value is not statically known cannot be checked against the allowlist, so it
+		// is unmodeled — the same rule this function exists to apply. Returning "modeled" here was
+		// the allowlist failing open on exactly the input it cannot read: `set "${OPTS}"` left the
+		// option unchecked while errexitToggle conservatively recorded errexit as OFF, which made
+		// parseExecuted skip every later command — including a second `workload push`.
 		if !litOK[i] {
-			return "", false
+			return nonLiteralOption, true
 		}
 
 		word := lits[i]
@@ -1170,18 +1183,24 @@ var interpreters = map[string]bool{
 // Only the leading interpreter is stripped, and only when it names a script. An interpreter carrying
 // inline code (`bash -c …`) names no script and runs text this file never parses, so it is rejected
 // by unmodeledShellState rather than guessed at here.
+// The `command`/`builtin` prefixes are stripped first. They execute the named command with its
+// arguments, so `command ./scripts/run-ksail-prod-with-pull-auth.sh workload push` publishes exactly
+// as the bare form does — but reading argv[0] returns `command`, which matches no wrapper and hid the
+// operation. commandStart already decodes those prefixes for the errexit tracking; this uses the same
+// decoder rather than a second, differently-wrong one.
 func scriptTarget(cmd executedCommand) (string, bool, int) {
-	exec, known := cmd.name()
-	if !known {
+	start, executes := commandStart(cmd.lits, cmd.litOK)
+	if !executes || start >= len(cmd.lits) || !cmd.litOK[start] {
 		return "", false, 0
 	}
 
+	exec := cmd.lits[start]
 	if !interpreters[exec] {
-		return exec, true, 0
+		return exec, true, start
 	}
 
 	// Skip the interpreter's own options to reach the script operand.
-	for i := 1; i < len(cmd.lits); i++ {
+	for i := start + 1; i < len(cmd.lits); i++ {
 		if !cmd.litOK[i] {
 			return "", false, 0
 		}

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -40,6 +40,10 @@ type step struct {
 	ID   string `yaml:"id"`
 	Uses string `yaml:"uses"`
 	Run  string `yaml:"run"`
+	// Shell decides whether a failing command fails the step at all. GitHub runs `shell: bash` with
+	// `-e`; any other shell is not guaranteed to, so a required operation there cannot be assumed to
+	// gate the step. Composite actions require this field on every run step.
+	Shell string `yaml:"shell"`
 	// If is read because ordering is positional: a step keeps its position while carrying a
 	// condition that never fires, so the sequence can be satisfied by steps that do not run.
 	If string `yaml:"if"`
@@ -96,7 +100,7 @@ type assignment struct {
 //
 // A parse failure yields none, so an unparseable script can never satisfy a required marker: the
 // guard fails closed rather than falling back to matching text.
-func parseExecuted(run string) []executedCommand {
+func parseExecuted(run string, errexit bool) []executedCommand {
 	file, err := syntax.NewParser().Parse(strings.NewReader(run), "")
 	if err != nil {
 		return nil
@@ -116,10 +120,66 @@ func parseExecuted(run string) []executedCommand {
 			continue
 		}
 
-		out = append(out, newExecutedCommand(run, call))
+		cmd := newExecutedCommand(run, call)
+
+		// `set` changes how the shell treats a later failure, so it has to be tracked as state
+		// rather than matched as a shape. Applied before the errexit test so `set -e` enables
+		// itself, which is what makes an explicit re-enable after `set +e` work.
+		if toggled, ok := errexitToggle(cmd.words); ok {
+			errexit = toggled
+
+			continue
+		}
+
+		// Grammar says this command runs; errexit says its failure reaches the step status. A
+		// required operation needs both — under `set +e` cosign can fail, the next command succeed,
+		// and the step still exit zero.
+		if !errexit {
+			continue
+		}
+
+		out = append(out, cmd)
 	}
 
 	return out
+}
+
+// errexitToggle reports the new errexit state a `set` command establishes, if it establishes one.
+//
+// Both spellings count (`set -e` / `set -o errexit`), in either direction, and a combined form such
+// as `set -euo pipefail` carries the flag among others.
+func errexitToggle(words []string) (bool, bool) {
+	if len(words) < 2 || words[0] != "set" {
+		return false, false
+	}
+
+	state, found := false, false
+
+	for i := 1; i < len(words); i++ {
+		word := words[i]
+
+		switch {
+		case strings.HasPrefix(word, "-") && !strings.HasPrefix(word, "--") && strings.Contains(word, "e"):
+			state, found = true, true
+		case strings.HasPrefix(word, "+") && strings.Contains(word, "e"):
+			state, found = false, true
+		case (word == "-o" || word == "+o") && i+1 < len(words) && words[i+1] == "errexit":
+			state, found = word == "-o", true
+			i++
+		}
+	}
+
+	return state, found
+}
+
+// errexitAtStart reports whether the step begins with failure propagation on.
+//
+// GitHub runs `shell: bash` as `bash --noprofile --norc -eo pipefail`, so errexit is on before the
+// script's first line. Any other shell makes no such promise — and a step may still turn it on
+// explicitly, which the toggle tracking above picks up, so this is a starting value rather than a
+// verdict.
+func errexitAtStart(s step) bool {
+	return s.Shell == "" || s.Shell == "bash"
 }
 
 func newExecutedCommand(src string, call *syntax.CallExpr) executedCommand {
@@ -211,7 +271,7 @@ func viaKsail(exec string) bool {
 // prints it.
 func ksailWorkload(op string) func(step) bool {
 	return func(s step) bool {
-		for _, cmd := range parseExecuted(s.Run) {
+		for _, cmd := range parseExecuted(s.Run, errexitAtStart(s)) {
 			if len(cmd.words) == 0 || !viaKsail(cmd.words[0]) {
 				continue
 			}
@@ -228,10 +288,10 @@ func ksailWorkload(op string) func(step) bool {
 }
 
 // cosignSignCommands returns every executed `cosign sign` invocation in run.
-func cosignSignCommands(run string) []executedCommand {
+func cosignSignCommands(s step) []executedCommand {
 	var out []executedCommand
 
-	for _, cmd := range parseExecuted(run) {
+	for _, cmd := range parseExecuted(s.Run, errexitAtStart(s)) {
 		if len(cmd.words) >= 2 && cmd.words[0] == "cosign" && cmd.words[1] == "sign" {
 			out = append(out, cmd)
 		}
@@ -241,7 +301,7 @@ func cosignSignCommands(run string) []executedCommand {
 }
 
 func runsCosignSign(s step) bool {
-	return len(cosignSignCommands(s.Run)) > 0
+	return len(cosignSignCommands(s)) > 0
 }
 
 func usesPrefix(prefix string) func(step) bool {
@@ -322,8 +382,8 @@ const signRefArg = `"${REF}"`
 // substring test cannot tell an argument from a comment, so
 // `cosign sign --yes --recursive "${REF_TAG}" # "${REF}"` satisfied it while bash passed only the
 // mutable tag — restoring the exact tag-resolution race the check exists to prevent.
-func signsTheResolvedDigest(run string) bool {
-	signing := cosignSignCommands(run)
+func signsTheResolvedDigest(s step) bool {
+	signing := cosignSignCommands(s)
 
 	// No executed invocation at all means nothing signs, whatever the text contains.
 	if len(signing) == 0 {
@@ -532,7 +592,7 @@ func validate(source []byte) error {
 				publishedTagRef)
 		}
 
-		if !signsTheResolvedDigest(steps[at].Run) {
+		if !signsTheResolvedDigest(steps[at]) {
 			return fmt.Errorf(
 				"the signing step resolves the digest into %s but does not pass %s to `cosign sign`; "+
 					"the assignment is dead and the signature would cover whatever the mutable tag "+

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -113,6 +114,20 @@ func executable(run string) string {
 		word := firstWord(trimmed)
 		opens := slices.Contains(opensBlock, word)
 
+		// A line ending in `{` opens a function body or a group. Its contents are only reached if
+		// something invokes it, which this check cannot know, so they are not executed commands.
+		if strings.HasSuffix(trimmed, "{") {
+			depth++
+
+			continue
+		}
+
+		if trimmed == "}" && depth > 0 {
+			depth--
+
+			continue
+		}
+
 		if slices.Contains(closesBlock, word) && depth > 0 {
 			depth--
 
@@ -140,8 +155,39 @@ func executable(run string) string {
 	return strings.Join(kept, "\n")
 }
 
+// commandPrefix is what may precede a required match on its line: whitespace and at most a plain
+// command path. Anything else — an operator, a quote, an assignment, a substitution — means the
+// match is not itself the command being run.
+var commandPrefix = regexp.MustCompile(`^\s*[A-Za-z0-9_./-]*\s*$`)
+
+// isPlainCommand reports whether substr occurs on line as part of a plain top-level command.
+//
+// This inverts the question the earlier versions asked. Enumerating the ways an invocation can fail
+// to run — a comment, a step condition, a block, `&&`, `||`, a pipeline, a string literal, a command
+// substitution, an uninvoked function — is a list that keeps growing, and each omission is a silent
+// bypass. Requiring the match to BE a command closes the class instead of another instance of it.
+func isPlainCommand(line, substr string) bool {
+	idx := strings.Index(line, substr)
+	if idx < 0 {
+		return false
+	}
+
+	return commandPrefix.MatchString(line[:idx])
+}
+
+// containsCommand reports whether any executable line of run invokes substr as a plain command.
+func containsCommand(run, substr string) bool {
+	for _, line := range strings.Split(executable(run), "\n") {
+		if isPlainCommand(line, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func runContains(substr string) func(step) bool {
-	return func(s step) bool { return strings.Contains(executable(s.Run), substr) }
+	return func(s step) bool { return containsCommand(s.Run, substr) }
 }
 
 func usesPrefix(prefix string) func(step) bool {
@@ -211,17 +257,22 @@ const signRefArg = `"${REF}"`
 // signsTheResolvedDigest reports whether every cosign invocation in run signs
 // the reference built from the resolved digest.
 func signsTheResolvedDigest(run string) bool {
+	signed := false
+
 	for _, line := range strings.Split(executable(run), "\n") {
-		if !strings.Contains(line, "cosign sign ") {
+		if !isPlainCommand(line, "cosign sign ") {
 			continue
 		}
 
 		if !strings.Contains(line, signRefArg) {
 			return false
 		}
+
+		signed = true
 	}
 
-	return true
+	// No plain invocation at all means nothing signs, whatever the text contains.
+	return signed
 }
 
 // mustNotSkipIndependently rejects a required step whose condition lets it be skipped while the

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -478,12 +478,30 @@ func declarationWordsWriteTo(lits []string, litOK []bool, name string) bool {
 
 		// `export REF=…` writes REF directly; `declare -n target=REF` makes target an alias FOR REF,
 		// so there the protected name appears on the right.
-		if lhs == name || (nameref && rhs == name) {
+		if lhs == name || (nameref && namerefBase(rhs) == name) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// namerefBase strips an array subscript from a nameref target.
+//
+// Bash accepts a subscript on a nameref target, and on a scalar `REF[0]` denotes REF itself — so
+// `declare -n target=REF[0]` followed by a write through target assigns REF. Comparing the raw
+// target misses that.
+//
+// Stripping can only ever ADD detections, never remove one: it widens what counts as aliasing the
+// protected name, which is the direction this collector already errs in. A target that is genuinely
+// a distinct array (`OTHER[0]`) reduces to `OTHER` and still does not match the protected name.
+func namerefBase(target string) string {
+	base, _, found := strings.Cut(target, "[")
+	if !found {
+		return target
+	}
+
+	return base
 }
 
 // declaresNamerefTo reports whether decl creates a nameref aliasing the protected variable.
@@ -525,7 +543,7 @@ func declaresNamerefTo(decl *syntax.DeclClause, name string) bool {
 		}
 
 		target, readable := literalOf(assign.Value)
-		if !readable || target == name {
+		if !readable || namerefBase(target) == name {
 			return true
 		}
 	}

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -310,6 +310,15 @@ func errexitToggle(cmd executedCommand) (bool, bool) {
 	for i := 1; i < len(cmd.lits); i++ {
 		word := cmd.lits[i]
 
+		// `--` and a bare `-` end option parsing and assign every remaining word to the positional
+		// parameters (bash `help set`). Scanning past them read `set -- -e` as errexit being
+		// restored, so a signing block could turn failure propagation OFF, set positionals, and
+		// still be credited with a gate that no longer fails the step — the guard reporting the
+		// safe state precisely where the unsafe one holds.
+		if word == "--" || word == "-" {
+			break
+		}
+
 		switch {
 		case strings.HasPrefix(word, "-") && !strings.HasPrefix(word, "--") && strings.Contains(word, "e"):
 			state, found = true, true
@@ -399,6 +408,21 @@ func assignmentsTo(run, name string) []assignment {
 		switch typed := node.(type) {
 		case *syntax.CallExpr:
 			collect(typed.Assigns)
+
+			// A builtin can write a variable whose name it takes as an ARGUMENT, which the parser
+			// models as ordinary words rather than CallExpr.Assigns. `printf -v REF '%s' '<stale>'`
+			// was therefore invisible here: a correct resolution could be followed by an unseen
+			// overwrite, and both consumers — which require EVERY assignment to qualify — passed
+			// while cosign signed the overwritten value.
+			if builtinWritesTo(typed, name) {
+				out = append(out, assignment{
+					// Deliberately opaque. Both consumers compare against an exact required form or
+					// demand a resolved value, so an unreadable write fails each of them: the guard
+					// reports "cannot prove this" rather than guessing what the builtin wrote.
+					text:                 "",
+					consumesPublishedTag: false,
+				})
+			}
 		// `export`, `declare`, `local`, `readonly` and `typeset` assign too, and the parser models
 		// them as a DeclClause rather than a CallExpr. Reading only CallExpr made
 		// `declare -g DIGEST="sha256:…"` invisible, so a constant could silently override a correct
@@ -412,6 +436,158 @@ func assignmentsTo(run, name string) []assignment {
 	})
 
 	return out
+}
+
+// builtinWritesTo reports whether call writes the shell variable name through a builtin that takes
+// its destination as an ARGUMENT rather than as an assignment.
+//
+// Listing the class rather than the one builtin that was reported matters: `printf -v` is not
+// special, it is simply the instance a reviewer happened to find. `read`, `mapfile`/`readarray` and
+// `getopts` all take a destination name the same way, and `eval` can assemble any assignment at all,
+// so fixing only `printf` would leave four more spellings of the same bypass.
+//
+// Each builtin is decoded in its OWN argument grammar rather than by scanning every word for the
+// name. That precision is the point: `printf '%s' "${REF}" >>"${GITHUB_OUTPUT}"` is correct,
+// extremely common, and merely READS the variable. A guard that flagged any command mentioning REF
+// would reject correct workflows, and a guard people cannot ship past gets deleted, not obeyed. The
+// conservative direction is reserved for the destination position, where an unreadable word really
+// could be the name being written.
+func builtinWritesTo(call *syntax.CallExpr, name string) bool {
+	if len(call.Args) == 0 {
+		return false
+	}
+
+	command, ok := literalOf(call.Args[0])
+	if !ok {
+		return false
+	}
+
+	args := call.Args[1:]
+
+	switch command {
+	case "printf":
+		return printfWritesTo(args, name)
+	case "read":
+		return readLikeWritesTo(args, name, "adinNptu")
+	case "mapfile", "readarray":
+		return readLikeWritesTo(args, name, "dnOsuCc")
+	case "getopts":
+		// `getopts optstring NAME [arg...]`: the first operand is the option string, every later
+		// one is a destination or a scanned argument. Comparing all but the first keeps it simple
+		// and errs toward reporting a write.
+		return operandWritesTo(args, name, 1)
+	case "eval":
+		return evalWritesTo(args, name)
+	}
+
+	return false
+}
+
+// printfWritesTo decodes `printf -v NAME …`, including the attached `-vNAME` spelling that an exact
+// "-v then the next word" scan would miss.
+func printfWritesTo(args []*syntax.Word, name string) bool {
+	for i, arg := range args {
+		word, readable := literalOf(arg)
+		if !readable {
+			continue
+		}
+
+		if word == "--" {
+			return false
+		}
+
+		if word == "-v" {
+			if i+1 >= len(args) {
+				return false
+			}
+
+			target, targetReadable := literalOf(args[i+1])
+
+			return !targetReadable || target == name
+		}
+
+		if strings.HasPrefix(word, "-v") && len(word) > 2 {
+			return word[2:] == name
+		}
+	}
+
+	return false
+}
+
+// readLikeWritesTo decodes `read` and `mapfile`/`readarray`, whose destination names are the
+// operands left after option parsing. valueOpts lists the single-letter options that consume the
+// following word, so an option's ARGUMENT is never mistaken for a destination.
+//
+// `read -a NAME` is a write like any other: the array name is where the value lands.
+func readLikeWritesTo(args []*syntax.Word, name, valueOpts string) bool {
+	for i := 0; i < len(args); i++ {
+		word, readable := literalOf(args[i])
+		if !readable {
+			// Unreadable in operand position could be the destination.
+			return true
+		}
+
+		if word == "--" {
+			return operandWritesTo(args[i+1:], name, 0)
+		}
+
+		if !strings.HasPrefix(word, "-") || word == "-" {
+			return operandWritesTo(args[i:], name, 0)
+		}
+
+		// A value-taking option given as `-p prompt` consumes the next word; `-ppromopt` and
+		// clustered flags consume nothing further.
+		if len(word) == 2 && strings.ContainsRune(valueOpts, rune(word[1])) {
+			// `read -a NAME` names its destination in the option's own argument.
+			if word == "-a" && i+1 < len(args) {
+				target, targetReadable := literalOf(args[i+1])
+				if !targetReadable || target == name {
+					return true
+				}
+			}
+
+			i++
+		}
+	}
+
+	return false
+}
+
+// operandWritesTo reports whether any operand from skip onward names the protected variable. An
+// unreadable operand counts, because it could be the destination and the guard cannot prove it is
+// not.
+func operandWritesTo(args []*syntax.Word, name string, skip int) bool {
+	for i, arg := range args {
+		if i < skip {
+			continue
+		}
+
+		word, readable := literalOf(arg)
+		if !readable || word == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// evalWritesTo reports whether an eval could assign the protected variable. Its argument is a
+// program, so a readable one is searched for an assignment to the name and an unreadable one is
+// treated as a write: eval assembling text the guard cannot see is exactly the case it must not
+// certify.
+func evalWritesTo(args []*syntax.Word, name string) bool {
+	for _, arg := range args {
+		word, readable := literalOf(arg)
+		if !readable {
+			return true
+		}
+
+		if strings.Contains(word, name+"=") {
+			return true
+		}
+	}
+
+	return false
 }
 
 // sourceOf returns the source text a node spans. Comparing what was WRITTEN keeps the required

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -1,0 +1,222 @@
+// Command validate-publication-order checks that production is never pointed at
+// an artifact whose supply-chain evidence is still being assembled.
+//
+// The prod deploy publishes the platform manifests to a mutable tag, signs them
+// with keyless cosign, attests an SBOM and SLSA provenance, and only then tells
+// Flux to reconcile. That order is the whole guarantee: reordering any of it
+// leaves a window in which the cluster's root source — which delivers every
+// controller, tenant binding and policy — resolves bytes that carry no
+// signature or no attestation.
+//
+// Nothing about that window is visible in a green deploy. The steps all
+// succeed, the cluster converges, and the artifact ends up fully signed a
+// minute later; the defect is only that Flux could have looked in between. So
+// the ordering has no natural regression signal, and a later edit that moves
+// the reconcile trigger up to "fail faster" would be indistinguishable from an
+// improvement. This turns that into a pull-request failure.
+//
+// Scope: this pins the order of the steps that already exist. It does NOT
+// establish that publication is atomic — the mutable tag is still moved by the
+// push step before signing begins, which is the substance of
+// devantler-tech/platform#2627 and needs a staging reference to fix. Do not
+// read a green run here as that issue being closed.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// step is one entry of runs.steps, reduced to what identifies it here.
+type step struct {
+	Name string `yaml:"name"`
+	ID   string `yaml:"id"`
+	Uses string `yaml:"uses"`
+	Run  string `yaml:"run"`
+}
+
+type action struct {
+	Runs struct {
+		Steps []step `yaml:"steps"`
+	} `yaml:"runs"`
+}
+
+// marker locates one step of the publication sequence. Matching on what a step
+// DOES — the command it runs or the action it uses — rather than on its name
+// keeps the check working when a name is reworded, and failing when the step it
+// describes actually disappears.
+type marker struct {
+	// label is how the step is described in an error message.
+	label string
+	// match reports whether a step is this one.
+	match func(step) bool
+}
+
+func runContains(substr string) func(step) bool {
+	return func(s step) bool { return strings.Contains(s.Run, substr) }
+}
+
+func usesPrefix(prefix string) func(step) bool {
+	return func(s step) bool { return strings.HasPrefix(s.Uses, prefix) }
+}
+
+// The contract is a partial order, not a chain: publish first, then the
+// evidence in any order among itself, then the release. Modelling it as a
+// straight sequence would additionally forbid swapping the two attestations,
+// which is a free choice — failing CI on a legitimate reordering trains people
+// to treat this check as noise.
+//
+// The SBOM generator is deliberately absent: it produces a file rather than
+// publishing anything, so its position carries no guarantee.
+var (
+	// publish makes new bytes reachable and must come first — signing or
+	// attesting before it would cover the previous artifact.
+	publish = marker{"publish the manifests (`workload push`)", runContains("workload push")}
+
+	// evidence is what must exist before production may look. Order among
+	// these is unconstrained.
+	evidence = []marker{
+		{"sign the published digest (`cosign sign`)", runContains("cosign sign ")},
+		{"attest the SBOM (`actions/attest`)", usesPrefix("actions/attest@")},
+		{"attest build provenance (`actions/attest-build-provenance`)", usesPrefix("actions/attest-build-provenance@")},
+	}
+
+	// release is the step that advances what production can see.
+	release = marker{"tell Flux to reconcile (`workload reconcile`)", runContains("workload reconcile")}
+)
+
+// digestRef is the form the signing step must use. Signing the mutable tag
+// instead would let a concurrent deploy move it between resolve and sign, so
+// the signature would cover bytes this run never published.
+const digestRef = `REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`
+
+// indexOf returns the position of the first step matching m.
+func indexOf(steps []step, m marker) (int, bool) {
+	for i, s := range steps {
+		if m.match(s) {
+			return i, true
+		}
+	}
+
+	return 0, false
+}
+
+func validate(source []byte) error {
+	var parsed action
+	if err := yaml.Unmarshal(source, &parsed); err != nil {
+		return fmt.Errorf("could not parse as YAML: %w", err)
+	}
+
+	steps := parsed.Runs.Steps
+	if len(steps) == 0 {
+		return errors.New("no runs.steps; this does not look like a composite action")
+	}
+
+	locate := func(m marker) (int, error) {
+		at, ok := indexOf(steps, m)
+		if !ok {
+			return 0, fmt.Errorf(
+				"no step appears to %s.\n"+
+					"If that step was renamed, this check follows what a step does rather than what it is called — "+
+					"restore the command or action it matches on, or update the marker here deliberately",
+				m.label)
+		}
+
+		return at, nil
+	}
+
+	mustPrecede := func(earlier marker, earlierAt int, later marker, laterAt int) error {
+		if earlierAt < laterAt {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"the deploy must %s BEFORE it can %s, but the steps are in the opposite order "+
+				"(positions %d and %d).\n"+
+				"Flux resolves the mutable tag on its own schedule, so any step that advances what "+
+				"production can see must come after the evidence it depends on is published",
+			earlier.label, later.label, earlierAt+1, laterAt+1)
+	}
+
+	publishAt, err := locate(publish)
+	if err != nil {
+		return err
+	}
+
+	releaseAt, err := locate(release)
+	if err != nil {
+		return err
+	}
+
+	signAt := -1
+
+	for _, m := range evidence {
+		at, err := locate(m)
+		if err != nil {
+			return err
+		}
+
+		if err := mustPrecede(publish, publishAt, m, at); err != nil {
+			return err
+		}
+
+		if err := mustPrecede(m, at, release, releaseAt); err != nil {
+			return err
+		}
+
+		if strings.Contains(m.label, "cosign sign") {
+			signAt = at
+		}
+	}
+
+	if !strings.Contains(steps[signAt].Run, digestRef) {
+		return fmt.Errorf(
+			"the signing step must build its reference from the resolved digest (%s); "+
+				"signing the mutable tag lets a concurrent deploy move it between resolve and sign",
+			digestRef)
+	}
+
+	return nil
+}
+
+func run(paths []string, stderr io.Writer) error {
+	if len(paths) == 0 {
+		return errors.New("usage: validate-publication-order <action.yml>")
+	}
+
+	failed := false
+
+	for _, path := range paths {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			// Fail closed: an unreadable action is not a validated action.
+			_, _ = fmt.Fprintf(stderr, "::error::%s: could not read: %v\n", path, err)
+			failed = true
+
+			continue
+		}
+
+		if err := validate(source); err != nil {
+			_, _ = fmt.Fprintf(stderr, "::error::%s: %v\n", path, err)
+			failed = true
+		}
+	}
+
+	if failed {
+		return errors.New("the publication ordering contract is not satisfied")
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "::error::%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/scripts/validate-publication-order/main.go
+++ b/scripts/validate-publication-order/main.go
@@ -261,6 +261,11 @@ func parseExecuted(run string, errexit bool) []executedCommand {
 // exactly as much state as the bare form does. Depth is what this walk must not stop at.
 func unmodeledShellState(file *syntax.File) (string, bool) {
 	found := ""
+	// The state axis is only sound where BOTH halves agree. This walk sees every node, but
+	// parseExecuted tracks errexit from top-level statements alone, so a `set` anywhere else
+	// changes the shell without moving the tracked state.
+	tracked := stateTrackedCalls(file)
+	subshell := callsInSubshells(file)
 
 	syntax.Walk(file, func(node syntax.Node) bool {
 		if found != "" {
@@ -306,6 +311,20 @@ func unmodeledShellState(file *syntax.File) (string, bool) {
 				}
 			}
 		case "set":
+			// A brace group, branch, loop or function body is not a top-level statement, so
+			// errexitToggle never sees this call — while bash still applies it, because all of
+			// them run in the CURRENT shell. Accepting them credited a later `cosign` as
+			// failure-propagating when errexit was in fact off.
+			//
+			// A subshell is the opposite case and must still pass: `$( set -euo pipefail; … )`
+			// changes only the child, so the parent state this file tracks is correctly
+			// unchanged. Rejecting it would fail ordinary scripting.
+			if !tracked[call] && !subshell[call] {
+				found = "`set` in a compound construct that runs in the step's own shell"
+
+				return false
+			}
+
 			if opt, ok := unmodeledSetOption(lits[start+1:], litOK[start+1:]); ok {
 				if opt == nonLiteralOption {
 					found = "`set` with an option whose value is not statically known"
@@ -321,6 +340,68 @@ func unmodeledShellState(file *syntax.File) (string, bool) {
 	})
 
 	return found, found != ""
+}
+
+// stateTrackedCalls returns the calls whose shell-state effect parseExecuted actually evaluates:
+// the top-level statements it iterates, minus the negated and backgrounded ones it skips. Anything
+// outside this set can change the shell without the tracked state moving, so it fails closed.
+func stateTrackedCalls(file *syntax.File) map[*syntax.CallExpr]bool {
+	out := make(map[*syntax.CallExpr]bool, len(file.Stmts))
+
+	for _, stmt := range file.Stmts {
+		if stmt.Negated || stmt.Background {
+			continue
+		}
+
+		if call, isCall := stmt.Cmd.(*syntax.CallExpr); isCall {
+			out[call] = true
+		}
+	}
+
+	return out
+}
+
+// callsInSubshells returns the calls that run in a CHILD shell rather than the step's own.
+//
+// This is the line between a `set` that must fail closed and one that must pass: a brace group,
+// branch or loop applies to the shell parseExecuted is tracking, while a command substitution,
+// explicit subshell, process substitution, backgrounded statement or pipeline stage applies only
+// to a child that exits. `$( set -euo pipefail; crane digest … )` is ordinary scripting and stays
+// legal for exactly that reason.
+func callsInSubshells(file *syntax.File) map[*syntax.CallExpr]bool {
+	out := make(map[*syntax.CallExpr]bool)
+
+	markAll := func(n syntax.Node) {
+		syntax.Walk(n, func(inner syntax.Node) bool {
+			if call, isCall := inner.(*syntax.CallExpr); isCall {
+				out[call] = true
+			}
+
+			return true
+		})
+	}
+
+	syntax.Walk(file, func(node syntax.Node) bool {
+		switch typed := node.(type) {
+		case *syntax.Subshell, *syntax.CmdSubst, *syntax.ProcSubst:
+			markAll(node)
+		case *syntax.Stmt:
+			if typed.Background {
+				markAll(typed)
+			}
+		case *syntax.BinaryCmd:
+			// Each stage of a pipeline runs in its own shell, so neither side can move the
+			// state this file tracks. `&&`/`||` do NOT create one and are deliberately absent.
+			if typed.Op == syntax.Pipe || typed.Op == syntax.PipeAll {
+				markAll(typed.X)
+				markAll(typed.Y)
+			}
+		}
+
+		return true
+	})
+
+	return out
 }
 
 // nonLiteralOption marks a `set` word whose value is not statically known, so the allowlist cannot
@@ -606,7 +687,7 @@ func assignmentsTo(run, name string) []assignment {
 
 			out = append(out, assignment{
 				text:                 sourceOf(run, assign.Value.Pos(), assign.Value.End()),
-				consumesPublishedTag: valueResolvedFrom(assign.Value, publishedTagVar),
+				consumesPublishedTag: valueResolvedFrom(assign.Value, publishedTagVar, declaredNames(file)),
 			})
 		}
 	}
@@ -1034,7 +1115,7 @@ func sourceOf(src string, from, to syntax.Pos) string {
 //
 // The tag must be read by the statement whose output BECOMES the value, not merely by something
 // somewhere inside the substitution — see consumes for why that distinction is load-bearing.
-func valueResolvedFrom(word *syntax.Word, name string) bool {
+func valueResolvedFrom(word *syntax.Word, name string, shadowed map[string]bool) bool {
 	resolved := false
 
 	syntax.Walk(word, func(node syntax.Node) bool {
@@ -1043,7 +1124,7 @@ func valueResolvedFrom(word *syntax.Word, name string) bool {
 			return !resolved
 		}
 
-		if len(subst.Stmts) > 0 && consumes(subst.Stmts[len(subst.Stmts)-1], name) {
+		if len(subst.Stmts) > 0 && consumes(subst.Stmts[len(subst.Stmts)-1], name, shadowed) {
 			resolved = true
 		}
 
@@ -1087,7 +1168,7 @@ func valueResolvedFrom(word *syntax.Word, name string) bool {
 //
 // A retry belongs around the ASSIGNMENT (`for … do DIGEST=$(…) && break; done`), which is unaffected:
 // assignmentsTo finds it at any depth, so the idiomatic spelling still passes.
-func consumes(stmt *syntax.Stmt, name string) bool {
+func consumes(stmt *syntax.Stmt, name string, shadowed map[string]bool) bool {
 	call, isCall := stmt.Cmd.(*syntax.CallExpr)
 	if !isCall || len(call.Args) == 0 {
 		return false
@@ -1110,6 +1191,14 @@ func consumes(stmt *syntax.Stmt, name string) bool {
 	// each round found another one.
 	exec, known := literalOf(call.Args[0])
 	if !known || !digestResolvers[exec] {
+		return false
+	}
+
+	// Allow-listing the NAME only binds the value if the name still reaches that program. bash looks
+	// up functions before $PATH, so `docker() { printf 'sha256:<old>'; }` makes this call return a
+	// constant while reading as a genuine resolve. Top-level required commands were already checked
+	// against declaredNames; the resolver is the same question about a different call.
+	if shadowed[exec] {
 		return false
 	}
 

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1385,3 +1385,78 @@ func TestAllowsANamerefToAnUnrelatedVariable(t *testing.T) {
 		t.Fatalf("a nameref to an unrelated variable is correct code; got: %v", err)
 	}
 }
+
+// TestRejectsPrefixedBuiltinBypasses covers `builtin` and `command`, which bash accepts in front of a
+// builtin. Every check that keyed on a command's first word — the errexit toggle, builtin write
+// detection, nameref detection — was defeated by a single prefix, so one wrapper reopened three
+// separate bypasses at once. All four shapes below were verified to pass the validator before the
+// prefix stripping went in.
+func TestRejectsPrefixedBuiltinBypasses(t *testing.T) {
+	for _, testCase := range []struct{ name, inject string }{
+		{
+			"builtin printf -v",
+			`        builtin printf -v REF '%s' 'ghcr.io/devantler-tech/platform/manifests:latest'`,
+		},
+		{
+			"command printf -v",
+			`        command printf -v REF '%s' 'ghcr.io/devantler-tech/platform/manifests:latest'`,
+		},
+		{
+			"builtin declare -n",
+			"        builtin declare -n target=REF\n" +
+				`        target='ghcr.io/devantler-tech/platform/manifests:latest'`,
+		},
+		{"builtin set +e", "        builtin set +e"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			bypass := strings.Replace(validAction,
+				`        cosign sign --yes --recursive "${REF}"`,
+				testCase.inject+"\n"+`        cosign sign --yes --recursive "${REF}"`, 1)
+			mustChange(t, validAction, bypass)
+
+			if err := validate([]byte(bypass)); err == nil {
+				t.Fatal("a builtin/command prefix must not hide the write or the errexit toggle")
+			}
+		})
+	}
+}
+
+// TestAllowsCommandLookupOfARequiredTool is the over-tightening control for the prefix stripping.
+// `command -v` and `command -V` only LOOK UP a command — they execute nothing — so a preflight check
+// that a tool exists must stay correct code. Stripping the wrapper without honouring `-v` would read
+// this as running printf and writing REF.
+func TestAllowsCommandLookupOfARequiredTool(t *testing.T) {
+	preflight := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        command -v cosign >/dev/null\n"+
+			`        command -v printf >/dev/null`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, preflight)
+
+	if err := validate([]byte(preflight)); err != nil {
+		t.Fatalf("`command -v` is a lookup, not an execution; got: %v", err)
+	}
+}
+
+// TestReportsAMissingSigningStepID pins the error a reader actually needs. Without an `id:` the
+// evidence marker becomes `${{ steps..outputs.digest }}`, which no attestation can match — so the run
+// failed while pointing at the attestation steps and telling the reader to write that empty
+// expression into them. The defect is one step earlier, and a guard that misnames it sends people to
+// the wrong file.
+func TestReportsAMissingSigningStepID(t *testing.T) {
+	noID := strings.Replace(validAction, "      id: cosign-sign\n", "", 1)
+	mustChange(t, validAction, noID)
+
+	err := validate([]byte(noID))
+	if err == nil {
+		t.Fatal("a signing step with no id: cannot bind any attestation")
+	}
+
+	if !strings.Contains(err.Error(), "id:") {
+		t.Fatalf("the error must name the missing id:; got: %v", err)
+	}
+
+	if strings.Contains(err.Error(), "steps..outputs.digest") {
+		t.Fatalf("the error must not quote the empty marker back at the reader; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1431,6 +1431,82 @@ func TestRejectsPrefixedBuiltinBypasses(t *testing.T) {
 	}
 }
 
+// TestRejectsControlAndBindingBypasses covers four ways a signing block could look correct to the
+// validator while `cosign sign` never covers the released artifact. All four were reported as P1 on
+// the PR that added the surrounding guard, and all four passed the validator before these fixes.
+//
+// They are grouped because they share one failure signature: the step exits zero, the digest output
+// is exported correctly, and both attestations plus reconciliation advance over an artifact that is
+// unsigned or signed at a stale reference.
+func TestRejectsControlAndBindingBypasses(t *testing.T) {
+	const stale = "ghcr.io/devantler-tech/platform/manifests:latest"
+
+	for _, testCase := range []struct{ name, inject, wantErr string }{
+		{
+			// An unconditional top-level `exit` ends the shell, so the `cosign sign` written after it
+			// never runs — but the scan kept walking and credited it as executed.
+			"exit before cosign",
+			"        exit 0",
+			"no step appears to",
+		},
+		{
+			// `exec <cmd>` replaces the shell image; everything after it is equally unreachable.
+			"exec before cosign",
+			"        exec true",
+			"no step appears to",
+		},
+		{
+			// `builtin -- set +e` runs `set`, but the wrapper stripper advanced only past `builtin`
+			// and left `--` standing as the command, so errexit stayed tracked as enabled.
+			"builtin -- set +e",
+			"        builtin -- set +e",
+			"no step appears to",
+		},
+		{
+			// A subscripted printf destination writes REF; the decoder compared the target exactly.
+			"printf -v subscripted destination",
+			`        printf -v 'REF[0]' '%s' '` + stale + `'`,
+			"resolved digest",
+		},
+		{
+			// A `for` binding overwrites REF and leaves its final value in scope after the loop.
+			"for-loop binding overwrites REF",
+			"        for REF in '" + stale + "'; do :; done",
+			"resolved digest",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			bypass := strings.Replace(validAction,
+				`        cosign sign --yes --recursive "${REF}"`,
+				testCase.inject+"\n"+`        cosign sign --yes --recursive "${REF}"`, 1)
+			mustChange(t, validAction, bypass)
+
+			err := validate([]byte(bypass))
+			if err == nil {
+				t.Fatal("the bypass must not leave the publication-order contract satisfied")
+			}
+
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("want an error naming %q; got: %v", testCase.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestAllowsAnExecThatOnlyRedirects is the over-tightening control for the exit/exec termination.
+// A bare `exec` with no command applies redirections to the CURRENT shell and execution continues
+// past it, so treating it as terminating would blind the guard to the whole rest of the step.
+func TestAllowsAnExecThatOnlyRedirects(t *testing.T) {
+	withRedirect := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        exec 3>&1\n"+`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, withRedirect)
+
+	if err := validate([]byte(withRedirect)); err != nil {
+		t.Fatalf("a redirect-only exec must not hide the commands after it; got: %v", err)
+	}
+}
+
 // TestRejectsNamerefWithASubscriptTarget covers a nameref target that carries an array subscript.
 //
 // Bash accepts a subscript on a nameref target, and on a scalar `REF[0]` denotes REF itself, so

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1761,3 +1761,43 @@ func TestAllowsAnUnrelatedInterpretedScript(t *testing.T) {
 		t.Fatalf("running a helper script through bash is ordinary, got: %v", err)
 	}
 }
+
+// resolutionAssignments are the names whose VALUE decides what a later command resolves to, or what
+// the shell reads before running. They need their own table because they are assignments rather than
+// commands: the construct walk above sees calls, and an assignment is not one.
+//
+// The environment-prefix form is the interesting member — `PATH=… cosign sign …` is one statement
+// that both rebinds the lookup and issues the required command, so a rule keyed on statements that
+// "only assign" would miss it.
+var resolutionAssignments = map[string]string{
+	"PATH prepend":       `        PATH=/tmp/fake:$PATH` + "\n" + signCall,
+	"PATH exported":      `        export PATH=/tmp/fake:$PATH` + "\n" + signCall,
+	"BASH_ENV assigned":  `        BASH_ENV=./setup.sh` + "\n" + signCall,
+	"PATH as env prefix": `        PATH=/tmp/fake cosign sign --yes --recursive "${REF}"`,
+}
+
+func TestRejectsAssignmentsThatRedirectResolution(t *testing.T) {
+	for name, replacement := range resolutionAssignments {
+		t.Run(name, func(t *testing.T) {
+			mutated := strings.Replace(validAction, signCall, replacement, 1)
+			mustChange(t, validAction, mutated)
+
+			if err := validate([]byte(mutated)); err == nil {
+				t.Fatalf("expected %q to be rejected: it decides what `cosign` resolves to", name)
+			}
+		})
+	}
+}
+
+// TestAllowsOrdinaryAssignments is that rule's over-tightening control. The reference signing block
+// is mostly assignments — REF and DIGEST — so a rule that treated assignment itself as suspicious
+// would reject every real deploy.
+func TestAllowsOrdinaryAssignments(t *testing.T) {
+	mutated := strings.Replace(validAction, signCall,
+		"        export COSIGN_YES=true\n        SUBJECT=\"${REF}\"\n"+signCall, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err != nil {
+		t.Fatalf("ordinary assignments are how the real block works, got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -943,18 +943,23 @@ func TestRejectsADigestThatOnlyCONCATENATESThePublishedTag(t *testing.T) {
 	}
 }
 
-// TestAllowsResolvingThroughAPipeline is an over-tightening control. Reading the tag inside a
-// pipeline, a subshell or a redirection is ordinary scripting — the expansion still reaches the
-// program that resolves the digest — so the check must find it at any depth inside the substitution
-// rather than only in its first command.
-func TestAllowsResolvingThroughAPipeline(t *testing.T) {
+// TestRejectsAPipelineResolver pins the last construct this guard accepted on an unenforceable
+// claim. A pipeline of plain calls has no branches, so it LOOKS provenance-preserving, and an
+// earlier round accepted it on the reasoning that later stages "only reshape" the resolver output.
+// Shell syntax does not enforce that: `crane digest "${REF_TAG}" | printf '%s' 'sha256:…'`
+// reads the tag in its first stage, and printf never reads stdin, so the constant becomes DIGEST.
+//
+// A single call is therefore the whole accepted set — the only construct whose output is bound to a
+// command that demonstrably consumed the tag. The cost is real and deliberate: a pipeline resolver
+// must be rewritten as one command, and the error message says so.
+func TestRejectsAPipelineResolver(t *testing.T) {
 	piped := strings.Replace(validAction,
 		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
-		`        DIGEST=$(crane manifest "${REF_TAG}" | sha256sum | cut -d' ' -f1)`, 1)
+		`        DIGEST=$(crane digest "${REF_TAG}" | printf '%s' 'sha256:1111111111111111111111111111111111111111111111111111111111111111')`, 1)
 	mustChange(t, validAction, piped)
 
-	if err := validate([]byte(piped)); err != nil {
-		t.Fatalf("resolving through a pipeline still reads the published tag; got: %v", err)
+	if err := validate([]byte(piped)); err == nil {
+		t.Fatal("a later pipeline stage can emit a digest the resolver never produced")
 	}
 }
 

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -237,3 +237,52 @@ func TestRejectsSigningTheMutableTagWhileAssigningTheDigest(t *testing.T) {
 		t.Fatal("expected signing the mutable tag to be rejected even though REF is assigned the digest")
 	}
 }
+
+// TestRejectsACommentedOutSigningInvocation covers a hole in the matchers themselves: both
+// runContains("cosign sign ") and the digest check work on the raw script text, so commenting the
+// invocation out leaves BOTH satisfied — the comment still contains the command and the reference.
+// The deploy would then publish and reconcile an artifact nothing signed, while this check stays
+// green. A guard that a `#` disables is not a guard.
+func TestRejectsACommentedOutSigningInvocation(t *testing.T) {
+	commented := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        # cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, commented)
+
+	if err := validate([]byte(commented)); err == nil {
+		t.Fatal("expected a commented-out cosign invocation to be rejected")
+	}
+}
+
+// TestRejectsEvidenceThatCanSkipWhileTheReleaseRuns covers the other way the order can hold while the
+// guarantee does not. Ordering is positional, so an evidence step keeps its position while carrying a
+// condition that never fires; GitHub skips it without failing the composite and runs the unconditional
+// reconcile anyway. Production is then released without that evidence, with every ordering comparison
+// still satisfied.
+func TestRejectsEvidenceThatCanSkipWhileTheReleaseRuns(t *testing.T) {
+	skippable := strings.Replace(validAction,
+		"    - name: Attest provenance\n",
+		"    - name: Attest provenance\n      if: ${{ false }}\n", 1)
+	mustChange(t, validAction, skippable)
+
+	if err := validate([]byte(skippable)); err == nil {
+		t.Fatal("expected an evidence step that can skip independently of the release to be rejected")
+	}
+}
+
+// TestAllowsEvidenceSharingTheReleaseCondition is the companion that keeps the rule from becoming a
+// blanket ban on conditions. Evidence guarded by the SAME condition as the release cannot be skipped
+// while the release runs — they stand or fall together — so that arrangement stays legal.
+func TestAllowsEvidenceSharingTheReleaseCondition(t *testing.T) {
+	shared := strings.Replace(validAction,
+		"    - name: Attest provenance\n",
+		"    - name: Attest provenance\n      if: ${{ inputs.deploy }}\n", 1)
+	shared = strings.Replace(shared,
+		"    - name: Reconcile\n",
+		"    - name: Reconcile\n      if: ${{ inputs.deploy }}\n", 1)
+	mustChange(t, validAction, shared)
+
+	if err := validate([]byte(shared)); err != nil {
+		t.Fatalf("evidence sharing the release condition must stay legal, got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1587,3 +1587,177 @@ func TestReportsAMissingSigningStepID(t *testing.T) {
 		t.Fatalf("the error must not quote the empty marker back at the reader; got: %v", err)
 	}
 }
+
+// unmodeledStateChanges are the ways a signing block can change how the shell RESOLVES a command or
+// PROPAGATES its failure, using a construct the guard does not interpret. Each one leaves the
+// required invocation textually perfect, top-level, unnegated and errexit-guarded — every property
+// the guard checks — while producing no signature.
+//
+// They are enumerated as one table rather than one per review round because they are one class: the
+// guard models a fixed set of state changes (`set -e`, aliases, functions, namerefs) and SKIPPED
+// everything else, so each unmodeled construct was a silent bypass. That is the same blocklist
+// failure the grammar rule already fixed for "does it run"; this is the state axis of it.
+var unmodeledStateChanges = map[string]string{
+	// `hash -p PATH NAME` makes bash use PATH for NAME, ahead of any lookup (bash `help hash`).
+	"hash rebinding": "        hash -p /usr/bin/true cosign\n" + signCall,
+	// An ERR handler runs where errexit would exit, and `exit 0` then makes the step succeed.
+	"ERR trap": "        trap 'exit 0' ERR\n" + signCall,
+	// `set -n` reads commands without executing them (bash `help set`).
+	"noexec":      "        set -n\n" + signCall,
+	"noexec long": "        set -o noexec\n" + signCall,
+	// `source`/`.` and `eval` run text the guard never sees.
+	"sourced file": "        source ./setup.sh\n" + signCall,
+	"dot file":     "        . ./setup.sh\n" + signCall,
+	"eval":         "        eval 'cosign() { true; }'\n" + signCall,
+	// `enable -n` turns a builtin off; `shopt` changes expansion, including alias expansion.
+	"disabled builtin": "        enable -n printf\n" + signCall,
+	// State changed inside a top-level BLOCK still applies to the current shell, so nesting it does
+	// not make it someone else's problem.
+	"block-nested trap": "        { trap 'exit 0' ERR; }\n" + signCall,
+}
+
+func TestRejectsUnmodeledShellStateChanges(t *testing.T) {
+	for name, replacement := range unmodeledStateChanges {
+		t.Run(name, func(t *testing.T) {
+			mutated := strings.Replace(validAction, signCall, replacement, 1)
+			mustChange(t, validAction, mutated)
+
+			if err := validate([]byte(mutated)); err == nil {
+				t.Fatalf("expected %q to be rejected: it changes command resolution or failure "+
+					"propagation in a way the guard does not model", name)
+			}
+		})
+	}
+}
+
+// TestRejectsBashEnvOnASigningStep covers the same axis from the STEP rather than the script: bash
+// expands BASH_ENV and reads that file before running a non-interactive script, so a startup file
+// defining `cosign() { true; }` shadows the required command without appearing in the run block.
+func TestRejectsBashEnvOnASigningStep(t *testing.T) {
+	withEnv := strings.Replace(validAction,
+		"      id: cosign-sign\n",
+		"      id: cosign-sign\n      env:\n        BASH_ENV: ./setup.sh\n", 1)
+	mustChange(t, validAction, withEnv)
+
+	if err := validate([]byte(withEnv)); err == nil {
+		t.Fatal("BASH_ENV sources a startup file the guard never reads")
+	}
+}
+
+// TestAllowsOrdinarySigningStepEnv is the over-tightening control: the real signing step carries
+// `env: COSIGN_YES`, so rejecting env wholesale would reject the action this guard exists to protect.
+func TestAllowsOrdinarySigningStepEnv(t *testing.T) {
+	withEnv := strings.Replace(validAction,
+		"      id: cosign-sign\n",
+		"      id: cosign-sign\n      env:\n        COSIGN_YES: \"true\"\n", 1)
+	mustChange(t, validAction, withEnv)
+
+	if err := validate([]byte(withEnv)); err != nil {
+		t.Fatalf("an ordinary step env is how the real action configures cosign, got: %v", err)
+	}
+}
+
+// TestAllowsTheModeledOptionSet is the over-tightening control for the `set` allowlist: the real
+// signing block opens with `set -euo pipefail`, and a guard that rejected it would reject production.
+func TestAllowsTheModeledOptionSet(t *testing.T) {
+	withOpts := strings.Replace(validAction, signCall,
+		"        set -euo pipefail\n"+signCall, 1)
+	mustChange(t, validAction, withOpts)
+
+	if err := validate([]byte(withOpts)); err != nil {
+		t.Fatalf("`set -euo pipefail` opens the real signing block, got: %v", err)
+	}
+}
+
+// TestRejectsALoopBindingTheResolvedReference covers the ASSIGNMENT axis: a `for` loop binds its
+// variable and leaves the final value in scope, so `for REF in <stale>` overwrites the resolved
+// reference. The collector reads CallExpr and DeclClause writes, so the loop's binding is invisible
+// and the original valid assignment still satisfies the check.
+func TestRejectsALoopBindingTheResolvedReference(t *testing.T) {
+	mutated := strings.Replace(validAction, signCall,
+		"        for REF in ghcr.io/devantler-tech/platform/manifests:latest; do :; done\n"+signCall, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("`for REF in …` overwrites the resolved reference before cosign reads it")
+	}
+}
+
+// TestAllowsALoopBindingAnUnrelatedName is that rule's over-tightening control — the reference
+// sequence already loops over `attempt`, and iteration is ordinary scripting.
+func TestAllowsALoopBindingAnUnrelatedName(t *testing.T) {
+	mutated := strings.Replace(validAction, signCall,
+		"        for attempt in 1 2 3; do :; done\n"+signCall, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err != nil {
+		t.Fatalf("looping over an unrelated name is ordinary scripting, got: %v", err)
+	}
+}
+
+// TestRejectsASubscriptedBuiltinWrite covers the destination-normalisation gap: bash converts a
+// scalar to an array on `printf -v 'REF[0]'`, and `${REF}` then returns element zero — so the write
+// lands on REF while an exact name comparison sees a different destination.
+func TestRejectsASubscriptedBuiltinWrite(t *testing.T) {
+	mutated := strings.Replace(validAction, signCall,
+		`        printf -v 'REF[0]' '%s' 'ghcr.io/devantler-tech/platform/manifests:latest'`+"\n"+signCall, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("`printf -v 'REF[0]'` writes REF; ${REF} returns element zero")
+	}
+}
+
+// TestRejectsAnInterpreterWrappedExtraPush covers the OTHER direction of the same omission. The
+// guard's extra-operation rules can only reject what they can see, so an invocation whose executable
+// is `bash` was omitted entirely — and a second publish AFTER the evidence steps is exactly the
+// release-without-coverage this check exists to reject.
+func TestRejectsAnInterpreterWrappedExtraPush(t *testing.T) {
+	mutated := strings.Replace(validAction, reconcileStep,
+		"    - name: Sneak\n"+
+			"      run: bash ./scripts/run-ksail-prod-with-pull-auth.sh workload push\n"+
+			reconcileStep, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("a publish invoked through an interpreter still moves the tag production reads")
+	}
+}
+
+// TestRecognisesAnInterpreterWrappedRequiredPush is the same rule in the SATISFYING direction: if
+// looking through the interpreter only ever added rejections, the guard would reject a real deploy
+// that spelled its push that way.
+func TestRecognisesAnInterpreterWrappedRequiredPush(t *testing.T) {
+	mutated := strings.Replace(validAction,
+		"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push",
+		"      run: bash ./scripts/run-ksail-prod-with-pull-auth.sh workload push", 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err != nil {
+		t.Fatalf("an interpreter-wrapped push still publishes, got: %v", err)
+	}
+}
+
+// TestRejectsInlineInterpreterCode is where looking through the interpreter has to stop: `-c` names
+// no script, so there is nothing to resolve to and the code is never parsed by this file.
+func TestRejectsInlineInterpreterCode(t *testing.T) {
+	mutated := strings.Replace(validAction, signCall,
+		`        bash -c 'cosign() { true; }'`+"\n"+signCall, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("`bash -c` runs text this check never sees")
+	}
+}
+
+// TestAllowsAnUnrelatedInterpretedScript is the over-tightening control for both interpreter rules —
+// running a helper script through bash is ordinary scripting and must stay legal.
+func TestAllowsAnUnrelatedInterpretedScript(t *testing.T) {
+	mutated := strings.Replace(validAction, signCall,
+		"        bash ./scripts/collect-metadata.sh\n"+signCall, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err != nil {
+		t.Fatalf("running a helper script through bash is ordinary, got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -464,3 +464,21 @@ func TestAllowsAHeredocAlongsideTheRequiredInvocation(t *testing.T) {
 		t.Fatalf("a step may use a heredoc and still sign; got: %v", err)
 	}
 }
+
+// TestAllowsAHereStringInARequiredStep pins the here-string exclusion, which shipped WRONG in the
+// first version of heredoc skipping. `<<<` contains two overlapping `<<` pairs, so a pattern that
+// merely starts at `<<` matches one character later and reads the here-string's operand as a
+// delimiter — swallowing every line after it, including the real `cosign sign`, and failing a
+// perfectly valid action. The claim "a here-string is not an opener" therefore needs a test rather
+// than a comment: the comment was there, and it was false.
+func TestAllowsAHereStringInARequiredStep(t *testing.T) {
+	withHereString := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		"        grep -q x <<<\"sentinel\"\n"+
+			`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, withHereString)
+
+	if err := validate([]byte(withHereString)); err != nil {
+		t.Fatalf("a here-string is not a here-document opener; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1801,3 +1801,35 @@ func TestAllowsOrdinaryAssignments(t *testing.T) {
 		t.Fatalf("ordinary assignments are how the real block works, got: %v", err)
 	}
 }
+
+// TestRejectsAnUnparseableStep closes the same fail-open shape as the unmodeled-construct rule.
+// parseExecuted returns no commands for an unparseable block, which correctly refuses to CREDIT a
+// required operation but silently hides a forbidden one — so a step that does not parse could carry a
+// second publish after the evidence steps and still be reported as satisfying the contract.
+func TestRejectsAnUnparseableStep(t *testing.T) {
+	mutated := strings.Replace(validAction, reconcileStep,
+		"    - name: Sneak\n      run: |\n"+
+			"        ./scripts/run-ksail-prod-with-pull-auth.sh workload push\n"+
+			"        if [ -z \"$X\"\n"+
+			reconcileStep, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("an unparseable step hides everything in it, including a second publish")
+	}
+}
+
+// TestRejectsAnUnparseableSigningStep records the case that was ALREADY covered, so the two are not
+// confused. An unparseable step carrying a required operation is caught on the satisfy side —
+// parseExecuted yields nothing, so no step appears to sign — and removing the rule above leaves this
+// test green. That asymmetry is precisely why the rule above is needed: only the forbidding side was
+// open.
+func TestRejectsAnUnparseableSigningStep(t *testing.T) {
+	mutated := strings.Replace(validAction, signCall,
+		signCall+"\n        if [ -z \"$X\"\n", 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("an unparseable signing step cannot be certified either way")
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1272,6 +1272,42 @@ func TestRejectsAReleaseGatedOnACaseVariantStatusCheck(t *testing.T) {
 	}
 }
 
+// TestRejectsAReleaseGatedOnALineBrokenStatusCheck covers the WHITESPACE axis, which the case axis
+// above does not reach. Normalization stripped only U+0020, so any other whitespace between the
+// function name and its `(` slipped past a matcher looking for `always(`.
+//
+// A YAML LITERAL block scalar is the spelling that matters, and it is worth being precise about why:
+// a FOLDED scalar (`>-`) converts its newlines to spaces, so `always\n()` written that way arrives as
+// `always ()` and the space-only normalization already caught it. A literal block (`|`) preserves the
+// newline verbatim, so the condition arrives as `always\n()` — which GitHub evaluates as a call, and
+// which the guard did not see. Measured, not assumed: folded normalized to `always()`, literal stayed
+// `always\n()`.
+func TestRejectsAReleaseGatedOnALineBrokenStatusCheck(t *testing.T) {
+	broken := strings.Replace(validAction, reconcileStep,
+		"    - name: Reconcile\n      if: |\n        always\n        ()\n"+
+			"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile\n", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a release conditioned with a line-broken always() call to be rejected")
+	}
+}
+
+// TestRejectsAReleaseGatedOnATabSeparatedStatusCheck pins the second whitespace spelling. A
+// double-quoted scalar resolves `\t` to a real tab, so this reaches the matcher as `always\t()`.
+// It is a separate fixture from the line-broken one because they fail for different reasons under a
+// space-only strip, and a single-character fix could plausibly address one and miss the other.
+func TestRejectsAReleaseGatedOnATabSeparatedStatusCheck(t *testing.T) {
+	broken := strings.Replace(validAction, reconcileStep,
+		"    - name: Reconcile\n      if: \"always\\t()\"\n"+
+			"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile\n", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a release conditioned with a tab-separated always() call to be rejected")
+	}
+}
+
 // TestStatusChecksAreLowercase pins the invariant the case-insensitive match depends on. The
 // condition is lowercased before matching, so an entry added to the list with any uppercase letter
 // could never match anything — the list would silently stop covering that function while still

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -184,3 +184,56 @@ func TestRealDeployActionSatisfiesTheContract(t *testing.T) {
 		t.Fatalf("the shipped deploy-prod action violates the publication ordering contract: %v", err)
 	}
 }
+
+// TestRejectsASecondPushAfterReconcile pins that the order holds across EVERY
+// occurrence, not just the first of each kind. Locating one publish step and
+// stopping leaves a later `workload push` invisible: the earlier sequence still
+// validates while the deploy republishes bytes that nothing signed or attested,
+// which is the exact window this guard exists to close.
+func TestRejectsASecondPushAfterReconcile(t *testing.T) {
+	const latePush = `    - name: Push again
+      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push
+`
+
+	withLatePush := validAction + latePush
+	mustChange(t, validAction, withLatePush)
+
+	if err := validate([]byte(withLatePush)); err == nil {
+		t.Fatal("expected a second publish after the reconcile to be rejected")
+	}
+}
+
+// TestRejectsASecondReconcileBeforeSigning is the mirror: an added release step
+// that runs before the evidence must fail even though a correctly-placed
+// reconcile also exists later.
+func TestRejectsASecondReconcileBeforeSigning(t *testing.T) {
+	early := strings.Replace(validAction,
+		"    - name: Sign",
+		reconcileStep+"    - name: Sign", 1)
+	mustChange(t, validAction, early)
+
+	if err := validate([]byte(early)); err == nil {
+		t.Fatal("expected a reconcile placed before the signing step to be rejected")
+	}
+}
+
+// TestRejectsSigningTheMutableTagWhileAssigningTheDigest is the finding that a
+// contains-check on the assignment cannot catch: REF is still assigned the
+// resolved digest, so the old check passes, but the cosign invocation consumes
+// the mutable tag instead. The signature then covers whatever the tag points at
+// when cosign resolves it, which is the TOCTOU the digest resolve exists to
+// remove. Only the command argument changes here.
+func TestRejectsSigningTheMutableTagWhileAssigningTheDigest(t *testing.T) {
+	deadAssignment := strings.Replace(validAction,
+		`cosign sign --yes --recursive "${REF}"`,
+		`cosign sign --yes --recursive "${REF_TAG}"`, 1)
+	mustChange(t, validAction, deadAssignment)
+
+	if !strings.Contains(deadAssignment, `REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`) {
+		t.Fatal("fixture must keep the digest assignment, or it does not isolate the command argument")
+	}
+
+	if err := validate([]byte(deadAssignment)); err == nil {
+		t.Fatal("expected signing the mutable tag to be rejected even though REF is assigned the digest")
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validAction is the publication sequence in the order the guarantee requires.
+// Each test below moves or removes exactly one step, so a failure names the
+// property that broke.
+const validAction = `
+runs:
+  using: composite
+  steps:
+    - name: Push
+      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push
+    - name: Sign
+      id: cosign-sign
+      run: |
+        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')
+        REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"
+        cosign sign --yes --recursive "${REF}"
+    - name: Attest SBOM
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+    - name: Attest provenance
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+    - name: Reconcile
+      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile
+`
+
+func mustChange(t *testing.T, before, after string) {
+	t.Helper()
+
+	if before == after {
+		t.Fatal("fixture did not change; the test would pass vacuously")
+	}
+}
+
+func TestValidActionPasses(t *testing.T) {
+	if err := validate([]byte(validAction)); err != nil {
+		t.Fatalf("expected the reference sequence to satisfy the contract, got: %v", err)
+	}
+}
+
+const (
+	reconcileStep = `    - name: Reconcile
+      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile
+`
+	sbomStep = `    - name: Attest SBOM
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+`
+	provenanceStep = `    - name: Attest provenance
+      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+`
+)
+
+// TestRejectsReconcileBeforeAttestations is the defect the check exists for:
+// telling Flux to look before the evidence is complete. Moving the reconcile
+// up is exactly the edit that would read as "fail faster" in review.
+func TestRejectsReconcileBeforeAttestations(t *testing.T) {
+	broken := strings.Replace(validAction, reconcileStep, "", 1)
+	mustChange(t, validAction, broken)
+
+	broken = strings.Replace(broken, sbomStep, reconcileStep+sbomStep, 1)
+
+	err := validate([]byte(broken))
+	if err == nil {
+		t.Fatal("expected reconcile-before-attestation to be rejected")
+	}
+
+	if !strings.Contains(err.Error(), "reconcile") {
+		t.Errorf("error should name the release step, got: %v", err)
+	}
+}
+
+// TestAllowsSwappingTheTwoAttestations pins a deliberate freedom. Their
+// relative order carries no guarantee, so constraining it would fail CI on a
+// legitimate edit and teach people to route around this check.
+func TestAllowsSwappingTheTwoAttestations(t *testing.T) {
+	swapped := strings.Replace(validAction, sbomStep+provenanceStep, provenanceStep+sbomStep, 1)
+	mustChange(t, validAction, swapped)
+
+	if err := validate([]byte(swapped)); err != nil {
+		t.Fatalf("the two attestations may appear in either order, got: %v", err)
+	}
+}
+
+func TestRejectsSigningBeforePublishing(t *testing.T) {
+	// Signing first would sign whatever the tag pointed at previously.
+	broken := strings.Replace(validAction,
+		"    - name: Push\n      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push\n",
+		"", 1)
+	mustChange(t, validAction, broken)
+
+	broken = strings.Replace(broken,
+		"    - name: Attest SBOM",
+		"    - name: Push\n      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push\n    - name: Attest SBOM", 1)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected signing before publishing to be rejected")
+	}
+}
+
+func TestRejectsMissingSigningStep(t *testing.T) {
+	broken := strings.Replace(validAction, `cosign sign --yes --recursive "${REF}"`, "echo skip", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a publication with no signing step to be rejected")
+	}
+}
+
+func TestRejectsMissingProvenanceAttestation(t *testing.T) {
+	broken := strings.Replace(validAction,
+		"      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32\n",
+		"      uses: actions/checkout@v7\n", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a missing provenance attestation to be rejected")
+	}
+}
+
+func TestRejectsMissingReconcileStep(t *testing.T) {
+	broken := strings.Replace(validAction, "workload reconcile", "workload noop", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a missing reconcile step to be rejected")
+	}
+}
+
+// TestRejectsSigningTheMutableTag pins the resolve-then-sign shape: a
+// concurrent deploy can move the tag between the two.
+func TestRejectsSigningTheMutableTag(t *testing.T) {
+	broken := strings.Replace(validAction,
+		`        REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`,
+		`        REF="ghcr.io/devantler-tech/platform/manifests:latest"`, 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected signing the mutable tag to be rejected")
+	}
+}
+
+func TestRejectsActionWithNoSteps(t *testing.T) {
+	if err := validate([]byte("name: empty\n")); err == nil {
+		t.Fatal("expected an action with no steps to be rejected rather than pass vacuously")
+	}
+}
+
+func TestRejectsUnparseableAction(t *testing.T) {
+	if err := validate([]byte("runs: [ unbalanced")); err == nil {
+		t.Fatal("expected unparseable YAML to be rejected")
+	}
+}
+
+func TestRunFailsClosedOnUnreadableFile(t *testing.T) {
+	var stderr bytes.Buffer
+	if err := run([]string{filepath.Join(t.TempDir(), "absent.yml")}, &stderr); err == nil {
+		t.Fatal("expected an unreadable action to fail, not to pass vacuously")
+	}
+}
+
+func TestRunRequiresAPath(t *testing.T) {
+	var stderr bytes.Buffer
+	if err := run(nil, &stderr); err == nil {
+		t.Fatal("expected no arguments to be a usage error rather than a silent pass")
+	}
+}
+
+// TestRealDeployActionSatisfiesTheContract pins the shipped composite, so the
+// contract cannot be satisfied only by the fixture above.
+func TestRealDeployActionSatisfiesTheContract(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "..", ".github", "actions", "deploy-prod", "action.yml"))
+	if err != nil {
+		t.Fatalf("could not read the real composite action: %v", err)
+	}
+
+	if err := validate(source); err != nil {
+		t.Fatalf("the shipped deploy-prod action violates the publication ordering contract: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -697,3 +697,110 @@ func TestRejectsAnUnparseableRunBlock(t *testing.T) {
 		t.Fatal("an unparseable run block must not satisfy a required marker")
 	}
 }
+
+// The tests below cover CodeRabbit's round-6 P1 and its siblings. They are a different AXIS from
+// everything above: the grammar says the command runs, and it does — but `set +e` stops its failure
+// from reaching the step's exit status, so cosign can fail while the step succeeds and the deploy
+// releases unsigned. Syntax alone cannot see that; the shell's failure MODE has to be tracked too.
+
+// TestRejectsSigningAfterErrexitIsDisabled is the reported case.
+func TestRejectsSigningAfterErrexitIsDisabled(t *testing.T) {
+	disabled := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        set +e\n"+
+			`        cosign sign --yes --recursive "${REF}"`+"\n"+
+			`        echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"`, 1)
+	mustChange(t, validAction, disabled)
+
+	if err := validate([]byte(disabled)); err == nil {
+		t.Fatal("under `set +e` a failing cosign does not fail the step")
+	}
+}
+
+// TestRejectsSigningAfterErrexitIsDisabledTheLongWay covers `set +o errexit`, the same instruction
+// spelled differently. Matching only `+e` would be a blocklist with one entry.
+func TestRejectsSigningAfterErrexitIsDisabledTheLongWay(t *testing.T) {
+	disabled := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        set +o errexit\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, disabled)
+
+	if err := validate([]byte(disabled)); err == nil {
+		t.Fatal("`set +o errexit` disables failure propagation exactly as `set +e` does")
+	}
+}
+
+// TestAllowsErrexitDisabledThenRestored is the negative control, and it is why this is tracked as
+// STATE rather than matched as a shape. Turning errexit off around unrelated work and back on before
+// the signing call is correct code; rejecting it would fail a legitimate action.
+func TestAllowsErrexitDisabledThenRestored(t *testing.T) {
+	restored := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        set +e\n"+
+			"        docker logout ghcr.io\n"+
+			"        set -e\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, restored)
+
+	if err := validate([]byte(restored)); err != nil {
+		t.Fatalf("errexit restored before the signing call is correct code; got: %v", err)
+	}
+}
+
+// TestAllowsTheCombinedSetFlagsForm pins that `set -euo pipefail` — what the real composite uses —
+// reads as enabling errexit. A parser that only recognised a bare `set -e` would treat the real
+// action's own hardening as unrecognised.
+func TestAllowsTheCombinedSetFlagsForm(t *testing.T) {
+	hardened := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		"        set -euo pipefail\n"+
+			`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, hardened)
+
+	if err := validate([]byte(hardened)); err != nil {
+		t.Fatalf("`set -euo pipefail` enables errexit; got: %v", err)
+	}
+}
+
+// TestRejectsSigningInAShellThatDoesNotPropagateFailure covers the step-level sibling of `set +e`.
+// GitHub runs `shell: bash` as `bash --noprofile --norc -eo pipefail`, but a step may name another
+// shell — and then nothing promises that a failing cosign fails the step, without a single `set` line
+// appearing anywhere in the script.
+func TestRejectsSigningInAShellThatDoesNotPropagateFailure(t *testing.T) {
+	otherShell := strings.Replace(validAction,
+		`    - name: Sign
+      id: cosign-sign
+      run: |`,
+		`    - name: Sign
+      id: cosign-sign
+      shell: sh
+      run: |`, 1)
+	mustChange(t, validAction, otherShell)
+
+	if err := validate([]byte(otherShell)); err == nil {
+		t.Fatal("a shell GitHub does not run with -e cannot be assumed to gate the step")
+	}
+}
+
+// TestAllowsAnotherShellThatEnablesErrexitItself is that rule's negative control: naming a different
+// shell is not itself the defect, failing to propagate is. A script that turns errexit on explicitly
+// gates the step regardless of how the shell was launched.
+func TestAllowsAnotherShellThatEnablesErrexitItself(t *testing.T) {
+	explicit := strings.Replace(validAction,
+		`    - name: Sign
+      id: cosign-sign
+      run: |
+        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`    - name: Sign
+      id: cosign-sign
+      shell: sh
+      run: |
+        set -e
+        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, explicit)
+
+	if err := validate([]byte(explicit)); err != nil {
+		t.Fatalf("an explicit `set -e` gates the step whatever the shell; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -482,3 +482,218 @@ func TestAllowsAHereStringInARequiredStep(t *testing.T) {
 		t.Fatalf("a here-string is not a here-document opener; got: %v", err)
 	}
 }
+
+// The five tests below are the Codex round at 5add867d. Three of them —
+// backslash-quoted heredoc, swallowed failure, trailing comment — are the SAME root cause wearing
+// three disguises: the matchers read the `run:` block as TEXT, so anything that changes whether a
+// line runs, or what a word actually is, was invisible. Patching each shape individually is the
+// blocklist this guard has already been bitten by, so they are fixed together by parsing the script
+// as shell. Each still gets its own test: a shared cause is not a shared proof.
+
+// TestRejectsSigningInsideABackslashQuotedHeredoc covers the delimiter form bash accepts and a
+// hand-rolled matcher missed. `<<\UNSIGNED` quotes the delimiter with a backslash rather than quotes,
+// so a pattern enumerating '...', "..." and bare identifiers does not recognise it — and the body it
+// opens then reads as ordinary top-level lines. Bash feeds those words to `:` and signs nothing.
+func TestRejectsSigningInsideABackslashQuotedHeredoc(t *testing.T) {
+	hidden := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        : <<\\UNSIGNED\n"+
+			`        cosign sign --yes --recursive "${REF}"`+"\n"+
+			"        UNSIGNED", 1)
+	mustChange(t, validAction, hidden)
+
+	err := validate([]byte(hidden))
+	if err == nil {
+		t.Fatal("a signing command inside a backslash-quoted heredoc body is input to `:`, not a signature")
+	}
+
+	if !strings.Contains(err.Error(), "sign") {
+		t.Errorf("error should name the signing step, got: %v", err)
+	}
+}
+
+// TestRejectsSigningWhoseFailureIsSwallowed covers `|| true`. The invocation is real and its
+// arguments are right, so every text-level check passes — but the step succeeds even when cosign
+// fails, the attestations still run, and reconciliation releases an artifact carrying no signature.
+// The guard exists to prove a signature was produced, not that a signing command was written down.
+func TestRejectsSigningWhoseFailureIsSwallowed(t *testing.T) {
+	swallowed := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        cosign sign --yes --recursive "${REF}" || true`, 1)
+	mustChange(t, validAction, swallowed)
+
+	err := validate([]byte(swallowed))
+	if err == nil {
+		t.Fatal("a signing failure that cannot fail the step does not evidence a signature")
+	}
+
+	if !strings.Contains(err.Error(), "sign") {
+		t.Errorf("error should name the signing step, got: %v", err)
+	}
+}
+
+// TestRejectsSigningTheMutableTagWithTheDigestInAComment covers the trailing comment. Substring
+// matching for `"${REF}"` cannot tell an argument from a comment, so signing the mutable tag while
+// merely MENTIONING the resolved reference satisfied the digest check — restoring precisely the
+// tag-resolution race the check was added to prevent.
+func TestRejectsSigningTheMutableTagWithTheDigestInAComment(t *testing.T) {
+	commented := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        cosign sign --yes --recursive "${REF_TAG}" # "${REF}"`, 1)
+	mustChange(t, validAction, commented)
+
+	err := validate([]byte(commented))
+	if err == nil {
+		t.Fatal("a resolved reference named only in a comment is not passed to cosign")
+	}
+
+	if !strings.Contains(err.Error(), signRefArg) {
+		t.Errorf("error should name the required argument, got: %v", err)
+	}
+}
+
+// TestRejectsASecondReleaseThatEvidenceCannotGate covers condition checking against only the FIRST
+// release. Conditions were compared to releaseIdx[0], so evidence guarded by the same condition as a
+// never-firing first reconcile looked correctly coupled — while a second, unconditional reconcile
+// released the artifact with every piece of evidence skipped.
+//
+// A required step must stand or fall with EVERY release, not with whichever one happens to come
+// first.
+func TestRejectsASecondReleaseThatEvidenceCannotGate(t *testing.T) {
+	const falseCondition = "      if: ${{ false }}\n"
+
+	// The evidence and the first release share a condition that never fires, so the existing
+	// same-condition allowance accepts them as coupled.
+	gated := strings.Replace(validAction, sbomStep,
+		`    - name: Attest SBOM
+`+falseCondition+`      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+`, 1)
+	mustChange(t, validAction, gated)
+
+	withGatedRelease := strings.Replace(gated, reconcileStep,
+		`    - name: Reconcile
+`+falseCondition+`      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile
+`, 1)
+	mustChange(t, gated, withGatedRelease)
+
+	// ...and then an unconditional second release publishes anyway.
+	broken := withGatedRelease + reconcileStep
+	mustChange(t, withGatedRelease, broken)
+
+	err := validate([]byte(broken))
+	if err == nil {
+		t.Fatal("a second unconditional release runs with the gated evidence skipped")
+	}
+}
+
+// TestRejectsADigestNotResolvedFromThePublishedTag covers DIGEST's provenance, which nothing bound.
+// The validator required the REF assignment's exact text but never asked where DIGEST came from, so
+// substituting a constant digest for an older manifest passed: cosign and both attestations then
+// cover that old artifact in full, while reconciliation releases the newly pushed — and unsigned —
+// `latest`. Every ordering check still holds, which is what makes this the worst of the five.
+func TestRejectsADigestNotResolvedFromThePublishedTag(t *testing.T) {
+	constant := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="sha256:1111111111111111111111111111111111111111111111111111111111111111"`, 1)
+	mustChange(t, validAction, constant)
+
+	err := validate([]byte(constant))
+	if err == nil {
+		t.Fatal("a constant digest signs whatever it names, not what this run published")
+	}
+
+	if !strings.Contains(err.Error(), "DIGEST") {
+		t.Errorf("error should name the unbound variable, got: %v", err)
+	}
+}
+
+// TestAllowsResolvingTheDigestWithAnotherTool is the negative control for the provenance check. The
+// requirement is that DIGEST is derived from the published tag, NOT that one specific tool derives
+// it — pinning `docker buildx imagetools` would fail a legitimate switch to crane or a cosign
+// equivalent, and a guard that rejects correct input gets suppressed.
+func TestAllowsResolvingTheDigestWithAnotherTool(t *testing.T) {
+	otherTool := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST=$(crane digest "${REF_TAG}")`, 1)
+	mustChange(t, validAction, otherTool)
+
+	if err := validate([]byte(otherTool)); err != nil {
+		t.Fatalf("any tool may resolve the digest so long as it reads the published tag; got: %v", err)
+	}
+}
+
+// TestRejectsAConstantDigestBesideAResolvedOne is the "every assignment" rule's own proof. Accepting
+// the mere PRESENCE of a correct resolution would be a bypass in one move: a later assignment
+// overwrites an earlier one, so a constant sitting beside a resolved digest decides what cosign
+// actually signs while the resolution makes the step look right.
+func TestRejectsAConstantDigestBesideAResolvedOne(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`+"\n"+
+			`        DIGEST="sha256:1111111111111111111111111111111111111111111111111111111111111111"`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("a constant assignment after the resolution decides what is signed")
+	}
+}
+
+// TestRejectsASecondRefAssignmentAfterTheResolvedOne is the same rule for REF, which cosign consumes
+// directly. Reassigning it to the mutable tag after building the digest reference restores the race
+// while leaving the required assignment textually present.
+func TestRejectsASecondRefAssignmentAfterTheResolvedOne(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        REF="${REF_TAG}"`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("a later REF assignment decides what cosign signs")
+	}
+}
+
+// TestAllowsRetryingTheDigestResolution pins the freedom the provenance check must NOT take away.
+// Wrapping the resolution in a retry is correct code — if every attempt fails, DIGEST stays empty,
+// REF is malformed and cosign fails the step — so requiring the assignment to sit at the top level
+// would reject a legitimate action. A guard that fails correct input gets suppressed, not fixed.
+func TestAllowsRetryingTheDigestResolution(t *testing.T) {
+	withRetry := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		"        for attempt in 1 2 3; do\n"+
+			`          DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}') && break`+"\n"+
+			"        done", 1)
+	mustChange(t, validAction, withRetry)
+
+	if err := validate([]byte(withRetry)); err != nil {
+		t.Fatalf("a retry around the digest resolution is correct code; got: %v", err)
+	}
+}
+
+// TestRejectsSigningWhoseFailureIsDetached covers `&`, the sibling of `|| true`. A backgrounded
+// cosign cannot fail the step either: the shell moves on, the attestations run, and reconciliation
+// releases before the signature is known to exist — if it ever does.
+func TestRejectsSigningWhoseFailureIsDetached(t *testing.T) {
+	detached := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        cosign sign --yes --recursive "${REF}" &`, 1)
+	mustChange(t, validAction, detached)
+
+	if err := validate([]byte(detached)); err == nil {
+		t.Fatal("a backgrounded signing command cannot fail the step")
+	}
+}
+
+// TestRejectsAnUnparseableRunBlock pins the fail-closed direction. If the shell cannot be parsed the
+// guard learns nothing about what runs, so it must report a missing operation rather than fall back
+// to matching text — the fallback is what every bypass in this file exploited.
+func TestRejectsAnUnparseableRunBlock(t *testing.T) {
+	broken := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        cosign sign --yes --recursive "${REF}" $(`, 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("an unparseable run block must not satisfy a required marker")
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -25,8 +25,14 @@ runs:
         cosign sign --yes --recursive "${REF}"
     - name: Attest SBOM
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+      with:
+        subject-digest: ${{ steps.cosign-sign.outputs.digest }}
+        push-to-registry: "true"
     - name: Attest provenance
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+      with:
+        subject-digest: ${{ steps.cosign-sign.outputs.digest }}
+        push-to-registry: "true"
     - name: Reconcile
       run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile
 `
@@ -51,9 +57,15 @@ const (
 `
 	sbomStep = `    - name: Attest SBOM
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+      with:
+        subject-digest: ${{ steps.cosign-sign.outputs.digest }}
+        push-to-registry: "true"
 `
 	provenanceStep = `    - name: Attest provenance
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+      with:
+        subject-digest: ${{ steps.cosign-sign.outputs.digest }}
+        push-to-registry: "true"
 `
 )
 
@@ -1071,5 +1083,156 @@ func TestRejectsAResolverInAnUNTAKENBranch(t *testing.T) {
 
 	if err := validate([]byte(deadBranch)); err == nil {
 		t.Fatal("a resolver in an untaken branch never runs; the constant beside it is what gets signed")
+	}
+}
+
+// The tests below cover a sixth axis and three refinements of earlier ones, all found by review at
+// `fa710581`. Each names the property that breaks, because each was a GREEN result over a deploy
+// that published nothing — the shape this guard exists to make impossible.
+
+const signCall = `        cosign sign --yes --recursive "${REF}"`
+
+// TestRejectsQuotedSetPlusE covers WORD INTERPRETATION: bash removes quotes before reading a word,
+// so `set '+e'` disables errexit exactly as `set +e` does. Comparing the source form left errexit
+// tracked as enabled, and a cosign failure could then be followed by a succeeding command with the
+// step still green.
+func TestRejectsQuotedSetPlusE(t *testing.T) {
+	broken := strings.Replace(validAction, signCall, "        set '+e'\n"+signCall, 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a quoted `set '+e'` to disable failure propagation and be rejected")
+	}
+}
+
+// TestAllowsQuotedSetMinusE is the over-tightening control for the test above: quote removal has to
+// work in BOTH directions, or an ordinary `set '-e'` would start failing.
+func TestAllowsQuotedSetMinusE(t *testing.T) {
+	fixture := strings.Replace(validAction, signCall, "        set '-e'\n"+signCall, 1)
+	mustChange(t, validAction, fixture)
+
+	if err := validate([]byte(fixture)); err != nil {
+		t.Fatalf("a quoted `set '-e'` enables errexit and is correct code, got: %v", err)
+	}
+}
+
+// TestRejectsAnAliasShadowingARequiredCommand covers NAME RESOLUTION. Bash resolves aliases before
+// functions and PATH, so with `shopt -s expand_aliases` a textually perfect, failure-propagating,
+// top-level cosign invocation expands to `true` and signs nothing.
+func TestRejectsAnAliasShadowingARequiredCommand(t *testing.T) {
+	broken := strings.Replace(validAction, signCall,
+		"        shopt -s expand_aliases\n        alias cosign=true\n"+signCall, 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected an alias shadowing cosign to be rejected")
+	}
+}
+
+// TestAllowsAnUnrelatedAlias is the over-tightening control: defining an alias is ordinary
+// scripting, and only one that rebinds a REQUIRED name may fail the check.
+func TestAllowsAnUnrelatedAlias(t *testing.T) {
+	fixture := strings.Replace(validAction, signCall,
+		"        alias ll='ls -l'\n"+signCall, 1)
+	mustChange(t, validAction, fixture)
+
+	if err := validate([]byte(fixture)); err != nil {
+		t.Fatalf("an unrelated alias is ordinary scripting, got: %v", err)
+	}
+}
+
+const resolverCall = `        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`
+
+// TestRejectsAResolverThatIgnoresTheTag closes the last hole in the digest-provenance axis. A single
+// direct call taking the tag as an argument still proves nothing about the OUTPUT: printf ignores
+// extra arguments when its format carries no conversion, so this returns a constant digest for an
+// older manifest, which cosign and both attestations then cover in full.
+func TestRejectsAResolverThatIgnoresTheTag(t *testing.T) {
+	broken := strings.Replace(validAction, resolverCall,
+		`        DIGEST=$(printf 'sha256:0000000000000000000000000000000000000000000000000000000000000000' "${REF_TAG}")`, 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a resolver whose output ignores the published tag to be rejected")
+	}
+}
+
+// TestAllowsAnotherResolverTool is the over-tightening control. The accepted set is about a
+// program's contract, not about which tool this repo currently uses; switching to crane is a
+// legitimate refactor and must not fail CI.
+func TestAllowsAnotherResolverTool(t *testing.T) {
+	fixture := strings.Replace(validAction, resolverCall,
+		`        DIGEST=$(crane digest "${REF_TAG}")`, 1)
+	mustChange(t, validAction, fixture)
+
+	if err := validate([]byte(fixture)); err != nil {
+		t.Fatalf("crane is a legitimate digest resolver, got: %v", err)
+	}
+}
+
+// TestRejectsSigningWithUploadDisabled covers the SIGNING OPTION surface. `--upload=false` produces
+// the signature locally and never writes it to the registry: the command succeeds, carries the exact
+// required reference, and leaves the artifact unsigned.
+func TestRejectsSigningWithUploadDisabled(t *testing.T) {
+	broken := strings.Replace(validAction, signCall,
+		`        cosign sign --yes --recursive --upload=false "${REF}"`, 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected `cosign sign --upload=false` to be rejected: it publishes no signature")
+	}
+}
+
+// TestRejectsAnAttestationOfAnotherDigest covers the ATTESTATION SUBJECT. The action reference says
+// only which program runs; subject-digest is free, so a step can keep its position, its pinned
+// `uses:` and its green result while attesting an older artifact.
+func TestRejectsAnAttestationOfAnotherDigest(t *testing.T) {
+	broken := strings.Replace(validAction,
+		"        subject-digest: ${{ steps.cosign-sign.outputs.digest }}",
+		"        subject-digest: sha256:0000000000000000000000000000000000000000000000000000000000000000", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected an attestation of a digest this run did not resolve to be rejected")
+	}
+}
+
+// TestRejectsAnAttestationThatIsNeverPushed is the same axis from the other side: evidence that is
+// generated but not published leaves the registry with nothing attached, while the step succeeds.
+func TestRejectsAnAttestationThatIsNeverPushed(t *testing.T) {
+	broken := strings.Replace(validAction,
+		`        push-to-registry: "true"`, `        push-to-registry: "false"`, 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected an attestation that is never pushed to the registry to be rejected")
+	}
+}
+
+// TestRejectsAReleaseThatRunsAfterFailure covers FAILURE COUPLING, which every ordering guarantee
+// here silently assumes. A step's `if:` is implicitly `success() && …` unless it calls a status
+// check function; `always()` removes that, so the release runs precisely when the evidence failed.
+func TestRejectsAReleaseThatRunsAfterFailure(t *testing.T) {
+	broken := strings.Replace(validAction, reconcileStep,
+		"    - name: Reconcile\n      if: always()\n"+
+			"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile\n", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a release conditioned with always() to be rejected")
+	}
+}
+
+// TestAllowsANonStatusCheckReleaseCondition is the over-tightening control. An ordinary condition
+// keeps the implicit success() and therefore keeps the coupling, so gating the release on a branch
+// or an input stays legal.
+func TestAllowsANonStatusCheckReleaseCondition(t *testing.T) {
+	fixture := strings.Replace(validAction, reconcileStep,
+		"    - name: Reconcile\n      if: github.ref == 'refs/heads/main'\n"+
+			"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile\n", 1)
+	mustChange(t, validAction, fixture)
+
+	if err := validate([]byte(fixture)); err != nil {
+		t.Fatalf("an ordinary release condition keeps the implicit success(), got: %v", err)
 	}
 }

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -901,3 +901,109 @@ func TestAllowsExportingTheResolvedDigest(t *testing.T) {
 		t.Fatalf("exporting a correctly resolved digest is ordinary scripting; got: %v", err)
 	}
 }
+
+// TestRejectsADigestWhoseResolutionOnlyMENTIONSThePublishedTag closes the provenance check's last
+// text-shaped hole. `resolvesDigestFromPublishedTag` compared the assignment's raw SOURCE SPAN, and
+// a source span includes the comments inside a command substitution — so a substitution that emits a
+// constant digest and merely names `${REF_TAG}` in a comment satisfied it. Bash never expands that
+// comment, so cosign and both attestations complete in full over an OLDER manifest while the tag
+// this run actually published ships unsigned. This is the same class the parser closed for the
+// required OPERATIONS, arriving one level down: a mention is not an expansion.
+func TestRejectsADigestWhoseResolutionOnlyMENTIONSThePublishedTag(t *testing.T) {
+	mentioned := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="$(`+"\n"+
+			`          printf '%s' 'sha256:1111111111111111111111111111111111111111111111111111111111111111'`+"\n"+
+			`          # ${REF_TAG}`+"\n"+
+			`        )"`, 1)
+	mustChange(t, validAction, mentioned)
+
+	err := validate([]byte(mentioned))
+	if err == nil {
+		t.Fatal("a commented mention of the published tag resolves nothing; the digest is still a constant")
+	}
+
+	if !strings.Contains(err.Error(), "DIGEST") {
+		t.Errorf("error should name the unbound variable, got: %v", err)
+	}
+}
+
+// TestRejectsADigestThatOnlyCONCATENATESThePublishedTag is the same rule read from the other side.
+// The published tag has to be consumed by the command that resolves the digest, not merely stand
+// next to its output: `${REF_TAG}$(…constant…)` expands the tag for real, yet the value cosign ends
+// up signing is still whatever the substitution printed.
+func TestRejectsADigestThatOnlyCONCATENATESThePublishedTag(t *testing.T) {
+	concatenated := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="${REF_TAG}$(printf '%s' 'sha256:1111111111111111111111111111111111111111111111111111111111111111')"`, 1)
+	mustChange(t, validAction, concatenated)
+
+	if err := validate([]byte(concatenated)); err == nil {
+		t.Fatal("expanding the tag beside a constant does not make the constant derived from it")
+	}
+}
+
+// TestAllowsResolvingThroughAPipeline is an over-tightening control. Reading the tag inside a
+// pipeline, a subshell or a redirection is ordinary scripting — the expansion still reaches the
+// program that resolves the digest — so the check must find it at any depth inside the substitution
+// rather than only in its first command.
+func TestAllowsResolvingThroughAPipeline(t *testing.T) {
+	piped := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST=$(crane manifest "${REF_TAG}" | sha256sum | cut -d' ' -f1)`, 1)
+	mustChange(t, validAction, piped)
+
+	if err := validate([]byte(piped)); err != nil {
+		t.Fatalf("resolving through a pipeline still reads the published tag; got: %v", err)
+	}
+}
+
+// TestAllowsTheUnbracedExpansion is the second over-tightening control. `$REF_TAG` and `${REF_TAG}`
+// are the SAME expansion; only the spelling differs. Requiring the braced source text made the guard
+// enforce a style rule it has no stake in, and a guard that rejects an equivalent spelling of correct
+// code gets suppressed rather than fixed.
+func TestAllowsTheUnbracedExpansion(t *testing.T) {
+	unbraced := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST=$(docker buildx imagetools inspect "$REF_TAG" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, unbraced)
+
+	if err := validate([]byte(unbraced)); err != nil {
+		t.Fatalf("$REF_TAG and ${REF_TAG} are the same expansion; got: %v", err)
+	}
+}
+
+// TestRejectsThePublishedTagExpandedOnlyInAHereDocument pins the "as an ARGUMENT" half of the
+// provenance rule, which nothing else covers: a here-document body IS parsed for expansions, so
+// `${REF_TAG}` inside one is a real expansion node rather than a mention. Accepting any expansion
+// found anywhere inside the substitution would therefore let a body fed to a discarding command
+// stand in for the resolution. The tag has to reach a command that runs, as an argument.
+func TestRejectsThePublishedTagExpandedOnlyInAHereDocument(t *testing.T) {
+	inHereDoc := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="$(cat >/dev/null <<EOF`+"\n"+
+			`        ${REF_TAG}`+"\n"+
+			`        EOF`+"\n"+
+			`        printf '%s' 'sha256:1111111111111111111111111111111111111111111111111111111111111111')"`, 1)
+	mustChange(t, validAction, inHereDoc)
+
+	if err := validate([]byte(inHereDoc)); err == nil {
+		t.Fatal("a here-document body is not an argument to the command that resolves the digest")
+	}
+}
+
+// TestRejectsAProcessSubstitution pins the "command SUBSTITUTION" half of the provenance rule. A
+// process substitution also runs a command that reads the published tag, but it expands to a
+// `/dev/fd/…` path rather than that command's output — so the digest would be a file descriptor
+// name, and nothing would have resolved. Only the form whose VALUE is the command's output proves
+// the digest came from this run's publication.
+func TestRejectsAProcessSubstitution(t *testing.T) {
+	procSubst := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST=<(crane digest "${REF_TAG}")`, 1)
+	mustChange(t, validAction, procSubst)
+
+	if err := validate([]byte(procSubst)); err == nil {
+		t.Fatal("a process substitution yields a file descriptor path, not the resolved digest")
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1911,3 +1911,39 @@ func TestRecognisesACommandPrefixedRequiredPush(t *testing.T) {
 		t.Fatalf("a command-prefixed push still publishes, got: %v", err)
 	}
 }
+
+// TestRejectsErrexitDisabledInsideACompoundConstruct covers a state change the two halves of this
+// file disagreed about. unmodeledShellState walks the WHOLE tree, so it sees the nested `set +e`,
+// finds `e` modeled, and accepts it; parseExecuted iterated only top-level statements and skipped
+// the brace group entirely, so errexitToggle never saw the toggle. Bash runs a brace group in the
+// CURRENT shell, so errexit really is off — and the validator still credited cosign as
+// failure-propagating. Two individually-defensible decisions composing into a permissive one.
+func TestRejectsErrexitDisabledInsideACompoundConstruct(t *testing.T) {
+	disabled := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        { set +e; }\n"+
+			`        cosign sign --yes --recursive "${REF}"`+"\n"+
+			`        echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"`, 1)
+	mustChange(t, validAction, disabled)
+
+	if err := validate([]byte(disabled)); err == nil {
+		t.Fatal("a brace group runs in the current shell, so `{ set +e; }` disables errexit at the signing call")
+	}
+}
+
+// TestRejectsDigestResolvedByAShadowedFunction covers the resolver half of command resolution.
+// Top-level required commands are already checked against declaredNames, but the digest-resolver
+// predicate trusted the literal executable name on its own. bash looks up functions before $PATH,
+// so a `docker` function returns a constant while the call still reads as a genuine resolve — the
+// old digest is then signed and exported before reconciliation releases the new artifact.
+func TestRejectsDigestResolvedByAShadowedFunction(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        docker() { printf 'sha256:aaaa'; }`+"\n"+
+			`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("a `docker` function shadows the resolver, so DIGEST never depends on the published tag")
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1352,3 +1352,36 @@ func TestAllowsReadIntoAnUnrelatedVariable(t *testing.T) {
 		t.Fatalf("read into an unrelated variable is correct code; got: %v", err)
 	}
 }
+
+// TestRejectsANamerefOverwriteOfTheSignedReference covers the same overwrite one level of indirection
+// out. `declare -n target=REF` makes every later `target=…` write REF, but a collector matching only
+// assignments literally named REF sees just the correct one — so cosign signs whatever went through
+// the alias while the validator reports the resolution intact.
+func TestRejectsANamerefOverwriteOfTheSignedReference(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        declare -n target=REF\n"+
+			`        target='ghcr.io/devantler-tech/platform/manifests:latest'`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("`declare -n target=REF` is a handle on REF; writes through it decide what cosign signs")
+	}
+}
+
+// TestAllowsANamerefToAnUnrelatedVariable is the over-tightening control: namerefs are a normal bash
+// feature, and refusing every one of them would reject correct code. Only an alias whose TARGET is
+// the protected variable is a write to it.
+func TestAllowsANamerefToAnUnrelatedVariable(t *testing.T) {
+	unrelated := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        declare -n target=GITHUB_OUTPUT\n"+
+			`        printf '%s\n' "${REF}" >>"${target}"`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, unrelated)
+
+	if err := validate([]byte(unrelated)); err != nil {
+		t.Fatalf("a nameref to an unrelated variable is correct code; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1660,6 +1660,23 @@ func TestRejectsBashEnvOnASigningStep(t *testing.T) {
 	}
 }
 
+// TestRejectsPathOnASigningStep closes the step-level half of command resolution. The script-level
+// forms are already covered by resolutionAssignments below, but PATH set through the STEP's `env:`
+// never appears in the run block at all: bash then resolves the textually perfect
+// `cosign sign …` to whatever `cosign` sits in that directory. Same shadowing as BASH_ENV, reached
+// without touching the script — and this file already treats PATH as resolution state when it is
+// assigned inside one.
+func TestRejectsPathOnASigningStep(t *testing.T) {
+	withEnv := strings.Replace(validAction,
+		"      id: cosign-sign\n",
+		"      id: cosign-sign\n      env:\n        PATH: /tmp/fake\n", 1)
+	mustChange(t, validAction, withEnv)
+
+	if err := validate([]byte(withEnv)); err == nil {
+		t.Fatal("a step-level PATH decides which binary the required command resolves to")
+	}
+}
+
 // TestAllowsOrdinarySigningStepEnv is the over-tightening control: the real signing step carries
 // `env: COSIGN_YES`, so rejecting env wholesale would reject the action this guard exists to protect.
 func TestAllowsOrdinarySigningStepEnv(t *testing.T) {

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1253,6 +1253,38 @@ func TestAllowsANonStatusCheckReleaseCondition(t *testing.T) {
 	}
 }
 
+// TestRejectsAReleaseGatedOnACaseVariantStatusCheck covers the SPELLING of a status check call
+// rather than which function is called. The rule keys on the call, but the match was written
+// lowercase-only, so `ALWAYS()` reached the release step through a matcher looking for `always(`.
+//
+// This is rejected under either reading of GitHub's expression parser, which is why the guard does
+// not depend on settling that question: if function names resolve case-insensitively then `ALWAYS()`
+// is a working bypass and must be rejected; if they do not, it is not a legitimate condition anybody
+// writes, so rejecting it costs nothing. Fail closed on both.
+func TestRejectsAReleaseGatedOnACaseVariantStatusCheck(t *testing.T) {
+	broken := strings.Replace(validAction, reconcileStep,
+		"    - name: Reconcile\n      if: ALWAYS()\n"+
+			"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile\n", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a release conditioned with a case-variant ALWAYS() call to be rejected")
+	}
+}
+
+// TestStatusChecksAreLowercase pins the invariant the case-insensitive match depends on. The
+// condition is lowercased before matching, so an entry added to the list with any uppercase letter
+// could never match anything — the list would silently stop covering that function while still
+// reading as though it did. Asserting the entries here is cheaper than discovering it from a bypass.
+func TestStatusChecksAreLowercase(t *testing.T) {
+	for _, check := range statusChecks {
+		if check != strings.ToLower(check) {
+			t.Fatalf("statusChecks entry %q must be lowercase: the condition is lowercased before"+
+				" matching, so an entry with uppercase can never match", check)
+		}
+	}
+}
+
 // TestRejectsErrexitApparentlyRestoredBySetPositionals covers `set --`, which assigns the remaining
 // words to the POSITIONAL PARAMETERS rather than to shell options (bash `help set`). A scan that
 // kept reading flags past it accepted `set -- -e` as errexit being restored, so a signing block

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1223,6 +1223,22 @@ func TestRejectsAReleaseThatRunsAfterFailure(t *testing.T) {
 	}
 }
 
+// TestRejectsAReleaseGatedOnAnExplicitSuccessCall is the same axis reached through the status check
+// the list omitted. `success()` is ITSELF a status check function, so writing it explicitly also
+// replaces the implicit gate — and once it is an operand of `||` the expression evaluates true on a
+// failed evidence step, releasing exactly what `always()` would while reading as if it required
+// success. Matching only always/failure/cancelled left that spelling open.
+func TestRejectsAReleaseGatedOnAnExplicitSuccessCall(t *testing.T) {
+	broken := strings.Replace(validAction, reconcileStep,
+		"    - name: Reconcile\n      if: success() || true\n"+
+			"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile\n", 1)
+	mustChange(t, validAction, broken)
+
+	if err := validate([]byte(broken)); err == nil {
+		t.Fatal("expected a release conditioned with an explicit success() call to be rejected")
+	}
+}
+
 // TestAllowsANonStatusCheckReleaseCondition is the over-tightening control. An ordinary condition
 // keeps the implicit success() and therefore keeps the coupling, so gating the release on a branch
 // or an input stays legal.

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -352,3 +352,43 @@ func TestAllowsControlFlowElsewhereInAStep(t *testing.T) {
 		t.Fatalf("control flow around non-required work must stay legal, got: %v", err)
 	}
 }
+
+// signingReplacements are the ways a required invocation can appear in the text while not running as
+// a plain top-level command. Enumerated together rather than one per review round: they are one
+// class, and a matcher that reads raw text is blind to all of them for the same reason.
+var signingReplacements = map[string]string{
+	"short-circuit &&":     `false && cosign sign --yes --recursive "${REF}"`,
+	"short-circuit ||":     `true || cosign sign --yes --recursive "${REF}"`,
+	"pipeline":             `printf '' | cosign sign --yes --recursive "${REF}"`,
+	"string literal":       `echo "would run: cosign sign --yes --recursive ${REF}"`,
+	"command substitution": `RESULT=$(cosign sign --yes --recursive "${REF}")`,
+	"uninvoked function":   "sign_it() {\n          cosign sign --yes --recursive \"${REF}\"\n        }",
+	"trailing semicolon":   `false; cosign sign --yes --recursive "${REF}" && true`,
+}
+
+// TestRejectsSigningThatIsNotAPlainTopLevelCommand is the general form of the comment, conditional
+// and control-flow bypasses: the step keeps its position and its digest assignment, the text contains
+// the invocation, and no signature is produced. The guard requires the invocation to BE a command,
+// rather than trying to enumerate every way it can fail to be one.
+func TestRejectsSigningThatIsNotAPlainTopLevelCommand(t *testing.T) {
+	for name, replacement := range signingReplacements {
+		t.Run(name, func(t *testing.T) {
+			mutated := strings.Replace(validAction,
+				`        cosign sign --yes --recursive "${REF}"`,
+				"        "+replacement, 1)
+			mustChange(t, validAction, mutated)
+
+			if err := validate([]byte(mutated)); err == nil {
+				t.Fatalf("expected %q to be rejected; it produces no signature", replacement)
+			}
+		})
+	}
+}
+
+// TestAllowsAPlainInvocationWithArguments keeps the rule usable: the real steps invoke a script with
+// arguments, so a command path preceding the matched text must stay legal.
+func TestAllowsAPlainInvocationWithArguments(t *testing.T) {
+	if err := validate([]byte(validAction)); err != nil {
+		t.Fatalf("the reference sequence invokes a script with arguments and must pass, got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1947,3 +1947,91 @@ func TestRejectsDigestResolvedByAShadowedFunction(t *testing.T) {
 		t.Fatal("a `docker` function shadows the resolver, so DIGEST never depends on the published tag")
 	}
 }
+
+// TestRejectsIndirectPathWriteByBuiltin is the PATH sibling of the builtin-write rule that already
+// guards DIGEST and REF. unmodeledShellState rejected only a `*syntax.Assign` to PATH, so
+// `printf -v PATH …` reached the same cosign shadowing without ever producing an Assign node.
+func TestRejectsIndirectPathWriteByBuiltin(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        printf -v PATH '%s' '/tmp/fake:/usr/bin'`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("`printf -v PATH` rebinds command resolution exactly as an assignment does")
+	}
+}
+
+// TestRejectsExecWithOptionsButNoCommand covers `exec -c`, which carries a word but names no
+// program, so bash CONTINUES the shell. Counting words treated it as terminating, which let a
+// later `workload push` hide behind it.
+func TestRejectsExecWithOptionsButNoCommand(t *testing.T) {
+	hidden := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        cosign sign --yes --recursive "${REF}"`+"\n"+
+			`        exec -c`+"\n"+
+			`        ksail workload push`, 1)
+	mustChange(t, validAction, hidden)
+
+	if err := validate([]byte(hidden)); err == nil {
+		t.Fatal("`exec -c` names no program, so the shell continues and the later push runs")
+	}
+}
+
+// TestRejectsAssignmentFormParameterExpansionWrite covers `: "${DIGEST:=<stale>}"`, which assigns
+// without producing an Assign, DeclClause or recognised builtin destination — so the collector saw
+// only the earlier valid resolution while bash signed the fallback.
+func TestRejectsAssignmentFormParameterExpansionWrite(t *testing.T) {
+	stale := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        unset DIGEST`+"\n"+
+			`        : "${DIGEST:=sha256:aaaa}"`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, stale)
+
+	if err := validate([]byte(stale)); err == nil {
+		t.Fatal("an assignment-form parameter expansion writes DIGEST invisibly to the collector")
+	}
+}
+
+// TestCompoundConstructShapeMatrix pins the LINE the compound-construct rule draws, in both
+// directions at once. The distinction is the SHELL, not the nesting: a construct that runs in the
+// step's own shell moves the errexit state parseExecuted tracks and must fail closed, while a
+// subshell form changes only a child that exits and must stay legal — rejecting those would fail
+// ordinary scripting such as `$(set -euo pipefail; crane digest …)`.
+func TestCompoundConstructShapeMatrix(t *testing.T) {
+	cases := []struct {
+		name       string
+		snippet    string
+		wantReject bool
+	}{
+		{"brace group", "        { set +e; }", true},
+		{"if branch", "        if true; then set +e; fi", true},
+		{"for loop", "        for i in 1; do set +e; done", true},
+		{"while loop", "        while false; do set +e; done", true},
+		{"function body", "        f() { set +e; }", true},
+		{"and-list", "        true && set +e", true},
+		{"explicit subshell", "        ( set +e )", false},
+		{"backgrounded", "        { set +e; } &", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := strings.Replace(validAction,
+				`        cosign sign --yes --recursive "${REF}"`,
+				tc.snippet+"\n"+`        cosign sign --yes --recursive "${REF}"`+"\n"+
+					`        echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"`, 1)
+			mustChange(t, validAction, mutated)
+
+			err := validate([]byte(mutated))
+			if tc.wantReject && err == nil {
+				t.Error("must be rejected: this construct runs in the step's own shell")
+			}
+
+			if !tc.wantReject && err != nil {
+				t.Errorf("must stay legal: a subshell cannot move the tracked state; got: %v", err)
+			}
+		})
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1236,3 +1236,119 @@ func TestAllowsANonStatusCheckReleaseCondition(t *testing.T) {
 		t.Fatalf("an ordinary release condition keeps the implicit success(), got: %v", err)
 	}
 }
+
+// TestRejectsErrexitApparentlyRestoredBySetPositionals covers `set --`, which assigns the remaining
+// words to the POSITIONAL PARAMETERS rather than to shell options (bash `help set`). A scan that
+// kept reading flags past it accepted `set -- -e` as errexit being restored, so a signing block
+// could turn failure propagation off, set positionals, and still be credited with a gate that no
+// longer fails the step. The guard then reported the safe state exactly where the unsafe one held —
+// the worst direction for it to be wrong in.
+func TestRejectsErrexitApparentlyRestoredBySetPositionals(t *testing.T) {
+	bypass := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        set +e\n"+
+			"        docker logout ghcr.io\n"+
+			"        set -- -e\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, bypass)
+
+	if err := validate([]byte(bypass)); err == nil {
+		t.Fatal("`set -- -e` assigns positional parameters; errexit is still off at the signing call")
+	}
+}
+
+// TestAllowsSetOptionsBeforeTheDoubleDash is the over-tightening control for the test above.
+// Terminating the scan at `--` must not blind it to the options that come BEFORE one: `set -e --`
+// really does restore errexit, and rejecting it would fail correct code.
+func TestAllowsSetOptionsBeforeTheDoubleDash(t *testing.T) {
+	restored := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        set +e\n"+
+			"        docker logout ghcr.io\n"+
+			"        set -e -- keep-positionals\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, restored)
+
+	if err := validate([]byte(restored)); err != nil {
+		t.Fatalf("`set -e --` restores errexit before signing; got: %v", err)
+	}
+}
+
+// TestRejectsAPrintfOverwriteOfTheSignedReference covers a builtin that writes a variable named by
+// its ARGUMENTS. The parser models `printf -v REF …` as command words, not as CallExpr.Assigns, so
+// the overwrite was invisible: a correct resolution stood in the source while cosign signed the
+// mutable tag written after it. Same bypass as a second `REF=` assignment, spelled so the assignment
+// scan could not see it.
+func TestRejectsAPrintfOverwriteOfTheSignedReference(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        printf -v REF '%s' 'ghcr.io/devantler-tech/platform/manifests:latest'`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("`printf -v REF` overwrites the resolved reference before cosign reads it")
+	}
+}
+
+// TestRejectsAnAttachedPrintfOverwrite pins the spelling an exact "-v then the next word" scan would
+// miss. Bash accepts the option argument attached, so `-vREF` is the same write as `-v REF`, and a
+// guard that caught only the detached form would document its own bypass.
+func TestRejectsAnAttachedPrintfOverwrite(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        printf -vREF '%s' 'ghcr.io/devantler-tech/platform/manifests:latest'`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("`printf -vREF` is the attached spelling of the same overwrite")
+	}
+}
+
+// TestAllowsPrintfReadingTheReference is the over-tightening control for the builtin-write
+// detection, and it is the one that keeps the guard usable. Writing a value OUT — to a step output,
+// a log line, a file — is the single most common thing a workflow does with a resolved reference,
+// and it only READS the variable. A detector that flagged any command mentioning REF would reject
+// correct actions, and a guard people cannot ship past is suppressed rather than satisfied.
+func TestAllowsPrintfReadingTheReference(t *testing.T) {
+	reported := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        printf '%s\n' "${REF}" >>"${GITHUB_OUTPUT}"`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, reported)
+
+	if err := validate([]byte(reported)); err != nil {
+		t.Fatalf("printf READING the reference is correct code; got: %v", err)
+	}
+}
+
+// TestRejectsAReadOverwriteOfTheSignedReference proves the fix addresses the CLASS rather than the
+// one builtin that was reported. `read` takes its destination as an operand exactly as `printf -v`
+// takes it as an option argument, so a detector special-cased to printf would leave this open.
+func TestRejectsAReadOverwriteOfTheSignedReference(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        read -r REF <<<'ghcr.io/devantler-tech/platform/manifests:latest'`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("`read REF` is the same overwrite through a different builtin")
+	}
+}
+
+// TestAllowsReadIntoAnUnrelatedVariable is the control for the operand decoding: `read` writing
+// something else entirely must not be mistaken for a write to the protected name, or every action
+// that parses anything would be rejected.
+func TestAllowsReadIntoAnUnrelatedVariable(t *testing.T) {
+	unrelated := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        read -r -p 'REF: ' answer <<<'ignored'`+"\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, unrelated)
+
+	if err := validate([]byte(unrelated)); err != nil {
+		t.Fatalf("read into an unrelated variable is correct code; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -804,3 +804,56 @@ func TestAllowsAnotherShellThatEnablesErrexitItself(t *testing.T) {
 		t.Fatalf("an explicit `set -e` gates the step whatever the shell; got: %v", err)
 	}
 }
+
+// TestRejectsSigningShadowedByAShellFunction covers the third axis: NAME RESOLUTION. The grammar says
+// the command runs and errexit says its failure would matter, but bash looks up functions before
+// PATH — so a script can define `cosign` as a no-op and then issue a textually perfect invocation
+// that signs nothing.
+func TestRejectsSigningShadowedByAShellFunction(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		"        cosign() {\n"+
+			"          true\n"+
+			"        }\n"+
+			`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("a `cosign` shell function shadows the real binary and produces no signature")
+	}
+}
+
+// TestRejectsPublishShadowedByAShellFunction pins that the rule is not cosign-specific. The wrapper
+// the composite publishes through is an ordinary command name too, so the same trick hides a push.
+func TestRejectsPublishShadowedByAShellFunction(t *testing.T) {
+	shadowed := strings.Replace(validAction,
+		`      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push`,
+		"      run: |\n"+
+			"        ./scripts/run-ksail-prod-with-pull-auth.sh() {\n"+
+			"          true\n"+
+			"        }\n"+
+			"        ./scripts/run-ksail-prod-with-pull-auth.sh workload push", 1)
+	mustChange(t, validAction, shadowed)
+
+	if err := validate([]byte(shadowed)); err == nil {
+		t.Fatal("a function shadowing the publish wrapper hides the push")
+	}
+}
+
+// TestAllowsAnUnrelatedShellFunction is the over-tightening control. Defining helpers is ordinary,
+// correct scripting; only a function that shadows a REQUIRED operation's own name is a problem, and
+// banning functions outright would fail legitimate actions.
+func TestAllowsAnUnrelatedShellFunction(t *testing.T) {
+	withHelper := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		"        log() {\n"+
+			"          echo \"$@\" >&2\n"+
+			"        }\n"+
+			"        log resolving digest\n"+
+			`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, withHelper)
+
+	if err := validate([]byte(withHelper)); err != nil {
+		t.Fatalf("an unrelated helper function is ordinary scripting; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -364,6 +364,10 @@ var signingReplacements = map[string]string{
 	"command substitution": `RESULT=$(cosign sign --yes --recursive "${REF}")`,
 	"uninvoked function":   "sign_it() {\n          cosign sign --yes --recursive \"${REF}\"\n        }",
 	"trailing semicolon":   `false; cosign sign --yes --recursive "${REF}" && true`,
+	// An arbitrary command in front of the match, with the invocation as its unquoted ARGUMENTS.
+	// The quoted "string literal" case above was rejected incidentally, by its quote — this one has
+	// no quote to catch, so it isolates the prefix rule itself.
+	"printed as arguments": `echo cosign sign --yes --recursive "${REF}"`,
 }
 
 // TestRejectsSigningThatIsNotAPlainTopLevelCommand is the general form of the comment, conditional
@@ -390,5 +394,38 @@ func TestRejectsSigningThatIsNotAPlainTopLevelCommand(t *testing.T) {
 func TestAllowsAPlainInvocationWithArguments(t *testing.T) {
 	if err := validate([]byte(validAction)); err != nil {
 		t.Fatalf("the reference sequence invokes a script with arguments and must pass, got: %v", err)
+	}
+}
+
+// operationReplacements covers the same prefix bypass on the OTHER two required operations. `echo`
+// is a plain command path, so a rule that allows any word before the match accepts these while bash
+// only prints them. They need their own table because they are matched as subcommands of a wrapper
+// (`./scripts/run-ksail-prod-with-pull-auth.sh workload push`), where — unlike `cosign sign` — a
+// preceding word is legitimate and cannot simply be banned.
+var operationReplacements = map[string]struct{ from, to string }{
+	"publish printed as arguments": {
+		"./scripts/run-ksail-prod-with-pull-auth.sh workload push",
+		"echo workload push",
+	},
+	"release printed as arguments": {
+		"./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile",
+		"echo workload reconcile",
+	},
+}
+
+// TestRejectsOperationsPrintedRatherThanRun extends the plain-command rule to publish and release.
+// Requiring the match to be a command is not enough on its own when the match is a SUBCOMMAND: the
+// check also has to know which executable carries it, or `echo` passes for the same reason `ksail`
+// does.
+func TestRejectsOperationsPrintedRatherThanRun(t *testing.T) {
+	for name, replacement := range operationReplacements {
+		t.Run(name, func(t *testing.T) {
+			mutated := strings.Replace(validAction, replacement.from, replacement.to, 1)
+			mustChange(t, validAction, mutated)
+
+			if err := validate([]byte(mutated)); err == nil {
+				t.Fatalf("expected %q to be rejected; bash only prints it", replacement.to)
+			}
+		})
 	}
 }

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1047,20 +1047,24 @@ func TestAllowsSetupBeforeTheResolver(t *testing.T) {
 	}
 }
 
-// TestAllowsAResolverInsideARetryLoop is the second over-tightening control. A resolver wrapped in a
-// retry is correct code whose output still terminates in the digest, so requiring the LAST statement
-// to consume the tag must recurse into compound commands rather than demanding a bare call.
-func TestAllowsAResolverInsideARetryLoop(t *testing.T) {
-	retried := strings.Replace(validAction,
+// TestRejectsAResolverInAnUNTAKENBranch is the reason the accepted shape is enumerated rather than
+// searched. A branch that never runs is still part of the last statement, so recursing through every
+// nested call found `crane digest` inside a dead `if` while bash returned the constant from the
+// `else`. Any construct whose output depends on which branch or iteration executes is rejected: it
+// cannot be bound without evaluating it, and guessing is what this guard keeps being bypassed by.
+func TestRejectsAResolverInAnUNTAKENBranch(t *testing.T) {
+	deadBranch := strings.Replace(validAction,
 		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
 		`        DIGEST="$(`+"\n"+
-			`          for _ in 1 2 3; do`+"\n"+
-			`            crane digest "${REF_TAG}" && break`+"\n"+
-			`          done`+"\n"+
+			`          if false; then`+"\n"+
+			`            crane digest "${REF_TAG}"`+"\n"+
+			`          else`+"\n"+
+			`            printf '%s' 'sha256:1111111111111111111111111111111111111111111111111111111111111111'`+"\n"+
+			`          fi`+"\n"+
 			`        )"`, 1)
-	mustChange(t, validAction, retried)
+	mustChange(t, validAction, deadBranch)
 
-	if err := validate([]byte(retried)); err != nil {
-		t.Fatalf("a retry around the resolver still ends in the resolved digest; got: %v", err)
+	if err := validate([]byte(deadBranch)); err == nil {
+		t.Fatal("a resolver in an untaken branch never runs; the constant beside it is what gets signed")
 	}
 }

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1007,3 +1007,60 @@ func TestRejectsAProcessSubstitution(t *testing.T) {
 		t.Fatal("a process substitution yields a file descriptor path, not the resolved digest")
 	}
 }
+
+// TestRejectsAResolverThatDISCARDSThePublishedTag closes what an earlier round documented as a
+// boundary and left open. Requiring only that SOME command inside the substitution receives
+// `${REF_TAG}` lets a no-op consume it while a later command prints the value that actually becomes
+// the digest — a real provenance bypass with a green CI, which is the worst combination a security
+// guard can have. "It would need dataflow analysis" argued for the wrong fix: the lesson from this
+// guard's first five rounds is that enumerating BAD shapes never converges, and the answer is to
+// narrow the ACCEPTED one instead.
+func TestRejectsAResolverThatDISCARDSThePublishedTag(t *testing.T) {
+	discarded := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="$(`+"\n"+
+			`          : "${REF_TAG}"`+"\n"+
+			`          printf '%s' 'sha256:1111111111111111111111111111111111111111111111111111111111111111'`+"\n"+
+			`        )"`, 1)
+	mustChange(t, validAction, discarded)
+
+	if err := validate([]byte(discarded)); err == nil {
+		t.Fatal("a no-op that consumes the tag does not make the constant it precedes a resolved digest")
+	}
+}
+
+// TestAllowsSetupBeforeTheResolver is that rule's over-tightening control. Only the command whose
+// output BECOMES the digest has to read the published tag; ordinary setup in front of it — shell
+// options, a variable, a guard — is correct scripting and must still pass.
+func TestAllowsSetupBeforeTheResolver(t *testing.T) {
+	withSetup := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="$(`+"\n"+
+			`          set -euo pipefail`+"\n"+
+			`          command -v crane >/dev/null`+"\n"+
+			`          crane digest "${REF_TAG}"`+"\n"+
+			`        )"`, 1)
+	mustChange(t, validAction, withSetup)
+
+	if err := validate([]byte(withSetup)); err != nil {
+		t.Fatalf("setup before the resolver is ordinary scripting; got: %v", err)
+	}
+}
+
+// TestAllowsAResolverInsideARetryLoop is the second over-tightening control. A resolver wrapped in a
+// retry is correct code whose output still terminates in the digest, so requiring the LAST statement
+// to consume the tag must recurse into compound commands rather than demanding a bare call.
+func TestAllowsAResolverInsideARetryLoop(t *testing.T) {
+	retried := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="$(`+"\n"+
+			`          for _ in 1 2 3; do`+"\n"+
+			`            crane digest "${REF_TAG}" && break`+"\n"+
+			`          done`+"\n"+
+			`        )"`, 1)
+	mustChange(t, validAction, retried)
+
+	if err := validate([]byte(retried)); err != nil {
+		t.Fatalf("a retry around the resolver still ends in the resolved digest; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -368,6 +368,10 @@ var signingReplacements = map[string]string{
 	// The quoted "string literal" case above was rejected incidentally, by its quote — this one has
 	// no quote to catch, so it isolates the prefix rule itself.
 	"printed as arguments": `echo cosign sign --yes --recursive "${REF}"`,
+	// A here-document body is INPUT, not commands. The invocation has no prefix and carries the
+	// resolved reference, so every line-level rule accepts it while bash feeds it to `:`.
+	"heredoc body":     ": <<'UNSIGNED'\n          cosign sign --yes --recursive \"${REF}\"\n          UNSIGNED",
+	"heredoc unquoted": ": <<UNSIGNED\n          cosign sign --yes --recursive \"${REF}\"\n          UNSIGNED",
 }
 
 // TestRejectsSigningThatIsNotAPlainTopLevelCommand is the general form of the comment, conditional
@@ -411,6 +415,18 @@ var operationReplacements = map[string]struct{ from, to string }{
 		"./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile",
 		"echo workload reconcile",
 	},
+	// These replace the whole `run:` line with a BLOCK scalar. Substituting a bare heredoc into the
+	// existing plain scalar would fold its lines into one, so the delimiter would end up inside the
+	// prefix and the case would be rejected for the wrong reason — passing without ever exercising
+	// heredoc handling.
+	"publish inside a heredoc": {
+		"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push",
+		"      run: |\n        : <<'NOPE'\n        ./scripts/run-ksail-prod-with-pull-auth.sh workload push\n        NOPE",
+	},
+	"release inside a heredoc": {
+		"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile",
+		"      run: |\n        : <<'NOPE'\n        ./scripts/run-ksail-prod-with-pull-auth.sh workload reconcile\n        NOPE",
+	},
 }
 
 // TestRejectsOperationsPrintedRatherThanRun extends the plain-command rule to publish and release.
@@ -427,5 +443,24 @@ func TestRejectsOperationsPrintedRatherThanRun(t *testing.T) {
 				t.Fatalf("expected %q to be rejected; bash only prints it", replacement.to)
 			}
 		})
+	}
+}
+
+// TestAllowsAHeredocAlongsideTheRequiredInvocation is the over-tightening control for heredoc
+// skipping. Hiding a here-document body must not cost a step the ability to USE one: a step that
+// writes an unrelated payload with a heredoc and then signs normally is legitimate, and rejecting it
+// would train people to treat this check as noise. The delimiter must also stop the skipping — if it
+// did not, everything after the heredoc (including the real invocation) would vanish with it.
+func TestAllowsAHeredocAlongsideTheRequiredInvocation(t *testing.T) {
+	withHeredoc := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        cat <<'NOTES' > /tmp/notes.txt\n"+
+			"        cosign sign is described here but not run\n"+
+			"        NOTES\n"+
+			`        cosign sign --yes --recursive "${REF}"`, 1)
+	mustChange(t, validAction, withHeredoc)
+
+	if err := validate([]byte(withHeredoc)); err != nil {
+		t.Fatalf("a step may use a heredoc and still sign; got: %v", err)
 	}
 }

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1833,3 +1833,48 @@ func TestRejectsAnUnparseableSigningStep(t *testing.T) {
 		t.Fatal("an unparseable signing step cannot be certified either way")
 	}
 }
+
+// TestRejectsADynamicallyExpandedSetOption closes a fail-open in the option allowlist itself: a word
+// whose value is not statically known cannot be checked against the allowlist, so accepting it was
+// the allowlist failing open on exactly the input it cannot read.
+//
+// The consequence runs through errexit rather than through `set` directly. `set "${OPTS}"` left the
+// option unchecked, while errexitToggle conservatively recorded errexit as OFF — which made
+// parseExecuted skip every command after it, including a second `workload push`.
+func TestRejectsADynamicallyExpandedSetOption(t *testing.T) {
+	mutated := strings.Replace(validAction, reconcileStep,
+		"    - name: Sneak\n      run: |\n        OPTS=-u\n        set \"${OPTS}\"\n"+
+			"        ./scripts/run-ksail-prod-with-pull-auth.sh workload push\n"+reconcileStep, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("an unreadable `set` option cannot be checked, so it cannot be accepted")
+	}
+}
+
+// TestSeesACommandPrefixedWorkloadOperation is the `command` half of the wrapper rule. `command X …`
+// executes X with its arguments, so reading argv[0] returns `command` and hid the operation entirely
+// — the same omission as the interpreter form, and fail-open in the same direction.
+func TestSeesACommandPrefixedWorkloadOperation(t *testing.T) {
+	mutated := strings.Replace(validAction, reconcileStep,
+		"    - name: Sneak\n      run: command ./scripts/run-ksail-prod-with-pull-auth.sh workload push\n"+
+			reconcileStep, 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err == nil {
+		t.Fatal("a `command`-prefixed publish still moves the tag production reads")
+	}
+}
+
+// TestRecognisesACommandPrefixedRequiredPush is that rule in the satisfying direction, so looking
+// through the prefix cannot only ever add rejections.
+func TestRecognisesACommandPrefixedRequiredPush(t *testing.T) {
+	mutated := strings.Replace(validAction,
+		"      run: ./scripts/run-ksail-prod-with-pull-auth.sh workload push",
+		"      run: command ./scripts/run-ksail-prod-with-pull-auth.sh workload push", 1)
+	mustChange(t, validAction, mutated)
+
+	if err := validate([]byte(mutated)); err != nil {
+		t.Fatalf("a command-prefixed push still publishes, got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -857,3 +857,47 @@ func TestAllowsAnUnrelatedShellFunction(t *testing.T) {
 		t.Fatalf("an unrelated helper function is ordinary scripting; got: %v", err)
 	}
 }
+
+// TestAllowsAQuotedCommandSubstitution is an over-tightening control for the provenance check.
+// `DIGEST="$(…)"` wraps the substitution in a DblQuoted node, and quoting it is BETTER practice than
+// leaving it bare — so scanning only the word's top-level parts rejected the more careful spelling of
+// correct code. A guard that fails a correct refactor gets suppressed rather than fixed.
+func TestAllowsAQuotedCommandSubstitution(t *testing.T) {
+	quoted := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        DIGEST="$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')"`, 1)
+	mustChange(t, validAction, quoted)
+
+	if err := validate([]byte(quoted)); err != nil {
+		t.Fatalf("quoting a command substitution is good practice, not a defect; got: %v", err)
+	}
+}
+
+// TestRejectsAConstantDigestViaDeclare covers the declaration builtins. `export`, `declare`, `local`,
+// `readonly` and `typeset` all assign, but the parser models them as a DeclClause rather than a
+// CallExpr — so reading only CallExpr made a constant override invisible, and it silently won over a
+// correct resolution earlier in the same script.
+func TestRejectsAConstantDigestViaDeclare(t *testing.T) {
+	overridden := strings.Replace(validAction,
+		`        REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`,
+		`        declare -g DIGEST="sha256:1111111111111111111111111111111111111111111111111111111111111111"`+"\n"+
+			`        REF="ghcr.io/devantler-tech/platform/manifests@${DIGEST}"`, 1)
+	mustChange(t, validAction, overridden)
+
+	if err := validate([]byte(overridden)); err == nil {
+		t.Fatal("a `declare -g` constant overrides the resolved digest and decides what is signed")
+	}
+}
+
+// TestAllowsExportingTheResolvedDigest is that rule's control: a declaration builtin is not itself
+// suspicious. Exporting a correctly resolved value is ordinary scripting and must still pass.
+func TestAllowsExportingTheResolvedDigest(t *testing.T) {
+	exported := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		`        export DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`, 1)
+	mustChange(t, validAction, exported)
+
+	if err := validate([]byte(exported)); err != nil {
+		t.Fatalf("exporting a correctly resolved digest is ordinary scripting; got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -286,3 +286,22 @@ func TestAllowsEvidenceSharingTheReleaseCondition(t *testing.T) {
 		t.Fatalf("evidence sharing the release condition must stay legal, got: %v", err)
 	}
 }
+
+// TestAllowsACommentedAlternativeBesideARealSigningInvocation pins the other half of comment
+// handling. Stripping comments before matching is what stops a `#` from disabling the guard; it is
+// ALSO what stops a commented-out alternative from failing a composite that signs correctly.
+//
+// Without it, signsTheResolvedDigest walks the raw text, finds "cosign sign " on the commented line,
+// sees no "${REF}" there, and rejects a file whose real invocation is exactly right — a guard that
+// fails valid input gets suppressed, which is how the real one stops being enforced.
+func TestAllowsACommentedAlternativeBesideARealSigningInvocation(t *testing.T) {
+	withAlternative := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        cosign sign --yes --recursive "${REF}"`+"\n"+
+			`        # cosign sign --yes --recursive "${REF_TAG}"  # pre-digest form, kept for reference`, 1)
+	mustChange(t, validAction, withAlternative)
+
+	if err := validate([]byte(withAlternative)); err != nil {
+		t.Fatalf("a commented alternative beside a correct invocation must stay legal, got: %v", err)
+	}
+}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -1392,21 +1392,24 @@ func TestAllowsANamerefToAnUnrelatedVariable(t *testing.T) {
 // separate bypasses at once. All four shapes below were verified to pass the validator before the
 // prefix stripping went in.
 func TestRejectsPrefixedBuiltinBypasses(t *testing.T) {
-	for _, testCase := range []struct{ name, inject string }{
+	for _, testCase := range []struct{ name, inject, wantErr string }{
 		{
 			"builtin printf -v",
 			`        builtin printf -v REF '%s' 'ghcr.io/devantler-tech/platform/manifests:latest'`,
+			"resolved digest",
 		},
 		{
 			"command printf -v",
 			`        command printf -v REF '%s' 'ghcr.io/devantler-tech/platform/manifests:latest'`,
+			"resolved digest",
 		},
 		{
 			"builtin declare -n",
 			"        builtin declare -n target=REF\n" +
 				`        target='ghcr.io/devantler-tech/platform/manifests:latest'`,
+			"resolved digest",
 		},
-		{"builtin set +e", "        builtin set +e"},
+		{"builtin set +e", "        builtin set +e", "no step appears to"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			bypass := strings.Replace(validAction,
@@ -1414,8 +1417,56 @@ func TestRejectsPrefixedBuiltinBypasses(t *testing.T) {
 				testCase.inject+"\n"+`        cosign sign --yes --recursive "${REF}"`, 1)
 			mustChange(t, validAction, bypass)
 
-			if err := validate([]byte(bypass)); err == nil {
+			err := validate([]byte(bypass))
+			if err == nil {
 				t.Fatal("a builtin/command prefix must not hide the write or the errexit toggle")
+			}
+
+			// Assert WHICH contract rejected it. A bare non-nil check passes for any reason at all,
+			// so a case could stop exercising the prefix stripping it names and still look green.
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("want an error naming %q; got: %v", testCase.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestRejectsNamerefWithASubscriptTarget covers a nameref target that carries an array subscript.
+//
+// Bash accepts a subscript on a nameref target, and on a scalar `REF[0]` denotes REF itself, so
+// `declare -n target=REF[0]` followed by a write through target assigns REF. Both write detectors
+// compared the target to the protected name EXACTLY, so the subscript slipped past each of them.
+//
+// Both spellings are covered because they are separate code paths: the unprefixed form is modelled
+// as a DeclClause, while a `builtin`/`command` prefix stops the parser doing that and falls through
+// to the word scanner. Only the prefixed shape was reported; fixing that one alone would have left
+// the commoner unprefixed spelling open.
+func TestRejectsNamerefWithASubscriptTarget(t *testing.T) {
+	for _, testCase := range []struct{ name, inject string }{
+		{
+			"declare -n subscript",
+			"        declare -n target=REF[0]\n" +
+				`        target='ghcr.io/devantler-tech/platform/manifests:latest'`,
+		},
+		{
+			"builtin declare -n subscript",
+			"        builtin declare -n target=REF[0]\n" +
+				`        target='ghcr.io/devantler-tech/platform/manifests:latest'`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			bypass := strings.Replace(validAction,
+				`        cosign sign --yes --recursive "${REF}"`,
+				testCase.inject+"\n"+`        cosign sign --yes --recursive "${REF}"`, 1)
+			mustChange(t, validAction, bypass)
+
+			err := validate([]byte(bypass))
+			if err == nil {
+				t.Fatal("a subscripted nameref target must not hide the write to REF")
+			}
+
+			if !strings.Contains(err.Error(), "resolved digest") {
+				t.Fatalf("want the resolved-digest contract to reject it; got: %v", err)
 			}
 		})
 	}

--- a/scripts/validate-publication-order/main_test.go
+++ b/scripts/validate-publication-order/main_test.go
@@ -305,3 +305,50 @@ func TestAllowsACommentedAlternativeBesideARealSigningInvocation(t *testing.T) {
 		t.Fatalf("a commented alternative beside a correct invocation must stay legal, got: %v", err)
 	}
 }
+
+// TestRejectsSigningInsideAStaticallyFalseBranch is the last bypass of the matcher family: the step
+// carries no `if:`, keeps its position, and builds REF from the resolved digest, so every check above
+// is satisfied — while the invocation sits in a branch that never runs. GitHub attests and reconciles
+// an unsigned artifact.
+func TestRejectsSigningInsideAStaticallyFalseBranch(t *testing.T) {
+	nested := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		"        if false; then\n"+
+			`          cosign sign --yes --recursive "${REF}"`+"\n"+
+			"        fi", 1)
+	mustChange(t, validAction, nested)
+
+	if err := validate([]byte(nested)); err == nil {
+		t.Fatal("expected a signing invocation inside a conditional branch to be rejected")
+	}
+}
+
+// TestRejectsSigningInAOneLineConditional is the same bypass written on one line, where the block
+// opens and closes before the line ends. A depth counter alone returns to zero by the end of it, so
+// the line would look unnested.
+func TestRejectsSigningInAOneLineConditional(t *testing.T) {
+	inline := strings.Replace(validAction,
+		`        cosign sign --yes --recursive "${REF}"`,
+		`        if false; then cosign sign --yes --recursive "${REF}"; fi`, 1)
+	mustChange(t, validAction, inline)
+
+	if err := validate([]byte(inline)); err == nil {
+		t.Fatal("expected a one-line conditional around the signing invocation to be rejected")
+	}
+}
+
+// TestAllowsControlFlowElsewhereInAStep keeps the rule from banning shell control flow outright.
+// Only the required invocations must be unconditional; a retry loop or a precondition check
+// alongside them is ordinary scripting and stays legal.
+func TestAllowsControlFlowElsewhereInAStep(t *testing.T) {
+	withLoop := strings.Replace(validAction,
+		`        DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}')`,
+		"        for attempt in 1 2 3; do\n"+
+			`          DIGEST=$(docker buildx imagetools inspect "${REF_TAG}" --format '{{.Manifest.Digest}}') && break`+"\n"+
+			"        done", 1)
+	mustChange(t, validAction, withLoop)
+
+	if err := validate([]byte(withLoop)); err != nil {
+		t.Fatalf("control flow around non-required work must stay legal, got: %v", err)
+	}
+}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The production deploy makes the platform manifests reachable, signs them, attests an SBOM and build
provenance, and only then tells Flux to look. If any of that gets reordered, the cluster's root source —
which delivers every controller, tenant binding and policy — can resolve an artifact whose supply-chain
evidence is still being assembled.

Nothing about that reordering fails. The steps all succeed, the cluster converges, and the artifact ends
up fully signed a minute later; the only difference is that production *could* have looked in between. So
the ordering has no natural regression signal, and an edit that moved the reconcile trigger earlier to
"fail faster" would read as an improvement in review.

## What

A CI check that pins the order as a partial order — publish, then the signature and both attestations in
any order, then the reconcile. It also holds two things the order alone cannot: that the required steps
cannot be skipped while a release still runs, and that the signature covers *this* run's artifact rather
than one named by hand.

The check decides what a deploy step actually does by parsing it as shell rather than reading its text.
That matters because the text-based version was worked around repeatedly during review — a comment, a
condition, a swallowed failure, a rebound command name — each time silently. Parsing removes those
whole classes instead of the latest example of each.

It is deliberately **fail-closed**: where the check cannot fully understand a step, it says so and
fails, rather than assuming the step is fine. That is what stopped the review treadmill — the last
nine findings were all "a shell construct you did not model", and the fix was to accept only what the
check has reasoned about instead of listing the tricks one at a time. The error names the construct
and what to do about it.

The cost of that is real and worth naming: a future edit to this action that reaches for `trap`,
`source`, `eval` or similar will now fail CI rather than pass quietly. None of them are used today,
the rule covers only `deploy-prod/action.yml`, and the failure names the construct and the remedy —
but it is a constraint on one file, not a free win.

⚠️ **New dependency:** `mvdan.cc/sh/v3` (the shell parser behind `shfmt`), used only by this check.

**Known gaps, tracked separately.** This check is deliberately scoped, and four limits are handed off
rather than fixed here:

- The manual production deploy path can reach `deploy-prod` without this check running at all (#2879).
- Work reached indirectly — through a wrapper, or delegated to another action mid-window — is outside
  what the check inspects (#2873).
- The check proves a step *references* the right artifact, not that the value it passes is the right
  one (#2870).
- A condition shared by several steps is re-evaluated as each is reached, so a step in between can
  change it and silence the evidence steps without failing anything (#2884).

Until those close, this gate protects the reviewed path rather than every path. That is the point of
shipping it now: it removes the classes it does model, and each remaining class is named and owned.

**#2627 stays open.** This locks the ordering that already holds; it does not make publication
atomic. The mutable tag is still moved by the push step before signing begins, which is the substance of
that issue and needs a staging reference to fix.

Part of #2627


