### PR TITLE
fix(ci): re-root SARIF fixes[] paths and cover the guard with a test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,10 @@ jobs:
               - 'scripts/validate-embedded-json.py'
               - 'scripts/tests/test-openbao-oidc-role.sh'
               - 'scripts/generate-kubescape-exceptions/**'
+              # Both halves, so editing the guard alone — or its test alone —
+              # still runs the check that covers it.
               - 'scripts/normalize-sarif-paths.sh'
+              - 'scripts/tests/test-normalize-sarif-paths.sh'
               - 'scripts/summarize-sarif-findings.sh'
               - 'scripts/tests/test-summarize-sarif-findings.sh'
               - 'go.mod'
@@ -293,6 +296,15 @@ jobs:
         # the two SARIF shapes that turn into hard jq errors if indexed naively: a
         # result with no ruleId, and a ruleId absent from the rule table.
         run: bash scripts/tests/test-summarize-sarif-findings.sh
+
+      - name: 🧭 Validate SARIF path normalisation
+        if: needs.changes.outputs.k8s == 'true'
+        # normalize-sarif-paths.sh is a fail-closed guard, and until now shellcheck
+        # was its only gate — which cannot see a jq path that was never written.
+        # That is exactly how fixes[] stayed un-rooted while the guard reported
+        # success (#2863). Pin the rewrite over BOTH path-bearing fields, plus
+        # idempotency, the hard error, and the clean-scan case.
+        run: bash scripts/tests/test-normalize-sarif-paths.sh
 
       - name: 📢 Validate reconciliation-Alert namespace coverage
         if: needs.changes.outputs.k8s == 'true'

--- a/scripts/normalize-sarif-paths.sh
+++ b/scripts/normalize-sarif-paths.sh
@@ -46,9 +46,24 @@ PREFIX="${PREFIX%/}"
 
 # `while read` rather than `mapfile`, which is bash 4+ and so unavailable on the
 # macOS bash 3.2 a maintainer may run this under locally.
+#
+# Collected separately because the two lists mean different things: the empty-uri
+# DROP is a property of a result's location (a finding with no manifest to anchor
+# to), whereas RESOLUTION must cover every path-bearing field in the document.
+location_uris=()
+while IFS= read -r line; do location_uris+=("$line"); done < <(jq -r '
+  [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty] | unique[]
+' "$SARIF")
+
+# BOTH path-bearing fields. Kubescape repeats a finding's path under
+# fixes[].artifactChanges[], so normalising only locations[] leaves a dead path
+# inside a document this script then certifies as clean — the guard reports
+# success while the defect it exists to prevent survives in the other field
+# (#2863).
 uris=()
 while IFS= read -r line; do uris+=("$line"); done < <(jq -r '
-  [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty] | unique[]
+  [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty,
+   .runs[]?.results[]?.fixes[]?.artifactChanges[]?.artifactLocation.uri // empty] | unique[]
 ' "$SARIF")
 
 rewrite_args=()
@@ -91,9 +106,13 @@ jq --arg prefix "$PREFIX" --argjson rewrite "$(printf '%s\n' "${rewrite_args[@]+
     (.results //= [])
     | .results |= map(select((.locations[0].physicalLocation.artifactLocation.uri // "") != ""))
     | .results |= map(
-        .locations |= map(
+        (.locations |= map(
           .physicalLocation.artifactLocation.uri |= fix(.)
-        )
+        ))
+        # `[]?` rather than `//= []`: a result without fixes must stay without
+        # fixes. Creating an empty array here would change the shape of every
+        # finding that has no suggested change.
+        | ((.fixes[]?.artifactChanges[]?.artifactLocation.uri) |= fix(.))
       )
   )
 ' "$SARIF" >"$tmp"
@@ -103,15 +122,19 @@ mv "$tmp" "$SARIF"
 # all, printf still emits one newline, so the grep form reports 1 dropped group on
 # a clean scan that had none.
 dropped=0
-for uri in ${uris[@]+"${uris[@]}"}; do
+for uri in ${location_uris[@]+"${location_uris[@]}"}; do
   [ -n "$uri" ] || dropped=$((dropped + 1))
 done
 echo "normalize-sarif-paths: ${kept} already root-relative, ${prefixed} prefixed with '${PREFIX}/', ${dropped} empty-uri group(s) dropped."
 
-# Fail-closed re-check: every surviving path must now resolve.
+# Fail-closed re-check: every surviving path must now resolve. This reads the
+# SAME field set as the resolve loop above — a re-check narrower than the
+# rewrite is how a dead path got certified as clean in the first place (#2863),
+# so the two lists must not drift apart again.
 after=()
 while IFS= read -r line; do after+=("$line"); done < <(jq -r '
-  [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty] | unique[]
+  [.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty,
+   .runs[]?.results[]?.fixes[]?.artifactChanges[]?.artifactLocation.uri // empty] | unique[]
 ' "$SARIF")
 bad=0
 for uri in ${after[@]+"${after[@]}"}; do

--- a/scripts/normalize-sarif-paths.sh
+++ b/scripts/normalize-sarif-paths.sh
@@ -112,7 +112,15 @@ jq --arg prefix "$PREFIX" --argjson rewrite "$(printf '%s\n' "${rewrite_args[@]+
         # `[]?` rather than `//= []`: a result without fixes must stay without
         # fixes. Creating an empty array here would change the shape of every
         # finding that has no suggested change.
-        | ((.fixes[]?.artifactChanges[]?.artifactLocation.uri) |= fix(.))
+        #
+        # The select() is load-bearing: an artifactLocation may reference the
+        # run artifacts[] table by index and carry no uri at all. `|=` visits an
+        # absent path and writes the result back, so without this guard such an
+        # entry gains `"uri": null` — invalid against a schema that requires a
+        # string, which can make Code Scanning reject the entire upload.
+        | (.fixes[]?.artifactChanges[]?.artifactLocation
+           | select(.uri? | type == "string")
+           | .uri) |= fix(.)
       )
   )
 ' "$SARIF" >"$tmp"

--- a/scripts/tests/test-normalize-sarif-paths.sh
+++ b/scripts/tests/test-normalize-sarif-paths.sh
@@ -180,7 +180,43 @@ bash "${script}" "${clean_sarif}" k8s "${fixture_root}" >/dev/null ||
   fail "a zero-result SARIF should succeed; the clean-scan case must not fail closed"
 
 # ---------------------------------------------------------------------------
-# 6. CI actually runs this test, so the gate cannot be added and then orphaned.
+
+# ---------------------------------------------------------------------------
+# 6. An artifactChange that identifies its artifact by INDEX has no uri, and
+#    must not acquire one.
+#
+#    SARIF lets an artifactLocation reference the run's artifacts[] table by
+#    index instead of carrying a uri. jq's `|=` visits an absent path and writes
+#    the result back, so rewriting `.artifactLocation.uri` on such an entry
+#    CREATES `"uri": null`. The schema requires uri to be a string when present,
+#    so the document becomes invalid and Code Scanning can reject the whole
+#    upload — turning a path fix into a total findings outage.
+#
+#    Both shapes sit in one artifactChanges[] so the control is exact: the
+#    uri-identified entry must still be re-rooted in the same pass that leaves
+#    the index-identified one alone. Skipping fixes[] wholesale would satisfy
+#    the first assertion and reintroduce the very bug #2863 fixed.
+# ---------------------------------------------------------------------------
+index_sarif="${work_dir}/index.sarif"
+write_sarif "${index_sarif}"
+jq '.runs[0].results[0].fixes[0].artifactChanges += [{"artifactLocation": {"index": 0}}]' \
+  "${index_sarif}" >"${index_sarif}.tmp" && mv "${index_sarif}.tmp" "${index_sarif}"
+
+bash "${script}" "${index_sarif}" k8s "${fixture_root}" >/dev/null ||
+  fail "an index-identified artifactChange should not fail the run"
+
+jq -e '.runs[0].results[0].fixes[0].artifactChanges[1].artifactLocation | has("uri") | not' \
+  "${index_sarif}" >/dev/null ||
+  fail "rewriting an index-identified artifactLocation created a uri key; SARIF requires uri to be a string when present, so the document is now schema-invalid"
+
+jq -e '.runs[0].results[0].fixes[0].artifactChanges[1].artifactLocation.index == 0' \
+  "${index_sarif}" >/dev/null ||
+  fail "the index reference was lost"
+
+[ "$(jq -r '.runs[0].results[0].fixes[0].artifactChanges[0].artifactLocation.uri' "${index_sarif}")" \
+  = "k8s/bases/apps/demo/cm.yaml" ] ||
+  fail "the uri-identified artifactChange beside it was left un-rooted; the index guard is too broad"
+# 7. CI actually runs this test, so the gate cannot be added and then orphaned.
 # ---------------------------------------------------------------------------
 grep -Fq 'scripts/tests/test-normalize-sarif-paths.sh' "${ci_workflow}" ||
   fail "ci.yaml does not reference this test; adding it without wiring it in gates nothing"

--- a/scripts/tests/test-normalize-sarif-paths.sh
+++ b/scripts/tests/test-normalize-sarif-paths.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Pin the path rewriting that scripts/normalize-sarif-paths.sh performs.
+#
+# WHY THIS EXISTS. That script is a fail-closed guard: it certifies that every
+# path in a SARIF file resolves at the repository root before the file is
+# uploaded to Code Scanning, because an unresolvable path produces an alert that
+# is created, looks correct in the API, and is unclickable (#2830). Until this
+# test existed the only gate over it was `shellcheck`, which cannot see a jq
+# path that was never written — and that is exactly the gap #2863 found: the
+# script rewrote `locations[]` while leaving `fixes[]` un-rooted, and its own
+# closing re-check read only `locations[]`, so the guard stayed green while
+# certifying four dead paths.
+#
+# The failure mode is therefore a MISSING rewrite, never a crash, which is why
+# this asserts on the rewritten document rather than on exit status alone. Each
+# assertion below is paired with a control where a control is what makes it
+# meaningful.
+#
+# Bash plus the runner's jq; no cluster, no secrets, no network.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly script="${root_dir}/scripts/normalize-sarif-paths.sh"
+readonly ci_workflow="${root_dir}/.github/workflows/ci.yaml"
+
+work_dir="$(mktemp -d)"
+readonly work_dir
+cleanup() {
+  rm -rf "${work_dir}"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# A fixture repo root holding one real manifest under the k8s/ prefix, so the
+# script's resolve-based rule has something true to resolve against.
+readonly fixture_root="${work_dir}/repo"
+mkdir -p "${fixture_root}/k8s/bases/apps/demo"
+printf 'apiVersion: v1\nkind: ConfigMap\n' >"${fixture_root}/k8s/bases/apps/demo/cm.yaml"
+
+# Emits a SARIF whose single result carries the same un-rooted path in BOTH
+# locations[] and fixes[] — the shape Kubescape actually produces.
+write_sarif() {
+  local path="$1"
+  cat >"${path}" <<'SARIF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "kubescape" } },
+      "results": [
+        {
+          "ruleId": "C-0034",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "bases/apps/demo/cm.yaml" },
+                "region": { "startLine": 1 }
+              }
+            }
+          ],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "bases/apps/demo/cm.yaml" },
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 1 } }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+SARIF
+}
+
+location_uris() {
+  jq -r '[.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty] | unique[]' "$1"
+}
+
+fix_uris() {
+  jq -r '[.runs[]?.results[]?.fixes[]?.artifactChanges[]?.artifactLocation.uri // empty] | unique[]' "$1"
+}
+
+# Every path the document still carries must resolve under the fixture root.
+# This is the property the script promises; it is asserted over BOTH fields
+# because a promise that silently excludes one of them is the defect itself.
+assert_all_resolve() {
+  local sarif="$1"
+  local label="$2"
+  local uri
+
+  while IFS= read -r uri; do
+    [ -n "${uri}" ] || continue
+    [ -e "${fixture_root}/${uri}" ] ||
+      fail "${label}: path does not resolve under the repo root: ${uri}"
+  done < <(
+    location_uris "${sarif}"
+    fix_uris "${sarif}"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# 1. Both fields are re-rooted.
+# ---------------------------------------------------------------------------
+sarif="${work_dir}/both.sarif"
+write_sarif "${sarif}"
+
+# CONTROL: before the script runs, neither field resolves. Without this the
+# assertion below would also pass against a script that did nothing at all on an
+# input that happened to be correct already.
+[ ! -e "${fixture_root}/$(location_uris "${sarif}")" ] ||
+  fail "control: the fixture location path already resolved, so the rewrite is untestable"
+[ ! -e "${fixture_root}/$(fix_uris "${sarif}")" ] ||
+  fail "control: the fixture fixes path already resolved, so the rewrite is untestable"
+
+bash "${script}" "${sarif}" k8s "${fixture_root}" >/dev/null
+
+[ "$(location_uris "${sarif}")" = "k8s/bases/apps/demo/cm.yaml" ] ||
+  fail "locations[] was not re-rooted (got: $(location_uris "${sarif}"))"
+
+# THE REGRESSION THIS FILE EXISTS FOR (#2863). Kubescape repeats the path under
+# fixes[]; leaving it un-rooted keeps a dead path in a document the script has
+# just certified as clean.
+[ "$(fix_uris "${sarif}")" = "k8s/bases/apps/demo/cm.yaml" ] ||
+  fail "fixes[].artifactChanges[].artifactLocation.uri was not re-rooted (got: $(fix_uris "${sarif}"))"
+
+assert_all_resolve "${sarif}" "after rewrite"
+
+# ---------------------------------------------------------------------------
+# 2. Idempotent: a second run over an already-rooted document changes nothing.
+# ---------------------------------------------------------------------------
+before="$(cat "${sarif}")"
+bash "${script}" "${sarif}" k8s "${fixture_root}" >/dev/null
+[ "${before}" = "$(cat "${sarif}")" ] ||
+  fail "second run mutated an already-root-relative document; the rewrite is not idempotent"
+
+# ---------------------------------------------------------------------------
+# 3. A path that resolves under NEITHER root is a hard error, not a silent pass.
+# ---------------------------------------------------------------------------
+bad_sarif="${work_dir}/bad.sarif"
+write_sarif "${bad_sarif}"
+jq '.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri = "bases/apps/ghost/nope.yaml"' \
+  "${bad_sarif}" >"${bad_sarif}.tmp" && mv "${bad_sarif}.tmp" "${bad_sarif}"
+
+if bash "${script}" "${bad_sarif}" k8s "${fixture_root}" >/dev/null 2>&1; then
+  fail "an unresolvable path was accepted; the fail-closed guard did not fire"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. An empty uri is dropped with a warning, not treated as an error.
+#    Kubescape emits one for cluster-RBAC controls with no backing manifest.
+# ---------------------------------------------------------------------------
+empty_sarif="${work_dir}/empty.sarif"
+write_sarif "${empty_sarif}"
+jq '.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri = ""' \
+  "${empty_sarif}" >"${empty_sarif}.tmp" && mv "${empty_sarif}.tmp" "${empty_sarif}"
+
+bash "${script}" "${empty_sarif}" k8s "${fixture_root}" >/dev/null ||
+  fail "an empty uri should be dropped with a warning, not fail the run"
+[ "$(jq '[.runs[]?.results[]?] | length' "${empty_sarif}")" = "0" ] ||
+  fail "the empty-uri result was not dropped"
+
+# ---------------------------------------------------------------------------
+# 5. A clean scan (zero results) is not an error.
+# ---------------------------------------------------------------------------
+clean_sarif="${work_dir}/clean.sarif"
+printf '%s\n' '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"kubescape"}},"results":[]}]}' \
+  >"${clean_sarif}"
+bash "${script}" "${clean_sarif}" k8s "${fixture_root}" >/dev/null ||
+  fail "a zero-result SARIF should succeed; the clean-scan case must not fail closed"
+
+# ---------------------------------------------------------------------------
+# 6. CI actually runs this test, so the gate cannot be added and then orphaned.
+# ---------------------------------------------------------------------------
+grep -Fq 'scripts/tests/test-normalize-sarif-paths.sh' "${ci_workflow}" ||
+  fail "ci.yaml does not reference this test; adding it without wiring it in gates nothing"
+
+printf 'TEST PASS: normalize-sarif-paths rewrites locations[] and fixes[], stays idempotent, and fails closed.\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

We just started publishing Kubescape findings to Code Scanning (#2830). The guard that makes those alerts clickable was only doing half its job: it re-rooted the path under `locations[]` but not the copy Kubescape repeats under `fixes[]`, and its own fail-closed re-check looked at the same narrow field set — so it reported success over a file that still held four paths pointing nowhere.

Nothing is visibly broken today, and the body of #2863 says so plainly: GitHub does not render autofix from third-party SARIF yet. What is real now is that a guard whose whole purpose is "no dead paths get uploaded" was not actually checking for them, and the SARIF we publish contradicts itself — the same finding carrying one live path and one dead one.

The contributing cause matters more than the bug: the script had **no test**. `shellcheck` was its only gate, and shellcheck cannot see a jq path nobody wrote.

## What

Re-roots `fixes[]` by the same resolve-based rule as `locations[]`, widens the fail-closed re-check to match, and adds the missing test — wired into CI so editing the guard or the test runs the check. Measured on this repo: **4 of 4 `fixes[]` paths resolved to nothing before, 0 after**; the test fails against the old script and passes against the new one.

Behaviour is otherwise unchanged — idempotency, the empty-uri drop, the hard error and the clean-scan case are all pinned rather than altered.

Fixes #2863
Part of #2451