### PR TITLE
security(k8s): disposition CKV_SECRET_6 as key references, not secret material

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -83,16 +83,28 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (73) and trivy (620): Kubernetes misconfiguration in k8s/, which the section above
+  # checkov (37) and trivy (624): Kubernetes misconfiguration in k8s/, which the section above
   # explains is NOT covered elsewhere. Tracked by #2787.
+  #
+  # checkov's remaining 37 are all `kubernetes` framework, led by CKV_K8S_40 (11). The `secrets`
+  # framework is at 0: its 31 CKV_SECRET_6 findings were ExternalSecret/PushSecret key NAMES and
+  # OpenBao paths rather than secret material, and each site now carries a scoped skip naming the
+  # control and the reason (#2892). CKV_SECRET_6 is NOT disabled — a real base64 secret committed
+  # into one of those same directories is still flagged.
   #
   # Reproduce both counts before pushing with `scripts/megalinter-scan-counts.sh` — it runs the
   # exact commands this job runs, so a slice can show the number moved without a CI round trip.
   #
   # ⚠️ Read trivy's number from that script, NOT from the MegaLinter summary. MegaLinter reports
-  # this trivy scan as "1 non blocking error" while the scan actually fails 620 checks across 458
+  # this trivy scan as "1 non blocking error" while the scan actually fails 624 checks across 459
   # targets; the 1 is an artifact of how MegaLinter counts trivy's output. checkov's number is a
   # genuine sum of "Failed checks:" and needs no such caveat.
+  #
+  # ⚠️ Both numbers above DRIFT without anyone touching this file — they moved between the slice
+  # that recorded them and the next one (checkov's kubernetes framework 42 → 37, trivy 620 → 624)
+  # because merged work and scanner rule-set changes both move them. Re-run the script and correct
+  # these figures as part of any slice, rather than reading a stale figure as the current state.
+  # #2853 tracks making that drift detectable rather than something a slice has to notice.
   - REPOSITORY_CHECKOV
   - REPOSITORY_TRIVY
   # jscpd (17): all in test files — scripts/validate-eks-ci-role-policy/main_test.go (#2777) and

--- a/k8s/bases/apps/actual-budget/external-secret-enablebanking.yaml
+++ b/k8s/bases/apps/actual-budget/external-secret-enablebanking.yaml
@@ -15,7 +15,7 @@ spec:
   # Consumed by the enablebanking-seed sidecar, which reconciles these into
   # Actual's internal secrets table — Enable Banking has no env/config hook.
   data:
-    - secretKey: application-id
+    - secretKey: application-id  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/actual-budget/enablebanking
         property: application-id

--- a/k8s/bases/apps/actual-budget/external-secret.yaml
+++ b/k8s/bases/apps/actual-budget/external-secret.yaml
@@ -12,7 +12,7 @@ spec:
     name: actual-budget-oidc
     creationPolicy: Owner
   data:
-    - secretKey: client-secret
+    - secretKey: client-secret  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/oidc/dex
         property: client-secret

--- a/k8s/bases/apps/actual-budget/helm-release.yaml
+++ b/k8s/bases/apps/actual-budget/helm-release.yaml
@@ -224,4 +224,4 @@ spec:
         tokenExpiration: "never"
         existingSecret:
           name: actual-budget-oidc
-          clientSecretKey: client-secret
+          clientSecretKey: client-secret  # checkov:skip=CKV_SECRET_6:names a key inside an existing Secret; the value lives in OpenBao

--- a/k8s/bases/apps/ascoachingogvaner/external-secret.yaml
+++ b/k8s/bases/apps/ascoachingogvaner/external-secret.yaml
@@ -31,7 +31,7 @@ spec:
       data:
         .dockerconfigjson: "{{ .dockerconfigjson }}"
   data:
-    - secretKey: dockerconfigjson
+    - secretKey: dockerconfigjson  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/ghcr/auth
         property: dockerconfigjson

--- a/k8s/bases/apps/crossview/external-secret.yaml
+++ b/k8s/bases/apps/crossview/external-secret.yaml
@@ -41,7 +41,7 @@ spec:
     name: crossview-credentials
     creationPolicy: Owner
   data:
-    - secretKey: db-password
+    - secretKey: db-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/crossview/db
         property: db-password
@@ -49,11 +49,11 @@ spec:
       remoteRef:
         key: apps/crossview/app
         property: session-secret
-    - secretKey: admin-password
+    - secretKey: admin-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/crossview/admin
         property: admin-password
-    - secretKey: oidc-client-secret
+    - secretKey: oidc-client-secret  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/oidc/dex
         property: client-secret

--- a/k8s/bases/apps/fleetdm/external-secret-fleet-license.yaml
+++ b/k8s/bases/apps/fleetdm/external-secret-fleet-license.yaml
@@ -13,7 +13,7 @@ spec:
     name: fleet-license
     creationPolicy: Owner
   data:
-    - secretKey: license-key
+    - secretKey: license-key  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/fleetdm/license
         property: license-key

--- a/k8s/bases/apps/fleetdm/external-secret-mysql.yaml
+++ b/k8s/bases/apps/fleetdm/external-secret-mysql.yaml
@@ -16,15 +16,15 @@ spec:
     name: mysql
     creationPolicy: Owner
   data:
-    - secretKey: mysql-root-password
+    - secretKey: mysql-root-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/fleetdm/mysql
         property: mysql-root-password
-    - secretKey: mysql-replication-password
+    - secretKey: mysql-replication-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/fleetdm/mysql
         property: mysql-replication-password
-    - secretKey: mysql-password
+    - secretKey: mysql-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/fleetdm/mysql
         property: mysql-password

--- a/k8s/bases/apps/fleetdm/external-secret-redis.yaml
+++ b/k8s/bases/apps/fleetdm/external-secret-redis.yaml
@@ -13,7 +13,7 @@ spec:
     name: redis
     creationPolicy: Owner
   data:
-    - secretKey: redis-password
+    - secretKey: redis-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: apps/fleetdm/redis
         property: redis-password

--- a/k8s/bases/apps/fleetdm/helm-release.yaml
+++ b/k8s/bases/apps/fleetdm/helm-release.yaml
@@ -325,7 +325,7 @@ spec:
         repository: bitnamilegacy/redis
       auth:
         existingSecret: redis
-        existingSecretPasswordKey: redis-password
+        existingSecretPasswordKey: redis-password  # checkov:skip=CKV_SECRET_6:names a key inside an existing Secret; the value lives in OpenBao
       master:
         podSecurityContext:
           enabled: true

--- a/k8s/bases/apps/headlamp/external-secret.yaml
+++ b/k8s/bases/apps/headlamp/external-secret.yaml
@@ -12,7 +12,7 @@ spec:
     name: headlamp-oidc
     creationPolicy: Owner
   data:
-    - secretKey: client-secret
+    - secretKey: client-secret  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/oidc/dex
         property: client-secret

--- a/k8s/bases/apps/umami/helm-release.yaml
+++ b/k8s/bases/apps/umami/helm-release.yaml
@@ -115,7 +115,7 @@ spec:
         port: "5432"
         name: umami
         username: umami
-        existingSecret: umami-db-rotated
+        existingSecret: umami-db-rotated  # checkov:skip=CKV_SECRET_6:names an existing Secret; the value lives in OpenBao
         existingSecretPasswordKey: password
     service:
       # Service port 80 -> container port 3000 (named `http`).

--- a/k8s/bases/apps/wedding-app/external-secret-ghcr-auth.yaml
+++ b/k8s/bases/apps/wedding-app/external-secret-ghcr-auth.yaml
@@ -31,7 +31,7 @@ spec:
       data:
         .dockerconfigjson: "{{ .dockerconfigjson }}"
   data:
-    - secretKey: dockerconfigjson
+    - secretKey: dockerconfigjson  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/ghcr/auth
         property: dockerconfigjson

--- a/k8s/bases/infrastructure/controllers/dex/external-secret.yaml
+++ b/k8s/bases/infrastructure/controllers/dex/external-secret.yaml
@@ -27,7 +27,7 @@ spec:
     name: dex-github-connector
     creationPolicy: Owner
   data:
-    - secretKey: client-secret
+    - secretKey: client-secret  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/oidc/github
         property: client-secret

--- a/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/velero/helm-release.yaml
@@ -105,7 +105,7 @@ spec:
     # generated one. The chart only consults it; it never writes to it.
     credentials:
       useSecret: true
-      existingSecret: velero-r2-credentials
+      existingSecret: velero-r2-credentials  # checkov:skip=CKV_SECRET_6:names an existing Secret; the value lives in OpenBao
 
     # Cloudflare R2 backup target. Bucket + endpoint come from the shared
     # variables-base ConfigMap; prefix is reused per consumer (PR #3).

--- a/k8s/bases/infrastructure/external-secrets/ghcr-auth.yaml
+++ b/k8s/bases/infrastructure/external-secrets/ghcr-auth.yaml
@@ -22,7 +22,7 @@ spec:
       data:
         .dockerconfigjson: "{{ .dockerconfigjson }}"
   data:
-    - secretKey: dockerconfigjson
+    - secretKey: dockerconfigjson  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/ghcr/auth
         property: dockerconfigjson

--- a/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
+++ b/k8s/bases/infrastructure/resource-graph-definitions/tenant/resource-graph-definition.yaml
@@ -163,7 +163,7 @@ spec:
               data:
                 .dockerconfigjson: "{{ .dockerconfigjson }}"
           data:
-            - secretKey: dockerconfigjson
+            - secretKey: dockerconfigjson  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
               remoteRef:
                 key: infrastructure/ghcr/auth
                 property: dockerconfigjson

--- a/k8s/bases/infrastructure/vault-config/external-secret.yaml
+++ b/k8s/bases/infrastructure/vault-config/external-secret.yaml
@@ -12,7 +12,7 @@ spec:
     name: vault-config-oidc
     creationPolicy: Owner
   data:
-    - secretKey: dex-client-secret
+    - secretKey: dex-client-secret  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/oidc/dex
         property: client-secret

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-actual-budget-enablebanking.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-actual-budget-enablebanking.yaml
@@ -23,7 +23,7 @@ spec:
       name: actual-budget-enablebanking-placeholder
   data:
     - match:
-        secretKey: application-id
+        secretKey: application-id  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
         remoteRef:
           remoteKey: apps/actual-budget/enablebanking
           property: application-id

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-actual-budget-enablebanking.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-actual-budget-enablebanking.yaml
@@ -23,7 +23,7 @@ spec:
       name: actual-budget-enablebanking-placeholder
   data:
     - match:
-        secretKey: application-id  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
+        secretKey: application-id  # checkov:skip=CKV_SECRET_6:names the key in the source Secret; the value is mirrored to OpenBao
         remoteRef:
           remoteKey: apps/actual-budget/enablebanking
           property: application-id

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-oauth2-proxy-cookie-secret.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-oauth2-proxy-cookie-secret.yaml
@@ -14,7 +14,7 @@ spec:
       name: variables-cluster
   data:
     - match:
-        secretKey: oauth2_proxy_cookie_secret  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
+        secretKey: oauth2_proxy_cookie_secret  # checkov:skip=CKV_SECRET_6:names the key in the source Secret; the value is mirrored to OpenBao
         remoteRef:
           remoteKey: infrastructure/oidc/oauth2-proxy
           property: cookie-secret

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-oauth2-proxy-cookie-secret.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-oauth2-proxy-cookie-secret.yaml
@@ -14,7 +14,7 @@ spec:
       name: variables-cluster
   data:
     - match:
-        secretKey: oauth2_proxy_cookie_secret
+        secretKey: oauth2_proxy_cookie_secret  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
         remoteRef:
           remoteKey: infrastructure/oidc/oauth2-proxy
           property: cookie-secret

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-r2-credentials.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-r2-credentials.yaml
@@ -41,12 +41,12 @@ spec:
       name: variables-cluster
   data:
     - match:
-        secretKey: r2_access_key_id  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
+        secretKey: r2_access_key_id  # checkov:skip=CKV_SECRET_6:names the key in the source Secret; the value is mirrored to OpenBao
         remoteRef:
           remoteKey: infrastructure/backup/r2
           property: access_key_id
     - match:
-        secretKey: r2_secret_access_key  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
+        secretKey: r2_secret_access_key  # checkov:skip=CKV_SECRET_6:names the key in the source Secret; the value is mirrored to OpenBao
         remoteRef:
           remoteKey: infrastructure/backup/r2
           property: secret_access_key

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-r2-credentials.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-r2-credentials.yaml
@@ -41,12 +41,12 @@ spec:
       name: variables-cluster
   data:
     - match:
-        secretKey: r2_access_key_id
+        secretKey: r2_access_key_id  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
         remoteRef:
           remoteKey: infrastructure/backup/r2
           property: access_key_id
     - match:
-        secretKey: r2_secret_access_key
+        secretKey: r2_secret_access_key  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
         remoteRef:
           remoteKey: infrastructure/backup/r2
           property: secret_access_key

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-velero-repo-credentials.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-velero-repo-credentials.yaml
@@ -33,7 +33,7 @@ spec:
       name: velero-repo-credentials
   data:
     - match:
-        secretKey: repository-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
+        secretKey: repository-password  # checkov:skip=CKV_SECRET_6:names the key in the source Secret; the value is mirrored to OpenBao
         remoteRef:
           remoteKey: infrastructure/backup/velero-repo
           property: repository-password

--- a/k8s/bases/infrastructure/vault-seed/push-secret-seed-velero-repo-credentials.yaml
+++ b/k8s/bases/infrastructure/vault-seed/push-secret-seed-velero-repo-credentials.yaml
@@ -33,7 +33,7 @@ spec:
       name: velero-repo-credentials
   data:
     - match:
-        secretKey: repository-password
+        secretKey: repository-password  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
         remoteRef:
           remoteKey: infrastructure/backup/velero-repo
           property: repository-password

--- a/k8s/bases/infrastructure/vault-seed/secret-actual-budget-encryption-placeholder.yaml
+++ b/k8s/bases/infrastructure/vault-seed/secret-actual-budget-encryption-placeholder.yaml
@@ -22,4 +22,4 @@ metadata:
   namespace: flux-system
 type: Opaque
 stringData:
-  password: PLACEHOLDER
+  password: PLACEHOLDER  # checkov:skip=CKV_SECRET_6:literal placeholder; the operator types the real value into OpenBao

--- a/k8s/providers/hetzner/apps/unifi/external-secret-wireguard.yaml
+++ b/k8s/providers/hetzner/apps/unifi/external-secret-wireguard.yaml
@@ -23,11 +23,11 @@ spec:
     name: cluster-wireguard
     creationPolicy: Owner
   data:
-    - secretKey: private-key
+    - secretKey: private-key  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/unifi/wireguard
         property: private_key
-    - secretKey: peer-public-key
+    - secretKey: peer-public-key  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/unifi/wireguard
         property: peer_public_key

--- a/k8s/providers/hetzner/infrastructure/cluster-issuers/cloudflare-api-token-external-secret.yaml
+++ b/k8s/providers/hetzner/infrastructure/cluster-issuers/cloudflare-api-token-external-secret.yaml
@@ -12,7 +12,7 @@ spec:
     name: cloudflare-api-token
     creationPolicy: Owner
   data:
-    - secretKey: api-token
+    - secretKey: api-token  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/dns/cloudflare
         property: api_token

--- a/k8s/providers/hetzner/infrastructure/external-dns/external-secret.yaml
+++ b/k8s/providers/hetzner/infrastructure/external-dns/external-secret.yaml
@@ -21,7 +21,7 @@ spec:
     name: external-dns-cloudflare
     creationPolicy: Owner
   data:
-    - secretKey: api-token
+    - secretKey: api-token  # checkov:skip=CKV_SECRET_6:names the key in the synced Secret; the value lives in OpenBao
       remoteRef:
         key: infrastructure/dns/cloudflare
         property: api_token


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The platform's checkov scan is currently reporting-only, not blocking, because it has a backlog of
findings to work off (#2787). Nearly half that backlog — 31 of 68 — is a single check firing on
things that are not secrets at all: the *names* of secret keys and the OpenBao paths they map to.
While that noise is there, the scanner cannot be turned back into a gate, so a genuinely leaked
credential would land in a report nobody is required to act on.

## What

Dispositions that one check family. All 31 sites were read individually and each carries a scoped
skip naming the check and why it does not apply. The check stays active everywhere else in the tree,
so this removes noise without removing a control.

Reproduced checkov count drops **68 → 37**, entirely from this family. Both overlays validate.

Fixes #2892
Part of #2787

