### PR TITLE
feat(homepage): add requested bookmarks and regroup them by purpose

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -199,8 +199,12 @@ data:
         - Codex Findings:
             - icon: si-openai-#412991
               href: https://chatgpt.com/codex/cloud/security/findings
+        # mdi, not si-stepsecurity: Simple Icons carries no `stepsecurity` slug
+        # (nor does dashboard-icons), so the si- form 404s at the CDN and renders
+        # as a blank tile. Homepage resolves icons in the browser at render time,
+        # so a wrong slug fails silently rather than at deploy.
         - StepSecurity:
-            - icon: si-stepsecurity
+            - icon: mdi-shield-check-outline
               href: https://app.stepsecurity.io
         - Renovate:
             - icon: si-renovatebot-#007fa0

--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -239,9 +239,6 @@ data:
         - skills.sh:
             - icon: mdi-certificate-outline
               href: https://skills.sh
-        - Gramaton:
-            - icon: mdi-translate
-              href: https://gramaton.io
         - LLM Stats:
             - icon: mdi-chart-bar
               href: https://llm-stats.com
@@ -252,6 +249,9 @@ data:
         - Netflix:
             - icon: si-netflix-#E50914
               href: https://netflix.com
+        - Gramaton:
+            - icon: mdi-movie-open-play-outline
+              href: https://gramaton.io
         - Reddit:
             - icon: si-reddit-#FF4500
               href: https://reddit.com

--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -91,6 +91,31 @@ data:
         icon: mdi-web
       Customer Sites:
         icon: mdi-briefcase-account
+      # Bookmark groups (bookmarks.yaml). Listing them here is what gives them a
+      # real icon and a deterministic position; unlisted groups fall back to
+      # alphabetical with a generic icon, which is why the bookmark rail used to
+      # order itself differently from the way the groups actually relate. Their
+      # names are deliberately distinct from the service groups above — Homepage
+      # renders services and bookmarks as separate sections, so a shared name
+      # paints the same heading twice with different contents under each.
+      GitHub:
+        icon: si-github-#181717
+      Security & Supply Chain:
+        icon: mdi-shield-search
+      Code Quality:
+        icon: mdi-code-braces-box
+      Kubernetes Reference:
+        icon: si-kubernetes-#326CE5
+      Package Registries:
+        icon: mdi-package-variant-closed
+      Learning & Reference:
+        icon: mdi-school
+      Media:
+        icon: mdi-play-circle-outline
+      Banking:
+        icon: mdi-bank-outline
+      Personal:
+        icon: mdi-account-circle
   kubernetes.yaml: |
     mode: cluster
     gateway: true
@@ -136,11 +161,18 @@ data:
     # Analytics is populated dynamically from the gethomepage.dev annotations on
     # Umami's Flagger-generated HTTPRoute (k8s/bases/apps/umami/canary.yaml,
     # spec.service.apex.annotations).
+  # Bookmarks are grouped by WHAT YOU GO THERE TO DO, matching how services.yaml
+  # and the settings.yaml layout already group by function (Security, Cloud,
+  # Network, Finance, …) rather than by vendor. One console can therefore appear
+  # in more than one group — GitHub's org navigation sits under GitHub while its
+  # security overview sits under Security & Supply Chain, because that is where
+  # you look when the question is "what is vulnerable", not "where is the repo".
+  #
+  # Group names are deliberately DISTINCT from the service group names in
+  # settings.yaml (Security, Kubernetes, Finance, …). Homepage renders services
+  # and bookmarks as separate sections, so reusing a name paints the same heading
+  # twice on one page with different contents under each.
   bookmarks.yaml: |
-    - Personal:
-        - Personal Site:
-            - icon: github-light
-              href: https://devantler.tech
     - GitHub:
         - GitHub:
             - icon: github-light
@@ -148,41 +180,39 @@ data:
         - DevantlerTech:
             - icon: github-light
               href: https://github.com/devantler-tech
-        - Security:
+        - Project Board:
             - icon: si-github-#181717
-              href: https://github.com/orgs/devantler-tech/security/overview
+              href: https://github.com/orgs/devantler-tech/projects/5/views/1
         - Insights:
             - icon: si-github-#181717
               href: https://github.com/orgs/devantler-tech/insights
+        - Actions Usage:
+            - icon: si-githubactions-#2088FF
+              href: https://github.com/orgs/devantler-tech/actions/metrics/usage
         - Packages:
             - icon: si-github-#181717
               href: https://github.com/orgs/devantler-tech/packages
-        - Projects:
+    - Security & Supply Chain:
+        - GitHub Security:
             - icon: si-github-#181717
-              href: https://github.com/orgs/devantler-tech/projects/5
-    - Developer Tools:
-        - Codecov:
-            - icon: si-codecov-#F01F7A
-              href: https://app.codecov.io
-        - CodeRabbit:
-            - icon: si-coderabbit-#FF570A
-              href: https://app.coderabbit.ai
-        - Enable Banking:
-            - icon: mdi-bank-outline
-              href: https://enablebanking.com
+              href: https://github.com/orgs/devantler-tech/security/overview
+        - Codex Findings:
+            - icon: si-openai-#412991
+              href: https://chatgpt.com/codex/cloud/security/findings
         - StepSecurity:
             - icon: si-stepsecurity
               href: https://app.stepsecurity.io
         - Renovate:
             - icon: si-renovatebot-#007fa0
               href: https://developer.mend.io
-        - skills.sh:
-            - icon: mdi-certificate-outline
-              href: https://skills.sh
-        - lllm-stats.com:
-            - icon: mdi-chart-bar
-              href: https://lllm-stats.com
-    - Kubernetes:
+    - Code Quality:
+        - Codecov:
+            - icon: si-codecov-#F01F7A
+              href: https://app.codecov.io
+        - CodeRabbit:
+            - icon: si-coderabbit-#FF570A
+              href: https://app.coderabbit.ai
+    - Kubernetes Reference:
         - ArtifactHUB:
             - icon: si-artifacthub-#417598
               href: https://artifacthub.io
@@ -199,6 +229,40 @@ data:
         - NuGet:
             - icon: si-nuget-#1088d6
               href: https://www.nuget.org
+    - Learning & Reference:
+        - KodeKloud:
+            - icon: mdi-school-outline
+              href: https://kodekloud.com
+        - Killercoda:
+            - icon: mdi-console
+              href: https://killercoda.com
+        - skills.sh:
+            - icon: mdi-certificate-outline
+              href: https://skills.sh
+        - Gramaton:
+            - icon: mdi-translate
+              href: https://gramaton.io
+        - LLM Stats:
+            - icon: mdi-chart-bar
+              href: https://llm-stats.com
+    - Media:
+        - YouTube:
+            - icon: si-youtube-#FF0000
+              href: https://youtube.com
+        - Netflix:
+            - icon: si-netflix-#E50914
+              href: https://netflix.com
+        - Reddit:
+            - icon: si-reddit-#FF4500
+              href: https://reddit.com
+    - Banking:
+        - Enable Banking:
+            - icon: mdi-bank-outline
+              href: https://enablebanking.com
+    - Personal:
+        - Personal Site:
+            - icon: github-light
+              href: https://devantler.tech
   docker.yaml: ""
   # Theme: mirror https://devantler.tech. That site is Astro Starlight with the
   # stock dark palette — a gray ramp at hue 224 but only ~6-14% saturation, i.e.

--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -206,8 +206,13 @@ data:
         - StepSecurity:
             - icon: mdi-shield-check-outline
               href: https://app.stepsecurity.io
+        # si-renovate, not si-renovatebot: both resolve today, but they are
+        # different marks — `renovatebot.svg` is titled "RenovateBot" (the old
+        # branding) and `renovate.svg` is titled "Renovate", which is the brand's
+        # current name and the one Simple Icons lists. This is a branding
+        # correction, not a fix for a blank icon.
         - Renovate:
-            - icon: si-renovatebot-#007fa0
+            - icon: si-renovate-#007fa0
               href: https://developer.mend.io
     - Code Quality:
         - Codecov:

--- a/scripts/tests/test_validate_homepage_bookmarks.py
+++ b/scripts/tests/test_validate_homepage_bookmarks.py
@@ -222,7 +222,7 @@ class ExtractBookmarksYamlTests(unittest.TestCase):
 
 
 class RealConfigMapRegressionTests(unittest.TestCase):
-    """Guard the actual PR change against the real ConfigMap on disk."""
+    """Guard the real ConfigMap on disk against structural regressions."""
 
     @classmethod
     def setUpClass(cls):
@@ -230,17 +230,17 @@ class RealConfigMapRegressionTests(unittest.TestCase):
             validator.extract_bookmarks_yaml(validator.CONFIG_MAP)
         )
 
-    def test_coderabbit_bookmark_was_added_under_developer_tools(self):
+    def test_coderabbit_bookmark_is_under_code_quality(self):
         matches = [
             e for e in self.entries
-            if e["group"] == "Developer Tools" and e["name"] == "CodeRabbit"
+            if e["group"] == "Code Quality" and e["name"] == "CodeRabbit"
         ]
         self.assertEqual(len(matches), 1, "expected exactly one CodeRabbit bookmark")
         self.assertEqual(matches[0]["icon"], "si-coderabbit-#FF570A")
         self.assertEqual(matches[0]["href"], "https://app.coderabbit.ai")
 
     def test_coderabbit_entry_is_positioned_after_codecov(self):
-        names = [e["name"] for e in self.entries if e["group"] == "Developer Tools"]
+        names = [e["name"] for e in self.entries if e["group"] == "Code Quality"]
         self.assertIn("Codecov", names)
         self.assertIn("CodeRabbit", names)
         self.assertLess(names.index("Codecov"), names.index("CodeRabbit"))


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The homepage bookmark rail had drifted. **Developer Tools** had become a grab-bag holding code coverage, code review, a banking API, supply-chain security and dependency automation side by side, so there was no reliable answer to "which box do I look in". Meanwhile the requested links had nowhere obvious to go.

One of the existing bookmarks was also simply **broken**: the LLM stats entry pointed at `lllm-stats.com` — three Ls — which does not resolve. Nobody would notice until they clicked it.

## What

Adds the requested bookmarks and regroups all of them by **what you go there to do**, which is how `services.yaml` and the layout already work (Security, Cloud, Network, Finance…). Groups are now: GitHub, Security & Supply Chain, Code Quality, Kubernetes Reference, Package Registries, Learning & Reference, Media, Banking, Personal.

Three things worth your eye:

- **The dead link is fixed** — `llm-stats.com` resolves, `lllm-stats.com` is NXDOMAIN.
- **Two requested links were already there.** The security overview was already present, so it moved rather than duplicating; the project board pointed at `projects/5` and now points at the kanban view you gave.
- **A vendor split you may want to overrule.** GitHub's security overview now sits under *Security & Supply Chain* rather than *GitHub*, on the reasoning that you go there asking "what is vulnerable", not "where is the repo". If you would rather keep every github.com link in one place, say so and I will move it back — that is the one judgement call here.

Every bookmark group is now listed in the layout, which is what gives it a real icon and a fixed position instead of falling back to alphabetical with a generic one. Group names are kept distinct from the service group names, because Homepage renders services and bookmarks as separate sections and a shared name paints the same heading twice — which is why the old `Kubernetes` bookmark group is now `Kubernetes Reference`.

**One assumption flagged:** "gramaton" from your screenshot is taken as `gramaton.io`, a language-learning site. If you meant something else, tell me the URL.

## Verified

`kubectl kustomize` builds clean and the rendered ConfigMap parses. Bookmark count 19 → 27, all unique, with the only two removals being the intended replacements (the typo domain and the less specific project-board URL) — checked by diffing every href before and after, not by reading the diff.