### PR TITLE
fix(security): disposition the three unconstrained CKV_K8S_40 sites

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -86,7 +86,9 @@ DISABLE_ERRORS_LINTERS:
   # checkov (34) and trivy (620): Kubernetes misconfiguration in k8s/, which the section above
   # explains is NOT covered elsewhere. Tracked by #2787.
   #
-  # checkov's 34 are all `kubernetes` framework, and 8 of them are CKV_K8S_40.
+  # checkov's 34 are all `kubernetes` framework, and 8 of them are CKV_K8S_40. Those 8 break down as
+  # 4 withdrawn scoped skips (#2904) + 2 vendored bundles (#2899) + 2 unconstrained candidates. A
+  # further 3 were dispositioned by #2901 and are NOT in the 8 — the original count was 11.
   # Four scoped skips were tried and withdrawn: each named a per-site technical constraint that does
   # not survive checking. The two vault-backup jobs claimed to share the vault-snapshots PVC with the
   # OpenBao StatefulSet — but the live StatefulSet mounts `config`/`unseal-keys`/`tmp`/`home` plus
@@ -94,14 +96,15 @@ DISABLE_ERRORS_LINTERS:
   # preserve. The two user-namespace probes claimed their UID was the measurement subject — but
   # `/proc/self/uid_map` describes the pod's namespace and reads identically for every process in it
   # regardless of UID, and `fsGroup` supplies volume access as a GID independent of `runAsUser`.
-  # #2904 carries the per-site remediation and the risk-acceptance question for those four. Of the
-  # 8, two are inside the vendored KubeVirt and CDI release bundles and need a mechanism that
+  # #2904 carries the per-site remediation and the risk-acceptance question for those four. Two more
+  # of the 8 are inside the vendored KubeVirt and CDI release bundles and need a mechanism that
   # survives a vendor bump (#2899).
   #
-  # The remaining two have no demonstrated constraint and are candidates to simply raise: CoreDNS,
+  # The last two of the 8 have no demonstrated constraint and are candidates to simply raise: CoreDNS,
   # whose pinned image config reads `User: "nonroot:nonroot"` so an explicit `runAsUser: 65532`
   # would both match the image and clear the check, and the vault-config Job. #2901 dispositioned
-  # the other three of that group by checking each image rather than reasoning about it: the MinIO
+  # three further findings — outside the 8, and part of the original 11 — by checking each image
+  # rather than reasoning about it: the MinIO
   # server and its bucket-creation Job declare no `User` at all and carry no /etc/passwd entry for
   # the UID they ran under, so both were raised to 65532; the umami CronJob's 1001 turned out to BE
   # its image's baked `nextjs` user (`nextjs:x:1001:65533`), so it carries a scoped skip instead —

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -83,10 +83,10 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (37) and trivy (624): Kubernetes misconfiguration in k8s/, which the section above
+  # checkov (34) and trivy (620): Kubernetes misconfiguration in k8s/, which the section above
   # explains is NOT covered elsewhere. Tracked by #2787.
   #
-  # checkov's 37 are all `kubernetes` framework, and all 11 CKV_K8S_40 findings stand unsuppressed.
+  # checkov's 34 are all `kubernetes` framework, and 8 of them are CKV_K8S_40.
   # Four scoped skips were tried and withdrawn: each named a per-site technical constraint that does
   # not survive checking. The two vault-backup jobs claimed to share the vault-snapshots PVC with the
   # OpenBao StatefulSet — but the live StatefulSet mounts `config`/`unseal-keys`/`tmp`/`home` plus
@@ -95,11 +95,19 @@ DISABLE_ERRORS_LINTERS:
   # `/proc/self/uid_map` describes the pod's namespace and reads identically for every process in it
   # regardless of UID, and `fsGroup` supplies volume access as a GID independent of `runAsUser`.
   # #2904 carries the per-site remediation and the risk-acceptance question for those four. Of the
-  # 11, two are inside the vendored KubeVirt and CDI release bundles and need a mechanism that
-  # survives a vendor bump (#2899). The remaining five have no demonstrated constraint and are
-  # candidates to simply raise (#2901) — including CoreDNS, whose pinned
-  # image config reads `User: "nonroot:nonroot"`, so an explicit `runAsUser: 65532` would both match
-  # the image and clear the check. CKV_K8S_40 is NOT disabled: a new workload running
+  # 8, two are inside the vendored KubeVirt and CDI release bundles and need a mechanism that
+  # survives a vendor bump (#2899).
+  #
+  # The remaining two have no demonstrated constraint and are candidates to simply raise: CoreDNS,
+  # whose pinned image config reads `User: "nonroot:nonroot"` so an explicit `runAsUser: 65532`
+  # would both match the image and clear the check, and the vault-config Job. #2901 dispositioned
+  # the other three of that group by checking each image rather than reasoning about it: the MinIO
+  # server and its bucket-creation Job declare no `User` at all and carry no /etc/passwd entry for
+  # the UID they ran under, so both were raised to 65532; the umami CronJob's 1001 turned out to BE
+  # its image's baked `nextjs` user (`nextjs:x:1001:65533`), so it carries a scoped skip instead —
+  # the one demonstrated constraint of the three. That asymmetry is the point: the image decides.
+  #
+  # CKV_K8S_40 is NOT disabled: a new workload running
   # below UID 10000 with no stated reason is still flagged. The `secrets`
   # framework is at 0: its 31 CKV_SECRET_6 findings were ExternalSecret/PushSecret key NAMES and
   # OpenBao paths rather than secret material, and each site now carries a scoped skip naming the
@@ -110,7 +118,7 @@ DISABLE_ERRORS_LINTERS:
   # exact commands this job runs, so a slice can show the number moved without a CI round trip.
   #
   # ⚠️ Read trivy's number from that script, NOT from the MegaLinter summary. MegaLinter reports
-  # this trivy scan as "1 non blocking error" while the scan actually fails 624 checks across 459
+  # this trivy scan as "1 non blocking error" while the scan actually fails 620 checks across 459
   # targets; the 1 is an artifact of how MegaLinter counts trivy's output. checkov's number is a
   # genuine sum of "Failed checks:" and needs no such caveat.
   #

--- a/k8s/bases/apps/umami/cron-job.yaml
+++ b/k8s/bases/apps/umami/cron-job.yaml
@@ -46,6 +46,15 @@ kind: CronJob
 metadata:
   name: umami-provision-tenants
   namespace: umami
+  annotations:
+    # UID 1001 is the umami image's own baked user, not a number picked here:
+    # the image config sets `User: "nextjs"`, and that image's /etc/passwd
+    # reads `nextjs:x:1001:65533`. The container reuses the umami image for its
+    # Node runtime and runs out of its /app WORKDIR, so the UID that owns that
+    # tree is the one to run as. Raising it above 10000 would break the match
+    # the image asks for, and this workload is only deployed to the Hetzner
+    # provider, so nothing in CI would catch it going wrong.
+    checkov.io/skip1: CKV_K8S_40=UID 1001 is the umami image's baked `nextjs` user, which owns its /app WORKDIR
 spec:
   schedule: "*/15 * * * *"
   # Never run two reconciles at once; a slow run (e.g. waiting on a down Umami)

--- a/k8s/providers/docker/infrastructure/controllers/minio/deployment.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/minio/deployment.yaml
@@ -31,11 +31,22 @@ spec:
       # minio is a pure S3 server and never calls the Kubernetes API, so it has
       # no use for a mounted ServiceAccount token (kubescape C-0034).
       automountServiceAccountToken: false
+      # UID 65532 rather than a low one (checkov CKV_K8S_40). The minio image
+      # declares no `User`, so it would run as root unedited, and its
+      # /etc/passwd has no entry for the UID this ran under before — the server
+      # is already running unmapped. Its entrypoint only switches user when
+      # MINIO_USERNAME *and* MINIO_GROUPNAME are set; neither is, so it takes
+      # the plain `exec` branch and never looks the UID up.
+      #
+      # What makes `/data` writable is `fsGroup` == `runAsGroup`, not the UID:
+      # the kubelet chowns the emptyDir to that GID and grants it write. The
+      # two are raised together for that reason — moving one alone would be the
+      # change that breaks this.
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/k8s/providers/docker/infrastructure/controllers/minio/job.yaml
+++ b/k8s/providers/docker/infrastructure/controllers/minio/job.yaml
@@ -15,10 +15,17 @@ spec:
       # The bucket-creation Job runs the mc client only; it never calls the
       # Kubernetes API, so it needs no ServiceAccount token (kubescape C-0034).
       automountServiceAccountToken: false
+      # UID 65532 rather than a low one (checkov CKV_K8S_40). Nothing here
+      # constrains the UID: the mc image declares no `User` at all, so it would
+      # run as root unedited, and its /etc/passwd has no entry for the UID this
+      # ran under before — the client is already running unmapped and does not
+      # care. Its only volume is a `mc-config` emptyDir carrying no `fsGroup`,
+      # so no UID owns it, and `MC_CONFIG_DIR` points mc's state there rather
+      # than at a home directory that would have to exist.
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 65532
+        runAsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Three Kubernetes workloads ran under low user IDs that a security check flags, and nobody had
established whether that was a real requirement or just an old default. An earlier attempt marked
all three as "can't be changed" with reasons that turned out to be invented, so they were withdrawn
— which left the finding open with no answer either way.

## What

Checked what each container image actually asks for, rather than reasoning about it. Two of the
three (the local MinIO server and the job that creates its backup bucket) ask for nothing at all, so
they now run under a high, unprivileged ID. The third genuinely does have a requirement — its ID is
the one baked into the image it runs from — so it is recorded as an accepted exception with that
evidence, rather than changed.

**Security floor:** three of the eleven outstanding low-UID findings are now closed with a
demonstrated answer instead of an assumed one, and the check stays fully enabled, so a new workload
doing this is still caught.

**Everyday cost:** none — no new step, gate, or convention for anyone to follow.

Fixes #2901
Part of #2787
