### PR TITLE
chore: stop tracking Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ megalinter-reports/
 
 # MegaLinter also drops a generated GitHub config tree here.
 .megalinter_github_conf/
+
+# Python bytecode. The validators and their tests are a migration target, but while they
+# exist every run of them drops a __pycache__ tree next to the source, and the shared CI job
+# stages everything when it pushes auto-fixes back — which is how an empty .pyc reached main.
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A compiled Python file is checked into the repository, and nothing was stopping the next one. It
arrived through a shared CI job that stages the whole tree when it pushes fixes back — the same route
that once committed 182 MegaLinter report files, which is why that tool already has a rule here.
Python did not.

## What

Ignores Python bytecode and drops the tracked file. The pattern is scoped so unrelated stray files
stay visible rather than being silently swallowed.

This does not change the standing position that the Python validators are a migration target — that
work is tracked separately. It stops the mess they make in the meantime.
