### PR TITLE
chore(scripts): gitignore built Go binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,26 @@ megalinter-reports/
 # stages everything when it pushes auto-fixes back — which is how an empty .pyc reached main.
 __pycache__/
 *.py[cod]
+
+# Compiled Go binaries. Every scripts/<name>/ is a `main` package, so a build drops an
+# executable named after its directory — `go build ./scripts/<name>/` leaves it in the working
+# directory, and `go build ./...` from the root leaves one per package at the root. Neither has
+# an extension, so nothing else here covers them, and a directory-wide `git add` stages a ~4 MB
+# Mach-O binary alongside the source without comment.
+#
+# Listed by name rather than by a glob for extensionless files: that glob would also hide a
+# legitimately extensionless file someone adds later, and a silently ignored source file is a
+# worse failure than a binary that `git status` still shows. Add a line here when a new
+# scripts/<name>/ package appears.
+/generate-kubescape-exceptions
+/kubescape-backlog-bridge
+/validate-concurrency-queue
+/validate-dr-signing
+/validate-eks-ci-role-policy
+/validate-merge-group-heal
+/scripts/*/generate-kubescape-exceptions
+/scripts/*/kubescape-backlog-bridge
+/scripts/*/validate-concurrency-queue
+/scripts/*/validate-dr-signing
+/scripts/*/validate-eks-ci-role-policy
+/scripts/*/validate-merge-group-heal

--- a/.gitignore
+++ b/.gitignore
@@ -31,27 +31,39 @@ megalinter-reports/
 __pycache__/
 *.py[cod]
 
-# Compiled Go binaries. Every scripts/<name>/ is a `main` package, so a build drops an
-# executable named after its directory: `go build ./scripts/<name>/` from the repository root
-# writes it at the root, and `go build .` from inside scripts/<name>/ writes it there — hence the
-# two blocks below. (`go build ./...` builds every package but discards the executables, so it
-# leaves nothing to ignore.) Neither form gives the file an extension, so nothing else here covers
-# them, and a directory-wide `git add` stages a ~4 MB Mach-O binary alongside the source without
+# Compiled Go binaries. Every scripts/<name>/ is a `main` package, and a build drops its output in
+# one of two places: `go build ./scripts/<name>/` from the repository root writes at the root,
+# `go build .` from inside scripts/<name>/ writes there — hence the two blocks below. (`go build
+# ./...` builds every package but discards the executables, so it leaves nothing to ignore.) A
+# directory-wide `git add` otherwise stages a ~4 MB Mach-O binary alongside the source without
 # comment.
 #
-# Listed by name rather than by a glob for extensionless files: that glob would also hide a
-# legitimately extensionless file someone adds later, and a silently ignored source file is a
-# worse failure than a binary that `git status` still shows. Add a line here when a new
-# scripts/<name>/ package appears.
+# Four output names reach those two places:
+#   <name>       `go build ./scripts/<name>/`  — named after the package directory
+#   main         `go build main.go`            — named after the first source file
+#   <name>.test  `go test -c`                  — also retained by -cpuprofile and friends
+#   *.exe        any of the above under GOOS=windows (`go test -c` gives <name>.test.exe)
+#
+# The extensionless names are listed literally rather than matched by a glob for extensionless
+# files: that glob would also hide a legitimately extensionless file someone adds later, and a
+# silently ignored source file is a worse failure than a binary that `git status` still shows.
+# `.exe` and `.test` are unambiguous compiled-artifact extensions, so those two are globbed. Add a
+# line to each block when a new scripts/<name>/ package appears.
 /generate-kubescape-exceptions
 /kubescape-backlog-bridge
 /validate-concurrency-queue
 /validate-dr-signing
 /validate-eks-ci-role-policy
 /validate-merge-group-heal
+/main
+/*.exe
+/*.test
 /scripts/*/generate-kubescape-exceptions
 /scripts/*/kubescape-backlog-bridge
 /scripts/*/validate-concurrency-queue
 /scripts/*/validate-dr-signing
 /scripts/*/validate-eks-ci-role-policy
 /scripts/*/validate-merge-group-heal
+/scripts/*/main
+/scripts/*/*.exe
+/scripts/*/*.test

--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,12 @@ __pycache__/
 *.py[cod]
 
 # Compiled Go binaries. Every scripts/<name>/ is a `main` package, so a build drops an
-# executable named after its directory — `go build ./scripts/<name>/` leaves it in the working
-# directory, and `go build ./...` from the root leaves one per package at the root. Neither has
-# an extension, so nothing else here covers them, and a directory-wide `git add` stages a ~4 MB
-# Mach-O binary alongside the source without comment.
+# executable named after its directory: `go build ./scripts/<name>/` from the repository root
+# writes it at the root, and `go build .` from inside scripts/<name>/ writes it there — hence the
+# two blocks below. (`go build ./...` builds every package but discards the executables, so it
+# leaves nothing to ignore.) Neither form gives the file an extension, so nothing else here covers
+# them, and a directory-wide `git add` stages a ~4 MB Mach-O binary alongside the source without
+# comment.
 #
 # Listed by name rather than by a glob for extensionless files: that glob would also hide a
 # legitimately extensionless file someone adds later, and a silently ignored source file is a


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Building any of the Go tools under `scripts/` drops a compiled binary next to the source, and nothing in the ignore file covered it. A directory-wide `git add` then stages a multi-megabyte binary alongside the code without saying anything — the only thing preventing a committed binary was someone reading `git status` carefully. That near-miss has now happened three times while working on #2854.

## What

Ignores the built binaries, at both places a build can leave them.

They are listed by name rather than matched by a general "files without an extension" rule. That rule would be self-maintaining, but it would also silently hide a legitimately extensionless file someone adds later — a worse failure than a stray binary, which `git status` at least still shows. The trade is one line when a new tool is added.

Fixes #2888.