### PR TITLE
fix(security): move Flux cosign verify to the path KSail reads

### DIFF
--- a/ksail.prod.yaml
+++ b/ksail.prod.yaml
@@ -155,39 +155,6 @@ spec:
         - siderolabs/qemu-guest-agent
     localRegistry:
       registry: "devantler:${GHCR_TOKEN}@ghcr.io/devantler-tech/platform/manifests"
-    # Cosign keyless signature verification on the flux-system OCIRepository that
-    # KSail generates and owns (rendered onto spec.verify; a hand-written override
-    # would lose the reconcile fight, so it is configured here per ksail#4987).
-    # The manifests artifact is already cosign-signed keyless in the deploy-prod
-    # composite (push → sign → attest); this makes Flux REJECT any infra artifact
-    # whose signature is missing or whose signer is not the platform deploy
-    # workflow — closing the supply-chain gap #1559 opened for apps but left on
-    # the infra source (#1570). The signer identity + ref were confirmed against
-    # the live signature with `cosign verify`: the artifact is signed by
-    # .github/workflows/ci.yaml on refs/heads/gh-readonly-queue/main/<pr> (the
-    # merge-queue deploy-prod path — the real prod deploy) under GitHub's Fulcio
-    # OIDC issuer. The subject is pinned to the two *production* deploy refs only
-    # (merge-queue refs off main, plus a manual cd.yaml dispatch from main) rather
-    # than `@.+`, so a signature these workflows might produce on any other ref is
-    # not trusted (defence in depth on a high-blast-radius source).
-    verify:
-      provider: cosign
-      matchOIDCIdentity:
-        # Automatic prod deploy: ci.yaml deploy-prod runs on merge_group, which
-        # signs under the merge-queue ref refs/heads/gh-readonly-queue/main/<pr>.
-        - issuer: '^https://token\.actions\.githubusercontent\.com$'
-          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/ci\.yaml@refs/heads/gh-readonly-queue/main/.+$'
-        # Manual prod deploy: cd.yaml is workflow_dispatch, run from main.
-        - issuer: '^https://token\.actions\.githubusercontent\.com$'
-          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/cd\.yaml@refs/heads/main$'
-        # Disaster recovery: dr-rebuild.yaml is workflow_dispatch, run from main,
-        # and republishes this same artifact while rebuilding prod from zero.
-        # Without this entry a recovery produces a correctly-signed artifact that
-        # Flux still refuses — the one situation where a manual workaround is
-        # least available. Pinned to refs/heads/main, like cd.yaml above, so a DR
-        # run dispatched from any other ref is not trusted.
-        - issuer: '^https://token\.actions\.githubusercontent\.com$'
-          subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/dr-rebuild\.yaml@refs/heads/main$'
   provider:
     hetzner:
       # Hetzner account hard cap: at most 10 servers total. This mirrors the
@@ -230,6 +197,37 @@ spec:
     sourceDirectory: k8s
     kustomizationFile: clusters/prod
     tag: latest
+    flux:
+      # Cosign keyless signature verification on the flux-system OCIRepository
+      # that KSail generates and owns. KSail reads this at spec.workload.flux.verify
+      # and renders it onto that OCIRepository's spec.verify; a hand-written
+      # in-repo override would lose the reconcile fight, so it belongs here
+      # (ksail#4987). The manifests artifact is cosign-signed keyless in the
+      # deploy-prod composite (push → sign → attest); this makes Flux REJECT any
+      # infra artifact whose signature is missing or whose signer is not a
+      # platform deploy workflow — closing the supply-chain gap #1559 opened for
+      # apps but left on the infra source (#1570). Subjects are pinned to the
+      # production deploy refs only, rather than `@.+`, so a signature these
+      # workflows might produce on any other ref is not trusted (defence in depth
+      # on a high-blast-radius source).
+      verify:
+        provider: cosign
+        matchOIDCIdentity:
+          # Automatic prod deploy: ci.yaml deploy-prod runs on merge_group, which
+          # signs under the merge-queue ref refs/heads/gh-readonly-queue/main/<pr>.
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+            subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/ci\.yaml@refs/heads/gh-readonly-queue/main/.+$'
+          # Manual prod deploy: cd.yaml is workflow_dispatch, run from main.
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+            subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/cd\.yaml@refs/heads/main$'
+          # Disaster recovery: dr-rebuild.yaml is workflow_dispatch, run from main,
+          # and republishes this same artifact while rebuilding prod from zero.
+          # Without this entry a recovery produces a correctly-signed artifact that
+          # Flux still refuses — the one situation where a manual workaround is
+          # least available. Pinned to refs/heads/main, like cd.yaml above, so a DR
+          # run dispatched from any other ref is not trusted.
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+            subject: '^https://github\.com/devantler-tech/platform/\.github/workflows/dr-rebuild\.yaml@refs/heads/main$'
     validation:
       # Parity with ksail.yaml: the prod kustomization pulls the same shared
       # bases (Coroot + Flagger), so `ksail --config ksail.prod.yaml workload


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production has been pulling its infrastructure manifests with **signature verification switched off**, and nothing reported it. The cosign policy was written and looks correct — it just sits under a key KSail does not read, so it was silently discarded. Confirmed on the live cluster today: the `flux-system` source tracking the mutable `latest` tag has no verification attached.

## What

Moves the cosign block to the key KSail actually reads. The policy itself is untouched — same provider, same three trusted signers, same wording; only its location changes.

**Operational note — this changes production behaviour.** Once merged and reconciled, Flux starts *enforcing* signatures on the infrastructure source. That is the intended effect, but it is a real switch: if the published artifact does not match one of the three trusted signers, Flux stops applying new manifests (it keeps running the last good state, and reverting this restores the old behaviour).

**Staying a draft until one thing is confirmed.** I could not independently re-verify the live artifact's signature in this run — `cosign` is not installed on the agent host — so I have not proven the artifact will pass. That check is the promotion gate, not the review.

This delivers #2850. The rest of parent #2627 — publishing `latest` only after signing and attesting, and the DR rebuild's permissions — is tracked in its other children and untouched here.

Fixes #2850
Part of #2627