### PR TITLE
fix(deploy): await pre-handoff kustomize-controller pod termination

### DIFF
--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -3144,6 +3144,7 @@ read_flux_policy_fences() {
 restart_flux_kustomize_controller_for_handoff() {
   local resource_version deployment_uid replicas annotations_present
   local restart_token
+  local pre_handoff_pods_replaced attempt
 
   assert_sync_lease_held || return 1
   if ! read_flux_policy_fences ||
@@ -3255,27 +3256,43 @@ restart_flux_kustomize_controller_for_handoff() {
     echo "::error::kustomize-controller did not complete the policy handoff restart."
     return 1
   fi
-  if ! kubectl \
-    --context "${KUBE_CONTEXT}" \
-    --namespace flux-system \
-    get pods \
-    --selector "${FLUX_KUSTOMIZE_CONTROLLER_SELECTOR}" \
-    -o json >"${flux_controller_pods_after_file}" ||
-    ! jq -e \
-      --argjson replicas "${replicas}" \
-      --slurpfile before "${flux_controller_pods_before_file}" '
-      [.items[] | select((.metadata.deletionTimestamp // "") == "")] as $current
-      | [.items[].metadata.uid] as $post_uids
-      | [$before[0].items[].metadata.uid] as $old_uids
-      | ($current | length) >= $replicas
-      and all($current[];
-        (.metadata.uid | type == "string" and length > 0)
-        and any(.status.conditions[]?;
-          .type == "Ready" and .status == "True")
-      )
-      and all($old_uids[];
-        . as $old_uid | ($post_uids | index($old_uid)) == null)
-    ' "${flux_controller_pods_after_file}" >/dev/null; then
+  # `kubectl rollout status` returns as soon as the new ReplicaSet is available; it does not wait
+  # for the superseded Pods to finish terminating. Sampling the proof once therefore fails a
+  # correct rollout whenever a pre-handoff Pod is still inside its termination grace period. Poll
+  # instead, on the same budget as the rest of this script. The success condition is unchanged: a
+  # pre-handoff Pod object that never goes away still exhausts the budget and fails, because its
+  # process can still hold the superseded GHCR credential.
+  pre_handoff_pods_replaced=false
+  for ((attempt = 1; attempt <= SYNC_ATTEMPTS; attempt++)); do
+    if kubectl \
+      --context "${KUBE_CONTEXT}" \
+      --namespace flux-system \
+      get pods \
+      --selector "${FLUX_KUSTOMIZE_CONTROLLER_SELECTOR}" \
+      -o json >"${flux_controller_pods_after_file}" &&
+      jq -e \
+        --argjson replicas "${replicas}" \
+        --slurpfile before "${flux_controller_pods_before_file}" '
+        [.items[] | select((.metadata.deletionTimestamp // "") == "")] as $current
+        | [.items[].metadata.uid] as $post_uids
+        | [$before[0].items[].metadata.uid] as $old_uids
+        | ($current | length) >= $replicas
+        and all($current[];
+          (.metadata.uid | type == "string" and length > 0)
+          and any(.status.conditions[]?;
+            .type == "Ready" and .status == "True")
+        )
+        and all($old_uids[];
+          . as $old_uid | ($post_uids | index($old_uid)) == null)
+      ' "${flux_controller_pods_after_file}" >/dev/null; then
+      pre_handoff_pods_replaced=true
+      break
+    fi
+    if ((attempt < SYNC_ATTEMPTS)); then
+      sleep "${SYNC_INTERVAL}"
+    fi
+  done
+  if [[ "${pre_handoff_pods_replaced}" != "true" ]]; then
     echo "::error::Could not prove every pre-handoff kustomize-controller process was replaced by a Ready Pod."
     return 1
   fi

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -627,8 +627,21 @@ func fakeKubectlGetFluxControllerPods(namespace string) int {
 			}},
 		},
 	}}
+	// A pre-handoff Pod that lingers for a bounded number of samples and then disappears models
+	// the real termination grace period: the rollout is correct, the old Pod is simply not gone
+	// yet at the first sample. Distinct from FAKE_FLUX_CONTROLLER_OLD_POD_TERMINATING, where it
+	// never goes away and must keep failing.
+	terminatingSamples := parseInt(os.Getenv("FAKE_FLUX_CONTROLLER_OLD_POD_TERMINATING_SAMPLES"), 0)
+	if rolloutCount > 0 && terminatingSamples > 0 {
+		observed := parseInt(markerContent("flux-controller-pod-sample-count"), 0) + 1
+		setMarkerContent("flux-controller-pod-sample-count", strconv.Itoa(observed))
+		if observed > terminatingSamples {
+			terminatingSamples = 0
+		}
+	}
 	if rolloutCount > 0 &&
-		os.Getenv("FAKE_FLUX_CONTROLLER_OLD_POD_TERMINATING") == "true" {
+		(terminatingSamples > 0 ||
+			os.Getenv("FAKE_FLUX_CONTROLLER_OLD_POD_TERMINATING") == "true") {
 		items = append(items, map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Pod",

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_convergence_test.go
@@ -866,6 +866,24 @@ func TestTerminatingPrePauseFluxControllerBlocksPolicyMutation(t *testing.T) {
 	requireLine(t, operations, "flux-policy-parent-resume:flux-system")
 }
 
+// A pre-handoff Pod inside its termination grace period is a correct rollout, not a surviving
+// process: `kubectl rollout status` returns before the superseded Pod is gone. Sampling the proof
+// once failed these deploys and evicted their PRs from the merge queue (#2926).
+func TestTransientlyTerminatingFluxControllerPodIsAwaited(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_FLUX_CONTROLLER_OLD_POD_TERMINATING_SAMPLES": "1",
+		"FAKE_LOG_FLUX_CONTROLLER_RESTART":                 "true",
+	})
+	requireSuccessResult(t, result)
+	operations := readLines(f.operationLog)
+	requireLine(t, operations, "flux-controller-restart:kustomize-controller")
+	requireLine(t, operations, "ivpol-policy-apply:verify-app-images")
+	requireLine(t, operations, "flux-policy-resume:infrastructure")
+	requireLine(t, operations, "flux-policy-parent-resume:flux-system")
+}
+
 func TestAmbiguousFluxControllerRestartIsAdopted(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production deploys have been failing and kicking their pull requests back out of the merge queue —
four times today, and one PR needed three attempts before it landed. The deploy was reporting that
it could not prove the old Flux controller had been replaced, when in fact the rollout was
proceeding perfectly normally.

The check was looking a single time, immediately, and the old pod is legitimately still shutting
down at that moment. So a healthy deploy was being failed on a timing accident, and every merge
behind it was blocked.

## What

The deploy now waits, within a bounded budget, for the old controller to actually go away, instead
of giving up after one look. Nothing about what it demands has changed — a controller that never
goes away still fails the deploy, because it could still be holding the old registry credential.

Fixes #2926
