### PR TITLE
fix(security): preserve vendored Checkov dispositions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,10 @@ jobs:
               - 'scripts/tests/kyverno-admission-vpa-rules.yaml'
               - 'scripts/generate-kubescape-exceptions/**'
               - 'scripts/kubescape-backlog-bridge/**'
+              # The updater and its annotation helper are one fail-closed
+              # contract for the vendored CDI/KubeVirt manifests.
+              - 'scripts/annotate-vendored-checkov/**'
+              - 'scripts/update-vendored-operators.sh'
               # Both halves, so editing the guard alone — or its test alone —
               # still runs the check that covers it.
               - 'scripts/normalize-sarif-paths.sh'
@@ -237,6 +241,13 @@ jobs:
         # second, so it goes first — before the ksail download. See
         # scripts/validate-embedded-json.py (#2480).
         run: python3 scripts/validate-embedded-json.py
+
+      - name: 🧷 Validate vendored operator Checkov dispositions
+        if: needs.changes.outputs.k8s == 'true'
+        # Exercise the real annotator over multi-document fixtures. The updater
+        # must preserve unrelated resources, remain idempotent, and refuse a
+        # vendor rename before it can replace either committed bundle.
+        run: go test ./scripts/annotate-vendored-checkov
 
       - name: 🔐 Validate OpenBao OIDC admin role
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,13 +244,17 @@ jobs:
 
       - name: 🧷 Validate vendored operator Checkov dispositions
         if: needs.changes.outputs.k8s == 'true'
-        # Exercise the real annotator over multi-document fixtures. The updater
-        # must preserve unrelated resources, remain idempotent, and refuse a
-        # vendor rename before it can replace either committed bundle.
+        # Exercise the annotator over multi-document fixtures, then prove the
+        # committed bundles contain only the configured resource-scoped
+        # dispositions. A hand edit or vendor rename must fail offline.
         run: |
           bash -n scripts/update-vendored-operators.sh
           shellcheck scripts/update-vendored-operators.sh
           go test ./scripts/annotate-vendored-checkov
+          go run ./scripts/annotate-vendored-checkov --bundle cdi --validate-annotated \
+            < k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+          go run ./scripts/annotate-vendored-checkov --bundle kubevirt --validate-annotated \
+            < k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
 
       - name: 🔐 Validate OpenBao OIDC admin role
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -245,16 +245,14 @@ jobs:
       - name: 🧷 Validate vendored operator Checkov dispositions
         if: needs.changes.outputs.k8s == 'true'
         # Exercise the annotator over multi-document fixtures, then prove the
-        # committed bundles contain only the configured resource-scoped
-        # dispositions. A hand edit or vendor rename must fail offline.
+        # committed bundles are the pinned upstream bytes plus only the
+        # configured resource-scoped dispositions. Any other hand edit or a
+        # vendor rename must fail offline.
         run: |
           bash -n scripts/update-vendored-operators.sh
           shellcheck scripts/update-vendored-operators.sh
           go test ./scripts/annotate-vendored-checkov
-          go run ./scripts/annotate-vendored-checkov --bundle cdi --validate-annotated \
-            < k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
-          go run ./scripts/annotate-vendored-checkov --bundle kubevirt --validate-annotated \
-            < k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+          scripts/update-vendored-operators.sh --validate-committed
 
       - name: 🔐 Validate OpenBao OIDC admin role
         if: needs.changes.outputs.k8s == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,7 +247,10 @@ jobs:
         # Exercise the real annotator over multi-document fixtures. The updater
         # must preserve unrelated resources, remain idempotent, and refuse a
         # vendor rename before it can replace either committed bundle.
-        run: go test ./scripts/annotate-vendored-checkov
+        run: |
+          bash -n scripts/update-vendored-operators.sh
+          shellcheck scripts/update-vendored-operators.sh
+          go test ./scripts/annotate-vendored-checkov
 
       - name: 🔐 Validate OpenBao OIDC admin role
         if: needs.changes.outputs.k8s == 'true'

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -83,12 +83,12 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (34) and trivy (620): Kubernetes misconfiguration in k8s/, which the section above
+  # checkov (18) and trivy (620): Kubernetes misconfiguration in k8s/, which the section above
   # explains is NOT covered elsewhere. Tracked by #2787.
   #
-  # checkov's 34 are all `kubernetes` framework, and 8 of them are CKV_K8S_40. Those 8 break down as
-  # 4 withdrawn scoped skips (#2904) + 2 vendored bundles (#2899) + 2 unconstrained candidates. A
-  # further 3 were dispositioned by #2901 and are NOT in the 8 — the original count was 11.
+  # checkov's 18 are all `kubernetes` framework, and 6 of them are CKV_K8S_40. Those 6 break down as
+  # 4 withdrawn scoped skips (#2904) + 2 unconstrained candidates. A further 3 were dispositioned by
+  # #2901 and are NOT in the 6 — the original count was 11.
   # Four scoped skips were tried and withdrawn: each named a per-site technical constraint that does
   # not survive checking. The two vault-backup jobs claimed to share the vault-snapshots PVC with the
   # OpenBao StatefulSet — but the live StatefulSet mounts `config`/`unseal-keys`/`tmp`/`home` plus
@@ -96,11 +96,9 @@ DISABLE_ERRORS_LINTERS:
   # preserve. The two user-namespace probes claimed their UID was the measurement subject — but
   # `/proc/self/uid_map` describes the pod's namespace and reads identically for every process in it
   # regardless of UID, and `fsGroup` supplies volume access as a GID independent of `runAsUser`.
-  # #2904 carries the per-site remediation and the risk-acceptance question for those four. Two more
-  # of the 8 are inside the vendored KubeVirt and CDI release bundles and need a mechanism that
-  # survives a vendor bump (#2899).
+  # #2904 carries the per-site remediation and the risk-acceptance question for those four.
   #
-  # The last two of the 8 have no demonstrated constraint and are candidates to simply raise: CoreDNS,
+  # The last two of the 6 have no demonstrated constraint and are candidates to simply raise: CoreDNS,
   # whose pinned image config reads `User: "nonroot:nonroot"` so an explicit `runAsUser: 65532`
   # would both match the image and clear the check, and the vault-config Job. #2901 dispositioned
   # three further findings — outside the 8, and part of the original 11 — by checking each image
@@ -109,6 +107,11 @@ DISABLE_ERRORS_LINTERS:
   # the UID they ran under, so both were raised to 65532; the umami CronJob's 1001 turned out to BE
   # its image's baked `nextjs` user (`nextjs:x:1001:65533`), so it carries a scoped skip instead —
   # the one demonstrated constraint of the three. That asymmetry is the point: the image decides.
+  #
+  # #2899 removed 16 findings from the two vendored CDI/KubeVirt release bundles without disabling
+  # a check or path globally. The bundles carry resource-scoped annotations, and
+  # scripts/update-vendored-operators.sh re-applies them and refuses any new finding before replacing
+  # the committed files, so a vendor bump cannot silently restore the backlog.
   #
   # CKV_K8S_40 is NOT disabled: a new workload running
   # below UID 10000 with no stated reason is still flagged. The `secrets`

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -101,7 +101,7 @@ DISABLE_ERRORS_LINTERS:
   # The last two of the 6 have no demonstrated constraint and are candidates to simply raise: CoreDNS,
   # whose pinned image config reads `User: "nonroot:nonroot"` so an explicit `runAsUser: 65532`
   # would both match the image and clear the check, and the vault-config Job. #2901 dispositioned
-  # three further findings — outside the 8, and part of the original 11 — by checking each image
+  # three further findings — outside the 6, and part of the original 11 — by checking each image
   # rather than reasoning about it: the MinIO
   # server and its bucket-creation Job declare no `User` at all and carry no /etc/passwd entry for
   # the UID they ran under, so both were raised to 65532; the umami CronJob's 1001 turned out to BE

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -100,9 +100,9 @@ DISABLE_ERRORS_LINTERS:
   #
   # The last two of the 6 have no demonstrated constraint and are candidates to simply raise: CoreDNS,
   # whose pinned image config reads `User: "nonroot:nonroot"` so an explicit `runAsUser: 65532`
-  # would both match the image and clear the check, and the vault-config Job. #2901 dispositioned
-  # three further findings — outside the 6, and part of the original 11 — by checking each image
-  # rather than reasoning about it: the MinIO
+  # would both match the image and clear the check, and the vault-config Job. Of the original 11,
+  # #2901 dispositioned three outside the 6, while #2899 removed the two vendored operator findings,
+  # leaving 6. #2901 checked each image rather than reasoning about it: the MinIO
   # server and its bucket-creation Job declare no `User` at all and carry no /etc/passwd entry for
   # the UID they ran under, so both were raised to 65532; the umami CronJob's 1001 turned out to BE
   # its image's baked `nextjs` user (`nextjs:x:1001:65533`), so it carries a scoped skip instead —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ frameworks. That keeps an upstream fix from leaving a stale exception and preven
 material from slipping through the non-blocking repository backlog scan.
 The scan runs with an isolated home, empty Checkov config, and no inherited `CKV_*` environment;
 upstream annotation and inline-comment suppressions are rejected before either framework runs.
+The secrets scan adds one synthetic AWS-key canary and requires Checkov's explicit `secrets` report
+to contain exactly that finding, so an empty or silently omitted secrets framework cannot pass.
 Each reviewed finding also pins its Checkov evaluated keys and a line-number-independent fingerprint
 of the affected resource in `scripts/annotate-vendored-checkov/main.go`. A real vendor bump that
 changes either target therefore stops before replacement. Review the upstream resource diff and the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,10 @@ The scan is a **hard gate**: it fails the PR if the NSA compliance score drops b
 
 The CDI and KubeVirt operator files are pinned upstream release bundles. Refresh them only through
 [`scripts/update-vendored-operators.sh`](scripts/update-vendored-operators.sh): edit its two version
-constants and run it from any directory in this repository. The updater downloads the pinned release
-assets, reapplies the reviewed resource-scoped Checkov dispositions with the tested
+and SHA-256 constants and run it from any directory in this repository. The updater downloads the
+pinned release assets, reapplies the reviewed resource-scoped Checkov dispositions with the tested
 `scripts/annotate-vendored-checkov` helper, and runs Checkov before replacing either committed file.
+It requires `curl`, `go`, `checkov`, and `sha256sum` on the local path.
 
 This convention deliberately keeps the suppressions narrow: only the named upstream ClusterRole and
 Deployment receive annotations, no Checkov check is disabled repository-wide, and an unrelated new

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,9 @@ of the affected resource in `scripts/annotate-vendored-checkov/main.go`. A real 
 changes either target therefore stops before replacement. Review the upstream resource diff and the
 new finding evidence before updating those keys or fingerprints alongside the version and asset
 digest; never copy a reported fingerprint without inspecting the changed resource.
+CI runs the updater's offline `--validate-committed` mode, removes only those exact configured
+disposition lines, and requires the remaining bytes to match the pinned upstream SHA-256. Any other
+manual or automated rewrite of a generated bundle therefore fails before merge.
 Its isolated-file scan excludes CKV2_K8S_6 only: Checkov does not model the committed
 `CiliumNetworkPolicy` that protects every CDI endpoint, while the full-repository CI scan retains the
 check and remains authoritative for graph findings. Before applying that file-level exclusion, the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,21 @@ The scan is a **hard gate**: it fails the PR if the NSA compliance score drops b
 - **ksail is Renovate-managed** (the Setup step, grouped `ksail` with the deploy pins). It was previously frozen at 7.65.0 because 7.66.x parallelised the in-process Helm render and made it racy — two distinct symptoms of the same regression: `ksail workload validate` non-deterministically corrupted the render with varying YAML parse errors ([devantler-tech/ksail#5362](https://github.com/devantler-tech/ksail/issues/5362), closed — contained since KSail v7.163.1 by the [ksail#5978](https://github.com/devantler-tech/ksail/issues/5978) stream-splitting fix, which is what let the temporary `--skip-helm-render` workaround be removed), and the scan's compliance score swung run-to-run ([devantler-tech/ksail#5371](https://github.com/devantler-tech/ksail/issues/5371), closed). Both are resolved upstream, so the pin is lifted back onto the latest release. Tripwire (kept in sync with the comments in `.github/workflows/ci.yaml`): if `validate` output or the `scan` score varies run-to-run again, re-add `--skip-helm-render` and reopen ksail#5362 (or re-pin to a known-good version, reopening #5371 if only the score swings).
 - **The threshold is a regression floor, not the actual score — and the scan runs WITH the platform's justified exceptions applied.** The `ClusterSecurityException` CRs (`k8s/bases/infrastructure/cluster-security-exceptions/` — the single source of truth, consumed in-cluster by the kubescape-operator) are converted at scan time into Kubescape's native exceptions format by [`scripts/generate-kubescape-exceptions`](scripts/generate-kubescape-exceptions) (fail-closed: an unrecognised CR shape aborts the scan step rather than silently dropping or widening an exception; Go unit tests alongside it), so runtime-enforced (Kyverno mutation, `CiliumNetworkPolicy`) and except-only findings (e.g. **C-0002**, the KubeVirt operator's `pods/exec` RBAC) no longer depress the score and the floor gates the residual REAL posture (#2264). The score has historically been **environment-dependent** (Linux CI runner vs macOS — a gap that is *not* the render mode, the framework cache, or PR-merge content, all ruled out) and shifts with the ksail render, so **CI is the source of truth** (re-baseline the floor after a ksail bump); the observed CI reference with exceptions applied is **≈98.9%** (2026-07-11, ksail 7.165.2), with the floor a few points under it. A new justified exception is added as a CSE CR (kind+name-scoped, minimal — see the existing CRs' conventions), never by lowering the floor: **ratchet up** as genuine gaps close; never lower it.
 
+### Updating Vendored Operator Bundles
+
+The CDI and KubeVirt operator files are pinned upstream release bundles. Refresh them only through
+[`scripts/update-vendored-operators.sh`](scripts/update-vendored-operators.sh): edit its two version
+constants and run it from any directory in this repository. The updater downloads the pinned release
+assets, reapplies the reviewed resource-scoped Checkov dispositions with the tested
+`scripts/annotate-vendored-checkov` helper, and runs Checkov before replacing either committed file.
+
+This convention deliberately keeps the suppressions narrow: only the named upstream ClusterRole and
+Deployment receive annotations, no Checkov check is disabled repository-wide, and an unrelated new
+finding still fails the update. A vendor rename/removal also fails closed because the annotator
+requires exactly one of every expected target. Do not hand-edit the generated bundles or fetch them
+directly; the updater is what makes a future vendor bump retain the dispositions instead of silently
+reintroducing the scanner backlog (#2899).
+
 ## Local Development Cluster
 
 **Primary method (requires KSail + Docker):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,9 @@ changes either target therefore stops before replacement. Review the upstream re
 new finding evidence before updating those keys or fingerprints alongside the version and asset
 digest; never copy a reported fingerprint without inspecting the changed resource.
 CI runs the updater's offline `--validate-committed` mode, removes only those exact configured
-disposition lines, and requires the remaining bytes to match the pinned upstream SHA-256. Any other
-manual or automated rewrite of a generated bundle therefore fails before merge.
+disposition lines, requires the remaining bytes to match the pinned upstream SHA-256, and binds each
+release version to the operator image tag in that source. Any other manual or automated rewrite of a
+generated bundle, or a mismatched version/digest pair, therefore fails before merge.
 Its isolated-file scan excludes CKV2_K8S_6 only: Checkov does not model the committed
 `CiliumNetworkPolicy` that protects every CDI endpoint, while the full-repository CI scan retains the
 check and remains authoritative for graph findings. Before applying that file-level exclusion, the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,11 @@ The updater scans the unannotated asset first and refuses a disposition that no 
 to a current upstream finding, then scans the annotated result across both the Kubernetes and secrets
 frameworks. That keeps an upstream fix from leaving a stale exception and prevents embedded secret
 material from slipping through the non-blocking repository backlog scan.
+Each reviewed finding also pins its Checkov evaluated keys and a line-number-independent fingerprint
+of the affected resource in `scripts/annotate-vendored-checkov/main.go`. A real vendor bump that
+changes either target therefore stops before replacement. Review the upstream resource diff and the
+new finding evidence before updating those keys or fingerprints alongside the version and asset
+digest; never copy a reported fingerprint without inspecting the changed resource.
 Its isolated-file scan excludes CKV2_K8S_6 only: Checkov does not model the committed
 `CiliumNetworkPolicy` that protects every CDI endpoint, while the full-repository CI scan retains the
 check and remains authoritative for graph findings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ The CDI and KubeVirt operator files are pinned upstream release bundles. Refresh
 and SHA-256 constants and run it from any directory in this repository. The updater downloads the
 pinned release assets, reapplies the reviewed resource-scoped Checkov dispositions with the tested
 `scripts/annotate-vendored-checkov` helper, and runs Checkov before replacing either committed file.
-It requires `curl`, `go`, `checkov`, and `sha256sum` on the local path.
+It requires `curl`, `go`, `sha256sum`, and the Checkov version pinned in the script on the local path.
 
 This convention deliberately keeps the suppressions narrow: only the named upstream ClusterRole and
 Deployment receive annotations, no Checkov check is disabled repository-wide, and an unrelated new
@@ -120,6 +120,13 @@ finding still fails the update. A vendor rename/removal also fails closed becaus
 requires exactly one of every expected target. Do not hand-edit the generated bundles or fetch them
 directly; the updater is what makes a future vendor bump retain the dispositions instead of silently
 reintroducing the scanner backlog (#2899).
+The updater scans the unannotated asset first and refuses a disposition that no longer corresponds
+to a current upstream finding, then scans the annotated result across both the Kubernetes and secrets
+frameworks. That keeps an upstream fix from leaving a stale exception and prevents embedded secret
+material from slipping through the non-blocking repository backlog scan.
+Its isolated-file scan excludes CKV2_K8S_6 only: Checkov does not model the committed
+`CiliumNetworkPolicy` that protects every CDI endpoint, while the full-repository CI scan retains the
+check and remains authoritative for graph findings.
 
 ## Local Development Cluster
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,8 @@ The updater scans the unannotated asset first and refuses a disposition that no 
 to a current upstream finding, then scans the annotated result across both the Kubernetes and secrets
 frameworks. That keeps an upstream fix from leaving a stale exception and prevents embedded secret
 material from slipping through the non-blocking repository backlog scan.
+The scan runs with an isolated home, empty Checkov config, and no inherited `CKV_*` environment;
+upstream annotation and inline-comment suppressions are rejected before either framework runs.
 Each reviewed finding also pins its Checkov evaluated keys and a line-number-independent fingerprint
 of the affected resource in `scripts/annotate-vendored-checkov/main.go`. A real vendor bump that
 changes either target therefore stops before replacement. Review the upstream resource diff and the
@@ -131,7 +133,9 @@ new finding evidence before updating those keys or fingerprints alongside the ve
 digest; never copy a reported fingerprint without inspecting the changed resource.
 Its isolated-file scan excludes CKV2_K8S_6 only: Checkov does not model the committed
 `CiliumNetworkPolicy` that protects every CDI endpoint, while the full-repository CI scan retains the
-check and remains authoritative for graph findings.
+check and remains authoritative for graph findings. Before applying that file-level exclusion, the
+source validator requires every bundled workload to remain in the corresponding `cdi` or `kubevirt`
+namespace covered by those policies.
 
 ## Local Development Cluster
 

--- a/k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+++ b/k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
@@ -5061,6 +5061,8 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    checkov.io/skip1: "CKV_K8S_155=Vendored upstream operator RBAC; changes must go through the pinned vendor update path tracked by platform issue 2899."
   labels:
     operator.cdi.kubevirt.io: ""
   name: cdi-operator-cluster
@@ -5671,6 +5673,14 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: "CKV_K8S_11=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip2: "CKV_K8S_13=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip3: "CKV_K8S_15=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip4: "CKV_K8S_22=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip5: "CKV_K8S_38=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip6: "CKV_K8S_40=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip7: "CKV_K8S_43=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
   labels:
     cdi.kubevirt.io: cdi-operator
     name: cdi-operator

--- a/k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+++ b/k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
@@ -7135,6 +7135,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    checkov.io/skip1: "CKV_K8S_155=Vendored upstream operator RBAC; changes must go through the pinned vendor update path tracked by platform issue 2899."
   labels:
     kubevirt.io: ""
   name: kubevirt-operator
@@ -8486,6 +8488,14 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: "CKV_K8S_11=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip2: "CKV_K8S_13=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip3: "CKV_K8S_15=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip4: "CKV_K8S_22=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip5: "CKV_K8S_38=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip6: "CKV_K8S_40=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+    checkov.io/skip7: "CKV_K8S_43=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
   labels:
     kubevirt.io: virt-operator
   name: virt-operator

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -7,12 +7,15 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -25,10 +28,11 @@ const (
 )
 
 type targetSpec struct {
-	kind   string
-	name   string
-	checks []string
-	reason string
+	kind                string
+	name                string
+	checks              []string
+	reason              string
+	resourceFingerprint string
 }
 
 type manifestIdentity struct {
@@ -42,8 +46,12 @@ type checkovReport struct {
 	CheckType string `json:"check_type"`
 	Results   struct {
 		FailedChecks []struct {
-			CheckID  string `json:"check_id"`
-			Resource string `json:"resource"`
+			CheckID     string  `json:"check_id"`
+			Resource    string  `json:"resource"`
+			CodeBlock   [][]any `json:"code_block"`
+			CheckResult struct {
+				EvaluatedKeys []string `json:"evaluated_keys"`
+			} `json:"check_result"`
 		} `json:"failed_checks"`
 	} `json:"results"`
 	Summary checkovSummary `json:"summary"`
@@ -54,14 +62,17 @@ type checkovSummary struct {
 	ParsingErrors *int `json:"parsing_errors"`
 }
 
+// resourceFingerprint hashes Checkov's resource code_block without its source
+// line numbers. A vendor refresh must therefore re-review any target change,
+// including a known check moving to a different container or field.
 var bundleTargets = map[string][]targetSpec{
 	"cdi": {
-		{kind: "ClusterRole", name: "cdi-operator-cluster", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason},
-		{kind: "Deployment", name: "cdi-operator", checks: deploymentChecks(), reason: deploymentReason},
+		{kind: "ClusterRole", name: "cdi-operator-cluster", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason, resourceFingerprint: "df06bcec640e27ea586a8d12bffa509558eb8a244978a0de46c35743ec85341e"},
+		{kind: "Deployment", name: "cdi-operator", checks: deploymentChecks(), reason: deploymentReason, resourceFingerprint: "f81c6d025990a3a550fbe12e38033c8c0c4e3d4397dc14c357c7c6dc601abe07"},
 	},
 	"kubevirt": {
-		{kind: "ClusterRole", name: "kubevirt-operator", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason},
-		{kind: "Deployment", name: "virt-operator", checks: deploymentChecks(), reason: deploymentReason},
+		{kind: "ClusterRole", name: "kubevirt-operator", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason, resourceFingerprint: "6eb8526d222f837be3a38f82c18710be5f64aa10e27cbe741b7707198b3df842"},
+		{kind: "Deployment", name: "virt-operator", checks: deploymentChecks(), reason: deploymentReason, resourceFingerprint: "a983d7303c2daf4c74e806ddfe9caf3eb1f25c6238798716d6c80e124016b51e"},
 	},
 }
 
@@ -74,6 +85,28 @@ func deploymentChecks() []string {
 		"CKV_K8S_38",
 		"CKV_K8S_40",
 		"CKV_K8S_43",
+	}
+}
+
+func expectedEvaluatedKeys(check string) []string {
+	switch check {
+	case "CKV_K8S_11":
+		return []string{"spec/template/spec/containers/[0]/resources/limits/cpu"}
+	case "CKV_K8S_13":
+		return []string{"spec/template/spec/containers/[0]/resources/limits/memory"}
+	case "CKV_K8S_15":
+		return []string{
+			"spec/template/spec/containers/[0]/image",
+			"spec/template/spec/containers/[0]/imagePullPolicy",
+		}
+	case "CKV_K8S_22":
+		return []string{"spec/template/spec/containers/[0]/securityContext/readOnlyRootFilesystem"}
+	case "CKV_K8S_43":
+		return []string{"spec/template/spec/containers/[0]/image"}
+	case "CKV_K8S_38", "CKV_K8S_40", "CKV_K8S_155":
+		return []string{}
+	default:
+		return nil
 	}
 }
 
@@ -171,6 +204,31 @@ func validateCheckovFindings(input []byte, targets []targetSpec) error {
 				}
 				for _, check := range target.checks {
 					if failed.CheckID == check {
+						expectedKeys := expectedEvaluatedKeys(check)
+						if !slices.Equal(failed.CheckResult.EvaluatedKeys, expectedKeys) {
+							return fmt.Errorf(
+								"%s finding for %s/%s evaluated keys changed: found %v, want %v",
+								check,
+								target.kind,
+								target.name,
+								failed.CheckResult.EvaluatedKeys,
+								expectedKeys,
+							)
+						}
+						fingerprint, err := codeBlockFingerprint(failed.CodeBlock)
+						if err != nil {
+							return fmt.Errorf("fingerprint %s finding for %s/%s: %w", check, target.kind, target.name, err)
+						}
+						if fingerprint != target.resourceFingerprint {
+							return fmt.Errorf(
+								"%s finding for %s/%s resource fingerprint changed: found %s, want %s",
+								check,
+								target.kind,
+								target.name,
+								fingerprint,
+								target.resourceFingerprint,
+							)
+						}
 						found[target.kind+"/"+target.name+"/"+check]++
 					}
 				}
@@ -193,6 +251,29 @@ func validateCheckovFindings(input []byte, targets []targetSpec) error {
 		}
 	}
 	return nil
+}
+
+func codeBlockFingerprint(codeBlock [][]any) (string, error) {
+	if len(codeBlock) == 0 {
+		return "", errors.New("Checkov finding omits code_block")
+	}
+	hash := sha256.New()
+	for index, line := range codeBlock {
+		if len(line) != 2 {
+			return "", fmt.Errorf("code_block line %d has %d fields", index, len(line))
+		}
+		text, ok := line[1].(string)
+		if !ok {
+			return "", fmt.Errorf("code_block line %d text is %T", index, line[1])
+		}
+		if err := binary.Write(hash, binary.BigEndian, uint64(len(text))); err != nil {
+			return "", fmt.Errorf("hash code_block line %d length: %w", index, err)
+		}
+		if _, err := hash.Write([]byte(text)); err != nil {
+			return "", fmt.Errorf("hash code_block line %d: %w", index, err)
+		}
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
 func decodeCheckovReports(input []byte, expectedFramework string, rejectFindings bool) ([]checkovReport, error) {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -200,7 +200,7 @@ func annotateDocument(lines []string, target targetSpec) ([]string, error) {
 		}
 	}
 
-	insertAt := annotationsEnd
+	var insertAt int
 	if annotationsIndex == -1 {
 		annotationsIndex = metadataIndex + 1
 		insertAt = annotationsIndex + 1

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -76,6 +77,8 @@ var bundleTargets = map[string][]targetSpec{
 	},
 }
 
+var inlineCheckovSkip = regexp.MustCompile(`(?i)checkov\s*:\s*skip\s*=`)
+
 func deploymentChecks() []string {
 	return []string{
 		"CKV_K8S_11",
@@ -127,6 +130,11 @@ func main() {
 		false,
 		"validate that an upstream bundle contains no Checkov suppressions",
 	)
+	validateAnnotated := flag.Bool(
+		"validate-annotated",
+		false,
+		"validate that a committed bundle contains exactly the configured Checkov dispositions",
+	)
 	framework := flag.String(
 		"framework",
 		"",
@@ -142,7 +150,7 @@ func main() {
 		fail("unsupported bundle %q", *bundle)
 	}
 	modeCount := 0
-	for _, enabled := range []bool{*validateFindings, *validateReport, *validateSource} {
+	for _, enabled := range []bool{*validateFindings, *validateReport, *validateSource, *validateAnnotated} {
 		if enabled {
 			modeCount++
 		}
@@ -173,6 +181,12 @@ func main() {
 	if *validateSource {
 		if err := validateVendorSource(input); err != nil {
 			fail("validate %s source: %v", *bundle, err)
+		}
+		return
+	}
+	if *validateAnnotated {
+		if err := validateAnnotatedBundle(input, targets); err != nil {
+			fail("validate %s annotated bundle: %v", *bundle, err)
 		}
 		return
 	}
@@ -354,6 +368,9 @@ func validateVendorSource(input []byte) error {
 		if len(document.Content) == 0 || document.Content[0].Kind == 0 {
 			continue
 		}
+		if err := rejectInlineCheckovSuppression(&document); err != nil {
+			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
+		}
 		root := document.Content[0]
 		if root.Kind != yaml.MappingNode {
 			return fmt.Errorf("vendor document %d must contain a top-level mapping", documentIndex)
@@ -379,6 +396,110 @@ func validateVendorSource(input []byte) error {
 			}
 		}
 	}
+}
+
+func validateAnnotatedBundle(input []byte, targets []targetSpec) error {
+	targetsByIdentity := make(map[string]targetSpec, len(targets))
+	expectedByIdentity := make(map[string]map[string]string, len(targets))
+	for _, target := range targets {
+		identity := target.kind + "/" + target.name
+		targetsByIdentity[identity] = target
+		expected := make(map[string]string, len(target.checks))
+		for index, check := range target.checks {
+			expected["checkov.io/skip"+strconv.Itoa(index+1)] = check + "=" + target.reason
+		}
+		expectedByIdentity[identity] = expected
+	}
+
+	seenTargets := make(map[string]int, len(targets))
+	seenDispositions := make(map[string]int)
+	decoder := yaml.NewDecoder(strings.NewReader(string(input)))
+	for documentIndex := 1; ; documentIndex++ {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("parse committed document %d: %w", documentIndex, err)
+		}
+		if len(document.Content) == 0 || document.Content[0].Kind == 0 {
+			continue
+		}
+		if err := rejectInlineCheckovSuppression(&document); err != nil {
+			return fmt.Errorf("committed document %d contains %w", documentIndex, err)
+		}
+		root := document.Content[0]
+		if root.Kind != yaml.MappingNode {
+			return fmt.Errorf("committed document %d must contain a top-level mapping", documentIndex)
+		}
+		kind := mappingScalar(root, "kind")
+		metadata := mappingValue(root, "metadata")
+		if metadata == nil {
+			continue
+		}
+		if metadata.Kind != yaml.MappingNode {
+			return fmt.Errorf("committed document %d metadata must be a mapping", documentIndex)
+		}
+		name := mappingScalar(metadata, "name")
+		identity := kind + "/" + name
+		if _, configured := targetsByIdentity[identity]; configured {
+			seenTargets[identity]++
+		}
+
+		annotations := mappingValue(metadata, "annotations")
+		if annotations == nil {
+			continue
+		}
+		if annotations.Kind != yaml.MappingNode {
+			return fmt.Errorf("committed document %d metadata.annotations must be a mapping", documentIndex)
+		}
+		for index := 0; index+1 < len(annotations.Content); index += 2 {
+			annotationKey := annotations.Content[index].Value
+			if !strings.HasPrefix(annotationKey, "checkov.io/skip") {
+				continue
+			}
+			expected, configuredTarget := expectedByIdentity[identity]
+			expectedValue, configuredDisposition := expected[annotationKey]
+			if !configuredTarget || !configuredDisposition {
+				return fmt.Errorf("unexpected Checkov disposition %s on %s", annotationKey, identity)
+			}
+			annotationValue := annotations.Content[index+1]
+			if annotationValue.Kind != yaml.ScalarNode || annotationValue.Value != expectedValue {
+				return fmt.Errorf(
+					"%s on %s does not match the configured disposition",
+					annotationKey,
+					identity,
+				)
+			}
+			seenDispositions[identity+"/"+annotationKey]++
+		}
+	}
+
+	for identity, expected := range expectedByIdentity {
+		if seenTargets[identity] != 1 {
+			return fmt.Errorf("expected exactly one committed %s, found %d", identity, seenTargets[identity])
+		}
+		for annotationKey := range expected {
+			if seenDispositions[identity+"/"+annotationKey] != 1 {
+				return fmt.Errorf("expected exactly one configured %s on %s", annotationKey, identity)
+			}
+		}
+	}
+	return nil
+}
+
+func rejectInlineCheckovSuppression(node *yaml.Node) error {
+	for _, comment := range []string{node.HeadComment, node.LineComment, node.FootComment} {
+		if inlineCheckovSkip.MatchString(comment) {
+			return errors.New("inline Checkov suppression")
+		}
+	}
+	for _, child := range node.Content {
+		if err := rejectInlineCheckovSuppression(child); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func fail(format string, args ...any) {
@@ -561,6 +682,14 @@ func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
 		}
 	}
 	return nil
+}
+
+func mappingScalar(mapping *yaml.Node, key string) string {
+	value := mappingValue(mapping, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return value.Value
 }
 
 func existingCheckovAnnotations(lines []string, start, end int) (map[string]string, int, error) {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -455,6 +455,9 @@ func validateVendorSource(input []byte, bundle string) error {
 		if err := rejectInlineCheckovSuppression(&document); err != nil {
 			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
 		}
+		if err := rejectYAMLMergeKey(&document); err != nil {
+			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
+		}
 		root := document.Content[0]
 		if root.Kind != yaml.MappingNode {
 			return fmt.Errorf("vendor document %d must contain a top-level mapping", documentIndex)
@@ -468,11 +471,15 @@ func validateVendorSource(input []byte, bundle string) error {
 func validateVendorResource(root *yaml.Node, protectedNamespace string) error {
 	kind := mappingScalar(root, "kind")
 	metadata := mappingValue(root, "metadata")
+	_, workload := workloadKinds[kind]
+	if workload && metadata == nil {
+		return fmt.Errorf("%s metadata is missing", kind)
+	}
 	if metadata != nil {
 		if metadata.Kind != yaml.MappingNode {
 			return errors.New("metadata must be a mapping")
 		}
-		if _, workload := workloadKinds[kind]; workload {
+		if workload {
 			name := mappingScalar(metadata, "name")
 			namespace := mappingScalar(metadata, "namespace")
 			if namespace != protectedNamespace {
@@ -876,6 +883,23 @@ func rejectInlineCheckovSuppression(node *yaml.Node) error {
 	}
 	for _, child := range node.Content {
 		if err := rejectInlineCheckovSuppression(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectYAMLMergeKey(node *yaml.Node) error {
+	if node.Kind == yaml.MappingNode {
+		for index := 0; index+1 < len(node.Content); index += 2 {
+			key := node.Content[index]
+			if key.Value == "<<" || key.Tag == "!!merge" {
+				return errors.New("YAML merge key")
+			}
+		}
+	}
+	for _, child := range node.Content {
+		if err := rejectYAMLMergeKey(child); err != nil {
 			return err
 		}
 	}

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -1035,7 +1035,7 @@ func annotateListDocument(lines []string, targets []targetSpec, found map[string
 			}
 			identity := target.kind + "/" + target.name
 			found[identity]++
-			insertion, err := annotationInsertion(resource, target)
+			insertion, err := annotationInsertion(lines, resource, target)
 			if err != nil {
 				return fmt.Errorf("%s: %w", identity, err)
 			}
@@ -1057,7 +1057,7 @@ func annotateListDocument(lines []string, targets []targetSpec, found map[string
 	return lines, nil
 }
 
-func annotationInsertion(resource *yaml.Node, target targetSpec) (lineInsertion, error) {
+func annotationInsertion(lines []string, resource *yaml.Node, target targetSpec) (lineInsertion, error) {
 	metadataKey, metadata := mappingEntry(resource, "metadata")
 	if metadata == nil || metadata.Kind != yaml.MappingNode || metadata.Style&yaml.FlowStyle != 0 {
 		return lineInsertion{}, errors.New("metadata must use block mapping style")
@@ -1096,7 +1096,11 @@ func annotationInsertion(resource *yaml.Node, target targetSpec) (lineInsertion,
 		highest++
 		additions = append(additions, fmt.Sprintf("%scheckov.io/skip%d: %q", indent, highest, value))
 	}
-	return lineInsertion{index: maxNodeLine(annotations), lines: additions}, nil
+	insertAt, err := blockMappingEnd(lines, annotationsKey)
+	if err != nil {
+		return lineInsertion{}, err
+	}
+	return lineInsertion{index: insertAt, lines: additions}, nil
 }
 
 func existingCheckovAnnotationNodes(annotations *yaml.Node) (map[string]string, int, error) {
@@ -1130,12 +1134,26 @@ func existingCheckovAnnotationNodes(annotations *yaml.Node) (map[string]string, 
 	return existing, highest, nil
 }
 
-func maxNodeLine(node *yaml.Node) int {
-	line := node.Line
-	for _, child := range node.Content {
-		line = max(line, maxNodeLine(child))
+func blockMappingEnd(lines []string, key *yaml.Node) (int, error) {
+	if key.Line < 1 || key.Line > len(lines) || key.Column < 1 {
+		return 0, errors.New("mapping key source position is invalid")
 	}
-	return line
+	parentIndent := key.Column - 1
+	end := key.Line
+	for end < len(lines) {
+		line := lines[end]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			end++
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		if indent <= parentIndent {
+			break
+		}
+		end++
+	}
+	return end, nil
 }
 
 func splitDocuments(lines []string) [][]string {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"regexp"
 	"slices"
 	"strconv"
@@ -49,6 +50,7 @@ type checkovReport struct {
 		FailedChecks []struct {
 			CheckID     string  `json:"check_id"`
 			Resource    string  `json:"resource"`
+			FilePath    string  `json:"file_path"`
 			CodeBlock   [][]any `json:"code_block"`
 			CheckResult struct {
 				EvaluatedKeys []string `json:"evaluated_keys"`
@@ -102,25 +104,25 @@ func deploymentChecks() []string {
 	}
 }
 
-func expectedEvaluatedKeys(check string) []string {
+func expectedEvaluatedKeys(check string) ([]string, bool) {
 	switch check {
 	case "CKV_K8S_11":
-		return []string{"spec/template/spec/containers/[0]/resources/limits/cpu"}
+		return []string{"spec/template/spec/containers/[0]/resources/limits/cpu"}, true
 	case "CKV_K8S_13":
-		return []string{"spec/template/spec/containers/[0]/resources/limits/memory"}
+		return []string{"spec/template/spec/containers/[0]/resources/limits/memory"}, true
 	case "CKV_K8S_15":
 		return []string{
 			"spec/template/spec/containers/[0]/image",
 			"spec/template/spec/containers/[0]/imagePullPolicy",
-		}
+		}, true
 	case "CKV_K8S_22":
-		return []string{"spec/template/spec/containers/[0]/securityContext/readOnlyRootFilesystem"}
+		return []string{"spec/template/spec/containers/[0]/securityContext/readOnlyRootFilesystem"}, true
 	case "CKV_K8S_43":
-		return []string{"spec/template/spec/containers/[0]/image"}
+		return []string{"spec/template/spec/containers/[0]/image"}, true
 	case "CKV_K8S_38", "CKV_K8S_40", "CKV_K8S_155":
-		return []string{}
+		return []string{}, true
 	default:
-		return nil
+		return nil, false
 	}
 }
 
@@ -151,6 +153,11 @@ func main() {
 		"",
 		"expected Checkov framework for --validate-report: kubernetes or secrets",
 	)
+	requireSecretsCanary := flag.Bool(
+		"require-secrets-canary",
+		false,
+		"require the updater's exact synthetic secrets finding in a secrets report",
+	)
 	flag.Parse()
 	if flag.NArg() != 0 {
 		fail("unexpected positional arguments")
@@ -172,6 +179,9 @@ func main() {
 	if *validateReport && *framework != "kubernetes" && *framework != "secrets" {
 		fail("--validate-report requires --framework kubernetes or --framework secrets")
 	}
+	if *requireSecretsCanary && (!*validateReport || *framework != "secrets") {
+		fail("--require-secrets-canary requires --validate-report --framework secrets")
+	}
 
 	input, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -184,7 +194,7 @@ func main() {
 		return
 	}
 	if *validateReport {
-		if _, err := decodeCheckovReports(input, *framework, true); err != nil {
+		if _, err := decodeCheckovReports(input, *framework, !*requireSecretsCanary, *requireSecretsCanary); err != nil {
 			fail("validate %s report: %v", *bundle, err)
 		}
 		return
@@ -211,7 +221,14 @@ func main() {
 }
 
 func validateCheckovFindings(input []byte, targets []targetSpec) error {
-	reports, err := decodeCheckovReports(input, "kubernetes", false)
+	for _, target := range targets {
+		for _, check := range target.checks {
+			if _, known := expectedEvaluatedKeys(check); !known {
+				return fmt.Errorf("%s has no reviewed evaluated keys", check)
+			}
+		}
+	}
+	reports, err := decodeCheckovReports(input, "kubernetes", false, false)
 	if err != nil {
 		return err
 	}
@@ -229,7 +246,10 @@ func validateCheckovFindings(input []byte, targets []targetSpec) error {
 				}
 				for _, check := range target.checks {
 					if failed.CheckID == check {
-						expectedKeys := expectedEvaluatedKeys(check)
+						expectedKeys, known := expectedEvaluatedKeys(check)
+						if !known {
+							return fmt.Errorf("%s has no reviewed evaluated keys", check)
+						}
 						if !slices.Equal(failed.CheckResult.EvaluatedKeys, expectedKeys) {
 							return fmt.Errorf(
 								"%s finding for %s/%s evaluated keys changed: found %v, want %v",
@@ -301,7 +321,12 @@ func codeBlockFingerprint(codeBlock [][]any) (string, error) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
-func decodeCheckovReports(input []byte, expectedFramework string, rejectFindings bool) ([]checkovReport, error) {
+func decodeCheckovReports(
+	input []byte,
+	expectedFramework string,
+	rejectFindings bool,
+	requireSecretsCanary bool,
+) ([]checkovReport, error) {
 	trimmed := strings.TrimSpace(string(input))
 	if trimmed == "" {
 		return nil, errors.New("checkov report is empty")
@@ -316,14 +341,6 @@ func decodeCheckovReports(input []byte, expectedFramework string, rejectFindings
 		var report checkovReport
 		if err := json.Unmarshal(input, &report); err != nil {
 			return nil, fmt.Errorf("decode Checkov report: %w", err)
-		}
-		if expectedFramework == "secrets" && report.CheckType == "" && report.Summary.ParsingErrors == nil {
-			var summary checkovSummary
-			if err := json.Unmarshal(input, &summary); err != nil {
-				return nil, fmt.Errorf("decode Checkov summary: %w", err)
-			}
-			report.CheckType = expectedFramework
-			report.Summary = summary
 		}
 		reports = []checkovReport{report}
 	}
@@ -362,8 +379,35 @@ func decodeCheckovReports(input []byte, expectedFramework string, rejectFindings
 		if rejectFindings && failedCount != 0 {
 			return nil, fmt.Errorf("%s report reported %d failed check(s)", report.CheckType, failedCount)
 		}
+		if requireSecretsCanary {
+			if err := validateSecretsCanary(report, failedCount); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return reports, nil
+}
+
+func validateSecretsCanary(report checkovReport, failedCount int) error {
+	if report.CheckType != "secrets" || failedCount != 1 || len(report.Results.FailedChecks) != 1 {
+		return fmt.Errorf("secrets report must contain exactly one synthetic canary finding, found %d", failedCount)
+	}
+	finding := report.Results.FailedChecks[0]
+	if finding.CheckID != "CKV_SECRET_2" || path.Base(finding.FilePath) != "checkov-secrets-canary.txt" {
+		return fmt.Errorf(
+			"secrets report contains unexpected canary identity %s in %s",
+			finding.CheckID,
+			finding.FilePath,
+		)
+	}
+	if len(finding.CodeBlock) != 1 || len(finding.CodeBlock[0]) != 2 {
+		return errors.New("secrets canary finding has an unexpected code_block")
+	}
+	line, ok := finding.CodeBlock[0][1].(string)
+	if !ok || line != "aws_access_key_id: AKIAQ**********\n" {
+		return errors.New("secrets canary finding does not contain the masked synthetic key")
+	}
+	return nil
 }
 
 func validateVendorSource(input []byte, bundle string) error {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -83,6 +83,7 @@ var bundleTargets = map[string][]targetSpec{
 
 var inlineCheckovSkip = regexp.MustCompile(`(?i)checkov\s*:\s*skip\s*=`)
 var sha256Digest = regexp.MustCompile(`^[0-9a-f]{64}$`)
+var yamlDocumentMarker = regexp.MustCompile(`^---(?:[ \t]+(?:#.*)?)?$`)
 
 var workloadKinds = map[string]struct{}{
 	"CronJob":               {},
@@ -986,7 +987,7 @@ func annotateBundle(input string, targets []targetSpec) (string, error) {
 func splitDocuments(lines []string) [][]string {
 	starts := []int{0}
 	for index, line := range lines {
-		if index > 0 && line == "---" {
+		if index > 0 && yamlDocumentMarker.MatchString(line) {
 			starts = append(starts, index)
 		}
 	}

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
@@ -35,6 +36,7 @@ type targetSpec struct {
 	checks              []string
 	reason              string
 	resourceFingerprint string
+	imageRepository     string
 }
 
 type manifestIdentity struct {
@@ -71,11 +73,11 @@ type checkovSummary struct {
 var bundleTargets = map[string][]targetSpec{
 	"cdi": {
 		{kind: "ClusterRole", name: "cdi-operator-cluster", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason, resourceFingerprint: "df06bcec640e27ea586a8d12bffa509558eb8a244978a0de46c35743ec85341e"},
-		{kind: "Deployment", name: "cdi-operator", checks: deploymentChecks(), reason: deploymentReason, resourceFingerprint: "f81c6d025990a3a550fbe12e38033c8c0c4e3d4397dc14c357c7c6dc601abe07"},
+		{kind: "Deployment", name: "cdi-operator", checks: deploymentChecks(), reason: deploymentReason, resourceFingerprint: "f81c6d025990a3a550fbe12e38033c8c0c4e3d4397dc14c357c7c6dc601abe07", imageRepository: "quay.io/kubevirt/cdi-operator"},
 	},
 	"kubevirt": {
 		{kind: "ClusterRole", name: "kubevirt-operator", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason, resourceFingerprint: "6eb8526d222f837be3a38f82c18710be5f64aa10e27cbe741b7707198b3df842"},
-		{kind: "Deployment", name: "virt-operator", checks: deploymentChecks(), reason: deploymentReason, resourceFingerprint: "a983d7303c2daf4c74e806ddfe9caf3eb1f25c6238798716d6c80e124016b51e"},
+		{kind: "Deployment", name: "virt-operator", checks: deploymentChecks(), reason: deploymentReason, resourceFingerprint: "a983d7303c2daf4c74e806ddfe9caf3eb1f25c6238798716d6c80e124016b51e", imageRepository: "quay.io/kubevirt/virt-operator"},
 	},
 }
 
@@ -154,6 +156,11 @@ func main() {
 		"",
 		"expected SHA-256 of the annotation-free upstream source for --validate-annotated",
 	)
+	sourceVersion := flag.String(
+		"source-version",
+		"",
+		"expected release version in the pinned operator image for --validate-annotated",
+	)
 	framework := flag.String(
 		"framework",
 		"",
@@ -191,8 +198,11 @@ func main() {
 	if *validateAnnotated && *sourceSHA256 == "" {
 		fail("--validate-annotated requires --source-sha256")
 	}
-	if !*validateAnnotated && *sourceSHA256 != "" {
-		fail("--source-sha256 requires --validate-annotated")
+	if *validateAnnotated && *sourceVersion == "" {
+		fail("--validate-annotated requires --source-version")
+	}
+	if !*validateAnnotated && (*sourceSHA256 != "" || *sourceVersion != "") {
+		fail("--source-sha256 and --source-version require --validate-annotated")
 	}
 
 	input, err := io.ReadAll(os.Stdin)
@@ -218,7 +228,7 @@ func main() {
 		return
 	}
 	if *validateAnnotated {
-		if err := validatePinnedSource(input, targets, *sourceSHA256); err != nil {
+		if err := validatePinnedSource(input, targets, *sourceSHA256, *sourceVersion); err != nil {
 			fail("validate %s annotated bundle: %v", *bundle, err)
 		}
 		return
@@ -603,7 +613,7 @@ func validateAnnotatedBundle(input []byte, targets []targetSpec) error {
 	return nil
 }
 
-func validatePinnedSource(input []byte, targets []targetSpec, expectedSHA256 string) error {
+func validatePinnedSource(input []byte, targets []targetSpec, expectedSHA256, expectedVersion string) error {
 	if !sha256Digest.MatchString(expectedSHA256) {
 		return fmt.Errorf("source SHA-256 must be 64 lowercase hexadecimal characters")
 	}
@@ -618,7 +628,140 @@ func validatePinnedSource(input []byte, targets []targetSpec, expectedSHA256 str
 	if actualSHA256 != expectedSHA256 {
 		return fmt.Errorf("source SHA-256 is %s, want %s", actualSHA256, expectedSHA256)
 	}
+	if err := validateOperatorImageVersion([]byte(source), targets, expectedVersion); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateOperatorImageVersion(input []byte, targets []targetSpec, expectedVersion string) error {
+	if expectedVersion == "" {
+		return errors.New("source version must not be empty")
+	}
+	expectedByIdentity := make(map[string]targetSpec)
+	for _, target := range targets {
+		if target.imageRepository != "" {
+			expectedByIdentity[target.kind+"/"+target.name] = target
+		}
+	}
+	if len(expectedByIdentity) == 0 {
+		return errors.New("no operator image is configured for the bundle")
+	}
+
+	seen := make(map[string]int, len(expectedByIdentity))
+	decoder := yaml.NewDecoder(bytes.NewReader(input))
+	for documentIndex := 1; ; documentIndex++ {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("parse pinned source document %d: %w", documentIndex, err)
+		}
+		if len(document.Content) == 0 || document.Content[0].Kind == 0 {
+			continue
+		}
+		if err := validateOperatorImageResource(
+			document.Content[0],
+			expectedByIdentity,
+			expectedVersion,
+			seen,
+		); err != nil {
+			return fmt.Errorf("pinned source document %d: %w", documentIndex, err)
+		}
+	}
+	for identity := range expectedByIdentity {
+		if seen[identity] != 1 {
+			return fmt.Errorf("expected exactly one operator image resource %s, found %d", identity, seen[identity])
+		}
+	}
+	return nil
+}
+
+func validateOperatorImageResource(
+	root *yaml.Node,
+	expectedByIdentity map[string]targetSpec,
+	expectedVersion string,
+	seen map[string]int,
+) error {
+	if root.Kind != yaml.MappingNode {
+		return errors.New("operator image resource must be a mapping")
+	}
+	kind := mappingScalar(root, "kind")
+	metadata := mappingValue(root, "metadata")
+	if metadata != nil && metadata.Kind == yaml.MappingNode {
+		identity := kind + "/" + mappingScalar(metadata, "name")
+		if target, configured := expectedByIdentity[identity]; configured {
+			seen[identity]++
+			expectedImage := target.imageRepository + ":" + expectedVersion
+			images, err := deploymentContainerImages(root)
+			if err != nil {
+				return fmt.Errorf("inspect operator image on %s: %w", identity, err)
+			}
+			repositoryReferences := 0
+			exactReferences := 0
+			for _, image := range images {
+				if strings.HasPrefix(image, target.imageRepository+":") ||
+					strings.HasPrefix(image, target.imageRepository+"@") {
+					repositoryReferences++
+				}
+				if image == expectedImage {
+					exactReferences++
+				}
+			}
+			if repositoryReferences != 1 || exactReferences != 1 {
+				return fmt.Errorf("%s operator image must be exactly %s", identity, expectedImage)
+			}
+		}
+	}
+
+	if kind != "List" && !strings.HasSuffix(kind, "List") {
+		return nil
+	}
+	items := mappingValue(root, "items")
+	if items == nil {
+		return nil
+	}
+	if items.Kind != yaml.SequenceNode {
+		return fmt.Errorf("%s items must be a sequence", kind)
+	}
+	for index, item := range items.Content {
+		if err := validateOperatorImageResource(item, expectedByIdentity, expectedVersion, seen); err != nil {
+			return fmt.Errorf("%s item %d: %w", kind, index+1, err)
+		}
+	}
+	return nil
+}
+
+func deploymentContainerImages(root *yaml.Node) ([]string, error) {
+	spec := mappingValue(root, "spec")
+	if spec == nil || spec.Kind != yaml.MappingNode {
+		return nil, errors.New("spec must be a mapping")
+	}
+	template := mappingValue(spec, "template")
+	if template == nil || template.Kind != yaml.MappingNode {
+		return nil, errors.New("spec.template must be a mapping")
+	}
+	podSpec := mappingValue(template, "spec")
+	if podSpec == nil || podSpec.Kind != yaml.MappingNode {
+		return nil, errors.New("spec.template.spec must be a mapping")
+	}
+	containers := mappingValue(podSpec, "containers")
+	if containers == nil || containers.Kind != yaml.SequenceNode {
+		return nil, errors.New("spec.template.spec.containers must be a sequence")
+	}
+	images := make([]string, 0, len(containers.Content))
+	for index, container := range containers.Content {
+		if container.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("container %d must be a mapping", index+1)
+		}
+		image := mappingScalar(container, "image")
+		if image == "" {
+			return nil, fmt.Errorf("container %d image must be a scalar", index+1)
+		}
+		images = append(images, image)
+	}
+	return images, nil
 }
 
 func stripConfiguredDispositions(input string, targets []targetSpec) (string, error) {
@@ -699,7 +842,8 @@ func stripTargetDispositions(lines []string, target targetSpec) ([]string, error
 			expectedLines[lines[index]] = true
 			continue
 		}
-		if strings.TrimSpace(lines[index]) != "" {
+		trimmedLine := strings.TrimSpace(lines[index])
+		if trimmedLine != "" && !strings.HasPrefix(trimmedLine, "#") {
 			remainingAnnotations = true
 		}
 	}

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -1,0 +1,278 @@
+// Command annotate-vendored-checkov adds the repository's reviewed Checkov
+// dispositions to pinned upstream operator bundles without reformatting them.
+//
+// The upstream files are deliberately kept byte-for-byte apart from these
+// annotations. The updater can therefore replace a bundle, run this command,
+// and fail closed when a target resource is renamed or removed.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	clusterRoleReason = "Vendored upstream operator RBAC; changes must go through the pinned vendor update path tracked by platform issue 2899."
+	deploymentReason  = "Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+)
+
+type targetSpec struct {
+	kind   string
+	name   string
+	checks []string
+	reason string
+}
+
+type manifestIdentity struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+}
+
+var bundleTargets = map[string][]targetSpec{
+	"cdi": {
+		{kind: "ClusterRole", name: "cdi-operator-cluster", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason},
+		{kind: "Deployment", name: "cdi-operator", checks: deploymentChecks(), reason: deploymentReason},
+	},
+	"kubevirt": {
+		{kind: "ClusterRole", name: "kubevirt-operator", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason},
+		{kind: "Deployment", name: "virt-operator", checks: deploymentChecks(), reason: deploymentReason},
+	},
+}
+
+func deploymentChecks() []string {
+	return []string{
+		"CKV_K8S_11",
+		"CKV_K8S_13",
+		"CKV_K8S_15",
+		"CKV_K8S_22",
+		"CKV_K8S_38",
+		"CKV_K8S_40",
+		"CKV_K8S_43",
+	}
+}
+
+func main() {
+	bundle := flag.String("bundle", "", "bundle to annotate: cdi or kubevirt")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fail("unexpected positional arguments")
+	}
+
+	targets, ok := bundleTargets[*bundle]
+	if !ok {
+		fail("unsupported bundle %q", *bundle)
+	}
+
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fail("read bundle: %v", err)
+	}
+	output, err := annotateBundle(string(input), targets)
+	if err != nil {
+		fail("annotate %s bundle: %v", *bundle, err)
+	}
+	if _, err := io.WriteString(os.Stdout, output); err != nil {
+		fail("write bundle: %v", err)
+	}
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "annotate-vendored-checkov: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func annotateBundle(input string, targets []targetSpec) (string, error) {
+	if input == "" {
+		return "", errors.New("bundle is empty")
+	}
+
+	hasTrailingNewline := strings.HasSuffix(input, "\n")
+	trimmed := strings.TrimSuffix(input, "\n")
+	lines := strings.Split(trimmed, "\n")
+	documents := splitDocuments(lines)
+	found := make(map[string]int, len(targets))
+	output := make([]string, 0, len(lines)+len(targets)*10)
+
+	for _, document := range documents {
+		identity, err := readIdentity(document)
+		if err != nil {
+			return "", err
+		}
+
+		annotated := document
+		for _, target := range targets {
+			if identity.Kind != target.kind || identity.Metadata.Name != target.name {
+				continue
+			}
+			key := target.kind + "/" + target.name
+			found[key]++
+			annotated, err = annotateDocument(annotated, target)
+			if err != nil {
+				return "", fmt.Errorf("%s: %w", key, err)
+			}
+		}
+		output = append(output, annotated...)
+	}
+
+	for _, target := range targets {
+		key := target.kind + "/" + target.name
+		if found[key] != 1 {
+			return "", fmt.Errorf("expected exactly one %s, found %d", key, found[key])
+		}
+	}
+
+	result := strings.Join(output, "\n")
+	if hasTrailingNewline {
+		result += "\n"
+	}
+	return result, nil
+}
+
+func splitDocuments(lines []string) [][]string {
+	starts := []int{0}
+	for index, line := range lines {
+		if index > 0 && line == "---" {
+			starts = append(starts, index)
+		}
+	}
+
+	documents := make([][]string, 0, len(starts))
+	for index, start := range starts {
+		end := len(lines)
+		if index+1 < len(starts) {
+			end = starts[index+1]
+		}
+		documents = append(documents, append([]string(nil), lines[start:end]...))
+	}
+	return documents
+}
+
+func readIdentity(lines []string) (manifestIdentity, error) {
+	var identity manifestIdentity
+	if err := yaml.Unmarshal([]byte(strings.Join(lines, "\n")), &identity); err != nil {
+		return identity, fmt.Errorf("parse vendor document: %w", err)
+	}
+	return identity, nil
+}
+
+func annotateDocument(lines []string, target targetSpec) ([]string, error) {
+	metadataIndex := -1
+	metadataEnd := len(lines)
+	for index, line := range lines {
+		if line == "metadata:" {
+			if metadataIndex != -1 {
+				return nil, errors.New("multiple top-level metadata mappings")
+			}
+			metadataIndex = index
+			continue
+		}
+		if metadataIndex != -1 && line != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "#") {
+			metadataEnd = index
+			break
+		}
+	}
+	if metadataIndex == -1 {
+		return nil, errors.New("top-level metadata mapping is missing")
+	}
+
+	annotationsIndex := -1
+	annotationsEnd := metadataEnd
+	for index := metadataIndex + 1; index < metadataEnd; index++ {
+		if lines[index] == "  annotations:" {
+			if annotationsIndex != -1 {
+				return nil, errors.New("multiple metadata.annotations mappings")
+			}
+			annotationsIndex = index
+			continue
+		}
+		if annotationsIndex != -1 && lines[index] != "" && !strings.HasPrefix(lines[index], "    ") && !strings.HasPrefix(strings.TrimSpace(lines[index]), "#") {
+			annotationsEnd = index
+			break
+		}
+	}
+
+	insertAt := annotationsEnd
+	if annotationsIndex == -1 {
+		annotationsIndex = metadataIndex + 1
+		insertAt = annotationsIndex + 1
+		lines = insertLines(lines, annotationsIndex, []string{"  annotations:"})
+	} else {
+		insertAt = annotationsEnd
+	}
+
+	existing, highest, err := existingCheckovAnnotations(lines, annotationsIndex+1, insertAt)
+	if err != nil {
+		return nil, err
+	}
+	additions := make([]string, 0, len(target.checks))
+	for _, check := range target.checks {
+		value := check + "=" + target.reason
+		if existingValue, ok := existing[check]; ok {
+			if existingValue != value {
+				return nil, fmt.Errorf("%s already has a different disposition", check)
+			}
+			continue
+		}
+		highest++
+		additions = append(additions, fmt.Sprintf("    checkov.io/skip%d: %q", highest, value))
+	}
+	if len(additions) == 0 {
+		return lines, nil
+	}
+
+	return insertLines(lines, insertAt, additions), nil
+}
+
+func existingCheckovAnnotations(lines []string, start, end int) (map[string]string, int, error) {
+	existing := make(map[string]string)
+	highest := 0
+	for index := start; index < end; index++ {
+		line := strings.TrimSpace(lines[index])
+		if !strings.HasPrefix(line, "checkov.io/skip") {
+			continue
+		}
+		key, rawValue, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, 0, fmt.Errorf("malformed Checkov annotation %q", line)
+		}
+		numberText := strings.TrimPrefix(key, "checkov.io/skip")
+		number, err := strconv.Atoi(numberText)
+		if err != nil || number < 1 {
+			return nil, 0, fmt.Errorf("malformed Checkov annotation key %q", key)
+		}
+		if number > highest {
+			highest = number
+		}
+
+		var value string
+		if err := yaml.Unmarshal([]byte(strings.TrimSpace(rawValue)), &value); err != nil {
+			return nil, 0, fmt.Errorf("parse %s: %w", key, err)
+		}
+		check, _, ok := strings.Cut(value, "=")
+		if !ok || check == "" {
+			return nil, 0, fmt.Errorf("%s does not name a Checkov check", key)
+		}
+		if _, duplicate := existing[check]; duplicate {
+			return nil, 0, fmt.Errorf("duplicate disposition for %s", check)
+		}
+		existing[check] = value
+	}
+	return existing, highest, nil
+}
+
+func insertLines(lines []string, index int, additions []string) []string {
+	result := make([]string, 0, len(lines)+len(additions))
+	result = append(result, lines[:index]...)
+	result = append(result, additions...)
+	result = append(result, lines[index:]...)
+	return result
+}

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -211,7 +211,7 @@ func decodeCheckovReports(input []byte, expectedFramework string, rejectFindings
 		if err := json.Unmarshal(input, &report); err != nil {
 			return nil, fmt.Errorf("decode Checkov report: %w", err)
 		}
-		if report.CheckType == "" && report.Summary.ParsingErrors == nil {
+		if expectedFramework == "secrets" && report.CheckType == "" && report.Summary.ParsingErrors == nil {
 			var summary checkovSummary
 			if err := json.Unmarshal(input, &summary); err != nil {
 				return nil, fmt.Errorf("decode Checkov summary: %w", err)

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"regexp"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -568,46 +569,16 @@ func validateAnnotatedBundle(input []byte, targets []targetSpec) error {
 		if root.Kind != yaml.MappingNode {
 			return fmt.Errorf("committed document %d must contain a top-level mapping", documentIndex)
 		}
-		kind := mappingScalar(root, "kind")
-		metadata := mappingValue(root, "metadata")
-		if metadata == nil {
-			continue
-		}
-		if metadata.Kind != yaml.MappingNode {
-			return fmt.Errorf("committed document %d metadata must be a mapping", documentIndex)
-		}
-		name := mappingScalar(metadata, "name")
-		identity := kind + "/" + name
-		if _, configured := targetsByIdentity[identity]; configured {
-			seenTargets[identity]++
-		}
-
-		annotations := mappingValue(metadata, "annotations")
-		if annotations == nil {
-			continue
-		}
-		if annotations.Kind != yaml.MappingNode {
-			return fmt.Errorf("committed document %d metadata.annotations must be a mapping", documentIndex)
-		}
-		for index := 0; index+1 < len(annotations.Content); index += 2 {
-			annotationKey := annotations.Content[index].Value
-			if !strings.HasPrefix(annotationKey, "checkov.io/skip") {
-				continue
-			}
-			expected, configuredTarget := expectedByIdentity[identity]
-			expectedValue, configuredDisposition := expected[annotationKey]
-			if !configuredTarget || !configuredDisposition {
-				return fmt.Errorf("unexpected Checkov disposition %s on %s", annotationKey, identity)
-			}
-			annotationValue := annotations.Content[index+1]
-			if annotationValue.Kind != yaml.ScalarNode || annotationValue.Value != expectedValue {
-				return fmt.Errorf(
-					"%s on %s does not match the configured disposition",
-					annotationKey,
-					identity,
-				)
-			}
-			seenDispositions[identity+"/"+annotationKey]++
+		if err := walkManifestResources(root, func(resource *yaml.Node) error {
+			return validateAnnotatedResource(
+				resource,
+				targetsByIdentity,
+				expectedByIdentity,
+				seenTargets,
+				seenDispositions,
+			)
+		}); err != nil {
+			return fmt.Errorf("committed document %d: %w", documentIndex, err)
 		}
 	}
 
@@ -620,6 +591,57 @@ func validateAnnotatedBundle(input []byte, targets []targetSpec) error {
 				return fmt.Errorf("expected exactly one configured %s on %s", annotationKey, identity)
 			}
 		}
+	}
+	return nil
+}
+
+func validateAnnotatedResource(
+	root *yaml.Node,
+	targetsByIdentity map[string]targetSpec,
+	expectedByIdentity map[string]map[string]string,
+	seenTargets map[string]int,
+	seenDispositions map[string]int,
+) error {
+	kind := mappingScalar(root, "kind")
+	metadata := mappingValue(root, "metadata")
+	if metadata == nil {
+		return nil
+	}
+	if metadata.Kind != yaml.MappingNode {
+		return errors.New("metadata must be a mapping")
+	}
+	name := mappingScalar(metadata, "name")
+	identity := kind + "/" + name
+	if _, configured := targetsByIdentity[identity]; configured {
+		seenTargets[identity]++
+	}
+
+	annotations := mappingValue(metadata, "annotations")
+	if annotations == nil {
+		return nil
+	}
+	if annotations.Kind != yaml.MappingNode {
+		return errors.New("metadata.annotations must be a mapping")
+	}
+	for index := 0; index+1 < len(annotations.Content); index += 2 {
+		annotationKey := annotations.Content[index].Value
+		if !strings.HasPrefix(annotationKey, "checkov.io/skip") {
+			continue
+		}
+		expected, configuredTarget := expectedByIdentity[identity]
+		expectedValue, configuredDisposition := expected[annotationKey]
+		if !configuredTarget || !configuredDisposition {
+			return fmt.Errorf("unexpected Checkov disposition %s on %s", annotationKey, identity)
+		}
+		annotationValue := annotations.Content[index+1]
+		if annotationValue.Kind != yaml.ScalarNode || annotationValue.Value != expectedValue {
+			return fmt.Errorf(
+				"%s on %s does not match the configured disposition",
+				annotationKey,
+				identity,
+			)
+		}
+		seenDispositions[identity+"/"+annotationKey]++
 	}
 	return nil
 }
@@ -778,105 +800,81 @@ func deploymentContainerImages(root *yaml.Node) ([]string, error) {
 func stripConfiguredDispositions(input string, targets []targetSpec) (string, error) {
 	hasTrailingNewline := strings.HasSuffix(input, "\n")
 	trimmed := strings.TrimSuffix(input, "\n")
-	documents := splitDocuments(strings.Split(trimmed, "\n"))
+	lines := strings.Split(trimmed, "\n")
 	targetsByIdentity := make(map[string]targetSpec, len(targets))
 	for _, target := range targets {
 		targetsByIdentity[target.kind+"/"+target.name] = target
 	}
-
-	output := make([]string, 0, len(strings.Split(trimmed, "\n")))
-	for _, document := range documents {
-		identity, err := readIdentity(document)
-		if err != nil {
-			return "", err
+	removeLines := make(map[int]struct{})
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	for documentIndex := 1; ; documentIndex++ {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return "", fmt.Errorf("parse annotated document %d for stripping: %w", documentIndex, err)
 		}
-		target, configured := targetsByIdentity[identity.Kind+"/"+identity.Metadata.Name]
-		if !configured {
-			output = append(output, document...)
+		if len(document.Content) == 0 || document.Content[0].Kind == 0 {
 			continue
 		}
-		stripped, err := stripTargetDispositions(document, target)
-		if err != nil {
-			return "", fmt.Errorf("%s/%s: %w", target.kind, target.name, err)
+		if err := walkManifestResources(document.Content[0], func(resource *yaml.Node) error {
+			kind := mappingScalar(resource, "kind")
+			_, metadata := mappingEntry(resource, "metadata")
+			if metadata == nil || metadata.Kind != yaml.MappingNode {
+				return nil
+			}
+			target, configured := targetsByIdentity[kind+"/"+mappingScalar(metadata, "name")]
+			if !configured {
+				return nil
+			}
+			annotationsKey, annotations := mappingEntry(metadata, "annotations")
+			if annotations == nil || annotations.Kind != yaml.MappingNode {
+				return errors.New("configured target annotations mapping is missing")
+			}
+			for index, check := range target.checks {
+				annotationKey := "checkov.io/skip" + strconv.Itoa(index+1)
+				key, value := mappingEntry(annotations, annotationKey)
+				if key == nil || value == nil {
+					return fmt.Errorf("configured disposition %s is missing", annotationKey)
+				}
+				expectedValue := check + "=" + target.reason
+				expectedLine := fmt.Sprintf(
+					"%s%s: %q",
+					strings.Repeat(" ", key.Column-1),
+					annotationKey,
+					expectedValue,
+				)
+				if key.Line < 1 || key.Line > len(lines) || lines[key.Line-1] != expectedLine {
+					return fmt.Errorf("configured disposition line %q is missing", expectedLine)
+				}
+				removeLines[key.Line-1] = struct{}{}
+			}
+			if len(annotations.Content)/2 == len(target.checks) {
+				if annotationsKey.Line < 1 || annotationsKey.Line > len(lines) ||
+					strings.TrimSpace(lines[annotationsKey.Line-1]) != "annotations:" {
+					return errors.New("introduced annotations mapping line is missing")
+				}
+				removeLines[annotationsKey.Line-1] = struct{}{}
+			}
+			return nil
+		}); err != nil {
+			return "", fmt.Errorf("strip annotated document %d: %w", documentIndex, err)
 		}
-		output = append(output, stripped...)
 	}
 
+	output := make([]string, 0, len(lines)-len(removeLines))
+	for index, line := range lines {
+		if _, remove := removeLines[index]; remove {
+			continue
+		}
+		output = append(output, line)
+	}
 	result := strings.Join(output, "\n")
 	if hasTrailingNewline {
 		result += "\n"
 	}
 	return result, nil
-}
-
-func stripTargetDispositions(lines []string, target targetSpec) ([]string, error) {
-	metadataIndex := -1
-	metadataEnd := len(lines)
-	for index, line := range lines {
-		if line == "metadata:" {
-			metadataIndex = index
-			continue
-		}
-		if metadataIndex != -1 && line != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "#") {
-			metadataEnd = index
-			break
-		}
-	}
-	if metadataIndex == -1 {
-		return nil, errors.New("top-level metadata mapping is missing")
-	}
-
-	annotationsIndex := -1
-	annotationsEnd := metadataEnd
-	for index := metadataIndex + 1; index < metadataEnd; index++ {
-		if lines[index] == "  annotations:" {
-			annotationsIndex = index
-			continue
-		}
-		if annotationsIndex != -1 && lines[index] != "" && !strings.HasPrefix(lines[index], "    ") && !strings.HasPrefix(strings.TrimSpace(lines[index]), "#") {
-			annotationsEnd = index
-			break
-		}
-	}
-	if annotationsIndex == -1 {
-		return nil, errors.New("metadata.annotations mapping is missing")
-	}
-
-	expectedLines := make(map[string]bool, len(target.checks))
-	for index, check := range target.checks {
-		line := fmt.Sprintf("    checkov.io/skip%d: %q", index+1, check+"="+target.reason)
-		expectedLines[line] = false
-	}
-	remainingAnnotations := false
-	for index := annotationsIndex + 1; index < annotationsEnd; index++ {
-		if _, expected := expectedLines[lines[index]]; expected {
-			expectedLines[lines[index]] = true
-			continue
-		}
-		trimmedLine := strings.TrimSpace(lines[index])
-		if trimmedLine != "" && !strings.HasPrefix(trimmedLine, "#") {
-			remainingAnnotations = true
-		}
-	}
-	for line, found := range expectedLines {
-		if !found {
-			return nil, fmt.Errorf("configured disposition line %q is missing", line)
-		}
-	}
-
-	stripped := make([]string, 0, len(lines)-len(target.checks))
-	for index, line := range lines {
-		if index > annotationsIndex && index < annotationsEnd {
-			if _, expected := expectedLines[line]; expected {
-				continue
-			}
-		}
-		if index == annotationsIndex && !remainingAnnotations {
-			continue
-		}
-		stripped = append(stripped, line)
-	}
-	return stripped, nil
 }
 
 func rejectInlineCheckovSuppression(node *yaml.Node) error {
@@ -956,6 +954,14 @@ func annotateBundle(input string, targets []targetSpec) (string, error) {
 		}
 
 		annotated := document
+		if identity.Kind == "List" || strings.HasSuffix(identity.Kind, "List") {
+			annotated, err = annotateListDocument(document, targets, found)
+			if err != nil {
+				return "", err
+			}
+			output = append(output, annotated...)
+			continue
+		}
 		for _, target := range targets {
 			if identity.Kind != target.kind || identity.Metadata.Name != target.name {
 				continue
@@ -982,6 +988,136 @@ func annotateBundle(input string, targets []targetSpec) (string, error) {
 		result += "\n"
 	}
 	return result, nil
+}
+
+type lineInsertion struct {
+	index int
+	lines []string
+}
+
+func annotateListDocument(lines []string, targets []targetSpec, found map[string]int) ([]string, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(strings.Join(lines, "\n")), &document); err != nil {
+		return nil, fmt.Errorf("parse vendor List document: %w", err)
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("vendor List document must contain a top-level mapping")
+	}
+	var insertions []lineInsertion
+	err := walkManifestResources(document.Content[0], func(resource *yaml.Node) error {
+		kind := mappingScalar(resource, "kind")
+		metadata := mappingValue(resource, "metadata")
+		if metadata == nil || metadata.Kind != yaml.MappingNode {
+			return nil
+		}
+		name := mappingScalar(metadata, "name")
+		for _, target := range targets {
+			if kind != target.kind || name != target.name {
+				continue
+			}
+			identity := target.kind + "/" + target.name
+			found[identity]++
+			insertion, err := annotationInsertion(resource, target)
+			if err != nil {
+				return fmt.Errorf("%s: %w", identity, err)
+			}
+			if len(insertion.lines) != 0 {
+				insertions = append(insertions, insertion)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(insertions, func(left, right int) bool {
+		return insertions[left].index > insertions[right].index
+	})
+	for _, insertion := range insertions {
+		lines = insertLines(lines, insertion.index, insertion.lines)
+	}
+	return lines, nil
+}
+
+func annotationInsertion(resource *yaml.Node, target targetSpec) (lineInsertion, error) {
+	metadataKey, metadata := mappingEntry(resource, "metadata")
+	if metadata == nil || metadata.Kind != yaml.MappingNode || metadata.Style&yaml.FlowStyle != 0 {
+		return lineInsertion{}, errors.New("metadata must use block mapping style")
+	}
+	annotationsKey, annotations := mappingEntry(metadata, "annotations")
+	if annotations == nil {
+		metadataIndent := strings.Repeat(" ", metadataKey.Column-1+2)
+		dispositionIndent := metadataIndent + "  "
+		additions := []string{metadataIndent + "annotations:"}
+		for index, check := range target.checks {
+			value := check + "=" + target.reason
+			additions = append(
+				additions,
+				fmt.Sprintf("%scheckov.io/skip%d: %q", dispositionIndent, index+1, value),
+			)
+		}
+		return lineInsertion{index: metadataKey.Line, lines: additions}, nil
+	}
+	if annotations.Kind != yaml.MappingNode || annotations.Style&yaml.FlowStyle != 0 {
+		return lineInsertion{}, errors.New("metadata.annotations must use block mapping style")
+	}
+	existing, highest, err := existingCheckovAnnotationNodes(annotations)
+	if err != nil {
+		return lineInsertion{}, err
+	}
+	indent := strings.Repeat(" ", annotationsKey.Column-1+2)
+	additions := make([]string, 0, len(target.checks))
+	for _, check := range target.checks {
+		value := check + "=" + target.reason
+		if existingValue, ok := existing[check]; ok {
+			if existingValue != value {
+				return lineInsertion{}, fmt.Errorf("%s already has a different disposition", check)
+			}
+			continue
+		}
+		highest++
+		additions = append(additions, fmt.Sprintf("%scheckov.io/skip%d: %q", indent, highest, value))
+	}
+	return lineInsertion{index: maxNodeLine(annotations), lines: additions}, nil
+}
+
+func existingCheckovAnnotationNodes(annotations *yaml.Node) (map[string]string, int, error) {
+	existing := make(map[string]string)
+	highest := 0
+	for index := 0; index+1 < len(annotations.Content); index += 2 {
+		key := annotations.Content[index]
+		if !strings.HasPrefix(key.Value, "checkov.io/skip") {
+			continue
+		}
+		number, err := strconv.Atoi(strings.TrimPrefix(key.Value, "checkov.io/skip"))
+		if err != nil || number < 1 {
+			return nil, 0, fmt.Errorf("invalid Checkov annotation key %q", key.Value)
+		}
+		if number > highest {
+			highest = number
+		}
+		value := annotations.Content[index+1]
+		if value.Kind != yaml.ScalarNode {
+			return nil, 0, fmt.Errorf("%s value must be a scalar", key.Value)
+		}
+		parts := strings.SplitN(value.Value, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, 0, fmt.Errorf("%s has an invalid disposition", key.Value)
+		}
+		if _, duplicate := existing[parts[0]]; duplicate {
+			return nil, 0, fmt.Errorf("duplicate disposition for %s", parts[0])
+		}
+		existing[parts[0]] = value.Value
+	}
+	return existing, highest, nil
+}
+
+func maxNodeLine(node *yaml.Node) int {
+	line := node.Line
+	for _, child := range node.Content {
+		line = max(line, maxNodeLine(child))
+	}
+	return line
 }
 
 func splitDocuments(lines []string) [][]string {
@@ -1106,12 +1242,17 @@ func validateAnnotationStyle(lines []string) error {
 }
 
 func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	_, value := mappingEntry(mapping, key)
+	return value
+}
+
+func mappingEntry(mapping *yaml.Node, key string) (*yaml.Node, *yaml.Node) {
 	for index := 0; index+1 < len(mapping.Content); index += 2 {
 		if mapping.Content[index].Value == key {
-			return mapping.Content[index+1]
+			return mapping.Content[index], mapping.Content[index+1]
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func mappingScalar(mapping *yaml.Node, key string) string {
@@ -1120,6 +1261,32 @@ func mappingScalar(mapping *yaml.Node, key string) string {
 		return ""
 	}
 	return value.Value
+}
+
+func walkManifestResources(root *yaml.Node, visit func(*yaml.Node) error) error {
+	if root.Kind != yaml.MappingNode {
+		return errors.New("manifest resource must be a mapping")
+	}
+	if err := visit(root); err != nil {
+		return err
+	}
+	kind := mappingScalar(root, "kind")
+	if kind != "List" && !strings.HasSuffix(kind, "List") {
+		return nil
+	}
+	items := mappingValue(root, "items")
+	if items == nil {
+		return nil
+	}
+	if items.Kind != yaml.SequenceNode {
+		return fmt.Errorf("%s items must be a sequence", kind)
+	}
+	for index, item := range items.Content {
+		if err := walkManifestResources(item, visit); err != nil {
+			return fmt.Errorf("%s item %d: %w", kind, index+1, err)
+		}
+	}
+	return nil
 }
 
 func existingCheckovAnnotations(lines []string, start, end int) (map[string]string, int, error) {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -449,14 +449,19 @@ func validateVendorSource(input []byte, bundle string) error {
 		if root.Kind != yaml.MappingNode {
 			return fmt.Errorf("vendor document %d must contain a top-level mapping", documentIndex)
 		}
-		metadata := mappingValue(root, "metadata")
-		if metadata == nil {
-			continue
+		if err := validateVendorResource(root, protectedNamespace); err != nil {
+			return fmt.Errorf("vendor document %d: %w", documentIndex, err)
 		}
+	}
+}
+
+func validateVendorResource(root *yaml.Node, protectedNamespace string) error {
+	kind := mappingScalar(root, "kind")
+	metadata := mappingValue(root, "metadata")
+	if metadata != nil {
 		if metadata.Kind != yaml.MappingNode {
-			return fmt.Errorf("vendor document %d metadata must be a mapping", documentIndex)
+			return errors.New("metadata must be a mapping")
 		}
-		kind := mappingScalar(root, "kind")
 		if _, workload := workloadKinds[kind]; workload {
 			name := mappingScalar(metadata, "name")
 			namespace := mappingScalar(metadata, "namespace")
@@ -471,19 +476,38 @@ func validateVendorSource(input []byte, bundle string) error {
 			}
 		}
 		annotations := mappingValue(metadata, "annotations")
-		if annotations == nil {
-			continue
-		}
-		if annotations.Kind != yaml.MappingNode {
-			return fmt.Errorf("vendor document %d metadata.annotations must be a mapping", documentIndex)
-		}
-		for index := 0; index+1 < len(annotations.Content); index += 2 {
-			key := annotations.Content[index].Value
-			if strings.HasPrefix(key, "checkov.io/skip") {
-				return fmt.Errorf("vendor document %d contains upstream Checkov suppression %s", documentIndex, key)
+		if annotations != nil {
+			if annotations.Kind != yaml.MappingNode {
+				return errors.New("metadata.annotations must be a mapping")
+			}
+			for index := 0; index+1 < len(annotations.Content); index += 2 {
+				key := annotations.Content[index].Value
+				if strings.HasPrefix(key, "checkov.io/skip") {
+					return fmt.Errorf("contains upstream Checkov suppression %s", key)
+				}
 			}
 		}
 	}
+
+	if kind != "List" && !strings.HasSuffix(kind, "List") {
+		return nil
+	}
+	items := mappingValue(root, "items")
+	if items == nil {
+		return nil
+	}
+	if items.Kind != yaml.SequenceNode {
+		return fmt.Errorf("%s items must be a sequence", kind)
+	}
+	for index, item := range items.Content {
+		if item.Kind != yaml.MappingNode {
+			return fmt.Errorf("%s item %d must be a mapping", kind, index+1)
+		}
+		if err := validateVendorResource(item, protectedNamespace); err != nil {
+			return fmt.Errorf("%s item %d: %w", kind, index+1, err)
+		}
+	}
+	return nil
 }
 
 func validateAnnotatedBundle(input []byte, targets []targetSpec) error {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -457,6 +457,9 @@ func validateVendorSource(input []byte, bundle string) error {
 		if err := rejectInlineCheckovSuppression(&document); err != nil {
 			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
 		}
+		if err := rejectYAMLAlias(&document); err != nil {
+			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
+		}
 		if err := rejectYAMLMergeKey(&document); err != nil {
 			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
 		}
@@ -563,6 +566,9 @@ func validateAnnotatedBundle(input []byte, targets []targetSpec) error {
 			continue
 		}
 		if err := rejectInlineCheckovSuppression(&document); err != nil {
+			return fmt.Errorf("committed document %d contains %w", documentIndex, err)
+		}
+		if err := rejectYAMLAlias(&document); err != nil {
 			return fmt.Errorf("committed document %d contains %w", documentIndex, err)
 		}
 		root := document.Content[0]
@@ -891,6 +897,18 @@ func rejectInlineCheckovSuppression(node *yaml.Node) error {
 	return nil
 }
 
+func rejectYAMLAlias(node *yaml.Node) error {
+	if node.Kind == yaml.AliasNode {
+		return errors.New("YAML alias")
+	}
+	for _, child := range node.Content {
+		if err := rejectYAMLAlias(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func rejectYAMLMergeKey(node *yaml.Node) error {
 	if node.Kind == yaml.MappingNode {
 		for index := 0; index+1 < len(node.Content); index += 2 {
@@ -1155,7 +1173,7 @@ func annotateDocument(lines []string, target targetSpec) ([]string, error) {
 	metadataIndex := -1
 	metadataEnd := len(lines)
 	for index, line := range lines {
-		if line == "metadata:" {
+		if isBlockMappingLine(line, "metadata:") {
 			if metadataIndex != -1 {
 				return nil, errors.New("multiple top-level metadata mappings")
 			}
@@ -1174,7 +1192,7 @@ func annotateDocument(lines []string, target targetSpec) ([]string, error) {
 	annotationsIndex := -1
 	annotationsEnd := metadataEnd
 	for index := metadataIndex + 1; index < metadataEnd; index++ {
-		if lines[index] == "  annotations:" {
+		if isBlockMappingLine(lines[index], "  annotations:") {
 			if annotationsIndex != -1 {
 				return nil, errors.New("multiple metadata.annotations mappings")
 			}
@@ -1217,6 +1235,14 @@ func annotateDocument(lines []string, target targetSpec) ([]string, error) {
 	}
 
 	return insertLines(lines, insertAt, additions), nil
+}
+
+func isBlockMappingLine(line, prefix string) bool {
+	if !strings.HasPrefix(line, prefix) {
+		return false
+	}
+	remainder := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	return remainder == "" || strings.HasPrefix(remainder, "#")
 }
 
 func validateAnnotationStyle(lines []string) error {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -80,6 +80,7 @@ var bundleTargets = map[string][]targetSpec{
 }
 
 var inlineCheckovSkip = regexp.MustCompile(`(?i)checkov\s*:\s*skip\s*=`)
+var sha256Digest = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
 var workloadKinds = map[string]struct{}{
 	"CronJob":               {},
@@ -146,7 +147,12 @@ func main() {
 	validateAnnotated := flag.Bool(
 		"validate-annotated",
 		false,
-		"validate that a committed bundle contains exactly the configured Checkov dispositions",
+		"validate that a committed bundle is the pinned source plus exactly the configured dispositions",
+	)
+	sourceSHA256 := flag.String(
+		"source-sha256",
+		"",
+		"expected SHA-256 of the annotation-free upstream source for --validate-annotated",
 	)
 	framework := flag.String(
 		"framework",
@@ -182,6 +188,12 @@ func main() {
 	if *requireSecretsCanary && (!*validateReport || *framework != "secrets") {
 		fail("--require-secrets-canary requires --validate-report --framework secrets")
 	}
+	if *validateAnnotated && *sourceSHA256 == "" {
+		fail("--validate-annotated requires --source-sha256")
+	}
+	if !*validateAnnotated && *sourceSHA256 != "" {
+		fail("--source-sha256 requires --validate-annotated")
+	}
 
 	input, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -206,7 +218,7 @@ func main() {
 		return
 	}
 	if *validateAnnotated {
-		if err := validateAnnotatedBundle(input, targets); err != nil {
+		if err := validatePinnedSource(input, targets, *sourceSHA256); err != nil {
 			fail("validate %s annotated bundle: %v", *bundle, err)
 		}
 		return
@@ -565,6 +577,127 @@ func validateAnnotatedBundle(input []byte, targets []targetSpec) error {
 		}
 	}
 	return nil
+}
+
+func validatePinnedSource(input []byte, targets []targetSpec, expectedSHA256 string) error {
+	if !sha256Digest.MatchString(expectedSHA256) {
+		return fmt.Errorf("source SHA-256 must be 64 lowercase hexadecimal characters")
+	}
+	if err := validateAnnotatedBundle(input, targets); err != nil {
+		return err
+	}
+	source, err := stripConfiguredDispositions(string(input), targets)
+	if err != nil {
+		return err
+	}
+	actualSHA256 := fmt.Sprintf("%x", sha256.Sum256([]byte(source)))
+	if actualSHA256 != expectedSHA256 {
+		return fmt.Errorf("source SHA-256 is %s, want %s", actualSHA256, expectedSHA256)
+	}
+	return nil
+}
+
+func stripConfiguredDispositions(input string, targets []targetSpec) (string, error) {
+	hasTrailingNewline := strings.HasSuffix(input, "\n")
+	trimmed := strings.TrimSuffix(input, "\n")
+	documents := splitDocuments(strings.Split(trimmed, "\n"))
+	targetsByIdentity := make(map[string]targetSpec, len(targets))
+	for _, target := range targets {
+		targetsByIdentity[target.kind+"/"+target.name] = target
+	}
+
+	output := make([]string, 0, len(strings.Split(trimmed, "\n")))
+	for _, document := range documents {
+		identity, err := readIdentity(document)
+		if err != nil {
+			return "", err
+		}
+		target, configured := targetsByIdentity[identity.Kind+"/"+identity.Metadata.Name]
+		if !configured {
+			output = append(output, document...)
+			continue
+		}
+		stripped, err := stripTargetDispositions(document, target)
+		if err != nil {
+			return "", fmt.Errorf("%s/%s: %w", target.kind, target.name, err)
+		}
+		output = append(output, stripped...)
+	}
+
+	result := strings.Join(output, "\n")
+	if hasTrailingNewline {
+		result += "\n"
+	}
+	return result, nil
+}
+
+func stripTargetDispositions(lines []string, target targetSpec) ([]string, error) {
+	metadataIndex := -1
+	metadataEnd := len(lines)
+	for index, line := range lines {
+		if line == "metadata:" {
+			metadataIndex = index
+			continue
+		}
+		if metadataIndex != -1 && line != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "#") {
+			metadataEnd = index
+			break
+		}
+	}
+	if metadataIndex == -1 {
+		return nil, errors.New("top-level metadata mapping is missing")
+	}
+
+	annotationsIndex := -1
+	annotationsEnd := metadataEnd
+	for index := metadataIndex + 1; index < metadataEnd; index++ {
+		if lines[index] == "  annotations:" {
+			annotationsIndex = index
+			continue
+		}
+		if annotationsIndex != -1 && lines[index] != "" && !strings.HasPrefix(lines[index], "    ") && !strings.HasPrefix(strings.TrimSpace(lines[index]), "#") {
+			annotationsEnd = index
+			break
+		}
+	}
+	if annotationsIndex == -1 {
+		return nil, errors.New("metadata.annotations mapping is missing")
+	}
+
+	expectedLines := make(map[string]bool, len(target.checks))
+	for index, check := range target.checks {
+		line := fmt.Sprintf("    checkov.io/skip%d: %q", index+1, check+"="+target.reason)
+		expectedLines[line] = false
+	}
+	remainingAnnotations := false
+	for index := annotationsIndex + 1; index < annotationsEnd; index++ {
+		if _, expected := expectedLines[lines[index]]; expected {
+			expectedLines[lines[index]] = true
+			continue
+		}
+		if strings.TrimSpace(lines[index]) != "" {
+			remainingAnnotations = true
+		}
+	}
+	for line, found := range expectedLines {
+		if !found {
+			return nil, fmt.Errorf("configured disposition line %q is missing", line)
+		}
+	}
+
+	stripped := make([]string, 0, len(lines)-len(target.checks))
+	for index, line := range lines {
+		if index > annotationsIndex && index < annotationsEnd {
+			if _, expected := expectedLines[line]; expected {
+				continue
+			}
+		}
+		if index == annotationsIndex && !remainingAnnotations {
+			continue
+		}
+		stripped = append(stripped, line)
+	}
+	return stripped, nil
 }
 
 func rejectInlineCheckovSuppression(node *yaml.Node) error {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -46,6 +46,9 @@ type checkovReport struct {
 			Resource string `json:"resource"`
 		} `json:"failed_checks"`
 	} `json:"results"`
+	Summary struct {
+		ParsingErrors *int `json:"parsing_errors"`
+	} `json:"summary"`
 }
 
 var bundleTargets = map[string][]targetSpec{
@@ -78,6 +81,11 @@ func main() {
 		false,
 		"validate that every configured disposition still matches a Checkov JSON finding",
 	)
+	validateReport := flag.Bool(
+		"validate-report",
+		false,
+		"validate that a Checkov JSON report contains no parsing errors",
+	)
 	flag.Parse()
 	if flag.NArg() != 0 {
 		fail("unexpected positional arguments")
@@ -87,6 +95,9 @@ func main() {
 	if !ok {
 		fail("unsupported bundle %q", *bundle)
 	}
+	if *validateFindings && *validateReport {
+		fail("--validate-findings and --validate-report are mutually exclusive")
+	}
 
 	input, err := io.ReadAll(os.Stdin)
 	if err != nil {
@@ -95,6 +106,12 @@ func main() {
 	if *validateFindings {
 		if err := validateCheckovFindings(input, targets); err != nil {
 			fail("validate %s findings: %v", *bundle, err)
+		}
+		return
+	}
+	if *validateReport {
+		if _, err := decodeCheckovReports(input); err != nil {
+			fail("validate %s report: %v", *bundle, err)
 		}
 		return
 	}
@@ -108,22 +125,9 @@ func main() {
 }
 
 func validateCheckovFindings(input []byte, targets []targetSpec) error {
-	trimmed := strings.TrimSpace(string(input))
-	if trimmed == "" {
-		return errors.New("checkov report is empty")
-	}
-
-	var reports []checkovReport
-	if strings.HasPrefix(trimmed, "[") {
-		if err := json.Unmarshal(input, &reports); err != nil {
-			return fmt.Errorf("decode Checkov reports: %w", err)
-		}
-	} else {
-		var report checkovReport
-		if err := json.Unmarshal(input, &report); err != nil {
-			return fmt.Errorf("decode Checkov report: %w", err)
-		}
-		reports = []checkovReport{report}
+	reports, err := decodeCheckovReports(input)
+	if err != nil {
+		return err
 	}
 
 	found := make(map[string]int)
@@ -161,6 +165,42 @@ func validateCheckovFindings(input []byte, targets []targetSpec) error {
 		}
 	}
 	return nil
+}
+
+func decodeCheckovReports(input []byte) ([]checkovReport, error) {
+	trimmed := strings.TrimSpace(string(input))
+	if trimmed == "" {
+		return nil, errors.New("checkov report is empty")
+	}
+
+	var reports []checkovReport
+	if strings.HasPrefix(trimmed, "[") {
+		if err := json.Unmarshal(input, &reports); err != nil {
+			return nil, fmt.Errorf("decode Checkov reports: %w", err)
+		}
+	} else {
+		var report checkovReport
+		if err := json.Unmarshal(input, &report); err != nil {
+			return nil, fmt.Errorf("decode Checkov report: %w", err)
+		}
+		reports = []checkovReport{report}
+	}
+	if len(reports) == 0 {
+		return nil, errors.New("checkov report contains no framework results")
+	}
+	for _, report := range reports {
+		if report.Summary.ParsingErrors == nil {
+			return nil, fmt.Errorf("%s report omits summary.parsing_errors", report.CheckType)
+		}
+		if *report.Summary.ParsingErrors != 0 {
+			return nil, fmt.Errorf(
+				"%s report reported %d parsing error(s)",
+				report.CheckType,
+				*report.Summary.ParsingErrors,
+			)
+		}
+	}
+	return reports, nil
 }
 
 func fail(format string, args ...any) {
@@ -243,6 +283,10 @@ func readIdentity(lines []string) (manifestIdentity, error) {
 }
 
 func annotateDocument(lines []string, target targetSpec) ([]string, error) {
+	if err := validateAnnotationStyle(lines); err != nil {
+		return nil, err
+	}
+
 	metadataIndex := -1
 	metadataEnd := len(lines)
 	for index, line := range lines {
@@ -308,6 +352,37 @@ func annotateDocument(lines []string, target targetSpec) ([]string, error) {
 	}
 
 	return insertLines(lines, insertAt, additions), nil
+}
+
+func validateAnnotationStyle(lines []string) error {
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(strings.Join(lines, "\n")), &document); err != nil {
+		return fmt.Errorf("parse vendor document: %w", err)
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return errors.New("vendor document must contain a top-level mapping")
+	}
+	metadata := mappingValue(document.Content[0], "metadata")
+	if metadata == nil || metadata.Kind != yaml.MappingNode {
+		return errors.New("top-level metadata mapping is missing")
+	}
+	annotations := mappingValue(metadata, "annotations")
+	if annotations == nil {
+		return nil
+	}
+	if annotations.Kind != yaml.MappingNode || annotations.Style&yaml.FlowStyle != 0 {
+		return errors.New("metadata.annotations must use block mapping style")
+	}
+	return nil
+}
+
+func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value == key {
+			return mapping.Content[index+1]
+		}
+	}
+	return nil
 }
 
 func existingCheckovAnnotations(lines []string, start, end int) (map[string]string, int, error) {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -46,9 +46,12 @@ type checkovReport struct {
 			Resource string `json:"resource"`
 		} `json:"failed_checks"`
 	} `json:"results"`
-	Summary struct {
-		ParsingErrors *int `json:"parsing_errors"`
-	} `json:"summary"`
+	Summary checkovSummary `json:"summary"`
+}
+
+type checkovSummary struct {
+	Failed        *int `json:"failed"`
+	ParsingErrors *int `json:"parsing_errors"`
 }
 
 var bundleTargets = map[string][]targetSpec{
@@ -84,7 +87,17 @@ func main() {
 	validateReport := flag.Bool(
 		"validate-report",
 		false,
-		"validate that a Checkov JSON report contains no parsing errors",
+		"validate that a Checkov JSON report contains no parsing errors or failed checks",
+	)
+	validateSource := flag.Bool(
+		"validate-source",
+		false,
+		"validate that an upstream bundle contains no Checkov suppressions",
+	)
+	framework := flag.String(
+		"framework",
+		"",
+		"expected Checkov framework for --validate-report: kubernetes or secrets",
 	)
 	flag.Parse()
 	if flag.NArg() != 0 {
@@ -95,8 +108,17 @@ func main() {
 	if !ok {
 		fail("unsupported bundle %q", *bundle)
 	}
-	if *validateFindings && *validateReport {
-		fail("--validate-findings and --validate-report are mutually exclusive")
+	modeCount := 0
+	for _, enabled := range []bool{*validateFindings, *validateReport, *validateSource} {
+		if enabled {
+			modeCount++
+		}
+	}
+	if modeCount > 1 {
+		fail("validation modes are mutually exclusive")
+	}
+	if *validateReport && *framework != "kubernetes" && *framework != "secrets" {
+		fail("--validate-report requires --framework kubernetes or --framework secrets")
 	}
 
 	input, err := io.ReadAll(os.Stdin)
@@ -110,8 +132,14 @@ func main() {
 		return
 	}
 	if *validateReport {
-		if _, err := decodeCheckovReports(input); err != nil {
+		if _, err := decodeCheckovReports(input, *framework, true); err != nil {
 			fail("validate %s report: %v", *bundle, err)
+		}
+		return
+	}
+	if *validateSource {
+		if err := validateVendorSource(input); err != nil {
+			fail("validate %s source: %v", *bundle, err)
 		}
 		return
 	}
@@ -125,7 +153,7 @@ func main() {
 }
 
 func validateCheckovFindings(input []byte, targets []targetSpec) error {
-	reports, err := decodeCheckovReports(input)
+	reports, err := decodeCheckovReports(input, "kubernetes", false)
 	if err != nil {
 		return err
 	}
@@ -167,7 +195,7 @@ func validateCheckovFindings(input []byte, targets []targetSpec) error {
 	return nil
 }
 
-func decodeCheckovReports(input []byte) ([]checkovReport, error) {
+func decodeCheckovReports(input []byte, expectedFramework string, rejectFindings bool) ([]checkovReport, error) {
 	trimmed := strings.TrimSpace(string(input))
 	if trimmed == "" {
 		return nil, errors.New("checkov report is empty")
@@ -183,14 +211,36 @@ func decodeCheckovReports(input []byte) ([]checkovReport, error) {
 		if err := json.Unmarshal(input, &report); err != nil {
 			return nil, fmt.Errorf("decode Checkov report: %w", err)
 		}
+		if report.CheckType == "" && report.Summary.ParsingErrors == nil {
+			var summary checkovSummary
+			if err := json.Unmarshal(input, &summary); err != nil {
+				return nil, fmt.Errorf("decode Checkov summary: %w", err)
+			}
+			report.CheckType = expectedFramework
+			report.Summary = summary
+		}
 		reports = []checkovReport{report}
 	}
-	if len(reports) == 0 {
-		return nil, errors.New("checkov report contains no framework results")
+	matching := 0
+	for _, report := range reports {
+		if report.CheckType == expectedFramework {
+			matching++
+		}
+	}
+	if len(reports) != 1 || matching != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly one %s report, found %d among %d framework result(s)",
+			expectedFramework,
+			matching,
+			len(reports),
+		)
 	}
 	for _, report := range reports {
 		if report.Summary.ParsingErrors == nil {
 			return nil, fmt.Errorf("%s report omits summary.parsing_errors", report.CheckType)
+		}
+		if report.Summary.Failed == nil {
+			return nil, fmt.Errorf("%s report omits summary.failed", report.CheckType)
 		}
 		if *report.Summary.ParsingErrors != 0 {
 			return nil, fmt.Errorf(
@@ -199,8 +249,55 @@ func decodeCheckovReports(input []byte) ([]checkovReport, error) {
 				*report.Summary.ParsingErrors,
 			)
 		}
+		failedCount := *report.Summary.Failed
+		if len(report.Results.FailedChecks) > failedCount {
+			failedCount = len(report.Results.FailedChecks)
+		}
+		if rejectFindings && failedCount != 0 {
+			return nil, fmt.Errorf("%s report reported %d failed check(s)", report.CheckType, failedCount)
+		}
 	}
 	return reports, nil
+}
+
+func validateVendorSource(input []byte) error {
+	decoder := yaml.NewDecoder(strings.NewReader(string(input)))
+	for documentIndex := 1; ; documentIndex++ {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("parse vendor document %d: %w", documentIndex, err)
+		}
+		if len(document.Content) == 0 || document.Content[0].Kind == 0 {
+			continue
+		}
+		root := document.Content[0]
+		if root.Kind != yaml.MappingNode {
+			return fmt.Errorf("vendor document %d must contain a top-level mapping", documentIndex)
+		}
+		metadata := mappingValue(root, "metadata")
+		if metadata == nil {
+			continue
+		}
+		if metadata.Kind != yaml.MappingNode {
+			return fmt.Errorf("vendor document %d metadata must be a mapping", documentIndex)
+		}
+		annotations := mappingValue(metadata, "annotations")
+		if annotations == nil {
+			continue
+		}
+		if annotations.Kind != yaml.MappingNode {
+			return fmt.Errorf("vendor document %d metadata.annotations must be a mapping", documentIndex)
+		}
+		for index := 0; index+1 < len(annotations.Content); index += 2 {
+			key := annotations.Content[index].Value
+			if strings.HasPrefix(key, "checkov.io/skip") {
+				return fmt.Errorf("vendor document %d contains upstream Checkov suppression %s", documentIndex, key)
+			}
+		}
+	}
 }
 
 func fail(format string, args ...any) {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -37,6 +38,16 @@ type manifestIdentity struct {
 	} `yaml:"metadata"`
 }
 
+type checkovReport struct {
+	CheckType string `json:"check_type"`
+	Results   struct {
+		FailedChecks []struct {
+			CheckID  string `json:"check_id"`
+			Resource string `json:"resource"`
+		} `json:"failed_checks"`
+	} `json:"results"`
+}
+
 var bundleTargets = map[string][]targetSpec{
 	"cdi": {
 		{kind: "ClusterRole", name: "cdi-operator-cluster", checks: []string{"CKV_K8S_155"}, reason: clusterRoleReason},
@@ -62,6 +73,11 @@ func deploymentChecks() []string {
 
 func main() {
 	bundle := flag.String("bundle", "", "bundle to annotate: cdi or kubevirt")
+	validateFindings := flag.Bool(
+		"validate-findings",
+		false,
+		"validate that every configured disposition still matches a Checkov JSON finding",
+	)
 	flag.Parse()
 	if flag.NArg() != 0 {
 		fail("unexpected positional arguments")
@@ -76,6 +92,12 @@ func main() {
 	if err != nil {
 		fail("read bundle: %v", err)
 	}
+	if *validateFindings {
+		if err := validateCheckovFindings(input, targets); err != nil {
+			fail("validate %s findings: %v", *bundle, err)
+		}
+		return
+	}
 	output, err := annotateBundle(string(input), targets)
 	if err != nil {
 		fail("annotate %s bundle: %v", *bundle, err)
@@ -83,6 +105,62 @@ func main() {
 	if _, err := io.WriteString(os.Stdout, output); err != nil {
 		fail("write bundle: %v", err)
 	}
+}
+
+func validateCheckovFindings(input []byte, targets []targetSpec) error {
+	trimmed := strings.TrimSpace(string(input))
+	if trimmed == "" {
+		return errors.New("checkov report is empty")
+	}
+
+	var reports []checkovReport
+	if strings.HasPrefix(trimmed, "[") {
+		if err := json.Unmarshal(input, &reports); err != nil {
+			return fmt.Errorf("decode Checkov reports: %w", err)
+		}
+	} else {
+		var report checkovReport
+		if err := json.Unmarshal(input, &report); err != nil {
+			return fmt.Errorf("decode Checkov report: %w", err)
+		}
+		reports = []checkovReport{report}
+	}
+
+	found := make(map[string]int)
+	for _, report := range reports {
+		if report.CheckType != "kubernetes" {
+			continue
+		}
+		for _, failed := range report.Results.FailedChecks {
+			for _, target := range targets {
+				if !strings.HasPrefix(failed.Resource, target.kind+".") ||
+					!strings.HasSuffix(failed.Resource, "."+target.name) {
+					continue
+				}
+				for _, check := range target.checks {
+					if failed.CheckID == check {
+						found[target.kind+"/"+target.name+"/"+check]++
+					}
+				}
+			}
+		}
+	}
+
+	for _, target := range targets {
+		for _, check := range target.checks {
+			key := target.kind + "/" + target.name + "/" + check
+			if found[key] != 1 {
+				return fmt.Errorf(
+					"configured disposition %s for %s/%s no longer matches exactly one current finding (found %d)",
+					check,
+					target.kind,
+					target.name,
+					found[key],
+				)
+			}
+		}
+	}
+	return nil
 }
 
 func fail(format string, args ...any) {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -255,7 +255,7 @@ func validateCheckovFindings(input []byte, targets []targetSpec) error {
 
 func codeBlockFingerprint(codeBlock [][]any) (string, error) {
 	if len(codeBlock) == 0 {
-		return "", errors.New("Checkov finding omits code_block")
+		return "", errors.New("checkov finding omits code_block")
 	}
 	hash := sha256.New()
 	for index, line := range codeBlock {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -79,6 +79,17 @@ var bundleTargets = map[string][]targetSpec{
 
 var inlineCheckovSkip = regexp.MustCompile(`(?i)checkov\s*:\s*skip\s*=`)
 
+var workloadKinds = map[string]struct{}{
+	"CronJob":               {},
+	"DaemonSet":             {},
+	"Deployment":            {},
+	"Job":                   {},
+	"Pod":                   {},
+	"ReplicaSet":            {},
+	"ReplicationController": {},
+	"StatefulSet":           {},
+}
+
 func deploymentChecks() []string {
 	return []string{
 		"CKV_K8S_11",
@@ -179,7 +190,7 @@ func main() {
 		return
 	}
 	if *validateSource {
-		if err := validateVendorSource(input); err != nil {
+		if err := validateVendorSource(input, *bundle); err != nil {
 			fail("validate %s source: %v", *bundle, err)
 		}
 		return
@@ -355,7 +366,14 @@ func decodeCheckovReports(input []byte, expectedFramework string, rejectFindings
 	return reports, nil
 }
 
-func validateVendorSource(input []byte) error {
+func validateVendorSource(input []byte, bundle string) error {
+	if inlineCheckovSkip.Match(input) {
+		return errors.New("source contains inline Checkov suppression")
+	}
+	protectedNamespace := map[string]string{
+		"cdi":      "cdi",
+		"kubevirt": "kubevirt",
+	}[bundle]
 	decoder := yaml.NewDecoder(strings.NewReader(string(input)))
 	for documentIndex := 1; ; documentIndex++ {
 		var document yaml.Node
@@ -382,6 +400,20 @@ func validateVendorSource(input []byte) error {
 		if metadata.Kind != yaml.MappingNode {
 			return fmt.Errorf("vendor document %d metadata must be a mapping", documentIndex)
 		}
+		kind := mappingScalar(root, "kind")
+		if _, workload := workloadKinds[kind]; workload {
+			name := mappingScalar(metadata, "name")
+			namespace := mappingScalar(metadata, "namespace")
+			if namespace != protectedNamespace {
+				return fmt.Errorf(
+					"%s/%s uses namespace %s, want %s before CKV2_K8S_6 can be excluded",
+					kind,
+					name,
+					namespace,
+					protectedNamespace,
+				)
+			}
+		}
 		annotations := mappingValue(metadata, "annotations")
 		if annotations == nil {
 			continue
@@ -399,6 +431,9 @@ func validateVendorSource(input []byte) error {
 }
 
 func validateAnnotatedBundle(input []byte, targets []targetSpec) error {
+	if inlineCheckovSkip.Match(input) {
+		return errors.New("committed bundle contains inline Checkov suppression")
+	}
 	targetsByIdentity := make(map[string]targetSpec, len(targets))
 	expectedByIdentity := make(map[string]map[string]string, len(targets))
 	for _, target := range targets {

--- a/scripts/annotate-vendored-checkov/main.go
+++ b/scripts/annotate-vendored-checkov/main.go
@@ -458,6 +458,9 @@ func validateVendorSource(input []byte, bundle string) error {
 		if err := rejectYAMLMergeKey(&document); err != nil {
 			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
 		}
+		if err := rejectDuplicateYAMLMappingKeys(&document); err != nil {
+			return fmt.Errorf("vendor document %d contains %w", documentIndex, err)
+		}
 		root := document.Content[0]
 		if root.Kind != yaml.MappingNode {
 			return fmt.Errorf("vendor document %d must contain a top-level mapping", documentIndex)
@@ -900,6 +903,28 @@ func rejectYAMLMergeKey(node *yaml.Node) error {
 	}
 	for _, child := range node.Content {
 		if err := rejectYAMLMergeKey(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectDuplicateYAMLMappingKeys(node *yaml.Node) error {
+	if node.Kind == yaml.MappingNode {
+		seen := make(map[string]struct{}, len(node.Content)/2)
+		for index := 0; index+1 < len(node.Content); index += 2 {
+			key := node.Content[index]
+			if key.Kind != yaml.ScalarNode {
+				return errors.New("non-scalar YAML mapping key")
+			}
+			if _, duplicate := seen[key.Value]; duplicate {
+				return fmt.Errorf("duplicate YAML mapping key %q", key.Value)
+			}
+			seen[key.Value] = struct{}{}
+		}
+	}
+	for _, child := range node.Content {
+		if err := rejectDuplicateYAMLMappingKeys(child); err != nil {
 			return err
 		}
 	}

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -177,6 +177,20 @@ spec: {}
 `
 }
 
+func cdiOperatorBundleFixture() string {
+	return strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"spec: {}",
+		`spec:
+  template:
+    spec:
+      containers:
+      - name: cdi-operator
+        image: quay.io/kubevirt/cdi-operator:v1.65.0`,
+		1,
+	)
+}
+
 func TestAnnotatorAddsOnlyResourceScopedSuppressions(t *testing.T) {
 	t.Parallel()
 
@@ -667,7 +681,7 @@ items:
 func TestAnnotatedValidationAcceptsOnlyConfiguredDispositions(t *testing.T) {
 	t.Parallel()
 
-	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	input := cdiOperatorBundleFixture()
 	annotated, err := annotateBundle(input, bundleTargets["cdi"])
 	if err != nil {
 		t.Fatalf("annotate fixture: %v", err)
@@ -680,28 +694,79 @@ func TestAnnotatedValidationAcceptsOnlyConfiguredDispositions(t *testing.T) {
 func TestPinnedSourceValidationAcceptsAnnotatedExactSource(t *testing.T) {
 	t.Parallel()
 
-	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	input := cdiOperatorBundleFixture()
 	annotated, err := annotateBundle(input, bundleTargets["cdi"])
 	if err != nil {
 		t.Fatalf("annotate fixture: %v", err)
 	}
 	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
-	if err := validatePinnedSource([]byte(annotated), bundleTargets["cdi"], expectedSHA256); err != nil {
+	if err := validatePinnedSource(
+		[]byte(annotated),
+		bundleTargets["cdi"],
+		expectedSHA256,
+		"v1.65.0",
+	); err != nil {
 		t.Fatalf("exact pinned source was rejected: %v", err)
+	}
+}
+
+func TestPinnedSourceStrippingPreservesMetadataComment(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"kind: ClusterRole\nmetadata:\n  name:",
+		"kind: ClusterRole\nmetadata:\n  # upstream metadata comment\n  name:",
+		1,
+	)
+	annotated, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate fixture: %v", err)
+	}
+	stripped, err := stripConfiguredDispositions(annotated, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("strip configured dispositions: %v", err)
+	}
+	if stripped != input {
+		t.Fatalf("stripped source did not preserve the exact commented metadata:\n%s", stripped)
+	}
+}
+
+func TestPinnedSourceValidationBindsOperatorImageVersion(t *testing.T) {
+	t.Parallel()
+
+	input := cdiOperatorBundleFixture()
+	if err := validateOperatorImageVersion([]byte(input), bundleTargets["cdi"], "v1.65.0"); err != nil {
+		t.Fatalf("matching release version was rejected: %v", err)
+	}
+	if err := validateOperatorImageVersion([]byte(input), bundleTargets["cdi"], "v1.66.0"); err == nil {
+		t.Fatal("operator-image validator accepted a mismatched release version")
+	} else if !strings.Contains(err.Error(), "operator image") {
+		t.Fatalf("error did not name the mismatched operator image: %v", err)
 	}
 }
 
 func TestPinnedSourceValidationRejectsNonAnnotationChange(t *testing.T) {
 	t.Parallel()
 
-	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	input := cdiOperatorBundleFixture()
 	annotated, err := annotateBundle(input, bundleTargets["cdi"])
 	if err != nil {
 		t.Fatalf("annotate fixture: %v", err)
 	}
 	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
-	annotated = strings.Replace(annotated, "spec: {}", "spec:\n  replicas: 9", 1)
-	if err := validatePinnedSource([]byte(annotated), bundleTargets["cdi"], expectedSHA256); err == nil {
+	annotated = strings.Replace(
+		annotated,
+		"quay.io/kubevirt/cdi-operator:v1.65.0",
+		"quay.io/kubevirt/cdi-operator:v9.99.0",
+		1,
+	)
+	if err := validatePinnedSource(
+		[]byte(annotated),
+		bundleTargets["cdi"],
+		expectedSHA256,
+		"v1.65.0",
+	); err == nil {
 		t.Fatal("pinned-source validator accepted a non-annotation bundle change")
 	} else if !strings.Contains(err.Error(), "source SHA-256") {
 		t.Fatalf("error did not name the pinned source digest: %v", err)

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -832,6 +832,44 @@ func TestPinnedSourceValidationBindsOperatorImageVersion(t *testing.T) {
 	}
 }
 
+func TestPinnedSourceValidationSupportsTargetsNestedInList(t *testing.T) {
+	t.Parallel()
+
+	input := `apiVersion: v1
+kind: List
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: cdi-operator-cluster
+  rules: []
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: cdi-operator
+    namespace: cdi
+  spec:
+    template:
+      spec:
+        containers:
+        - name: cdi-operator
+          image: quay.io/kubevirt/cdi-operator:v1.65.0
+`
+	annotated, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate List fixture: %v", err)
+	}
+	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
+	if err := validatePinnedSource(
+		[]byte(annotated),
+		bundleTargets["cdi"],
+		expectedSHA256,
+		"v1.65.0",
+	); err != nil {
+		t.Fatalf("nested List targets did not validate as pinned source: %v", err)
+	}
+}
+
 func TestPinnedSourceValidationRejectsNonAnnotationChange(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -924,6 +924,48 @@ items:
 	}
 }
 
+func TestAnnotatorInsertsAfterNestedListBlockScalarAnnotations(t *testing.T) {
+	t.Parallel()
+
+	input := `apiVersion: v1
+kind: List
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: cdi-operator-cluster
+    annotations:
+      release-note: |
+        first line
+        second line
+  rules: []
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: cdi-operator
+    namespace: cdi
+  spec:
+    template:
+      spec:
+        containers:
+        - name: cdi-operator
+          image: quay.io/kubevirt/cdi-operator:v1.65.0
+`
+	output, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate List block-scalar fixture: %v", err)
+	}
+	if !strings.Contains(
+		output,
+		"      release-note: |\n        first line\n        second line\n      checkov.io/skip1:",
+	) {
+		t.Fatalf("disposition was not inserted after the complete block scalar:\n%s", output)
+	}
+	if err := validateAnnotatedBundle([]byte(output), bundleTargets["cdi"]); err != nil {
+		t.Fatalf("annotated List block-scalar fixture is invalid: %v", err)
+	}
+}
+
 func TestPinnedSourceValidationRejectsNonAnnotationChange(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -80,6 +80,9 @@ func checkovFindingsFixture(t *testing.T, bundle, omittedCheck string) string {
 		"results": map[string]any{
 			"failed_checks": failedChecks,
 		},
+		"summary": map[string]any{
+			"parsing_errors": 0,
+		},
 	}
 	encoded, err := json.Marshal(report)
 	if err != nil {
@@ -236,6 +239,24 @@ func TestAnnotatorFailsClosedOnConflictingDisposition(t *testing.T) {
 	}
 }
 
+func TestAnnotatorFailsClosedOnInlineAnnotations(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"  annotations:\n    owner: upstream",
+		"  annotations: {owner: upstream}",
+		1,
+	)
+	_, stderr, err := runAnnotator(t, "cdi", input)
+	if err == nil {
+		t.Fatal("annotator accepted inline metadata.annotations that its line-preserving editor cannot merge")
+	}
+	if !strings.Contains(stderr, "metadata.annotations must use block mapping style") {
+		t.Fatalf("stderr did not explain the unsupported annotation style: %q", stderr)
+	}
+}
+
 func TestFindingsValidationAcceptsEveryCurrentDisposition(t *testing.T) {
 	t.Parallel()
 
@@ -269,6 +290,32 @@ func TestFindingsValidationRejectsObsoleteDisposition(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "CKV_K8S_43") || !strings.Contains(stderr, "no longer matches") {
 		t.Fatalf("stderr did not name the obsolete disposition: %q", stderr)
+	}
+}
+
+func TestCheckovReportValidationRejectsParsingErrors(t *testing.T) {
+	t.Parallel()
+
+	report := map[string]any{
+		"check_type": "kubernetes",
+		"results": map[string]any{
+			"failed_checks": []any{},
+		},
+		"summary": map[string]any{
+			"parsing_errors": 1,
+		},
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("encode Checkov fixture: %v", err)
+	}
+
+	_, stderr, err := runAnnotator(t, "cdi", string(encoded), "--validate-report")
+	if err == nil {
+		t.Fatal("validator accepted a Checkov report with parsing errors")
+	}
+	if !strings.Contains(stderr, "reported 1 parsing error") {
+		t.Fatalf("stderr did not name the parsing error count: %q", stderr)
 	}
 }
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -379,6 +379,26 @@ func TestCheckovReportValidationAcceptsEmptySecretsSummary(t *testing.T) {
 	}
 }
 
+func TestCheckovReportValidationRejectsFrameworklessKubernetesSummary(t *testing.T) {
+	t.Parallel()
+
+	report := `{"passed":0,"failed":0,"skipped":0,"parsing_errors":0,"resource_count":0,"checkov_version":"3.3.2"}`
+	_, stderr, err := runAnnotator(
+		t,
+		"cdi",
+		report,
+		"--validate-report",
+		"--framework",
+		"kubernetes",
+	)
+	if err == nil {
+		t.Fatal("validator treated a framework-less summary as proof of a Kubernetes scan")
+	}
+	if !strings.Contains(stderr, "expected exactly one kubernetes report") {
+		t.Fatalf("stderr did not require explicit Kubernetes report identity: %q", stderr)
+	}
+}
+
 func TestCheckovReportValidationRejectsSoftFailedFindings(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -688,6 +688,41 @@ metadata:
 	}
 }
 
+func TestSourceValidationRejectsDuplicateYAMLMappingKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"kind": `apiVersion: v1
+kind: ConfigMap
+kind: Deployment
+metadata:
+  name: ambiguous-kind
+  namespace: other
+`,
+		"metadata": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: first
+metadata:
+  name: second
+  annotations:
+    checkov.io/skip1: CKV_K8S_99=upstream suppression
+`,
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+			if err == nil {
+				t.Fatal("source validator accepted duplicate YAML mapping keys")
+			}
+			if !strings.Contains(stderr, "duplicate YAML mapping key") {
+				t.Fatalf("stderr did not name the duplicate YAML mapping key: %q", stderr)
+			}
+		})
+	}
+}
+
 func TestSourceValidationRejectsNestedListWorkloadOutsideProtectedNamespace(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -652,6 +652,42 @@ func TestSourceValidationRejectsWorkloadOutsideProtectedNamespace(t *testing.T) 
 	}
 }
 
+func TestSourceValidationRejectsWorkloadWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := `apiVersion: apps/v1
+kind: Deployment
+spec: {}
+`
+	_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+	if err == nil {
+		t.Fatal("source validator accepted a workload without metadata")
+	}
+	if !strings.Contains(stderr, "Deployment metadata is missing") {
+		t.Fatalf("stderr did not name the missing workload metadata: %q", stderr)
+	}
+}
+
+func TestSourceValidationRejectsYAMLMergeSuppression(t *testing.T) {
+	t.Parallel()
+
+	input := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: merged-suppression
+  annotations:
+    <<: &suppression
+      checkov.io/skip1: CKV_K8S_99=upstream suppression
+`
+	_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+	if err == nil {
+		t.Fatal("source validator accepted a Checkov suppression inherited through a YAML merge")
+	}
+	if !strings.Contains(stderr, "YAML merge key") {
+		t.Fatalf("stderr did not name the YAML merge key: %q", stderr)
+	}
+}
+
 func TestSourceValidationRejectsNestedListWorkloadOutsideProtectedNamespace(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type manifestMetadata struct {
+	Name        string            `yaml:"name"`
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+type manifestDocument struct {
+	Kind     string           `yaml:"kind"`
+	Metadata manifestMetadata `yaml:"metadata"`
+}
+
+func runAnnotator(t *testing.T, bundle, input string) (string, string, error) {
+	t.Helper()
+
+	command := exec.Command("go", "run", ".", "--bundle", bundle)
+	command.Stdin = strings.NewReader(input)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+
+	return stdout.String(), stderr.String(), err
+}
+
+func decodeDocuments(t *testing.T, input string) map[string]manifestDocument {
+	t.Helper()
+
+	decoder := yaml.NewDecoder(strings.NewReader(input))
+	documents := make(map[string]manifestDocument)
+	for {
+		var document manifestDocument
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("decode annotated output: %v", err)
+		}
+		if document.Kind == "" {
+			continue
+		}
+		documents[document.Kind+"/"+document.Metadata.Name] = document
+	}
+
+	return documents
+}
+
+func bundleFixture(clusterRoleName, deploymentName string) string {
+	return `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: untouched
+  annotations:
+    owner: platform
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ` + clusterRoleName + `
+rules: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ` + deploymentName + `
+  annotations:
+    owner: upstream
+spec: {}
+`
+}
+
+func TestAnnotatorAddsOnlyResourceScopedSuppressions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		bundle          string
+		clusterRoleName string
+		deploymentName  string
+	}{
+		{name: "CDI", bundle: "cdi", clusterRoleName: "cdi-operator-cluster", deploymentName: "cdi-operator"},
+		{name: "KubeVirt", bundle: "kubevirt", clusterRoleName: "kubevirt-operator", deploymentName: "virt-operator"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			input := bundleFixture(test.clusterRoleName, test.deploymentName)
+			output, stderr, err := runAnnotator(t, test.bundle, input)
+			if err != nil {
+				t.Fatalf("annotator failed: %v\nstderr: %s", err, stderr)
+			}
+
+			documents := decodeDocuments(t, output)
+			untouched := documents["ConfigMap/untouched"]
+			if len(untouched.Metadata.Annotations) != 1 || untouched.Metadata.Annotations["owner"] != "platform" {
+				t.Fatalf("unrelated manifest changed: %#v", untouched.Metadata.Annotations)
+			}
+
+			clusterRole := documents["ClusterRole/"+test.clusterRoleName]
+			if got := clusterRole.Metadata.Annotations["checkov.io/skip1"]; got != "CKV_K8S_155=Vendored upstream operator RBAC; changes must go through the pinned vendor update path tracked by platform issue 2899." {
+				t.Fatalf("ClusterRole suppression = %q", got)
+			}
+			if len(clusterRole.Metadata.Annotations) != 1 {
+				t.Fatalf("ClusterRole received unexpected annotations: %#v", clusterRole.Metadata.Annotations)
+			}
+
+			deployment := documents["Deployment/"+test.deploymentName]
+			wantChecks := []string{
+				"CKV_K8S_11",
+				"CKV_K8S_13",
+				"CKV_K8S_15",
+				"CKV_K8S_22",
+				"CKV_K8S_38",
+				"CKV_K8S_40",
+				"CKV_K8S_43",
+			}
+			if deployment.Metadata.Annotations["owner"] != "upstream" {
+				t.Fatalf("existing annotation was lost: %#v", deployment.Metadata.Annotations)
+			}
+			for index, check := range wantChecks {
+				key := "checkov.io/skip" + strconv.Itoa(index+1)
+				want := check + "=Pinned upstream operator deployment; changes must go through the vendor update path tracked by platform issue 2899."
+				if got := deployment.Metadata.Annotations[key]; got != want {
+					t.Fatalf("%s = %q, want %q", key, got, want)
+				}
+			}
+			if len(deployment.Metadata.Annotations) != 8 {
+				t.Fatalf("Deployment annotations = %#v", deployment.Metadata.Annotations)
+			}
+
+			secondOutput, secondStderr, err := runAnnotator(t, test.bundle, output)
+			if err != nil {
+				t.Fatalf("second annotator run failed: %v\nstderr: %s", err, secondStderr)
+			}
+			if secondOutput != output {
+				t.Fatal("annotator is not idempotent")
+			}
+		})
+	}
+}
+
+func TestAnnotatorFailsClosedWhenVendorTargetsDrift(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "renamed-cdi-operator")
+	_, stderr, err := runAnnotator(t, "cdi", input)
+	if err == nil {
+		t.Fatal("annotator accepted a bundle whose Deployment target drifted")
+	}
+	if !strings.Contains(stderr, "expected exactly one Deployment/cdi-operator") {
+		t.Fatalf("stderr did not name the missing target: %q", stderr)
+	}
+}
+
+func TestAnnotatorRejectsUnknownBundle(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, err := runAnnotator(t, "other", bundleFixture("role", "deployment"))
+	if err == nil {
+		t.Fatal("annotator accepted an unknown bundle")
+	}
+	if !strings.Contains(stderr, "unsupported bundle") {
+		t.Fatalf("stderr did not explain the rejected bundle: %q", stderr)
+	}
+}

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -262,6 +262,21 @@ func TestAnnotatorAddsOnlyResourceScopedSuppressions(t *testing.T) {
 	}
 }
 
+func TestAnnotatorAcceptsDecoratedDocumentMarkers(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	input = strings.Replace(input, "---\n", "--- # generated\n", 1)
+	input = strings.Replace(input, "---\n", "--- \t\n", 1)
+	output, stderr, err := runAnnotator(t, "cdi", input)
+	if err != nil {
+		t.Fatalf("annotator rejected decorated document markers: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(output, "--- # generated\n") || !strings.Contains(output, "--- \t\n") {
+		t.Fatalf("annotator did not preserve decorated document markers:\n%s", output)
+	}
+}
+
 func TestAnnotatorFailsClosedWhenVendorTargetsDrift(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -51,7 +51,6 @@ func checkovFindingsFixture(t *testing.T, bundle, omittedCheck string) string {
 		deploymentNamespace = "kubevirt"
 	}
 
-	failedChecks := make([]map[string]string, 0, 8)
 	checks := []struct {
 		id       string
 		resource string
@@ -65,13 +64,24 @@ func checkovFindingsFixture(t *testing.T, bundle, omittedCheck string) string {
 		{id: "CKV_K8S_40", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
 		{id: "CKV_K8S_43", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
 	}
+	failedChecks := make([]map[string]any, 0, len(checks))
 	for _, check := range checks {
 		if check.id == omittedCheck {
 			continue
 		}
-		failedChecks = append(failedChecks, map[string]string{
-			"check_id": check.id,
-			"resource": check.resource,
+		kind := "Deployment"
+		name := deploymentName
+		if check.id == "CKV_K8S_155" {
+			kind = "ClusterRole"
+			name = clusterRoleName
+		}
+		failedChecks = append(failedChecks, map[string]any{
+			"check_id":   check.id,
+			"resource":   check.resource,
+			"code_block": fixtureCodeBlock(kind, name),
+			"check_result": map[string]any{
+				"evaluated_keys": expectedEvaluatedKeys(check.id),
+			},
 		})
 	}
 
@@ -90,6 +100,29 @@ func checkovFindingsFixture(t *testing.T, bundle, omittedCheck string) string {
 		t.Fatalf("encode Checkov fixture: %v", err)
 	}
 	return string(encoded)
+}
+
+func fixtureCodeBlock(kind, name string) [][]any {
+	return [][]any{
+		{1, "kind: " + kind},
+		{2, "metadata:"},
+		{3, "  name: " + name},
+		{4, "container: operator"},
+	}
+}
+
+func fixtureTargets(t *testing.T, bundle string) []targetSpec {
+	t.Helper()
+
+	targets := append([]targetSpec(nil), bundleTargets[bundle]...)
+	for index := range targets {
+		fingerprint, err := codeBlockFingerprint(fixtureCodeBlock(targets[index].kind, targets[index].name))
+		if err != nil {
+			t.Fatalf("fingerprint fixture target: %v", err)
+		}
+		targets[index].resourceFingerprint = fingerprint
+	}
+	return targets
 }
 
 func decodeDocuments(t *testing.T, input string) map[string]manifestDocument {
@@ -264,14 +297,12 @@ func TestFindingsValidationAcceptsEveryCurrentDisposition(t *testing.T) {
 	for _, bundle := range []string{"cdi", "kubevirt"} {
 		t.Run(bundle, func(t *testing.T) {
 			t.Parallel()
-			_, stderr, err := runAnnotator(
-				t,
-				bundle,
-				checkovFindingsFixture(t, bundle, ""),
-				"--validate-findings",
+			err := validateCheckovFindings(
+				[]byte(checkovFindingsFixture(t, bundle, "")),
+				fixtureTargets(t, bundle),
 			)
 			if err != nil {
-				t.Fatalf("current dispositions were rejected: %v\nstderr: %s", err, stderr)
+				t.Fatalf("current dispositions were rejected: %v", err)
 			}
 		})
 	}
@@ -280,17 +311,51 @@ func TestFindingsValidationAcceptsEveryCurrentDisposition(t *testing.T) {
 func TestFindingsValidationRejectsObsoleteDisposition(t *testing.T) {
 	t.Parallel()
 
-	_, stderr, err := runAnnotator(
-		t,
-		"cdi",
-		checkovFindingsFixture(t, "cdi", "CKV_K8S_43"),
-		"--validate-findings",
+	err := validateCheckovFindings(
+		[]byte(checkovFindingsFixture(t, "cdi", "CKV_K8S_43")),
+		fixtureTargets(t, "cdi"),
 	)
 	if err == nil {
 		t.Fatal("validator accepted a disposition whose finding disappeared upstream")
 	}
-	if !strings.Contains(stderr, "CKV_K8S_43") || !strings.Contains(stderr, "no longer matches") {
-		t.Fatalf("stderr did not name the obsolete disposition: %q", stderr)
+	if !strings.Contains(err.Error(), "CKV_K8S_43") || !strings.Contains(err.Error(), "no longer matches") {
+		t.Fatalf("error did not name the obsolete disposition: %v", err)
+	}
+}
+
+func TestFindingsValidationRejectsMovedViolation(t *testing.T) {
+	t.Parallel()
+
+	report := strings.Replace(
+		checkovFindingsFixture(t, "cdi", ""),
+		"spec/template/spec/containers/[0]/image",
+		"spec/template/spec/containers/[1]/image",
+		1,
+	)
+	err := validateCheckovFindings([]byte(report), fixtureTargets(t, "cdi"))
+	if err == nil {
+		t.Fatal("validator accepted a reviewed check after its violation moved to another container")
+	}
+	if !strings.Contains(err.Error(), "evaluated keys changed") {
+		t.Fatalf("error did not explain the changed finding evidence: %v", err)
+	}
+}
+
+func TestFindingsValidationRejectsChangedResourceFingerprint(t *testing.T) {
+	t.Parallel()
+
+	report := strings.Replace(
+		checkovFindingsFixture(t, "cdi", ""),
+		"container: operator",
+		"container: sidecar",
+		1,
+	)
+	err := validateCheckovFindings([]byte(report), fixtureTargets(t, "cdi"))
+	if err == nil {
+		t.Fatal("validator accepted changed resource evidence for an empty-key disposition")
+	}
+	if !strings.Contains(err.Error(), "resource fingerprint changed") {
+		t.Fatalf("error did not explain the changed resource evidence: %v", err)
 	}
 }
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -82,6 +82,7 @@ func checkovFindingsFixture(t *testing.T, bundle, omittedCheck string) string {
 		},
 		"summary": map[string]any{
 			"parsing_errors": 0,
+			"failed":         len(failedChecks),
 		},
 	}
 	encoded, err := json.Marshal(report)
@@ -303,6 +304,7 @@ func TestCheckovReportValidationRejectsParsingErrors(t *testing.T) {
 		},
 		"summary": map[string]any{
 			"parsing_errors": 1,
+			"failed":         0,
 		},
 	}
 	encoded, err := json.Marshal(report)
@@ -310,12 +312,125 @@ func TestCheckovReportValidationRejectsParsingErrors(t *testing.T) {
 		t.Fatalf("encode Checkov fixture: %v", err)
 	}
 
-	_, stderr, err := runAnnotator(t, "cdi", string(encoded), "--validate-report")
+	_, stderr, err := runAnnotator(
+		t,
+		"cdi",
+		string(encoded),
+		"--validate-report",
+		"--framework",
+		"kubernetes",
+	)
 	if err == nil {
 		t.Fatal("validator accepted a Checkov report with parsing errors")
 	}
 	if !strings.Contains(stderr, "reported 1 parsing error") {
 		t.Fatalf("stderr did not name the parsing error count: %q", stderr)
+	}
+}
+
+func TestCheckovReportValidationRequiresExpectedFramework(t *testing.T) {
+	t.Parallel()
+
+	report := map[string]any{
+		"check_type": "kubernetes",
+		"results": map[string]any{
+			"failed_checks": []any{},
+		},
+		"summary": map[string]any{
+			"parsing_errors": 0,
+			"failed":         0,
+		},
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("encode Checkov fixture: %v", err)
+	}
+
+	_, stderr, err := runAnnotator(
+		t,
+		"cdi",
+		string(encoded),
+		"--validate-report",
+		"--framework",
+		"secrets",
+	)
+	if err == nil {
+		t.Fatal("validator accepted a report from the wrong Checkov framework")
+	}
+	if !strings.Contains(stderr, "expected exactly one secrets report") {
+		t.Fatalf("stderr did not name the missing framework: %q", stderr)
+	}
+}
+
+func TestCheckovReportValidationAcceptsEmptySecretsSummary(t *testing.T) {
+	t.Parallel()
+
+	report := `{"passed":0,"failed":0,"skipped":0,"parsing_errors":0,"resource_count":0,"checkov_version":"3.3.2"}`
+	_, stderr, err := runAnnotator(
+		t,
+		"cdi",
+		report,
+		"--validate-report",
+		"--framework",
+		"secrets",
+	)
+	if err != nil {
+		t.Fatalf("validator rejected Checkov's empty secrets summary: %v\nstderr: %s", err, stderr)
+	}
+}
+
+func TestCheckovReportValidationRejectsSoftFailedFindings(t *testing.T) {
+	t.Parallel()
+
+	report := map[string]any{
+		"check_type": "kubernetes",
+		"results": map[string]any{
+			"failed_checks": []map[string]string{{
+				"check_id": "CKV_K8S_99",
+				"resource": "Deployment.default.new-upstream-risk",
+			}},
+		},
+		"summary": map[string]any{
+			"parsing_errors": 0,
+			"failed":         1,
+		},
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("encode Checkov fixture: %v", err)
+	}
+
+	_, stderr, err := runAnnotator(
+		t,
+		"cdi",
+		string(encoded),
+		"--validate-report",
+		"--framework",
+		"kubernetes",
+	)
+	if err == nil {
+		t.Fatal("validator accepted undispositioned findings from a soft-failed Checkov run")
+	}
+	if !strings.Contains(stderr, "reported 1 failed check") {
+		t.Fatalf("stderr did not name the failed-check count: %q", stderr)
+	}
+}
+
+func TestSourceValidationRejectsUpstreamCheckovSuppressions(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"    owner: platform",
+		"    owner: platform\n    checkov.io/skip1: \"CKV_K8S_99=upstream suppression\"",
+		1,
+	)
+	_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+	if err == nil {
+		t.Fatal("source validator accepted an upstream Checkov suppression")
+	}
+	if !strings.Contains(stderr, "upstream Checkov suppression checkov.io/skip1") {
+		t.Fatalf("stderr did not name the upstream suppression: %q", stderr)
 	}
 }
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -519,6 +519,74 @@ func TestSourceValidationRejectsUpstreamCheckovSuppressions(t *testing.T) {
 	}
 }
 
+func TestSourceValidationRejectsInlineCheckovSuppressions(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"    owner: platform",
+		"    owner: platform # checkov:skip=CKV_SECRET_6:upstream suppression",
+		1,
+	)
+	_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+	if err == nil {
+		t.Fatal("source validator accepted an inline upstream Checkov suppression")
+	}
+	if !strings.Contains(stderr, "inline Checkov suppression") {
+		t.Fatalf("stderr did not name the inline upstream suppression: %q", stderr)
+	}
+}
+
+func TestAnnotatedValidationAcceptsOnlyConfiguredDispositions(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	annotated, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate fixture: %v", err)
+	}
+	if err := validateAnnotatedBundle([]byte(annotated), bundleTargets["cdi"]); err != nil {
+		t.Fatalf("configured dispositions were rejected: %v", err)
+	}
+}
+
+func TestAnnotatedValidationRejectsSuppressionOnUnrelatedResource(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	annotated, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate fixture: %v", err)
+	}
+	annotated = strings.Replace(
+		annotated,
+		"    owner: platform",
+		"    owner: platform\n    checkov.io/skip1: \"CKV_K8S_99=unreviewed\"",
+		1,
+	)
+	if err := validateAnnotatedBundle([]byte(annotated), bundleTargets["cdi"]); err == nil {
+		t.Fatal("committed-bundle validator accepted a suppression on an unrelated resource")
+	} else if !strings.Contains(err.Error(), "unexpected Checkov disposition") {
+		t.Fatalf("error did not name the unexpected disposition: %v", err)
+	}
+}
+
+func TestAnnotatedValidationRejectsChangedDisposition(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	annotated, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate fixture: %v", err)
+	}
+	annotated = strings.Replace(annotated, clusterRoleReason, "different reason", 1)
+	if err := validateAnnotatedBundle([]byte(annotated), bundleTargets["cdi"]); err == nil {
+		t.Fatal("committed-bundle validator accepted a changed disposition")
+	} else if !strings.Contains(err.Error(), "does not match the configured disposition") {
+		t.Fatalf("error did not name the changed disposition: %v", err)
+	}
+}
+
 func TestAnnotatorRejectsUnknownBundle(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -277,6 +277,40 @@ func TestAnnotatorAcceptsDecoratedDocumentMarkers(t *testing.T) {
 	}
 }
 
+func TestAnnotatorPreservesTrailingMappingComments(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	input = strings.Replace(
+		input,
+		"kind: ClusterRole\nmetadata:\n  name: cdi-operator-cluster",
+		"kind: ClusterRole\nmetadata: # generated upstream\n  name: cdi-operator-cluster",
+		1,
+	)
+	input = strings.Replace(
+		input,
+		"  annotations:\n    owner: upstream",
+		"  annotations: # generated upstream\n    owner: upstream",
+		1,
+	)
+
+	output, stderr, err := runAnnotator(t, "cdi", input)
+	if err != nil {
+		t.Fatalf("annotator rejected trailing mapping comments: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(output, "metadata: # generated upstream\n") ||
+		!strings.Contains(output, "  annotations: # generated upstream\n") {
+		t.Fatalf("annotator did not preserve trailing mapping comments:\n%s", output)
+	}
+	documents := decodeDocuments(t, output)
+	if documents["ClusterRole/cdi-operator-cluster"].Metadata.Annotations["checkov.io/skip1"] == "" {
+		t.Fatal("annotator did not add the ClusterRole disposition")
+	}
+	if documents["Deployment/cdi-operator"].Metadata.Annotations["checkov.io/skip1"] == "" {
+		t.Fatal("annotator did not add the Deployment disposition")
+	}
+}
+
 func TestAnnotatorFailsClosedWhenVendorTargetsDrift(t *testing.T) {
 	t.Parallel()
 
@@ -680,6 +714,26 @@ spec: {}
 	}
 	if !strings.Contains(stderr, "Deployment metadata is missing") {
 		t.Fatalf("stderr did not name the missing workload metadata: %q", stderr)
+	}
+}
+
+func TestSourceValidationRejectsYAMLAliases(t *testing.T) {
+	t.Parallel()
+
+	input := `apiVersion: apps/v1
+kindAnchor: &workload Deployment
+kind: *workload
+metadata:
+  name: aliased-workload
+  namespace: other
+spec: {}
+`
+	_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+	if err == nil {
+		t.Fatal("source validator accepted a workload kind hidden behind a YAML alias")
+	}
+	if !strings.Contains(stderr, "YAML alias") {
+		t.Fatalf("stderr did not name the YAML alias: %q", stderr)
 	}
 }
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -75,12 +75,16 @@ func checkovFindingsFixture(t *testing.T, bundle, omittedCheck string) string {
 			kind = "ClusterRole"
 			name = clusterRoleName
 		}
+		evaluatedKeys, known := expectedEvaluatedKeys(check.id)
+		if !known {
+			t.Fatalf("fixture check %s has no expected evaluated keys", check.id)
+		}
 		failedChecks = append(failedChecks, map[string]any{
 			"check_id":   check.id,
 			"resource":   check.resource,
 			"code_block": fixtureCodeBlock(kind, name),
 			"check_result": map[string]any{
-				"evaluated_keys": expectedEvaluatedKeys(check.id),
+				"evaluated_keys": evaluatedKeys,
 			},
 		})
 	}
@@ -427,7 +431,7 @@ func TestCheckovReportValidationRequiresExpectedFramework(t *testing.T) {
 	}
 }
 
-func TestCheckovReportValidationAcceptsEmptySecretsSummary(t *testing.T) {
+func TestCheckovReportValidationRejectsEmptySecretsSummary(t *testing.T) {
 	t.Parallel()
 
 	report := `{"passed":0,"failed":0,"skipped":0,"parsing_errors":0,"resource_count":0,"checkov_version":"3.3.2"}`
@@ -439,8 +443,67 @@ func TestCheckovReportValidationAcceptsEmptySecretsSummary(t *testing.T) {
 		"--framework",
 		"secrets",
 	)
+	if err == nil {
+		t.Fatal("validator accepted a framework-less empty secrets summary")
+	}
+	if !strings.Contains(stderr, "expected exactly one secrets report") {
+		t.Fatalf("stderr did not require explicit secrets report identity: %q", stderr)
+	}
+}
+
+func TestCheckovReportValidationAcceptsExactSecretsCanary(t *testing.T) {
+	t.Parallel()
+
+	report := map[string]any{
+		"check_type": "secrets",
+		"results": map[string]any{
+			"failed_checks": []map[string]any{{
+				"check_id":  "CKV_SECRET_2",
+				"file_path": "/tmp/checkov-secrets-canary.txt",
+				"code_block": [][]any{{
+					1,
+					"aws_access_key_id: AKIAQ**********\n",
+				}},
+			}},
+		},
+		"summary": map[string]any{
+			"parsing_errors": 0,
+			"failed":         1,
+		},
+	}
+	encoded, err := json.Marshal(report)
 	if err != nil {
-		t.Fatalf("validator rejected Checkov's empty secrets summary: %v\nstderr: %s", err, stderr)
+		t.Fatalf("encode Checkov fixture: %v", err)
+	}
+
+	_, stderr, err := runAnnotator(
+		t,
+		"cdi",
+		string(encoded),
+		"--validate-report",
+		"--framework",
+		"secrets",
+		"--require-secrets-canary",
+	)
+	if err != nil {
+		t.Fatalf("validator rejected the exact secrets canary: %v\nstderr: %s", err, stderr)
+	}
+}
+
+func TestFindingsValidationRejectsUnknownConfiguredCheck(t *testing.T) {
+	t.Parallel()
+
+	targets := fixtureTargets(t, "cdi")
+	targets[0].checks = append(targets[0].checks, "CKV_K8S_UNKNOWN")
+	err := validateCheckovFindings(
+		[]byte(checkovFindingsFixture(t, "cdi", "")),
+		targets,
+	)
+	if err == nil {
+		t.Fatal("validator accepted a configured check without reviewed evaluated keys")
+	}
+	if !strings.Contains(err.Error(), "CKV_K8S_UNKNOWN has no reviewed evaluated keys") {
+		t.Fatalf("error did not name the unknown configured check: %v", err)
 	}
 }
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -537,6 +537,42 @@ func TestSourceValidationRejectsInlineCheckovSuppressions(t *testing.T) {
 	}
 }
 
+func TestSourceValidationRejectsCheckovSuppressionsInBlockScalars(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"    owner: platform",
+		"    owner: platform\ndata:\n  embedded.yaml: |\n    password: value # checkov:skip=CKV_SECRET_6:upstream suppression",
+		1,
+	)
+	_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+	if err == nil {
+		t.Fatal("source validator accepted a Checkov suppression inside a block scalar")
+	}
+	if !strings.Contains(stderr, "inline Checkov suppression") {
+		t.Fatalf("stderr did not name the block-scalar suppression: %q", stderr)
+	}
+}
+
+func TestSourceValidationRejectsWorkloadOutsideProtectedNamespace(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"  name: cdi-operator\n  annotations:",
+		"  name: cdi-operator\n  namespace: other\n  annotations:",
+		1,
+	)
+	_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+	if err == nil {
+		t.Fatal("source validator accepted a workload outside the protected namespace")
+	}
+	if !strings.Contains(stderr, "Deployment/cdi-operator uses namespace other, want cdi") {
+		t.Fatalf("stderr did not name the unprotected workload namespace: %q", stderr)
+	}
+}
+
 func TestAnnotatedValidationAcceptsOnlyConfiguredDispositions(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"os/exec"
@@ -22,10 +23,12 @@ type manifestDocument struct {
 	Metadata manifestMetadata `yaml:"metadata"`
 }
 
-func runAnnotator(t *testing.T, bundle, input string) (string, string, error) {
+func runAnnotator(t *testing.T, bundle, input string, extraArgs ...string) (string, string, error) {
 	t.Helper()
 
-	command := exec.Command("go", "run", ".", "--bundle", bundle)
+	args := []string{"run", ".", "--bundle", bundle}
+	args = append(args, extraArgs...)
+	command := exec.Command("go", args...)
 	command.Stdin = strings.NewReader(input)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -34,6 +37,55 @@ func runAnnotator(t *testing.T, bundle, input string) (string, string, error) {
 	err := command.Run()
 
 	return stdout.String(), stderr.String(), err
+}
+
+func checkovFindingsFixture(t *testing.T, bundle, omittedCheck string) string {
+	t.Helper()
+
+	clusterRoleName := "cdi-operator-cluster"
+	deploymentName := "cdi-operator"
+	deploymentNamespace := "cdi"
+	if bundle == "kubevirt" {
+		clusterRoleName = "kubevirt-operator"
+		deploymentName = "virt-operator"
+		deploymentNamespace = "kubevirt"
+	}
+
+	failedChecks := make([]map[string]string, 0, 8)
+	checks := []struct {
+		id       string
+		resource string
+	}{
+		{id: "CKV_K8S_155", resource: "ClusterRole.default." + clusterRoleName},
+		{id: "CKV_K8S_11", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
+		{id: "CKV_K8S_13", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
+		{id: "CKV_K8S_15", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
+		{id: "CKV_K8S_22", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
+		{id: "CKV_K8S_38", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
+		{id: "CKV_K8S_40", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
+		{id: "CKV_K8S_43", resource: "Deployment." + deploymentNamespace + "." + deploymentName},
+	}
+	for _, check := range checks {
+		if check.id == omittedCheck {
+			continue
+		}
+		failedChecks = append(failedChecks, map[string]string{
+			"check_id": check.id,
+			"resource": check.resource,
+		})
+	}
+
+	report := map[string]any{
+		"check_type": "kubernetes",
+		"results": map[string]any{
+			"failed_checks": failedChecks,
+		},
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("encode Checkov fixture: %v", err)
+	}
+	return string(encoded)
 }
 
 func decodeDocuments(t *testing.T, input string) map[string]manifestDocument {
@@ -181,6 +233,42 @@ func TestAnnotatorFailsClosedOnConflictingDisposition(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "already has a different disposition") {
 		t.Fatalf("stderr did not explain the conflicting disposition: %q", stderr)
+	}
+}
+
+func TestFindingsValidationAcceptsEveryCurrentDisposition(t *testing.T) {
+	t.Parallel()
+
+	for _, bundle := range []string{"cdi", "kubevirt"} {
+		t.Run(bundle, func(t *testing.T) {
+			t.Parallel()
+			_, stderr, err := runAnnotator(
+				t,
+				bundle,
+				checkovFindingsFixture(t, bundle, ""),
+				"--validate-findings",
+			)
+			if err != nil {
+				t.Fatalf("current dispositions were rejected: %v\nstderr: %s", err, stderr)
+			}
+		})
+	}
+}
+
+func TestFindingsValidationRejectsObsoleteDisposition(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, err := runAnnotator(
+		t,
+		"cdi",
+		checkovFindingsFixture(t, "cdi", "CKV_K8S_43"),
+		"--validate-findings",
+	)
+	if err == nil {
+		t.Fatal("validator accepted a disposition whose finding disappeared upstream")
+	}
+	if !strings.Contains(stderr, "CKV_K8S_43") || !strings.Contains(stderr, "no longer matches") {
+		t.Fatalf("stderr did not name the obsolete disposition: %q", stderr)
 	}
 }
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -638,6 +638,32 @@ func TestSourceValidationRejectsWorkloadOutsideProtectedNamespace(t *testing.T) 
 	}
 }
 
+func TestSourceValidationRejectsNestedListWorkloadOutsideProtectedNamespace(t *testing.T) {
+	t.Parallel()
+
+	for _, listKind := range []string{"List", "DeploymentList"} {
+		t.Run(listKind, func(t *testing.T) {
+			t.Parallel()
+			input := `apiVersion: v1
+kind: ` + listKind + `
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: nested-operator
+    namespace: other
+`
+			_, stderr, err := runAnnotator(t, "cdi", input, "--validate-source")
+			if err == nil {
+				t.Fatal("source validator accepted a nested workload outside the protected namespace")
+			}
+			if !strings.Contains(stderr, "Deployment/nested-operator uses namespace other, want cdi") {
+				t.Fatalf("stderr did not name the unprotected nested workload namespace: %q", stderr)
+			}
+		})
+	}
+}
+
 func TestAnnotatedValidationAcceptsOnlyConfiguredDispositions(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"strconv"
@@ -646,6 +648,37 @@ func TestAnnotatedValidationAcceptsOnlyConfiguredDispositions(t *testing.T) {
 	}
 	if err := validateAnnotatedBundle([]byte(annotated), bundleTargets["cdi"]); err != nil {
 		t.Fatalf("configured dispositions were rejected: %v", err)
+	}
+}
+
+func TestPinnedSourceValidationAcceptsAnnotatedExactSource(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	annotated, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate fixture: %v", err)
+	}
+	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
+	if err := validatePinnedSource([]byte(annotated), bundleTargets["cdi"], expectedSHA256); err != nil {
+		t.Fatalf("exact pinned source was rejected: %v", err)
+	}
+}
+
+func TestPinnedSourceValidationRejectsNonAnnotationChange(t *testing.T) {
+	t.Parallel()
+
+	input := bundleFixture("cdi-operator-cluster", "cdi-operator")
+	annotated, err := annotateBundle(input, bundleTargets["cdi"])
+	if err != nil {
+		t.Fatalf("annotate fixture: %v", err)
+	}
+	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
+	annotated = strings.Replace(annotated, "spec: {}", "spec:\n  replicas: 9", 1)
+	if err := validatePinnedSource([]byte(annotated), bundleTargets["cdi"], expectedSHA256); err == nil {
+		t.Fatal("pinned-source validator accepted a non-annotation bundle change")
+	} else if !strings.Contains(err.Error(), "source SHA-256") {
+		t.Fatalf("error did not name the pinned source digest: %v", err)
 	}
 }
 

--- a/scripts/annotate-vendored-checkov/main_test.go
+++ b/scripts/annotate-vendored-checkov/main_test.go
@@ -96,7 +96,6 @@ func TestAnnotatorAddsOnlyResourceScopedSuppressions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			input := bundleFixture(test.clusterRoleName, test.deploymentName)
@@ -164,6 +163,24 @@ func TestAnnotatorFailsClosedWhenVendorTargetsDrift(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "expected exactly one Deployment/cdi-operator") {
 		t.Fatalf("stderr did not name the missing target: %q", stderr)
+	}
+}
+
+func TestAnnotatorFailsClosedOnConflictingDisposition(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Replace(
+		bundleFixture("cdi-operator-cluster", "cdi-operator"),
+		"    owner: upstream",
+		"    owner: upstream\n    checkov.io/skip1: \"CKV_K8S_11=some other reason\"",
+		1,
+	)
+	_, stderr, err := runAnnotator(t, "cdi", input)
+	if err == nil {
+		t.Fatal("annotator replaced a conflicting Checkov disposition")
+	}
+	if !strings.Contains(stderr, "already has a different disposition") {
+		t.Fatalf("stderr did not explain the conflicting disposition: %q", stderr)
 	}
 }
 

--- a/scripts/megalinter-scan-counts.sh
+++ b/scripts/megalinter-scan-counts.sh
@@ -45,7 +45,7 @@ set -euo pipefail
 readonly CI_CHECKOV_VERSION='3.3.2'
 readonly CI_TRIVY_VERSION='0.71.2'
 
-# The frameworks MegaLinter's checkov run reports, and their contribution to CI's total of 73.
+# The frameworks MegaLinter's checkov run reports, and their current contribution to the CI total.
 #
 # A missing framework is REPORTED, never refused, because the two causes are indistinguishable from
 # checkov's output alone: a framework whose last finding is fixed stops emitting a section entirely
@@ -57,7 +57,7 @@ readonly CI_TRIVY_VERSION='0.71.2'
 # What protects against the known defect is structural rather than a check: this script always runs
 # checkov from the repository root with a literal ".", the invocation whose absence caused the
 # kubernetes framework to vanish in the first place.
-readonly CI_CHECKOV_FRAMEWORKS=(cloudformation:0 kubernetes:42 secrets:31 github_actions:0)
+readonly CI_CHECKOV_FRAMEWORKS=(cloudformation:0 kubernetes:18 secrets:0 github_actions:0)
 
 # A parsing error means a file was NOT analysed, so findings can hide behind it. CI's run has
 # exactly one (in the cloudformation framework) and so does a correct local run, which is why this

--- a/scripts/megalinter-scan-counts.sh
+++ b/scripts/megalinter-scan-counts.sh
@@ -142,8 +142,9 @@ scan_checkov() {
   printf 'Running checkov (this takes ~1 minute)...\n' >&2
   # --directory MUST be the literal "." from the repository root, as CI runs it. Passing an
   # absolute path instead makes checkov's kubernetes framework return NOTHING — it disappears from
-  # the report entirely and the total silently drops from 73 to 31, with no error. Reproduced both
-  # with and without --skip-path, so it is the absolute path itself.
+  # the report entirely and, in the historical pre-#2899 reproduction, silently dropped the total
+  # from 73 to 31 with no error. Reproduced both with and without --skip-path, so it is the absolute
+  # path itself.
   (cd "$REPO_ROOT" && checkov --skip-path tests/ --skip-framework kustomize \
     --directory . --compact --quiet) >"$out" 2>&1 || rc=$?
   if [ "$rc" -gt 1 ]; then
@@ -153,8 +154,8 @@ scan_checkov() {
   fi
   # Every framework CI reports must be present. "At least one section" is not enough: a silently
   # dropped framework is the failure mode already seen here — an absolute --directory removes the
-  # whole kubernetes framework and its 42 findings while the other three still report, so the run
-  # looks healthy and the total is simply 42 lower.
+  # whole kubernetes framework and its then-current 42 findings while the other three still report,
+  # so the historical run looked healthy and the total was simply 42 lower.
   local absent='' entry fw baseline
   for entry in "${CI_CHECKOV_FRAMEWORKS[@]}"; do
     fw="${entry%%:*}"

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -34,24 +34,64 @@ require_tool() {
   fi
 }
 
+run_clean_framework_scan() {
+  local bundle="$1"
+  local phase="$2"
+  local manifest="$3"
+  local framework="$4"
+  local report="$5"
+  local checkov_rc=0
+  local -a checkov_args=(
+    --file "${manifest}"
+    --framework "${framework}"
+    --output json
+    --quiet
+  )
+  if [ "${framework}" = 'kubernetes' ]; then
+    checkov_args+=(--skip-check "${isolated_scan_skip_check}")
+  fi
+
+  checkov "${checkov_args[@]}" >"${report}" || checkov_rc=$?
+  (
+    cd "${repo_root}"
+    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
+      --validate-report --framework "${framework}" <"${report}"
+  )
+  if [ "${checkov_rc}" -ne 0 ]; then
+    printf 'checkov rejected the %s %s %s scan (exit %d):\n' \
+      "${phase}" "${bundle}" "${framework}" "${checkov_rc}" >&2
+    while IFS= read -r line; do
+      printf '%s\n' "${line}" >&2
+    done <"${report}"
+    exit 2
+  fi
+}
+
 prepare_bundle() {
   local bundle="$1"
   local url="$2"
   local expected_sha256="$3"
   local downloaded="${work_dir}/${bundle}-upstream.yaml"
-  local findings="${work_dir}/${bundle}-findings.json"
+  local findings="${work_dir}/${bundle}-kubernetes-findings.json"
+  local source_secrets_report="${work_dir}/${bundle}-source-secrets-report.json"
   local annotated="${work_dir}/${bundle}-annotated.yaml"
-  local annotated_report="${work_dir}/${bundle}-annotated-report.json"
+  local annotated_kubernetes_report="${work_dir}/${bundle}-annotated-kubernetes-report.json"
+  local annotated_secrets_report="${work_dir}/${bundle}-annotated-secrets-report.json"
   local checkov_rc=0
 
   curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
     --retry 3 --retry-all-errors "${url}" --output "${downloaded}"
   printf '%s  %s\n' "${expected_sha256}" "${downloaded}" | sha256sum -c -
+  (
+    cd "${repo_root}"
+    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
+      --validate-source <"${downloaded}"
+  )
 
   # Prove that every reviewed disposition is still necessary on this exact
   # upstream asset. An upstream security fix makes the update stop here until
   # the obsolete annotation is removed from the configured target list.
-  checkov --file "${downloaded}" --framework kubernetes secrets \
+  checkov --file "${downloaded}" --framework kubernetes \
     --skip-check "${isolated_scan_skip_check}" \
     --output json --quiet >"${findings}" || checkov_rc=$?
   if [ "${checkov_rc}" -gt 1 ]; then
@@ -67,27 +107,17 @@ prepare_bundle() {
     go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
       <"${downloaded}" >"${annotated}"
   )
+  run_clean_framework_scan \
+    "${bundle}" source "${downloaded}" secrets "${source_secrets_report}"
 
   # The known, reviewed dispositions must clear the current upstream bundle,
   # while any new check introduced by a vendor bump remains visible and blocks
-  # replacement until it receives an explicit disposition.
-  checkov_rc=0
-  checkov --file "${annotated}" --framework kubernetes secrets \
-    --skip-check "${isolated_scan_skip_check}" \
-    --output json --quiet >"${annotated_report}" || checkov_rc=$?
-  (
-    cd "${repo_root}"
-    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
-      --validate-report <"${annotated_report}"
-  )
-  if [ "${checkov_rc}" -ne 0 ]; then
-    printf 'checkov found an undispositioned issue in the annotated %s bundle (exit %d):\n' \
-      "${bundle}" "${checkov_rc}" >&2
-    while IFS= read -r line; do
-      printf '%s\n' "${line}" >&2
-    done <"${annotated_report}"
-    exit 2
-  fi
+  # replacement until it receives an explicit disposition. Run each framework
+  # separately so Checkov cannot silently omit an empty framework report.
+  run_clean_framework_scan \
+    "${bundle}" annotated "${annotated}" kubernetes "${annotated_kubernetes_report}"
+  run_clean_framework_scan \
+    "${bundle}" annotated "${annotated}" secrets "${annotated_secrets_report}"
 }
 
 require_tool curl

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -2,14 +2,16 @@
 # Refresh the pinned KubeVirt and CDI release bundles without losing the
 # repository's resource-scoped Checkov dispositions.
 #
-# Bump the two version constants below, then run this script from anywhere in
-# the repository. A renamed target or a new Checkov finding is a hard failure:
-# the updater never replaces the committed bundle until annotation and scan
-# validation both succeed.
+# Bump each version and SHA-256 constant below, then run this script from
+# anywhere in the repository. A renamed target or a new Checkov finding is a
+# hard failure: the updater never replaces the committed bundle until checksum,
+# annotation, and scan validation all succeed.
 set -euo pipefail
 
 readonly cdi_version='v1.65.0'
+readonly cdi_sha256='e96d59abdf358c5161cb96adcfdcc6107efc3fb608ec93ade11578c94a222015'
 readonly kubevirt_version='v1.8.0'
+readonly kubevirt_sha256='e9e92c15bca0531bf0b7db2c2dfc83b6b9bdbf1a6f3f96945f67d90d702193b5'
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly repo_root
@@ -28,11 +30,13 @@ require_tool() {
 prepare_bundle() {
   local bundle="$1"
   local url="$2"
+  local expected_sha256="$3"
   local downloaded="${work_dir}/${bundle}-upstream.yaml"
   local annotated="${work_dir}/${bundle}-annotated.yaml"
 
   curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
     --retry 3 --retry-all-errors "${url}" --output "${downloaded}"
+  printf '%s  %s\n' "${expected_sha256}" "${downloaded}" | sha256sum -c -
 
   (
     cd "${repo_root}"
@@ -43,20 +47,23 @@ prepare_bundle() {
   # The known, reviewed dispositions must clear the current upstream bundle,
   # while any new check introduced by a vendor bump remains visible and blocks
   # replacement until it receives an explicit disposition.
-  checkov --file "${annotated}" --framework kubernetes --compact --quiet >/dev/null
+  checkov --file "${annotated}" --framework kubernetes --compact --quiet
 }
 
 require_tool curl
 require_tool go
 require_tool checkov
+require_tool sha256sum
 
 prepare_bundle \
   cdi \
-  "https://github.com/kubevirt/containerized-data-importer/releases/download/${cdi_version}/cdi-operator.yaml"
+  "https://github.com/kubevirt/containerized-data-importer/releases/download/${cdi_version}/cdi-operator.yaml" \
+  "${cdi_sha256}"
 
 prepare_bundle \
   kubevirt \
-  "https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}/kubevirt-operator.yaml"
+  "https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}/kubevirt-operator.yaml" \
+  "${kubevirt_sha256}"
 
 # Commit both prepared outputs together only after both upstream bundles pass.
 # A failed second download or scan therefore cannot leave a half-updated pair.

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Refresh the pinned KubeVirt and CDI release bundles without losing the
+# repository's resource-scoped Checkov dispositions.
+#
+# Bump the two version constants below, then run this script from anywhere in
+# the repository. A renamed target or a new Checkov finding is a hard failure:
+# the updater never replaces the committed bundle until annotation and scan
+# validation both succeed.
+set -euo pipefail
+
+readonly cdi_version='v1.65.0'
+readonly kubevirt_version='v1.8.0'
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly repo_root
+work_dir="$(mktemp -d)"
+readonly work_dir
+trap 'rm -rf "${work_dir}"' EXIT
+
+require_tool() {
+  local tool="$1"
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    printf '%s is required to update vendored operators\n' "${tool}" >&2
+    exit 2
+  fi
+}
+
+prepare_bundle() {
+  local bundle="$1"
+  local url="$2"
+  local downloaded="${work_dir}/${bundle}-upstream.yaml"
+  local annotated="${work_dir}/${bundle}-annotated.yaml"
+
+  curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+    --retry 3 --retry-all-errors "${url}" --output "${downloaded}"
+
+  (
+    cd "${repo_root}"
+    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
+      <"${downloaded}" >"${annotated}"
+  )
+
+  # The known, reviewed dispositions must clear the current upstream bundle,
+  # while any new check introduced by a vendor bump remains visible and blocks
+  # replacement until it receives an explicit disposition.
+  checkov --file "${annotated}" --framework kubernetes --compact --quiet >/dev/null
+}
+
+require_tool curl
+require_tool go
+require_tool checkov
+
+prepare_bundle \
+  cdi \
+  "https://github.com/kubevirt/containerized-data-importer/releases/download/${cdi_version}/cdi-operator.yaml"
+
+prepare_bundle \
+  kubevirt \
+  "https://github.com/kubevirt/kubevirt/releases/download/${kubevirt_version}/kubevirt-operator.yaml"
+
+# Commit both prepared outputs together only after both upstream bundles pass.
+# A failed second download or scan therefore cannot leave a half-updated pair.
+mv \
+  "${work_dir}/cdi-annotated.yaml" \
+  "${repo_root}/k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml"
+mv \
+  "${work_dir}/kubevirt-annotated.yaml" \
+  "${repo_root}/k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml"
+
+printf 'Updated CDI %s and KubeVirt %s; both annotated bundles pass Checkov.\n' \
+  "${cdi_version}" "${kubevirt_version}"

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -25,6 +25,22 @@ readonly repo_root
 work_dir="$(mktemp -d)"
 readonly work_dir
 trap 'rm -rf "${work_dir}"' EXIT
+readonly checkov_home="${work_dir}/checkov-home"
+readonly checkov_config="${work_dir}/checkov.yaml"
+mkdir -p "${checkov_home}"
+printf '{}\n' >"${checkov_config}"
+
+# Ignore user/home configuration and CKV_* environment overrides. The updater
+# must prove its own explicit policy even when the caller normally soft-fails or
+# skips checks in an interactive shell.
+run_checkov() {
+  env -i \
+    HOME="${checkov_home}" \
+    LC_ALL=C \
+    PATH="${PATH}" \
+    PYTHONUTF8=1 \
+    checkov --config-file "${checkov_config}" "$@"
+}
 
 require_tool() {
   local tool="$1"
@@ -51,7 +67,7 @@ run_clean_framework_scan() {
     checkov_args+=(--skip-check "${isolated_scan_skip_check}")
   fi
 
-  checkov "${checkov_args[@]}" >"${report}" || checkov_rc=$?
+  run_checkov "${checkov_args[@]}" >"${report}" || checkov_rc=$?
   (
     cd "${repo_root}"
     go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
@@ -91,7 +107,7 @@ prepare_bundle() {
   # Prove that every reviewed disposition is still necessary on this exact
   # upstream asset. An upstream security fix makes the update stop here until
   # the obsolete annotation is removed from the configured target list.
-  checkov --file "${downloaded}" --framework kubernetes \
+  run_checkov --file "${downloaded}" --framework kubernetes \
     --skip-check "${isolated_scan_skip_check}" \
     --output json --quiet >"${findings}" || checkov_rc=$?
   if [ "${checkov_rc}" -gt 1 ]; then
@@ -125,7 +141,7 @@ require_tool go
 require_tool checkov
 require_tool sha256sum
 
-actual_checkov_version="$(checkov --version)"
+actual_checkov_version="$(run_checkov --version)"
 readonly actual_checkov_version
 if [ "${actual_checkov_version}" != "${checkov_version}" ]; then
   printf 'checkov %s is required; found %s\n' \

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -153,6 +153,29 @@ prepare_bundle() {
     "${bundle}" annotated "${annotated}" secrets "${annotated_secrets_report}"
 }
 
+validate_committed_bundles() {
+  (
+    cd "${repo_root}"
+    go run ./scripts/annotate-vendored-checkov --bundle cdi --validate-annotated \
+      --source-sha256 "${cdi_sha256}" \
+      <k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
+    go run ./scripts/annotate-vendored-checkov --bundle kubevirt --validate-annotated \
+      --source-sha256 "${kubevirt_sha256}" \
+      <k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
+  )
+}
+
+if [ "$#" -ne 0 ]; then
+  if [ "$#" -eq 1 ] && [ "$1" = '--validate-committed' ]; then
+    require_tool go
+    validate_committed_bundles
+    printf 'Committed CDI and KubeVirt bundles match their pinned upstream digests.\n'
+    exit 0
+  fi
+  printf 'usage: %s [--validate-committed]\n' "$0" >&2
+  exit 2
+fi
+
 require_tool curl
 require_tool go
 require_tool checkov

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -158,9 +158,11 @@ validate_committed_bundles() {
     cd "${repo_root}"
     go run ./scripts/annotate-vendored-checkov --bundle cdi --validate-annotated \
       --source-sha256 "${cdi_sha256}" \
+      --source-version "${cdi_version}" \
       <k8s/bases/infrastructure/controllers/cdi/cdi-operator.yaml
     go run ./scripts/annotate-vendored-checkov --bundle kubevirt --validate-annotated \
       --source-sha256 "${kubevirt_sha256}" \
+      --source-version "${kubevirt_version}" \
       <k8s/bases/infrastructure/controllers/kubevirt/kubevirt-operator.yaml
   )
 }
@@ -169,7 +171,7 @@ if [ "$#" -ne 0 ]; then
   if [ "$#" -eq 1 ] && [ "$1" = '--validate-committed' ]; then
     require_tool go
     validate_committed_bundles
-    printf 'Committed CDI and KubeVirt bundles match their pinned upstream digests.\n'
+    printf 'Committed CDI and KubeVirt bundles match their pinned upstream digests and versions.\n'
     exit 0
   fi
   printf 'usage: %s [--validate-committed]\n' "$0" >&2

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -27,8 +27,10 @@ readonly work_dir
 trap 'rm -rf "${work_dir}"' EXIT
 readonly checkov_home="${work_dir}/checkov-home"
 readonly checkov_config="${work_dir}/checkov.yaml"
+readonly checkov_secrets_canary="${work_dir}/checkov-secrets-canary.txt"
 mkdir -p "${checkov_home}"
 printf '{}\n' >"${checkov_config}"
+printf 'aws_access_key_id: AKIAQWERTYUIOPASDFGH\n' >"${checkov_secrets_canary}"
 
 # Ignore user/home configuration and CKV_* environment overrides. The updater
 # must prove its own explicit policy even when the caller normally soft-fails or
@@ -57,8 +59,16 @@ run_clean_framework_scan() {
   local framework="$4"
   local report="$5"
   local checkov_rc=0
+  local expected_checkov_rc=0
+  local -a input_files=("${manifest}")
+  local -a validator_args=(--validate-report --framework "${framework}")
+  if [ "${framework}" = 'secrets' ]; then
+    input_files+=("${checkov_secrets_canary}")
+    expected_checkov_rc=1
+    validator_args+=(--require-secrets-canary)
+  fi
   local -a checkov_args=(
-    --file "${manifest}"
+    --file "${input_files[@]}"
     --framework "${framework}"
     --output json
     --quiet
@@ -68,14 +78,21 @@ run_clean_framework_scan() {
   fi
 
   run_checkov "${checkov_args[@]}" >"${report}" || checkov_rc=$?
-  (
-    cd "${repo_root}"
-    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
-      --validate-report --framework "${framework}" <"${report}"
-  )
-  if [ "${checkov_rc}" -ne 0 ]; then
+  if [ "${checkov_rc}" -ne "${expected_checkov_rc}" ]; then
     printf 'checkov rejected the %s %s %s scan (exit %d):\n' \
       "${phase}" "${bundle}" "${framework}" "${checkov_rc}" >&2
+    while IFS= read -r line; do
+      printf '%s\n' "${line}" >&2
+    done <"${report}"
+    exit 2
+  fi
+  if ! (
+    cd "${repo_root}"
+    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
+      "${validator_args[@]}" <"${report}"
+  ); then
+    printf 'checkov report validation rejected the %s %s %s scan:\n' \
+      "${phase}" "${bundle}" "${framework}" >&2
     while IFS= read -r line; do
       printf '%s\n' "${line}" >&2
     done <"${report}"

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -41,6 +41,7 @@ prepare_bundle() {
   local downloaded="${work_dir}/${bundle}-upstream.yaml"
   local findings="${work_dir}/${bundle}-findings.json"
   local annotated="${work_dir}/${bundle}-annotated.yaml"
+  local annotated_report="${work_dir}/${bundle}-annotated-report.json"
   local checkov_rc=0
 
   curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
@@ -70,8 +71,23 @@ prepare_bundle() {
   # The known, reviewed dispositions must clear the current upstream bundle,
   # while any new check introduced by a vendor bump remains visible and blocks
   # replacement until it receives an explicit disposition.
+  checkov_rc=0
   checkov --file "${annotated}" --framework kubernetes secrets \
-    --skip-check "${isolated_scan_skip_check}" --compact --quiet
+    --skip-check "${isolated_scan_skip_check}" \
+    --output json --quiet >"${annotated_report}" || checkov_rc=$?
+  (
+    cd "${repo_root}"
+    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
+      --validate-report <"${annotated_report}"
+  )
+  if [ "${checkov_rc}" -ne 0 ]; then
+    printf 'checkov found an undispositioned issue in the annotated %s bundle (exit %d):\n' \
+      "${bundle}" "${checkov_rc}" >&2
+    while IFS= read -r line; do
+      printf '%s\n' "${line}" >&2
+    done <"${annotated_report}"
+    exit 2
+  fi
 }
 
 require_tool curl

--- a/scripts/update-vendored-operators.sh
+++ b/scripts/update-vendored-operators.sh
@@ -12,6 +12,13 @@ readonly cdi_version='v1.65.0'
 readonly cdi_sha256='e96d59abdf358c5161cb96adcfdcc6107efc3fb608ec93ade11578c94a222015'
 readonly kubevirt_version='v1.8.0'
 readonly kubevirt_sha256='e9e92c15bca0531bf0b7db2c2dfc83b6b9bdbf1a6f3f96945f67d90d702193b5'
+# Keep this aligned with CI_CHECKOV_VERSION in megalinter-scan-counts.sh so a
+# local vendor refresh cannot miss a rule that the non-blocking CI scan knows.
+readonly checkov_version='3.3.2'
+# CKV2_K8S_6 only understands networking.k8s.io NetworkPolicy. An isolated
+# bundle scan cannot see that cilium-network-policy.yaml protects every CDI
+# endpoint; the full-repository CI scan remains unskipped and owns graph checks.
+readonly isolated_scan_skip_check='CKV2_K8S_6'
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly repo_root
@@ -32,14 +39,30 @@ prepare_bundle() {
   local url="$2"
   local expected_sha256="$3"
   local downloaded="${work_dir}/${bundle}-upstream.yaml"
+  local findings="${work_dir}/${bundle}-findings.json"
   local annotated="${work_dir}/${bundle}-annotated.yaml"
+  local checkov_rc=0
 
   curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
     --retry 3 --retry-all-errors "${url}" --output "${downloaded}"
   printf '%s  %s\n' "${expected_sha256}" "${downloaded}" | sha256sum -c -
 
+  # Prove that every reviewed disposition is still necessary on this exact
+  # upstream asset. An upstream security fix makes the update stop here until
+  # the obsolete annotation is removed from the configured target list.
+  checkov --file "${downloaded}" --framework kubernetes secrets \
+    --skip-check "${isolated_scan_skip_check}" \
+    --output json --quiet >"${findings}" || checkov_rc=$?
+  if [ "${checkov_rc}" -gt 1 ]; then
+    printf 'checkov could not scan the unannotated %s bundle (exit %d)\n' \
+      "${bundle}" "${checkov_rc}" >&2
+    exit 2
+  fi
+
   (
     cd "${repo_root}"
+    go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
+      --validate-findings <"${findings}"
     go run ./scripts/annotate-vendored-checkov --bundle "${bundle}" \
       <"${downloaded}" >"${annotated}"
   )
@@ -47,13 +70,22 @@ prepare_bundle() {
   # The known, reviewed dispositions must clear the current upstream bundle,
   # while any new check introduced by a vendor bump remains visible and blocks
   # replacement until it receives an explicit disposition.
-  checkov --file "${annotated}" --framework kubernetes --compact --quiet
+  checkov --file "${annotated}" --framework kubernetes secrets \
+    --skip-check "${isolated_scan_skip_check}" --compact --quiet
 }
 
 require_tool curl
 require_tool go
 require_tool checkov
 require_tool sha256sum
+
+actual_checkov_version="$(checkov --version)"
+readonly actual_checkov_version
+if [ "${actual_checkov_version}" != "${checkov_version}" ]; then
+  printf 'checkov %s is required; found %s\n' \
+    "${checkov_version}" "${actual_checkov_version}" >&2
+  exit 2
+fi
 
 prepare_bundle \
   cdi \


### PR DESCRIPTION
> 🤖 Generated by the Daily AI Assistant

## Why
The pinned CDI and KubeVirt release bundles contributed 16 Checkov findings, but a repository-wide path exclusion would also hide unrelated future regressions. Their dispositions need to survive vendor refreshes without trusting mutable release assets or stale scanner behavior.

## What
- add a tested, resource-scoped annotator for the reviewed upstream findings
- add a digest-pinned updater that requires the CI Checkov version, rejects obsolete dispositions, and gates Kubernetes plus secrets findings
- wire static updater and annotator validation into CI and refresh the measured backlog baseline from 34 to 18
- document the only supported vendored-bundle refresh path

## Validation
- go test ./...
- golangci-lint and go vet for the annotator
- bash -n, shellcheck, and actionlint
- exact Checkov 3.3.2 updater refresh for both current bundles
- exact-version repository scan: 18 Kubernetes findings, 0 secrets findings
- 26 required GitHub checks green on the current head

Closes #2899
Part of #2787