### PR TITLE
feat(ci): verify published evidence before promoting the prod digest

### DIFF
--- a/.github/actions/deploy-prod/publish-platform-manifests/action.yml
+++ b/.github/actions/deploy-prod/publish-platform-manifests/action.yml
@@ -144,6 +144,7 @@ runs:
         GH_TOKEN: ${{ inputs.ghcr-token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         STAGING_DIGEST: ${{ steps.resolve_staging.outputs.digest }}
+        SUBJECT_NAME: ghcr.io/devantler-tech/platform/manifests
         WORKFLOW_REF: ${{ github.workflow_ref }}
       # Every step above can report success while leaving no usable evidence in
       # the registry, and the promotion below is the point of no return: once

--- a/.github/actions/deploy-prod/publish-platform-manifests/action.yml
+++ b/.github/actions/deploy-prod/publish-platform-manifests/action.yml
@@ -8,13 +8,14 @@ inputs:
   ghcr-token:
     description: >-
       GHCR PAT with write:packages for push, signing, attestation, and
-      promotion, and read access to this repository's attestations. The
+      promotion, and read:packages for reading the evidence back. The
       evidence-verification step below reuses this token as GH_TOKEN for
-      `gh attestation verify`, which fetches the bundle through the GitHub API:
-      a token that cannot read attestations makes that call fail for
-      authorization rather than for absent evidence, and the two are
-      indistinguishable in the verdict. On a fine-grained PAT this is the
-      attestations:read repository permission.
+      `gh attestation verify --bundle-from-oci`, which reads each bundle from
+      the registry beside the image rather than from the GitHub Attestations
+      API — the attestations are published with `create-storage-record: false`,
+      so no API record exists to read. A token that cannot read the package
+      makes that call fail for authorization rather than for absent evidence,
+      and the two are indistinguishable in the verdict.
     required: true
   hcloud-token:
     description: Hetzner Cloud API token required while KSail loads the production config.

--- a/.github/actions/deploy-prod/publish-platform-manifests/action.yml
+++ b/.github/actions/deploy-prod/publish-platform-manifests/action.yml
@@ -6,7 +6,15 @@ description: >-
 
 inputs:
   ghcr-token:
-    description: GHCR PAT with write:packages for push, signing, attestation, and promotion.
+    description: >-
+      GHCR PAT with write:packages for push, signing, attestation, and
+      promotion, and read access to this repository's attestations. The
+      evidence-verification step below reuses this token as GH_TOKEN for
+      `gh attestation verify`, which fetches the bundle through the GitHub API:
+      a token that cannot read attestations makes that call fail for
+      authorization rather than for absent evidence, and the two are
+      indistinguishable in the verdict. On a fine-grained PAT this is the
+      attestations:read repository permission.
     required: true
   hcloud-token:
     description: Hetzner Cloud API token required while KSail loads the production config.

--- a/.github/actions/deploy-prod/publish-platform-manifests/action.yml
+++ b/.github/actions/deploy-prod/publish-platform-manifests/action.yml
@@ -11,6 +11,14 @@ inputs:
   hcloud-token:
     description: Hetzner Cloud API token required while KSail loads the production config.
     required: true
+  enforce-evidence-verification:
+    description: >-
+      Fail the deploy when the published evidence cannot be verified. Default-off
+      while the gate proves itself on real deploys: a verification wrong about the
+      identity or issuer would break every production deploy, so it earns the
+      right to block by first being observed passing (platform#2859).
+    required: false
+    default: "false"
 
 outputs:
   digest:
@@ -118,6 +126,22 @@ runs:
         subject-name: ghcr.io/devantler-tech/platform/manifests
         push-to-registry: true
         create-storage-record: false
+
+    - name: 🔍 Verify the published evidence before promoting
+      id: verify_evidence
+      shell: bash
+      env:
+        ENFORCE: ${{ inputs.enforce-evidence-verification }}
+        GH_TOKEN: ${{ inputs.ghcr-token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        STAGING_DIGEST: ${{ steps.resolve_staging.outputs.digest }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
+      # Every step above can report success while leaving no usable evidence in
+      # the registry, and the promotion below is the point of no return: once
+      # latest names these bytes, production follows them within the minute. Ask
+      # the registry what it actually holds before that, rather than inferring it
+      # from the fact that the steps ran.
+      run: ./scripts/verify-published-evidence.sh "${STAGING_DIGEST}"
 
     - name: 🚀 Promote the evidenced digest to latest
       id: promote_latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,9 @@ jobs:
               # still runs the check that covers it.
               - 'scripts/dr-rebuild-supersession-guard.sh'
               - 'scripts/tests/test-dr-rebuild-supersession-guard.sh'
+              # Both halves, for the same reason as the guard above.
+              - 'scripts/verify-published-evidence.sh'
+              - 'scripts/tests/test-verify-published-evidence.sh'
               - 'scripts/validate-eks-ci-role-policy/**'
               - 'tests/**'
               - 'scripts/validate-alert-coverage.sh'
@@ -304,6 +307,15 @@ jobs:
         # and this pins both its decision and the wiring that reaches it — a
         # guard the destructive job does not depend on protects nothing.
         run: bash scripts/tests/test-dr-rebuild-supersession-guard.sh
+
+      - name: 🔍 Validate the published-evidence gate
+        if: needs.changes.outputs.k8s == 'true'
+        # Every publication step can report success while leaving no usable
+        # evidence in the registry, and the promotion that follows is what
+        # production starts following within the minute. This pins the gate's
+        # verdict in both rollout states and the wiring that reaches it — a gate
+        # that runs after latest already moved has verified nothing that matters.
+        run: bash scripts/tests/test-verify-published-evidence.sh
 
       - name: 📋 Validate Kubescape finding summary
         if: needs.changes.outputs.k8s == 'true'

--- a/scripts/tests/test-verify-published-evidence.sh
+++ b/scripts/tests/test-verify-published-evidence.sh
@@ -210,6 +210,23 @@ else
   bad "every check targets the digest, never the mutable tag" "${argv}"
 fi
 
+# The attestations are published with `create-storage-record: false`, so the
+# bundles exist only in the OCI registry and never in the GitHub Attestations
+# API. `gh attestation verify` reads the API by default, so without
+# --bundle-from-oci both checks look somewhere the evidence was never written:
+# they fail for absence, not for invalidity, and the two are indistinguishable
+# in the verdict. Counted rather than merely grepped, so adding a third
+# attestation without the flag cannot hide behind the two that carry it.
+attest_calls="$(grep -c -- "attestation verify" <<<"${argv}" || true)"
+from_oci_calls="$(grep -- "attestation verify" <<<"${argv}" | grep -c -- "--bundle-from-oci" || true)"
+
+if [[ "${attest_calls}" != "0" && "${attest_calls}" == "${from_oci_calls}" ]]; then
+  ok "every attestation check reads its bundle from the registry (${from_oci_calls}/${attest_calls})"
+else
+  bad "every attestation check reads its bundle from the registry" \
+    "${from_oci_calls}/${attest_calls} carried --bundle-from-oci: ${argv}"
+fi
+
 # An absent identity must refuse rather than fall back to a wildcard: verifying
 # that SOMEONE signed the bytes is not the property being asserted.
 dir="$(stub_dir 0 0)"

--- a/scripts/tests/test-verify-published-evidence.sh
+++ b/scripts/tests/test-verify-published-evidence.sh
@@ -281,6 +281,27 @@ else
   bad "the gate is given the resolved staging digest" "unexpected argument in ${action}"
 fi
 
+# The gate must be told which subject to verify, and it must be the same subject
+# the attestations were just published under. The script carries its own
+# fallback default, so leaving the env unset makes two files agree only by
+# coincidence: rename the package in one of them and the gate starts asking the
+# registry about a reference that was never published. It then fails for
+# absence, which in the default non-enforcing mode is a bare ::warning:: — the
+# drift is invisible exactly when it matters. Comparing the passed value against
+# the published one asserts the property; asserting the line merely exists would
+# pass for any value, including a wrong one.
+published_subjects="$(sed -nE 's/^[[:space:]]*subject-name:[[:space:]]*//p' "${action}" | sort -u || true)"
+published_count="$(printf '%s\n' "${published_subjects}" | grep -c . || true)"
+gate_subject="$(awk '/id: verify_evidence/,/run: /' "${action}" |
+  sed -nE 's/^[[:space:]]*SUBJECT_NAME:[[:space:]]*//p' || true)"
+
+if [[ -n "${gate_subject}" && "${published_count}" == "1" && "${gate_subject}" == "${published_subjects}" ]]; then
+  ok "the gate verifies the subject the attestations were published under (${gate_subject})"
+else
+  bad "the gate verifies the subject the attestations were published under" \
+    "gate=${gate_subject:-<unset>} published(${published_count})=[${published_subjects}]"
+fi
+
 # The rollout ratchet: default-off on this landing, so the enforcing flip is a
 # separate, deliberate change rather than something that arrives with it.
 if grep -q "enforce-evidence-verification" "${action}"; then

--- a/scripts/tests/test-verify-published-evidence.sh
+++ b/scripts/tests/test-verify-published-evidence.sh
@@ -227,6 +227,23 @@ else
     "${from_oci_calls}/${attest_calls} carried --bundle-from-oci: ${argv}"
 fi
 
+# --repo scopes an attestation check to the repository; it does NOT pin WHICH
+# workflow produced the attestation. Without --cert-identity any workflow in
+# this repo that can mint an attestation satisfies the gate, so a less-trusted
+# one becomes a path to a promotable digest — the exact substitution the cosign
+# check already refuses via --certificate-identity. Counted like the flag above,
+# so a third attestation added without it cannot hide behind the two that
+# carry it.
+identity_calls="$(grep -- "attestation verify" <<<"${argv}" |
+  grep -c -- "--cert-identity https://github.com/${workflow_ref}" || true)"
+
+if [[ "${attest_calls}" != "0" && "${attest_calls}" == "${identity_calls}" ]]; then
+  ok "every attestation check pins the calling workflow's identity (${identity_calls}/${attest_calls})"
+else
+  bad "every attestation check pins the calling workflow's identity" \
+    "${identity_calls}/${attest_calls} carried --cert-identity: ${argv}"
+fi
+
 # An absent identity must refuse rather than fall back to a wildcard: verifying
 # that SOMEONE signed the bytes is not the property being asserted.
 dir="$(stub_dir 0 0)"

--- a/scripts/tests/test-verify-published-evidence.sh
+++ b/scripts/tests/test-verify-published-evidence.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Behaviour and wiring tests for scripts/verify-published-evidence.sh.
+#
+# The behaviour half drives the gate through its tool seam: cosign and gh are
+# stubbed on PATH, so every verdict is exercised without a registry, a token, or
+# a network. The wiring half asserts the gate is actually reached — a gate the
+# publication action does not call, or calls AFTER the promotion, protects
+# nothing, which is the failure mode the whole slice exists to prevent.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly gate="${root_dir}/scripts/verify-published-evidence.sh"
+readonly action="${root_dir}/.github/actions/deploy-prod/publish-platform-manifests/action.yml"
+
+good_digest="sha256:$(printf 'a%.0s' {1..64})"
+readonly good_digest
+readonly workflow_ref="devantler-tech/platform/.github/workflows/ci.yaml@refs/heads/main"
+
+pass_count=0
+fail_count=0
+
+ok() {
+  echo "  ✅ $1"
+  pass_count=$((pass_count + 1))
+}
+
+bad() {
+  echo "  ❌ $1"
+  echo "     $2"
+  fail_count=$((fail_count + 1))
+}
+
+# stub_dir builds a PATH shim whose cosign and gh exit with the given codes, so
+# a verdict is chosen rather than discovered.
+#
+# Each stub also APPENDS its own argv to ${dir}/argv. The gate captures tool
+# output into a per-check log it only prints on failure, so asserting on the
+# gate's stdout cannot see what a passing check was actually asked to verify —
+# and "it passed" is not the property under test here. The argv file is the seam
+# that makes the pinned identity and issuer observable.
+stub_dir() {
+  local cosign_rc="$1" gh_rc="$2"
+  local dir
+  dir="$(mktemp -d)"
+
+  cat >"${dir}/cosign" <<EOF
+#!/usr/bin/env bash
+echo "cosign \$*" >>"${dir}/argv"
+echo "cosign stub: \$*"
+exit ${cosign_rc}
+EOF
+
+  cat >"${dir}/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >>"${dir}/argv"
+echo "gh stub: \$*"
+exit ${gh_rc}
+EOF
+
+  chmod +x "${dir}/cosign" "${dir}/gh"
+  echo "${dir}"
+}
+
+# run_gate invokes the gate with stubs and returns its exit code plus output.
+#
+# The digest default uses ${4-} rather than ${4:-}: an explicitly EMPTY digest is
+# one of the inputs under test, and :- would silently substitute the good one,
+# turning that case into a duplicate of the happy path.
+run_gate() {
+  local cosign_rc="$1" gh_rc="$2" enforce="$3" digest="${4-${good_digest}}"
+  local dir
+  dir="$(stub_dir "${cosign_rc}" "${gh_rc}")"
+
+  set +e
+  gate_output="$(
+    PATH="${dir}:${PATH}" \
+      ENFORCE="${enforce}" \
+      WORKFLOW_REF="${workflow_ref}" \
+      bash "${gate}" "${digest}" 2>&1
+  )"
+  gate_rc=$?
+  set -e
+
+  rm -rf "${dir}"
+}
+
+echo "verify-published-evidence: behaviour"
+
+# --- All evidence present -----------------------------------------------------
+run_gate 0 0 "false"
+if [[ "${gate_rc}" == "0" ]]; then
+  ok "complete evidence passes"
+else
+  bad "complete evidence passes" "exit ${gate_rc}: ${gate_output}"
+fi
+
+if grep -q "All published evidence verified" <<<"${gate_output}"; then
+  ok "complete evidence reports success"
+else
+  bad "complete evidence reports success" "${gate_output}"
+fi
+
+# --- BOTH STATES of the rollout flag, on the SAME failing input ---------------
+# This pair is the feature flag's contract: the verification runs identically in
+# each state and only the consequence differs. A flag that changed whether the
+# check ran would make the non-enforcing period prove nothing about the
+# enforcing one.
+run_gate 1 0 "false"
+if [[ "${gate_rc}" == "0" ]]; then
+  ok "non-enforcing: a missing signature does NOT fail the deploy"
+else
+  bad "non-enforcing: a missing signature does NOT fail the deploy" "exit ${gate_rc}"
+fi
+
+if grep -q "::warning::" <<<"${gate_output}"; then
+  ok "non-enforcing: reports the failure as a warning"
+else
+  bad "non-enforcing: reports the failure as a warning" "${gate_output}"
+fi
+
+run_gate 1 0 "true"
+if [[ "${gate_rc}" == "1" ]]; then
+  ok "enforcing: a missing signature FAILS the deploy"
+else
+  bad "enforcing: a missing signature FAILS the deploy" "exit ${gate_rc}: ${gate_output}"
+fi
+
+if grep -q "::error::" <<<"${gate_output}"; then
+  ok "enforcing: reports the failure as an error"
+else
+  bad "enforcing: reports the failure as an error" "${gate_output}"
+fi
+
+# --- Each evidence kind is load-bearing ---------------------------------------
+# Without this, a gate that only ever ran cosign would pass every test above.
+run_gate 0 1 "true"
+if [[ "${gate_rc}" == "1" ]]; then
+  ok "enforcing: missing ATTESTATIONS fail the deploy even when signed"
+else
+  bad "enforcing: missing attestations fail the deploy" "exit ${gate_rc}: ${gate_output}"
+fi
+
+if grep -q "SBOM attestation" <<<"${gate_output}" &&
+  grep -q "provenance attestation" <<<"${gate_output}"; then
+  ok "both attestation predicates are checked by name"
+else
+  bad "both attestation predicates are checked by name" "${gate_output}"
+fi
+
+# All three failures are reported in one run, so one fix per deploy is not
+# required to discover the next.
+run_gate 1 1 "false"
+if [[ "$(grep -c '❌' <<<"${gate_output}")" == "3" ]]; then
+  ok "every failing check is reported, not just the first"
+else
+  bad "every failing check is reported, not just the first" "${gate_output}"
+fi
+
+# --- A malformed digest is refused, in BOTH flag states -----------------------
+# The non-enforcing flag must not soften this: verifying an empty or malformed
+# digest would check the mutable tag instead of the staged bytes, which is the
+# "verified the wrong thing" outcome the gate exists to rule out.
+for enforce in "false" "true"; do
+  run_gate 0 0 "${enforce}" "sha256:not-a-digest"
+  if [[ "${gate_rc}" == "2" ]]; then
+    ok "malformed digest is refused (ENFORCE=${enforce})"
+  else
+    bad "malformed digest is refused (ENFORCE=${enforce})" "exit ${gate_rc}"
+  fi
+done
+
+run_gate 0 0 "false" ""
+if [[ "${gate_rc}" == "2" ]]; then
+  ok "empty digest is refused"
+else
+  bad "empty digest is refused" "exit ${gate_rc}"
+fi
+
+# --- The identity is pinned to the calling workflow ---------------------------
+# Asserted against the recorded argv, not the gate's stdout: a PASSING check's
+# tool output is captured into a log the gate never prints, so stdout cannot
+# show what was verified. What matters is not that cosign was run, but what it
+# was asked to prove.
+dir="$(stub_dir 0 0)"
+set +e
+PATH="${dir}:${PATH}" ENFORCE="false" WORKFLOW_REF="${workflow_ref}" \
+  bash "${gate}" "${good_digest}" >/dev/null 2>&1
+set -e
+argv="$(cat "${dir}/argv")"
+rm -rf "${dir}"
+
+if grep -q -- "--certificate-identity https://github.com/${workflow_ref}" <<<"${argv}"; then
+  ok "signature is verified against the calling workflow's exact identity"
+else
+  bad "signature is verified against the calling workflow's exact identity" "${argv}"
+fi
+
+if grep -q -- "--certificate-oidc-issuer https://token.actions.githubusercontent.com" <<<"${argv}"; then
+  ok "signature is verified against the GitHub Actions OIDC issuer"
+else
+  bad "signature is verified against the GitHub Actions OIDC issuer" "${argv}"
+fi
+
+# The verification must name the resolved digest, never the mutable tag.
+if grep -q -- "@${good_digest}" <<<"${argv}" && ! grep -q ":latest" <<<"${argv}"; then
+  ok "every check targets the digest, never the mutable tag"
+else
+  bad "every check targets the digest, never the mutable tag" "${argv}"
+fi
+
+# An absent identity must refuse rather than fall back to a wildcard: verifying
+# that SOMEONE signed the bytes is not the property being asserted.
+dir="$(stub_dir 0 0)"
+set +e
+PATH="${dir}:${PATH}" ENFORCE="false" WORKFLOW_REF="" GITHUB_WORKFLOW_REF="" \
+  bash "${gate}" "${good_digest}" >/dev/null 2>&1
+missing_identity_rc=$?
+set -e
+rm -rf "${dir}"
+
+if [[ "${missing_identity_rc}" == "2" ]]; then
+  ok "an unknown signing identity is refused, not wildcarded"
+else
+  bad "an unknown signing identity is refused, not wildcarded" "exit ${missing_identity_rc}"
+fi
+
+echo "verify-published-evidence: wiring"
+
+# --- The gate is reached, and BEFORE the promotion ----------------------------
+# Order is the half a static read CAN decide, and it is the half that matters
+# here: a gate that runs after latest already moved has verified bytes
+# production is already following.
+if grep -q "scripts/verify-published-evidence.sh" "${action}"; then
+  ok "the publication action calls the gate"
+else
+  bad "the publication action calls the gate" "no reference in ${action}"
+fi
+
+gate_line="$(grep -n "scripts/verify-published-evidence.sh" "${action}" | head -1 | cut -d: -f1)"
+promote_line="$(grep -n "id: promote_latest" "${action}" | head -1 | cut -d: -f1)"
+provenance_line="$(grep -n "id: attest_provenance" "${action}" | head -1 | cut -d: -f1)"
+
+if [[ -n "${gate_line}" && -n "${promote_line}" ]] && ((gate_line < promote_line)); then
+  ok "the gate runs BEFORE latest is promoted"
+else
+  bad "the gate runs BEFORE latest is promoted" "gate=${gate_line:-none} promote=${promote_line:-none}"
+fi
+
+if [[ -n "${gate_line}" && -n "${provenance_line}" ]] && ((provenance_line < gate_line)); then
+  ok "the gate runs AFTER both attestations are written"
+else
+  bad "the gate runs AFTER both attestations are written" "provenance=${provenance_line:-none} gate=${gate_line:-none}"
+fi
+
+# The gate must verify the digest the run actually resolved. Passing anything
+# else — most of all the mutable tag — would verify bytes other than the ones
+# about to be promoted.
+# shellcheck disable=SC2016  # the literal ${STAGING_DIGEST} is the text being matched
+if grep -q 'verify-published-evidence.sh "\${STAGING_DIGEST}"' "${action}"; then
+  ok "the gate is given the resolved staging digest"
+else
+  bad "the gate is given the resolved staging digest" "unexpected argument in ${action}"
+fi
+
+# The rollout ratchet: default-off on this landing, so the enforcing flip is a
+# separate, deliberate change rather than something that arrives with it.
+if grep -q "enforce-evidence-verification" "${action}"; then
+  ok "enforcement is a declared input"
+else
+  bad "enforcement is a declared input" "no input in ${action}"
+fi
+
+echo
+echo "passed=${pass_count} failed=${fail_count}"
+[[ "${fail_count}" == "0" ]]

--- a/scripts/tests/test-verify-published-evidence.sh
+++ b/scripts/tests/test-verify-published-evidence.sh
@@ -133,6 +133,53 @@ else
   bad "enforcing: reports the failure as an error" "${gate_output}"
 fi
 
+# --- The flag's DOMAIN is part of its contract --------------------------------
+# The enforcing branch compares against the literal "true", so ANY other value
+# selects the non-enforcing path. That makes a typo in the workflow env —
+# ENFORCE=True, ENFORCE=1, ENFORCE=ture — indistinguishable from a deliberate
+# ENFORCE=false: the gate emits a ::warning:: and exits 0 while the operator who
+# set it believes promotion is now being refused. A gate that is silently off is
+# the single failure this script exists to prevent, and it is least visible
+# precisely at the flip, so an unrecognised value must be a hard error rather
+# than a default.
+#
+# The loop COUNTS rejections instead of spot-checking one value: a guard that
+# only special-cased "True" would satisfy a single assertion while leaving every
+# other typo fail-open. Asserting the count makes a partial fix fail.
+invalid_enforce=("True" "TRUE" "1" "yes" "ture" "false ")
+invalid_rejected=0
+for invalid in "${invalid_enforce[@]}"; do
+  run_gate 1 0 "${invalid}"
+  [[ "${gate_rc}" == "2" ]] && invalid_rejected=$((invalid_rejected + 1))
+done
+
+if [[ "${invalid_rejected}" == "${#invalid_enforce[@]}" ]]; then
+  ok "an unrecognised ENFORCE value is refused (${invalid_rejected}/${#invalid_enforce[@]})"
+else
+  bad "an unrecognised ENFORCE value is refused" \
+    "only ${invalid_rejected}/${#invalid_enforce[@]} exited 2 — the rest fell through to a path that does not enforce"
+fi
+
+# Rejection must be loud. Exiting non-zero without saying why turns a typo into
+# an unexplained CI failure, which is how a guard gets deleted rather than fixed.
+run_gate 1 0 "True"
+if grep -q "::error::" <<<"${gate_output}" && grep -q "ENFORCE" <<<"${gate_output}"; then
+  ok "the refusal names ENFORCE as the cause"
+else
+  bad "the refusal names ENFORCE as the cause" "${gate_output}"
+fi
+
+# The control for the guard above: the two VALID values must still reach their
+# verdicts. A guard that rejected everything would pass the assertions above
+# while breaking the gate outright — an empty value included, since the script
+# documents unset as defaulting to non-enforcing.
+run_gate 1 0 ""
+if [[ "${gate_rc}" == "0" ]]; then
+  ok "an EMPTY ENFORCE still defaults to non-enforcing (not rejected)"
+else
+  bad "an EMPTY ENFORCE still defaults to non-enforcing" "exit ${gate_rc}: ${gate_output}"
+fi
+
 # --- Each evidence kind is load-bearing ---------------------------------------
 # Without this, a gate that only ever ran cosign would pass every test above.
 run_gate 0 1 "true"

--- a/scripts/verify-published-evidence.sh
+++ b/scripts/verify-published-evidence.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Verify that the supply-chain evidence for a staged digest actually reached the
+# registry, before that digest is promoted to the tag production follows.
+#
+# The publication transaction signs the resolved digest, attests an SBOM and
+# build provenance, and then promotes those exact bytes to latest. Every one of
+# those steps can report success while leaving no usable evidence behind: a
+# swallowed failure, a shadowed cosign, a resolver returning a constant digest,
+# or an upload that never happened all end with a green job and an artifact
+# production is about to consume with nothing signed for it.
+#
+# A static check over the workflow text cannot close that. It can decide what
+# order the steps appear in and what each is wired to, but not what the named
+# program actually did — which is exactly where the remaining bypasses live.
+# This asks the registry instead, which is decidable: it either carries valid
+# evidence for those exact bytes or it does not.
+#
+# Producer-side and complementary to the cluster's spec.verify: this fails fast
+# in CI with a clear message, that one refuses the pull. Neither replaces the
+# other.
+#
+# ENFORCE gates only whether a missing-evidence verdict FAILS the deploy. The
+# verification itself always runs, and always reports — a gate wrong about the
+# identity or issuer would break every production deploy, so it earns the right
+# to block by first being observed passing on real deploys.
+
+set -uo pipefail
+
+readonly subject_name="${SUBJECT_NAME:-ghcr.io/devantler-tech/platform/manifests}"
+readonly oidc_issuer="${OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
+
+# Predicate types the two attestation steps write. Checked by TYPE rather than
+# by counting attestations: any signed attestation would satisfy a bare presence
+# check, including one carrying neither of the predicates production relies on.
+readonly sbom_predicate="${SBOM_PREDICATE:-https://cyclonedx.org/bom}"
+readonly provenance_predicate="${PROVENANCE_PREDICATE:-https://slsa.dev/provenance/v1}"
+
+usage() {
+  echo "usage: ${0##*/} <sha256:digest>" >&2
+  echo "env: ENFORCE=true|false  WORKFLOW_REF=<owner/repo/.github/workflows/x.yaml@ref>" >&2
+}
+
+digest="${1-}"
+
+# Validate the digest rather than interpolating whatever arrived. An empty or
+# malformed value would otherwise be pasted into a reference and verified
+# against SOMETHING — most likely the mutable tag — which is precisely the
+# "verified the wrong bytes" outcome this gate exists to rule out.
+if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "::error::Refusing to verify an invalid digest: ${digest:-<empty>}" >&2
+  usage
+  exit 2
+fi
+
+# The identity is this run's own workflow, taken from the runner rather than
+# from a pattern. GITHUB_WORKFLOW_REF is "owner/repo/.github/workflows/f.yaml@ref",
+# and the Fulcio SAN is that with the GitHub host prefixed — so the signature is
+# checked against the exact workflow that claims to have produced it, not
+# against any workflow in the repository.
+workflow_ref="${WORKFLOW_REF:-${GITHUB_WORKFLOW_REF:-}}"
+if [[ -z "${workflow_ref}" ]]; then
+  echo "::error::WORKFLOW_REF is empty; cannot pin the signing identity" >&2
+  exit 2
+fi
+
+readonly identity="https://github.com/${workflow_ref}"
+readonly ref="${subject_name}@${digest}"
+readonly repo="${GITHUB_REPOSITORY:-devantler-tech/platform}"
+
+failures=0
+log_dir="$(mktemp -d)"
+trap 'rm -rf "${log_dir}"' EXIT
+
+# check runs one verification and records its verdict without aborting the rest.
+# All three are reported every run: stopping at the first failure would hide a
+# missing provenance behind a missing signature and turn one fix into three
+# deploys.
+check() {
+  local label="$1"
+  shift
+
+  if "$@" >"${log_dir}/${label}.log" 2>&1; then
+    echo "  ✅ ${label}"
+    return 0
+  fi
+
+  echo "  ❌ ${label}"
+  sed 's/^/       /' "${log_dir}/${label}.log" >&2
+  failures=$((failures + 1))
+
+  return 0
+}
+
+echo "Verifying published evidence for ${ref}"
+echo "  identity: ${identity}"
+echo "  issuer:   ${oidc_issuer}"
+
+check "cosign signature" \
+  cosign verify \
+  --certificate-identity "${identity}" \
+  --certificate-oidc-issuer "${oidc_issuer}" \
+  "${ref}"
+
+check "SBOM attestation" \
+  gh attestation verify "oci://${ref}" \
+  --repo "${repo}" \
+  --predicate-type "${sbom_predicate}"
+
+check "provenance attestation" \
+  gh attestation verify "oci://${ref}" \
+  --repo "${repo}" \
+  --predicate-type "${provenance_predicate}"
+
+# Compare as a string. A numeric test on a value that somehow became non-numeric
+# evaluates as an error inside a conditional and reads as "no failures", which
+# would let the gate pass exactly when its own bookkeeping broke.
+if [[ "${failures}" == "0" ]]; then
+  echo "All published evidence verified against ${digest}."
+  exit 0
+fi
+
+if [[ "${ENFORCE:-false}" == "true" ]]; then
+  echo "::error::${failures} evidence check(s) failed for ${digest}; refusing to promote it." >&2
+  exit 1
+fi
+
+echo "::warning::${failures} evidence check(s) failed for ${digest}." \
+  "This gate is not yet enforcing, so the deploy continues — see platform#2859." >&2
+exit 0

--- a/scripts/verify-published-evidence.sh
+++ b/scripts/verify-published-evidence.sh
@@ -108,16 +108,25 @@ check "cosign signature" \
 # and fail for ABSENT evidence — indistinguishable in the verdict from evidence
 # that is genuinely missing or invalid, which is the one distinction this gate
 # exists to make.
+#
+# --cert-identity on both: --repo scopes the lookup to this repository but says
+# nothing about WHICH workflow signed. Without it, any workflow here that can
+# mint an attestation satisfies the gate, so a less-trusted one becomes a path
+# to a promotable digest. That is the same substitution the cosign check above
+# already refuses, and the two must not disagree about who is allowed to vouch
+# for a digest.
 check "SBOM attestation" \
   gh attestation verify "oci://${ref}" \
   --bundle-from-oci \
   --repo "${repo}" \
+  --cert-identity "${identity}" \
   --predicate-type "${sbom_predicate}"
 
 check "provenance attestation" \
   gh attestation verify "oci://${ref}" \
   --bundle-from-oci \
   --repo "${repo}" \
+  --cert-identity "${identity}" \
   --predicate-type "${provenance_predicate}"
 
 # Compare as a string. A numeric test on a value that somehow became non-numeric

--- a/scripts/verify-published-evidence.sh
+++ b/scripts/verify-published-evidence.sh
@@ -52,6 +52,22 @@ if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
   exit 2
 fi
 
+# Validate the flag's DOMAIN, not just read it. The enforcing branch below tests
+# for the literal "true", so without this every other value — ENFORCE=True,
+# ENFORCE=1, a typo — would quietly select the non-enforcing path and be
+# indistinguishable from a deliberate ENFORCE=false. The operator who set it
+# would see a ::warning:: and a green job and conclude the gate was refusing
+# promotion, when it was off. Rejected here, with the other input validation, so
+# a misconfigured run fails before it spends registry calls to reach the same
+# verdict. An unset or empty value is not a typo — it is the documented default.
+enforce="${ENFORCE:-false}"
+if [[ "${enforce}" != "true" && "${enforce}" != "false" ]]; then
+  echo "::error::ENFORCE must be exactly 'true' or 'false' (got: '${enforce}')" >&2
+  usage
+  exit 2
+fi
+readonly enforce
+
 # The identity is this run's own workflow, taken from the runner rather than
 # from a pattern. GITHUB_WORKFLOW_REF is "owner/repo/.github/workflows/f.yaml@ref",
 # and the Fulcio SAN is that with the GitHub host prefixed — so the signature is
@@ -137,7 +153,7 @@ if [[ "${failures}" == "0" ]]; then
   exit 0
 fi
 
-if [[ "${ENFORCE:-false}" == "true" ]]; then
+if [[ "${enforce}" == "true" ]]; then
   echo "::error::${failures} evidence check(s) failed for ${digest}; refusing to promote it." >&2
   exit 1
 fi

--- a/scripts/verify-published-evidence.sh
+++ b/scripts/verify-published-evidence.sh
@@ -101,13 +101,22 @@ check "cosign signature" \
   --certificate-oidc-issuer "${oidc_issuer}" \
   "${ref}"
 
+# --bundle-from-oci on both: the attestations are published with
+# `create-storage-record: false`, so the bundles live in the registry beside the
+# image and were never written to the GitHub Attestations API that this command
+# reads by default. Without the flag both checks query the API, find nothing,
+# and fail for ABSENT evidence — indistinguishable in the verdict from evidence
+# that is genuinely missing or invalid, which is the one distinction this gate
+# exists to make.
 check "SBOM attestation" \
   gh attestation verify "oci://${ref}" \
+  --bundle-from-oci \
   --repo "${repo}" \
   --predicate-type "${sbom_predicate}"
 
 check "provenance attestation" \
   gh attestation verify "oci://${ref}" \
+  --bundle-from-oci \
   --repo "${repo}" \
   --predicate-type "${provenance_predicate}"
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production's deploy signs the manifests, attests an SBOM and build provenance, and then points the tag production follows at those bytes. Nothing checked that any of that evidence actually reached the registry.

Every one of those steps can report success while leaving nothing behind — so a green deploy can hand production an artifact with no usable signature or attestations. Checking the workflow text cannot rule this out: it can tell what order the steps run in, but not what each program actually did, which is where the remaining gaps are.

## What

Asks the registry directly, between the attestations and the promotion, whether valid evidence exists for exactly the bytes about to be promoted — the signature (pinned to the calling workflow's identity and issuer, not merely "something signed this") and both attestation types.

It lands **non-enforcing**: it runs and reports, but does not yet fail a deploy. A gate that is wrong about the identity would break every production deploy, so it earns the right to block by first being watched passing on real deploys. Flipping it on is a separate, deliberate follow-up.

Fixes #2859
Part of #2627
