### PR TITLE
feat(homepage): merge the Personal bookmark group into Personal Sites

### DIFF
--- a/k8s/bases/apps/homepage/config-map.yaml
+++ b/k8s/bases/apps/homepage/config-map.yaml
@@ -114,8 +114,6 @@ data:
         icon: mdi-play-circle-outline
       Banking:
         icon: mdi-bank-outline
-      Personal:
-        icon: mdi-account-circle
   kubernetes.yaml: |
     mode: cluster
     gateway: true
@@ -158,6 +156,16 @@ data:
             icon: unifi
             href: https://unifi.ui.com
             description: Central hub for managing on-prem UniFi network infrastructure.
+    # Personal Sites also gains cluster-hosted entries from the
+    # gethomepage.dev annotations on other repositories' HTTPRoutes (e.g.
+    # doggy-countdown). devantler.tech is not deployed from this cluster, so it
+    # is listed statically here; Homepage renders discovered services above
+    # static ones within the same group.
+    - Personal Sites:
+        - devantler.tech:
+            icon: mdi-web
+            href: https://devantler.tech
+            description: Personal site — portfolio, guides and product documentation.
     # Analytics is populated dynamically from the gethomepage.dev annotations on
     # Umami's Flagger-generated HTTPRoute (k8s/bases/apps/umami/canary.yaml,
     # spec.service.apex.annotations).
@@ -268,10 +276,6 @@ data:
         - Enable Banking:
             - icon: mdi-bank-outline
               href: https://enablebanking.com
-    - Personal:
-        - Personal Site:
-            - icon: github-light
-              href: https://devantler.tech
   docker.yaml: ""
   # Theme: mirror https://devantler.tech. That site is Astro Starlight with the
   # stock dark palette — a gray ramp at hue 224 but only ~6-14% saturation, i.e.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The dashboard showed two headings for the same idea: a **Personal** group whose only entry was a
link to devantler.tech, and a **Personal Sites** group for the personal sites hosted on the cluster.
Having one of each is confusing, and the single-link group earns its own heading for no reason.

## What

devantler.tech now lives in **Personal Sites**, and the **Personal** group is gone. One heading
covers personal sites whether or not the cluster hosts them.

The link had to *move* rather than be renamed: Homepage draws services and bookmarks as two separate
sections, so simply calling the bookmark group "Personal Sites" would have painted that heading
twice with different contents under each — the exact trap the layout comment in this file warns
about. devantler.tech is not deployed from this cluster, so it is a static services entry; the
cluster-hosted ones keep arriving from their own repositories' route annotations.

**One thing to confirm after it deploys**, which no amount of static validation can prove: that the
static entry and the annotation-discovered ones render under a *single* Personal Sites heading. That
group has no discovered members on `main` today, so the combined case only becomes real once
doggy-countdown#1 lands — I will check the live dashboard then rather than assume it.
