### PR TITLE
fix(ci): assert Flux verification is in effect, not merely configured

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,15 @@ jobs:
           go test ./scripts/validate-dr-signing
           go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml
 
+      # The DR contract above checks WHAT the verify block allows. This checks
+      # that the block is in effect at all: it ran at spec.cluster.verify for
+      # ~3 weeks, where KSail discards it, and every text-based check passed
+      # throughout (#2920).
+      - name: 🔐 Validate Flux verification is in effect
+        run: |
+          go test ./scripts/validate-flux-verify
+          go run ./scripts/validate-flux-verify ksail.prod.yaml
+
       # .github/actionlint.yaml silences actionlint's "unexpected key" diagnostic
       # for concurrency.queue, which also removes its enum check. This restores it.
       - name: 🚦 Validate concurrency queue values

--- a/scripts/validate-flux-verify/main.go
+++ b/scripts/validate-flux-verify/main.go
@@ -1,0 +1,190 @@
+// Command validate-flux-verify checks that the platform's Flux signature
+// verification is actually IN EFFECT, rather than merely present somewhere in
+// the cluster config.
+//
+// # WHY THIS IS NOT A GREP
+//
+// The flux-system OCIRepository is the root of the whole platform: every
+// controller, tenant binding and policy arrives through it. Verification on
+// that source ran with spec.verify unset for roughly three weeks (#2627) while
+// CI stayed green the entire time. The config was not missing the block — it
+// carried a complete, correct, well-commented cosign block the whole time, at
+// spec.cluster.verify. ClusterSpec has no verify field, so KSail discarded the
+// key in silence and rendered an OCIRepository that pulled a mutable tag
+// unverified.
+//
+// A text scan for `verify:` would have passed on every single day of that
+// outage. So would a scan for the cosign matcher subjects, which were also
+// present and also inert. The only question that separates a configured
+// platform from an unprotected one is whether the block resolves at the path
+// KSail READS, so that is the only question this validator asks.
+//
+// 🔴 THE ENABLED PREDICATE IS KSAIL'S, NOT AN APPROXIMATION OF IT.
+//
+// KSail decides whether to render spec.verify onto the OCIRepository with
+// FluxVerifySpec.Enabled(), which is `strings.TrimSpace(Provider) != ""`
+// (ksail pkg/apis/cluster/v1alpha1/flux_types.go). A check that asked the
+// obvious `provider != ""` instead would accept `provider: "  "` and report a
+// verified platform while KSail rendered no spec.verify at all — the identical
+// silent-inertness defect this validator exists to catch, one layer deeper and
+// considerably harder to see. Mirroring the consumer's own predicate is the
+// point, not an implementation detail; if KSail's predicate changes, this must
+// follow it rather than drift into a second, weaker opinion.
+//
+// A stray block is reported too, and deliberately fails closed. A verify key at
+// any other path is either the outage shape itself or a leftover copy that
+// invites someone to "tidy up" the live one. If a future KSail genuinely reads
+// a verify key elsewhere, this fails loudly on the pull request that
+// introduces it, which is the direction a security check should fail in.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// readPath is the only path KSail reads a Flux verify block from. Kept as a
+// slice so the walk below can compare a full path rather than a leaf name.
+var readPath = []string{"spec", "workload", "flux", "verify"}
+
+// verifyKey is the leaf name a misplaced block keeps when it is written at the
+// wrong level, which is how every observed instance of this defect has looked.
+const verifyKey = "verify"
+
+// enabled mirrors ksail's FluxVerifySpec.Enabled(). See the package comment:
+// this must track KSail, not approximate it.
+func enabled(provider string) bool {
+	return strings.TrimSpace(provider) != ""
+}
+
+// lookup walks a decoded YAML tree along path, returning the value at that path.
+func lookup(tree any, path []string) (any, bool) {
+	current := tree
+	for _, key := range path {
+		mapping, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = mapping[key]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+// strayVerifyPaths returns every path holding a `verify` key other than the one
+// KSail reads, in the order encountered.
+func strayVerifyPaths(tree any, path []string) []string {
+	var found []string
+
+	switch node := tree.(type) {
+	case map[string]any:
+		for key, value := range node {
+			child := append(append([]string{}, path...), key)
+			if key == verifyKey && !samePath(child, readPath) {
+				found = append(found, strings.Join(child, "."))
+			}
+
+			found = append(found, strayVerifyPaths(value, child)...)
+		}
+	case []any:
+		for index, value := range node {
+			child := append(append([]string{}, path...), fmt.Sprintf("[%d]", index))
+			found = append(found, strayVerifyPaths(value, child)...)
+		}
+	}
+
+	return found
+}
+
+func samePath(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// validate reports why the config's signature verification is not in effect, or
+// nil when it is.
+func validate(config []byte) error {
+	var tree any
+	if err := yaml.Unmarshal(config, &tree); err != nil {
+		return fmt.Errorf("cluster config does not parse, so verification cannot be established: %w", err)
+	}
+
+	// Reported before the read-path check, because a stray block is the reason
+	// the read path is usually empty and naming it is the actionable half.
+	if stray := strayVerifyPaths(tree, nil); len(stray) > 0 {
+		return fmt.Errorf(
+			"verify block at %s, which KSail does not read: move it to %s or delete it "+
+				"(a block at any other path is discarded in silence and verifies nothing)",
+			strings.Join(stray, ", "), strings.Join(readPath, "."),
+		)
+	}
+
+	value, ok := lookup(tree, readPath)
+	if !ok {
+		return fmt.Errorf(
+			"no verify block at %s, so the generated flux-system OCIRepository pulls unverified: "+
+				"add a cosign block there",
+			strings.Join(readPath, "."),
+		)
+	}
+
+	block, ok := value.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s is not a mapping, so KSail cannot decode it into a verify spec",
+			strings.Join(readPath, "."))
+	}
+
+	provider, _ := block["provider"].(string)
+	if !enabled(provider) {
+		return fmt.Errorf(
+			"%s.provider is %q, which KSail treats as verification DISABLED "+
+				"(it renders spec.verify only when the provider is non-blank): set it to cosign",
+			strings.Join(readPath, "."), provider,
+		)
+	}
+
+	return nil
+}
+
+func run(args []string, stderr io.Writer) int {
+	if len(args) != 1 {
+		_, _ = fmt.Fprintln(stderr, "usage: validate-flux-verify <ksail-config.yaml>")
+
+		return 1
+	}
+
+	config, err := os.ReadFile(args[0]) //nolint:gosec // Explicit path from the caller.
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "flux verify contract: read cluster config: %v\n", err)
+
+		return 1
+	}
+
+	if err := validate(config); err != nil {
+		_, _ = fmt.Fprintf(stderr, "flux verify contract: %v\n", err)
+
+		return 1
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stderr))
+}

--- a/scripts/validate-flux-verify/main.go
+++ b/scripts/validate-flux-verify/main.go
@@ -42,6 +42,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -61,14 +62,41 @@ func enabled(provider string) bool {
 	return strings.TrimSpace(provider) != ""
 }
 
+// asMapping normalises the two shapes yaml.v3 decodes a mapping into.
+//
+// A mapping whose keys are all strings decodes as map[string]any, but ONE
+// non-string key anywhere in it — `1:`, `true:`, `~:` — switches the ENTIRE
+// mapping to map[any]any. A walk matching only map[string]any would then skip
+// that whole level, so a stray verify block sitting beside an integer key would
+// go unreported while the read-path check still passed. That is a fail-open in
+// a check whose whole purpose is to fail closed, so both shapes are handled
+// here rather than at each call site.
+func asMapping(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case map[any]any:
+		normalised := make(map[string]any, len(typed))
+		for key, item := range typed {
+			normalised[fmt.Sprintf("%v", key)] = item
+		}
+
+		return normalised, true
+	default:
+		return nil, false
+	}
+}
+
 // lookup walks a decoded YAML tree along path, returning the value at that path.
 func lookup(tree any, path []string) (any, bool) {
 	current := tree
+
 	for _, key := range path {
-		mapping, ok := current.(map[string]any)
+		mapping, ok := asMapping(current)
 		if !ok {
 			return nil, false
 		}
+
 		current, ok = mapping[key]
 		if !ok {
 			return nil, false
@@ -79,24 +107,36 @@ func lookup(tree any, path []string) (any, bool) {
 }
 
 // strayVerifyPaths returns every path holding a `verify` key other than the one
-// KSail reads, in the order encountered.
+// KSail reads. Sorted, because Go randomises map iteration and an error message
+// that lists the same paths in a different order on every run is both harder to
+// read and impossible to assert on.
 func strayVerifyPaths(tree any, path []string) []string {
+	found := collectStrayVerifyPaths(tree, path)
+	sort.Strings(found)
+
+	return found
+}
+
+func collectStrayVerifyPaths(tree any, path []string) []string {
 	var found []string
 
-	switch node := tree.(type) {
-	case map[string]any:
+	if node, ok := asMapping(tree); ok {
 		for key, value := range node {
 			child := append(append([]string{}, path...), key)
 			if key == verifyKey && !samePath(child, readPath) {
 				found = append(found, strings.Join(child, "."))
 			}
 
-			found = append(found, strayVerifyPaths(value, child)...)
+			found = append(found, collectStrayVerifyPaths(value, child)...)
 		}
-	case []any:
+
+		return found
+	}
+
+	if node, ok := tree.([]any); ok {
 		for index, value := range node {
 			child := append(append([]string{}, path...), fmt.Sprintf("[%d]", index))
-			found = append(found, strayVerifyPaths(value, child)...)
+			found = append(found, collectStrayVerifyPaths(value, child)...)
 		}
 	}
 
@@ -144,7 +184,7 @@ func validate(config []byte) error {
 		)
 	}
 
-	block, ok := value.(map[string]any)
+	block, ok := asMapping(value)
 	if !ok {
 		return fmt.Errorf("%s is not a mapping, so KSail cannot decode it into a verify spec",
 			strings.Join(readPath, "."))

--- a/scripts/validate-flux-verify/main.go
+++ b/scripts/validate-flux-verify/main.go
@@ -39,6 +39,8 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -157,12 +159,61 @@ func samePath(a, b []string) bool {
 	return true
 }
 
+// decodeAll returns every YAML document in the input. yaml.Unmarshal reads only
+// the first and discards the rest silently, which is the behaviour this
+// validator exists to make loud, so it must not rely on it itself.
+func decodeAll(config []byte) ([]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(config))
+
+	var documents []any
+
+	for {
+		var document any
+
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			return documents, nil
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		// A trailing `---` with nothing after it decodes as a nil document and is
+		// not a second resource, so it must not trip the one-document rule.
+		if document == nil {
+			continue
+		}
+
+		documents = append(documents, document)
+	}
+}
+
 // validate reports why the config's signature verification is not in effect, or
 // nil when it is.
 func validate(config []byte) error {
-	var tree any
-	if err := yaml.Unmarshal(config, &tree); err != nil {
+	documents, err := decodeAll(config)
+	if err != nil {
 		return fmt.Errorf("cluster config does not parse, so verification cannot be established: %w", err)
+	}
+
+	// A cluster config is ONE `kind: Cluster` resource, so everything after the
+	// first document is not read as the cluster spec. yaml.Unmarshal drops those
+	// documents without a word, which makes a second document exactly the kind of
+	// place a verify block can sit while looking configured — measured: a valid
+	// document one plus a stray block in document two validated clean. Refusing
+	// the shape is simpler than guessing which document was meant to win.
+	if len(documents) > 1 {
+		return fmt.Errorf(
+			"cluster config has %d YAML documents; only the first is read as the cluster spec, "+
+				"so anything configured in the rest verifies nothing: keep it to one document",
+			len(documents),
+		)
+	}
+
+	var tree any
+	if len(documents) == 1 {
+		tree = documents[0]
 	}
 
 	// Reported before the read-path check, because a stray block is the reason

--- a/scripts/validate-flux-verify/main.go
+++ b/scripts/validate-flux-verify/main.go
@@ -190,12 +190,22 @@ func validate(config []byte) error {
 			strings.Join(readPath, "."))
 	}
 
-	provider, _ := block["provider"].(string)
+	// A non-string provider (`provider: 123`) fails the assertion and lands here
+	// as "", which is the right VERDICT — KSail cannot decode it into its string
+	// field either — but reporting it as "" would misname what the file says and
+	// send the reader looking for an empty value that is not there. Report the
+	// raw node so the message names the edit to make.
+	provider, isString := block["provider"].(string)
 	if !enabled(provider) {
+		reported := any(provider)
+		if !isString {
+			reported = block["provider"]
+		}
+
 		return fmt.Errorf(
-			"%s.provider is %q, which KSail treats as verification DISABLED "+
-				"(it renders spec.verify only when the provider is non-blank): set it to cosign",
-			strings.Join(readPath, "."), provider,
+			"%s.provider is %#v, which KSail treats as verification DISABLED "+
+				"(it renders spec.verify only when the provider is a non-blank string): set it to cosign",
+			strings.Join(readPath, "."), reported,
 		)
 	}
 

--- a/scripts/validate-flux-verify/main_test.go
+++ b/scripts/validate-flux-verify/main_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// goodConfig is the shape the corrected config (#2919) has: a cosign block at
+// the one path KSail reads.
+const goodConfig = `
+apiVersion: ksail.io/v1alpha1
+kind: Cluster
+metadata:
+  name: prod
+spec:
+  cluster:
+    distribution: Talos
+    gitOpsEngine: Flux
+  workload:
+    sourceDirectory: k8s
+    flux:
+      verify:
+        provider: cosign
+        matchOIDCIdentity:
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+            subject: '^https://github\.com/devantler-tech/platform/.+$'
+`
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// wantErr is a substring the failure must name, so an arm cannot pass
+		// on the wrong error. Empty means the config must validate.
+		wantErr string
+		config  string
+	}{
+		{
+			name:   "corrected config validates",
+			config: goodConfig,
+		},
+		{
+			// The reproduced outage: a complete, correct cosign block at a path
+			// ClusterSpec has no field for. Present in the text, inert in effect.
+			name: "block at spec.cluster.verify is rejected",
+			config: `
+spec:
+  cluster:
+    verify:
+      provider: cosign
+  workload:
+    flux: {}
+`,
+			wantErr: "spec.cluster.verify",
+		},
+		{
+			// Missing the flux level is the same class as the outage: one level
+			// off, silently discarded.
+			name: "block at spec.workload.verify is rejected",
+			config: `
+spec:
+  workload:
+    verify:
+      provider: cosign
+    flux: {}
+`,
+			wantErr: "spec.workload.verify",
+		},
+		{
+			// 🔴 THE DISCRIMINATING ARM. A whitespace-only provider is at the
+			// correct path and is a non-empty Go string, so a `provider != ""`
+			// check accepts it — while KSail's TrimSpace predicate renders no
+			// spec.verify at all. Removing the TrimSpace flips exactly this arm
+			// and nothing else.
+			name: "whitespace-only provider is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: "  \t "
+`,
+			wantErr: "DISABLED",
+		},
+		{
+			name: "empty provider is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: ""
+`,
+			wantErr: "DISABLED",
+		},
+		{
+			name: "verify block with no provider key is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        matchOIDCIdentity:
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+`,
+			wantErr: "DISABLED",
+		},
+		{
+			// A correct live block plus a leftover copy. The live one works
+			// today, but the stray invites a cleanup that deletes the wrong one.
+			name: "stray copy alongside a correct block is rejected",
+			config: `
+spec:
+  cluster:
+    verify:
+      provider: cosign
+  workload:
+    flux:
+      verify:
+        provider: cosign
+`,
+			wantErr: "spec.cluster.verify",
+		},
+		{
+			name: "missing verify block entirely is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      sourceDirectory: k8s
+`,
+			wantErr: "no verify block",
+		},
+		{
+			name: "scalar verify at the read path is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify: true
+`,
+			wantErr: "not a mapping",
+		},
+		{
+			name:    "unparseable config is rejected",
+			config:  "spec:\n\t- broken\n  indent: [",
+			wantErr: "does not parse",
+		},
+		{
+			// A verify key nested inside a list still counts; the walk must not
+			// stop at the first mapping level.
+			name: "stray verify nested in a sequence is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+  extras:
+    - name: a
+      verify:
+        provider: cosign
+`,
+			wantErr: "spec.extras",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validate([]byte(test.config))
+
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected the config to validate, got: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected a failure naming %q, got nil", test.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("expected the failure to name %q, got: %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestEnabledMirrorsKSail pins the predicate itself, separately from the
+// validator, because this is the one line that must track ksail's
+// FluxVerifySpec.Enabled() rather than a local opinion of it.
+func TestEnabledMirrorsKSail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		provider string
+		want     bool
+	}{
+		{provider: "cosign", want: true},
+		{provider: "notation", want: true},
+		{provider: "", want: false},
+		{provider: " ", want: false},
+		{provider: "  \t ", want: false},
+		{provider: "\n", want: false},
+		{provider: " cosign ", want: true},
+	}
+
+	for _, test := range tests {
+		if got := enabled(test.provider); got != test.want {
+			t.Errorf("enabled(%q) = %v, want %v", test.provider, got, test.want)
+		}
+	}
+}
+
+// TestRealConfigValidates is acceptance criterion 2: the check must pass on the
+// config production actually deploys, not only on the fixtures above. It reads
+// the real file so a future edit that breaks verification fails this test.
+func TestRealConfigValidates(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "ksail.prod.yaml")
+
+	config, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the production cluster config: %v", err)
+	}
+
+	if err := validate(config); err != nil {
+		t.Fatalf("the production config must have verification in effect, got: %v", err)
+	}
+}
+
+func TestRunExitCodes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	good := filepath.Join(dir, "good.yaml")
+	if err := os.WriteFile(good, []byte(goodConfig), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	bad := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(bad, []byte("spec:\n  cluster:\n    verify:\n      provider: cosign\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "valid config exits 0", args: []string{good}, want: 0},
+		{name: "misplaced block exits 1", args: []string{bad}, want: 1},
+		{name: "missing file exits 1", args: []string{filepath.Join(dir, "absent.yaml")}, want: 1},
+		{name: "no arguments exits 1", args: nil, want: 1},
+		{name: "two arguments exits 1", args: []string{good, good}, want: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr strings.Builder
+			if got := run(test.args, &stderr); got != test.want {
+				t.Fatalf("run(%v) = %d, want %d (stderr: %s)", test.args, got, test.want, stderr.String())
+			}
+		})
+	}
+}

--- a/scripts/validate-flux-verify/main_test.go
+++ b/scripts/validate-flux-verify/main_test.go
@@ -150,6 +150,44 @@ spec:
 			wantErr: "does not parse",
 		},
 		{
+			// 🔴 REGRESSION ARM. One non-string key switches the WHOLE mapping
+			// from map[string]any to map[any]any in yaml.v3, so a walk that
+			// matched only the former would skip this level entirely and miss
+			// the stray beside it — while the read path below stays valid, so
+			// nothing else reports the problem. Fail-open, in a check that only
+			// exists to fail closed.
+			name: "stray verify beside a non-string key is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+  extras:
+    1: numeric-key-demotes-this-mapping
+    verify:
+      provider: cosign
+`,
+			wantErr: "spec.extras.verify",
+		},
+		{
+			// Determinism: two strays must be listed in a stable order, or the
+			// message differs run to run.
+			name: "multiple strays are reported in sorted order",
+			config: `
+spec:
+  aaa:
+    verify: {provider: cosign}
+  zzz:
+    verify: {provider: cosign}
+  workload:
+    flux:
+      verify:
+        provider: cosign
+`,
+			wantErr: "spec.aaa.verify, spec.zzz.verify",
+		},
+		{
 			// A verify key nested inside a list still counts; the walk must not
 			// stop at the first mapping level.
 			name: "stray verify nested in a sequence is rejected",

--- a/scripts/validate-flux-verify/main_test.go
+++ b/scripts/validate-flux-verify/main_test.go
@@ -97,6 +97,19 @@ spec:
 			wantErr: "DISABLED",
 		},
 		{
+			// Fail-closed, and the message must name what the file actually
+			// says rather than the "" the failed type assertion leaves behind.
+			name: "non-string provider is rejected and reported as written",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: 123
+`,
+			wantErr: `provider is 123, which KSail treats as verification DISABLED`,
+		},
+		{
 			name: "verify block with no provider key is rejected",
 			config: `
 spec:

--- a/scripts/validate-flux-verify/main_test.go
+++ b/scripts/validate-flux-verify/main_test.go
@@ -163,6 +163,27 @@ spec:
 			wantErr: "does not parse",
 		},
 		{
+			// 🔴 REGRESSION ARM. yaml.Unmarshal reads document one and drops the
+			// rest without a word, so this validated CLEAN before: a correct
+			// document one, and a stray block in document two that nothing read
+			// and nothing reported.
+			name: "a second YAML document is rejected",
+			config: goodConfig + `
+---
+spec:
+  cluster:
+    verify:
+      provider: cosign
+`,
+			wantErr: "only the first is read as the cluster spec",
+		},
+		{
+			// A trailing separator is not a second resource and must not trip the
+			// rule above — the real ksail.prod.yaml opens with one.
+			name:   "leading and trailing document separators are fine",
+			config: "---\n" + goodConfig + "\n---\n",
+		},
+		{
 			// 🔴 REGRESSION ARM. One non-string key switches the WHOLE mapping
 			// from map[string]any to map[any]any in yaml.v3, so a walk that
 			// matched only the former would skip this level entirely and miss


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production's root Flux source ran **without signature verification for about three weeks** while CI stayed green the whole time.

The config was never missing the cosign block. It carried a complete, correct, well-commented one — just one level too high in the file, at a path KSail has no field for. KSail dropped the key in silence and pulled a mutable tag unverified.

Nothing could have caught that. Searching the config for the block would have found it on every single day of the outage, because it *was* there. The only question that separates a protected platform from an unprotected one is whether the block lands where KSail actually reads it, and nothing was asking that.

## What

A new pre-merge check that fails when the platform's signature verification is not genuinely in effect — a misplaced block, a leftover copy at the wrong path, or a provider value KSail treats as "off".

It deliberately borrows KSail's own definition of "verification is on" rather than writing a second, weaker one, so the check cannot drift into passing configs KSail would ignore. Failures name the offending path and the one edit that fixes it.

Runs in the same CI job as the existing static contracts. No manifest or runtime change — this only adds a gate.

Fixes #2920
Part of #2627
