### PR TITLE
fix(ci): refuse to promote a prod digest whose evidence cannot be verified

### DIFF
--- a/.github/actions/deploy-prod/publish-platform-manifests/action.yml
+++ b/.github/actions/deploy-prod/publish-platform-manifests/action.yml
@@ -22,12 +22,16 @@ inputs:
     required: true
   enforce-evidence-verification:
     description: >-
-      Fail the deploy when the published evidence cannot be verified. Default-off
-      while the gate proves itself on real deploys: a verification wrong about the
-      identity or issuer would break every production deploy, so it earns the
-      right to block by first being observed passing (platform#2859).
+      Refuse to promote a digest whose published evidence cannot be verified.
+      Enforcing by default: promotion is the point of no return, so a digest
+      carrying no usable signature or attestation must not reach the tag
+      production follows. Set to "false" only to stage a NEW evidence kind
+      through the same warn-then-enforce ratchet — a verification wrong about
+      the identity or issuer would break every production deploy, including
+      disaster recovery, so a new check earns the right to block by first being
+      observed passing on real deploys.
     required: false
-    default: "false"
+    default: "true"
 
 outputs:
   digest:

--- a/scripts/tests/test-verify-published-evidence.sh
+++ b/scripts/tests/test-verify-published-evidence.sh
@@ -418,11 +418,22 @@ fi
 
 # The gate reads the input rather than a constant. Without this, the default
 # above could be correct while the step passed a hardcoded value to ENFORCE.
-# shellcheck disable=SC2016  # the literal ${{ inputs... }} is the text being matched
-if grep -q 'ENFORCE: ${{ inputs.enforce-evidence-verification }}' "${action}"; then
+#
+# Resolved from the verify_evidence step specifically, not grepped over the whole
+# file: any OTHER step carrying the same env line would satisfy a file-wide match
+# while the gate itself was wired to a constant. That would make the assertion
+# about the file containing a string rather than about the gate reading the input
+# — and the input's default, asserted above, only governs enforcement if the gate
+# is what consumes it.
+# shellcheck disable=SC2016  # the literal ${{ inputs... }} is the expected value
+readonly expected_enforce='${{ inputs.enforce-evidence-verification }}'
+gate_enforce="$(yq '.runs.steps[] | select(.id == "verify_evidence") | .env.ENFORCE' "${action}")"
+
+if [[ "${gate_enforce}" == "${expected_enforce}" ]]; then
   ok "the gate step is wired to the declared input"
 else
-  bad "the gate step is wired to the declared input" "ENFORCE is not fed from the input in ${action}"
+  bad "the gate step is wired to the declared input" \
+    "verify_evidence reads ENFORCE='${gate_enforce}', not '${expected_enforce}'"
 fi
 
 echo

--- a/scripts/tests/test-verify-published-evidence.sh
+++ b/scripts/tests/test-verify-published-evidence.sh
@@ -169,15 +169,42 @@ else
   bad "the refusal names ENFORCE as the cause" "${gate_output}"
 fi
 
-# The control for the guard above: the two VALID values must still reach their
-# verdicts. A guard that rejected everything would pass the assertions above
-# while breaking the gate outright — an empty value included, since the script
-# documents unset as defaulting to non-enforcing.
+# --- An absent flag FAILS CLOSED ----------------------------------------------
+# `ENFORCE: ${{ inputs.enforce-evidence-verification }}` renders an EMPTY string
+# when the wiring is dropped or the input is renamed — not an unset variable and
+# not a typo, so neither the domain guard above nor a caller's review catches it.
+# Defaulting that to non-enforcing would silently return the gate to warn-only
+# while every deploy stayed green, which is the one failure this script exists to
+# prevent. It must still be ACCEPTED rather than rejected (that is the control for
+# the domain guard above, which must not reject everything), so the assertion is
+# rc==1 — enforcing — rather than merely rc!=2.
 run_gate 1 0 ""
-if [[ "${gate_rc}" == "0" ]]; then
-  ok "an EMPTY ENFORCE still defaults to non-enforcing (not rejected)"
+if [[ "${gate_rc}" == "1" ]]; then
+  ok "an EMPTY ENFORCE fails closed: accepted, and enforcing"
 else
-  bad "an EMPTY ENFORCE still defaults to non-enforcing" "exit ${gate_rc}: ${gate_output}"
+  bad "an EMPTY ENFORCE fails closed: accepted, and enforcing" "exit ${gate_rc}: ${gate_output}"
+fi
+
+# The same property for a genuinely ABSENT variable — the shape of deleting the
+# env: block outright. `${ENFORCE:-...}` treats unset and empty alike, so this
+# would pass for the wrong reason if the default were still read from elsewhere;
+# it is asserted separately because the two are different edits by a future
+# maintainer and only one of them is covered above.
+dir="$(stub_dir 1 0)"
+set +e
+(
+  unset ENFORCE
+  PATH="${dir}:${PATH}" WORKFLOW_REF="${workflow_ref}" \
+    bash "${gate}" "${good_digest}"
+) >/dev/null 2>&1
+unset_enforce_rc=$?
+set -e
+rm -rf "${dir}"
+
+if [[ "${unset_enforce_rc}" == "1" ]]; then
+  ok "an UNSET ENFORCE fails closed"
+else
+  bad "an UNSET ENFORCE fails closed" "exit ${unset_enforce_rc}"
 fi
 
 # --- Each evidence kind is load-bearing ---------------------------------------
@@ -372,6 +399,30 @@ if grep -q "enforce-evidence-verification" "${action}"; then
   ok "enforcement is a declared input"
 else
   bad "enforcement is a declared input" "no input in ${action}"
+fi
+
+# The ratchet is now ARMED, and this is the assertion that keeps it armed. No
+# caller passes the input, so this one default decides enforcement for all three
+# publication paths — ci.yaml's merge-queue deploy, cd.yaml's manual deploy and
+# dr-rebuild.yaml's recovery deploy. Read structurally rather than grepped: the
+# literal "false" also appears in this file's prose and in other inputs, so a
+# text match would answer a different question than "what does this input
+# default to".
+action_default="$(yq '.inputs.enforce-evidence-verification.default' "${action}")"
+if [[ "${action_default}" == "true" ]]; then
+  ok "the publication action defaults to ENFORCING (${action_default})"
+else
+  bad "the publication action defaults to ENFORCING" \
+    "default is '${action_default}' — a missing-evidence verdict would only warn"
+fi
+
+# The gate reads the input rather than a constant. Without this, the default
+# above could be correct while the step passed a hardcoded value to ENFORCE.
+# shellcheck disable=SC2016  # the literal ${{ inputs... }} is the text being matched
+if grep -q 'ENFORCE: ${{ inputs.enforce-evidence-verification }}' "${action}"; then
+  ok "the gate step is wired to the declared input"
+else
+  bad "the gate step is wired to the declared input" "ENFORCE is not fed from the input in ${action}"
 fi
 
 echo

--- a/scripts/verify-published-evidence.sh
+++ b/scripts/verify-published-evidence.sh
@@ -19,10 +19,17 @@
 # in CI with a clear message, that one refuses the pull. Neither replaces the
 # other.
 #
-# ENFORCE gates only whether a missing-evidence verdict FAILS the deploy. The
-# verification itself always runs, and always reports — a gate wrong about the
-# identity or issuer would break every production deploy, so it earns the right
-# to block by first being observed passing on real deploys.
+# ENFORCE gates only whether a missing-evidence verdict FAILS the deploy; the
+# verification itself always runs and always reports. It defaults to enforcing
+# and is validated against a closed domain, so the gate cannot be turned off by
+# an empty value, a typo, or dropped wiring — a gate that is silently off is
+# indistinguishable from a passing one, and that is the single failure this
+# script exists to prevent.
+#
+# ENFORCE=false remains available to stage a NEW evidence kind through the same
+# warn-then-enforce ratchet this check itself went through: a verification wrong
+# about the identity or issuer would break every production deploy, so a new
+# check earns the right to block by first being observed passing on real ones.
 
 set -uo pipefail
 
@@ -59,8 +66,14 @@ fi
 # would see a ::warning:: and a green job and conclude the gate was refusing
 # promotion, when it was off. Rejected here, with the other input validation, so
 # a misconfigured run fails before it spends registry calls to reach the same
-# verdict. An unset or empty value is not a typo — it is the documented default.
-enforce="${ENFORCE:-false}"
+# verdict.
+#
+# The default is ENFORCING, so the two ways this flag goes missing without being
+# a typo — an empty value from `ENFORCE: ${{ inputs.x }}` when the input is
+# renamed, and an absent variable when the env block is dropped — fail closed
+# rather than silently reverting the gate to warn-only on a green job. Disabling
+# it is therefore always an explicit, reviewable "false".
+enforce="${ENFORCE:-true}"
 if [[ "${enforce}" != "true" && "${enforce}" != "false" ]]; then
   echo "::error::ENFORCE must be exactly 'true' or 'false' (got: '${enforce}')" >&2
   usage
@@ -158,6 +171,10 @@ if [[ "${enforce}" == "true" ]]; then
   exit 1
 fi
 
+# Reached only when a caller explicitly set ENFORCE=false to stage a new evidence
+# kind. Name that as the reason the deploy continued, so the line cannot be read
+# as the gate merely not being armed yet.
 echo "::warning::${failures} evidence check(s) failed for ${digest}." \
-  "This gate is not yet enforcing, so the deploy continues — see platform#2859." >&2
+  "ENFORCE=false was set explicitly, so the deploy continues; promotion is" \
+  "refused whenever this gate runs with its default." >&2
 exit 0


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production follows a mutable tag. A publication that signs and attests the artifact but leaves no usable evidence behind in the registry was still allowed to move that tag — the check that noticed ran in warn-only mode, so the deploy went green and production consumed the artifact anyway. The gate observed the problem without stopping it.

## What

Arms the gate: a digest whose signature or attestations cannot be verified is no longer promoted. This covers all three routes to production at once — the merge-queue deploy, the manual deploy, and disaster recovery.

It also closes the way the gate could switch itself off unnoticed: if the wiring that feeds it is ever dropped or renamed, it now refuses rather than quietly reverting to warn-only on a green build. Turning it off is always an explicit, reviewable choice.

**Operational note:** this can now block a production deploy — that is the point. It was held back until it had been observed passing on real deploys, which it has (three consecutive merge-queue deploys, each under a different signing identity).

Fixes #2931