### PR TITLE
fix(ci): enforce the publication-contract gate on the merge-queue route

### DIFF
--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -42,6 +42,16 @@ const drIdentitySubject = `^https://github\.com/devantler-tech/platform/\.github
 // cannot drift apart silently.
 const cdContractGateJob = "validate-publication-contract"
 
+// mergeQueueContractGateJob is the ci.yaml job that carries this validator on
+// the merge-queue production path.
+//
+// Unlike cdContractGateJob this is NOT a dedicated gate job: `changes` also
+// detects changed paths and runs the other contract validators. That difference
+// is why the gate-job rule that constrains what else may run beside the
+// validator (gateJobRunsOnlyItsValidator) is deliberately NOT applied here —
+// every OTHER rule is, because none of them depends on the job being dedicated.
+const mergeQueueContractGateJob = "changes"
+
 // mergeQueueProductionJob is a ci.yaml job that reaches production, together
 // with whether its PURPOSE requires it to survive a failed dependency.
 type mergeQueueProductionJob struct {
@@ -343,6 +353,9 @@ func validateProductionRoutes(ci string) error {
 	if !ok {
 		return errors.New("merge-queue workflow has no jobs mapping")
 	}
+	if err := validateMergeQueueContractGate(documents, jobs); err != nil {
+		return err
+	}
 	for _, production := range mergeQueueProductionJobs {
 		jobName := production.name
 		job, ok := jobs[jobName].(map[string]any)
@@ -362,8 +375,64 @@ func validateProductionRoutes(ci string) error {
 		if err := refuseDependencyStatusOverride(job, production); err != nil {
 			return err
 		}
+		// Enforcing the gate step says nothing about whether this job WAITS for
+		// it. Read from the parsed job so only a real `needs` key counts: moving
+		// the validator into a job that production does not require would
+		// otherwise leave every rule above satisfied and the gate unreachable.
+		if !stringListContains(job["needs"], mergeQueueContractGateJob) {
+			return fmt.Errorf(
+				"merge-queue job %s does not require %s, so it can reach production without the job that runs the publication validator",
+				jobName, mergeQueueContractGateJob,
+			)
+		}
 	}
 	return nil
+}
+
+// validateMergeQueueContractGate holds the ci.yaml validator step to the same
+// enforcement rules as its cd.yaml counterpart.
+//
+// 🔴 THE CONTRACT CHECKED THE MERGE-QUEUE ROUTE'S DEPLOY AND NOT ITS GATE, so
+// every bypass already pinned for cd.yaml was reachable on the NORMAL path to
+// production while the exceptional one stayed sealed: `if: false`,
+// `continue-on-error`, a here-doc, `set +e`, a shadowing shell function, a
+// `defaults.run.shell` override, or a `BASH_ENV` injection. `deploy-prod` needs
+// `changes`, so a `changes` job that reported success on a neutered validator
+// was a green light to production.
+//
+// The premise of this whole file is that the guarantee is only as strong as its
+// weakest route, and the weakest route was the one almost every deploy takes.
+func validateMergeQueueContractGate(documents map[string]any, jobs map[string]any) error {
+	gate, ok := jobs[mergeQueueContractGateJob].(map[string]any)
+	if !ok {
+		return fmt.Errorf(
+			"merge-queue workflow is missing the %s job, so the publication validator has no home on the route production normally takes",
+			mergeQueueContractGateJob,
+		)
+	}
+	// Located by the SAME command equality cd.yaml uses, so the two routes
+	// cannot drift into checking different things under one contract.
+	step, err := requireEnforcedStep(
+		gate, runsCommand(validatorCommand),
+		fmt.Errorf(
+			"%s job does not EXECUTE %q as its own command line, so the merge-queue route can reach production without validating the publication contract",
+			mergeQueueContractGateJob, validatorCommand,
+		),
+		"the validator step in "+mergeQueueContractGateJob,
+	)
+	if err != nil {
+		return err
+	}
+	// Straight-line run block, no shell override at any of the three scopes, and
+	// no environment variable that could shadow `go` before the script starts.
+	if err := runBlockRunsOnlyAllowedCommands(
+		documents, gate, step, mergeQueueContractGateJob, gateRunBlockCommands,
+	); err != nil {
+		return err
+	}
+	// The job is the same question one level up: a skipped or failure-suppressed
+	// job still satisfies the `needs` that production depends on.
+	return enforcesFailure(gate, "the "+mergeQueueContractGateJob+" job")
 }
 
 // refuseDependencyStatusOverride is the merge-queue counterpart to the

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -982,3 +982,115 @@ func TestRunCLIRequiresBothPaths(t *testing.T) {
 		t.Fatalf("missing usage line: %q", stderr.String())
 	}
 }
+
+// TestMergeQueueContractGateIsEnforced covers the merge-queue route's VALIDATOR
+// step, which the route check previously left entirely unconstrained.
+//
+// 🔴 EVERY ARM ASSERTS THE REASON, NOT JUST THE REFUSAL. These ablations edit
+// YAML, so a mis-indented arm produces a parse error — and `validateProductionRoutes`
+// refuses an unparseable workflow. An arm checking only `err == nil` would then
+// pass while proving nothing about the rule it names, which is the exact vacuity
+// this file has been bitten by before. Matching the message keeps each arm
+// pinned to its own mechanism.
+func TestMergeQueueContractGateIsEnforced(t *testing.T) {
+	t.Parallel()
+
+	ci := repoFile(t, ".github/workflows/ci.yaml")
+	if err := validateProductionRoutes(ci); err != nil {
+		t.Fatalf("shipped ci.yaml fails the merge-queue gate rules: %v", err)
+	}
+
+	const (
+		stepName      = "      - name: \U0001F58B️ Validate DR signing contract\n"
+		validatorLine = "          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml\n"
+		testLine      = "          go test ./scripts/validate-dr-signing\n"
+		gateJobHeader = "  changes:\n"
+		deployNeeds   = "    needs: [changes, validate-eks-authorization]"
+	)
+
+	for name, arm := range map[string]struct {
+		ablate func(string) string
+		reason string
+	}{
+		// (1) Located by the same command equality cd.yaml uses.
+		"validator command absent from the gate job": {
+			func(s string) string { return strings.Replace(s, validatorLine, "", 1) },
+			"does not EXECUTE",
+		},
+		// (2) Enforced: neither skipped nor failure-suppressed, at either level.
+		"validator step is skipped": {
+			func(s string) string { return strings.Replace(s, stepName, stepName+"        if: false\n", 1) },
+			"declares a condition",
+		},
+		"validator step suppresses failure": {
+			func(s string) string {
+				return strings.Replace(s, stepName, stepName+"        continue-on-error: true\n", 1)
+			},
+			"continue-on-error",
+		},
+		"gate job suppresses failure": {
+			func(s string) string {
+				return strings.Replace(s, gateJobHeader, gateJobHeader+"    continue-on-error: true\n", 1)
+			},
+			"continue-on-error",
+		},
+		// (2) Straight-line: an extra command line can leave the validator present
+		// while the shell never reaches it.
+		"gate run block carries an extra command": {
+			func(s string) string { return strings.Replace(s, testLine, "          echo skipped\n"+testLine, 1) },
+			"which is not one of the commands this gate may contain",
+		},
+		// (2) No shell override at any of the three scopes GitHub applies.
+		"shell overridden at step scope": {
+			func(s string) string { return strings.Replace(s, stepName, stepName+"        shell: bash {0}\n", 1) },
+			"overrides the shell",
+		},
+		"shell overridden at gate-job scope": {
+			func(s string) string {
+				return strings.Replace(s, gateJobHeader, gateJobHeader+"    defaults:\n      run:\n        shell: bash {0}\n", 1)
+			},
+			"job sets defaults.run.shell",
+		},
+		"shell overridden at workflow scope": {
+			func(s string) string {
+				return strings.Replace(s, "\njobs:\n", "\ndefaults:\n  run:\n    shell: bash {0}\njobs:\n", 1)
+			},
+			"the workflow sets defaults.run.shell",
+		},
+		// (2) No inherited environment: BASH_ENV shadows `go` before the run block
+		// executes, so the allowlisted lines stay correct and run nothing.
+		"gate step inherits an environment variable": {
+			func(s string) string {
+				return strings.Replace(s, stepName, stepName+"        env:\n          BASH_ENV: /tmp/shadow\n", 1)
+			},
+			"which the publication-contract gate may not inherit",
+		},
+		// (3) Production must WAIT for the job that carries the validator.
+		"deploy-prod no longer requires the gate job": {
+			func(s string) string {
+				return strings.Replace(s, deployNeeds, "    needs: [validate-eks-authorization]", 1)
+			},
+			"does not require changes",
+		},
+		// The gate job itself moving or vanishing must fail rather than pass by
+		// finding nothing to check.
+		"gate job is renamed, so the validator has no home": {
+			func(s string) string { return strings.Replace(s, gateJobHeader, "  changes-renamed:\n", 1) },
+			"missing the changes job",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ablated := arm.ablate(ci)
+			if ablated == ci {
+				t.Fatal("ablation changed nothing; re-aim it rather than trusting the result")
+			}
+			err := validateProductionRoutes(ablated)
+			if err == nil {
+				t.Fatal("ablation was accepted, so the check does not constrain it")
+			}
+			if !strings.Contains(err.Error(), arm.reason) {
+				t.Fatalf("refused for the wrong reason: want %q in %q", arm.reason, err.Error())
+			}
+		})
+	}
+}

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -1006,6 +1006,7 @@ func TestMergeQueueContractGateIsEnforced(t *testing.T) {
 		testLine      = "          go test ./scripts/validate-dr-signing\n"
 		gateJobHeader = "  changes:\n"
 		deployNeeds   = "    needs: [changes, validate-eks-authorization]"
+		healNeeds     = "    needs: [changes, deploy-prod]"
 	)
 
 	for name, arm := range map[string]struct {
@@ -1065,10 +1066,25 @@ func TestMergeQueueContractGateIsEnforced(t *testing.T) {
 			},
 			"which the publication-contract gate may not inherit",
 		},
-		// (3) Production must WAIT for the job that carries the validator.
+		// (3) Production must WAIT for the job that carries the validator — and
+		// EVERY production job needs its own arm.
+		//
+		// 🔴 One arm covering only deploy-prod is not coverage of the rule, it is
+		// coverage of one iteration of it. The check runs inside the loop over
+		// mergeQueueProductionJobs, so a regression that narrowed it to the first
+		// entry would still satisfy the shipped-workflow control AND the
+		// deploy-prod arm, leaving the healing job — which also publishes to
+		// production — silently unchecked. The ablation below proves the two arms
+		// are not redundant.
 		"deploy-prod no longer requires the gate job": {
 			func(s string) string {
 				return strings.Replace(s, deployNeeds, "    needs: [validate-eks-authorization]", 1)
+			},
+			"does not require changes",
+		},
+		"heal-prod-on-failure no longer requires the gate job": {
+			func(s string) string {
+				return strings.Replace(s, healNeeds, "    needs: [deploy-prod]", 1)
 			},
 			"does not require changes",
 		},


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production is reached two ways: the merge queue (every ordinary merge) and a direct manual deploy (the exception). The publication-contract gate that proves a release was properly signed and ordered was only *enforced* on the exception.

On the normal route the validator runs, but nothing checked that it was allowed to fail the build. It could be switched off, have its verdict discarded, or be quietly starved — and the job would still report success, which is the green light production waits for.

Not reachable by an outside contributor; it needs a workflow edit. This is defence-in-depth on a gate that already exists, not a live exposure.

## What

Holds the merge-queue validator to the same rules the manual route's gate already passes, and additionally requires the production jobs to actually wait on the job that carries it — so moving the check somewhere unwatched fails instead of passing silently.

Reuses the existing rules against a second route rather than adding new logic. The shipped workflow passes unchanged.

**What it costs day to day:** one new constraint on `ci.yaml` — a workflow-wide environment variable or shell setting is now refused, because those genuinely do reach the gate and can neuter it. Measured: per-job and per-step settings elsewhere in the file are unaffected, so ordinary work is untouched, and the failure message names the one-line fix. Everything else is unchanged.

Fixes #2940
Part of #2627
