### PR TITLE
fix(ci): require the Flux verify block to constrain a signer

### DIFF
--- a/scripts/validate-flux-verify/main.go
+++ b/scripts/validate-flux-verify/main.go
@@ -64,6 +64,74 @@ func enabled(provider string) bool {
 	return strings.TrimSpace(provider) != ""
 }
 
+// constrainsSigner reports whether the verify block says WHO it trusts.
+//
+// A block that is present, at the read path, and enabled by KSail's predicate
+// can still verify nothing useful: Flux treats a missing secretRef as KEYLESS
+// verification, and matchOIDCIdentity is what pins the certificate issuer and
+// subject. So `verify: {provider: cosign}` accepts any keylessly-signed
+// artifact from any signer — configured, in effect, and guaranteeing nothing.
+// That is the same class as the misplaced-block outage this validator was
+// written for, one level further in.
+//
+// Three shapes constrain a signer, and any one of them is sufficient:
+// an OIDC matcher naming both an issuer and a subject, a secretRef pinning a
+// public key, or a trustedRootSecretRef pinning a trust root. The keyed
+// branches are accepted deliberately — a future keyed setup is a complete
+// configuration, and failing it would only teach someone to bypass the gate.
+func constrainsSigner(block map[string]any) bool {
+	return namesSecret(block["secretRef"]) ||
+		namesSecret(block["trustedRootSecretRef"]) ||
+		hasUsableOIDCMatcher(block["matchOIDCIdentity"])
+}
+
+// namesSecret reports whether a LocalObjectReference actually names something.
+// A `secretRef:` whose name is absent or blank pins no key, so presence of the
+// key is not the assertion — a non-blank name is.
+func namesSecret(value any) bool {
+	reference, ok := asMapping(value)
+	if !ok {
+		return false
+	}
+
+	name, _ := reference["name"].(string)
+
+	return strings.TrimSpace(name) != ""
+}
+
+// hasUsableOIDCMatcher reports whether at least ONE matcher entry pins both an
+// issuer and a subject.
+//
+// Requiring one usable entry rather than every entry is deliberate: a
+// half-written or commented-out sibling must not veto a block that does
+// constrain a signer, or the gate starts failing correct configs and gets
+// switched off. Requiring BOTH fields within that entry is equally deliberate —
+// a blank issuer lets the subject alone decide trust, and a blank subject
+// trusts every workflow the issuer will sign for, which on a public OIDC
+// issuer is everyone.
+func hasUsableOIDCMatcher(value any) bool {
+	entries, ok := value.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, entry := range entries {
+		matcher, ok := asMapping(entry)
+		if !ok {
+			continue
+		}
+
+		issuer, _ := matcher["issuer"].(string)
+		subject, _ := matcher["subject"].(string)
+
+		if strings.TrimSpace(issuer) != "" && strings.TrimSpace(subject) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // asMapping normalises the two shapes yaml.v3 decodes a mapping into.
 //
 // A mapping whose keys are all strings decodes as map[string]any, but ONE
@@ -257,6 +325,17 @@ func validate(config []byte) error {
 			"%s.provider is %#v, which KSail treats as verification DISABLED "+
 				"(it renders spec.verify only when the provider is a non-blank string): set it to cosign",
 			strings.Join(readPath, "."), reported,
+		)
+	}
+
+	// Reported last, because it is the only check here that assumes the block is
+	// otherwise well-formed and switched on.
+	if !constrainsSigner(block) {
+		return fmt.Errorf(
+			"%s is enabled but constrains no signer, so it accepts any keylessly-signed artifact "+
+				"from any signer (Flux reads a missing secretRef as keyless): add a matchOIDCIdentity "+
+				"entry with a non-blank issuer and subject, or a secretRef, or a trustedRootSecretRef",
+			strings.Join(readPath, "."),
 		)
 	}
 

--- a/scripts/validate-flux-verify/main.go
+++ b/scripts/validate-flux-verify/main.go
@@ -74,14 +74,24 @@ func enabled(provider string) bool {
 // That is the same class as the misplaced-block outage this validator was
 // written for, one level further in.
 //
-// Three shapes constrain a signer, and any one of them is sufficient:
-// an OIDC matcher naming both an issuer and a subject, a secretRef pinning a
-// public key, or a trustedRootSecretRef pinning a trust root. The keyed
-// branches are accepted deliberately — a future keyed setup is a complete
-// configuration, and failing it would only teach someone to bypass the gate.
+// TWO shapes constrain a signer, and either is sufficient: an OIDC matcher
+// naming both an issuer and a subject, or a secretRef pinning a public key.
+// The keyed branch is accepted deliberately — a future keyed setup is a
+// complete configuration, and failing it would only teach someone to bypass
+// the gate.
+//
+// 🔴 THE FIELD SET IS KSAIL'S, FOR THE SAME REASON THE ENABLED PREDICATE IS.
+//
+// KSail's FluxVerifySpec carries exactly three fields — Provider, SecretRef
+// and MatchOIDCIdentity (ksail pkg/apis/cluster/v1alpha1/flux_types.go, v7.178.14,
+// the version this repo pins). It has NO trustedRootSecretRef, so a block
+// written with one has that key dropped in silence and renders as a bare
+// provider: present, enabled, and constraining nobody. Honouring a field the
+// consumer does not model would make this check pass the exact configuration
+// it exists to reject. Only the two fields KSail actually reads count here; if
+// KSail gains a field, this follows it rather than anticipating it.
 func constrainsSigner(block map[string]any) bool {
 	return namesSecret(block["secretRef"]) ||
-		namesSecret(block["trustedRootSecretRef"]) ||
 		hasUsableOIDCMatcher(block["matchOIDCIdentity"])
 }
 
@@ -334,7 +344,8 @@ func validate(config []byte) error {
 		return fmt.Errorf(
 			"%s is enabled but constrains no signer, so it accepts any keylessly-signed artifact "+
 				"from any signer (Flux reads a missing secretRef as keyless): add a matchOIDCIdentity "+
-				"entry with a non-blank issuer and subject, or a secretRef, or a trustedRootSecretRef",
+				"entry with a non-blank issuer and subject, or a secretRef naming a key Secret "+
+				"(those are the only two KSail reads — a trustedRootSecretRef is dropped in silence)",
 			strings.Join(readPath, "."),
 		)
 	}

--- a/scripts/validate-flux-verify/main_test.go
+++ b/scripts/validate-flux-verify/main_test.go
@@ -334,9 +334,15 @@ spec:
 `,
 		},
 		{
-			// Same reasoning as secretRef: a pinned trusted root constrains who
-			// may sign.
-			name: "trustedRootSecretRef-only block validates",
+			// 🔴 REGRESSION ARM, and the counter-intuitive one. Flux's own
+			// OCIRepository has a trustedRootSecretRef, so this block LOOKS like a
+			// complete keyed configuration — but KSail's FluxVerifySpec models only
+			// provider, secretRef and matchOIDCIdentity, so the key is dropped in
+			// silence and what reaches the cluster is a bare provider that trusts
+			// everyone. Accepting it because Flux understands it would reproduce
+			// this validator's founding bug: honouring a field the CONSUMER does
+			// not read. Rejected until KSail models it.
+			name: "trustedRootSecretRef-only block is rejected: KSail does not model that field",
 			config: `
 spec:
   workload:
@@ -346,6 +352,7 @@ spec:
         trustedRootSecretRef:
           name: cosign-trusted-root
 `,
+			wantErr: "constrains no signer",
 		},
 		{
 			// A secretRef that names nothing constrains nothing — the same

--- a/scripts/validate-flux-verify/main_test.go
+++ b/scripts/validate-flux-verify/main_test.go
@@ -238,6 +238,130 @@ spec:
 `,
 			wantErr: "spec.extras",
 		},
+		{
+			// 🔴 #2948. The block is present, at the read path, and "on" by KSail's
+			// predicate — and constrains NOBODY. Flux reads a missing secretRef as
+			// keyless, so this trusts any keylessly-signed artifact from any signer
+			// on the platform's root source. Same failure class the gate exists to
+			// catch: configured, in effect, guaranteeing nothing.
+			name: "provider-only block is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+`,
+			wantErr: "constrains no signer",
+		},
+		{
+			// Presence is not the assertion. An empty list satisfies "the key is
+			// there" while matching no identity at all.
+			name: "empty matchOIDCIdentity is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        matchOIDCIdentity: []
+`,
+			wantErr: "constrains no signer",
+		},
+		{
+			// A blank issuer leaves the certificate issuer unconstrained, so the
+			// subject alone decides trust. Non-emptiness is the assertion.
+			name: "matchOIDCIdentity entry with a blank issuer is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        matchOIDCIdentity:
+          - issuer: '   '
+            subject: '^https://github\.com/devantler-tech/platform/.+$'
+`,
+			wantErr: "constrains no signer",
+		},
+		{
+			// The mirror of the arm above: a blank subject trusts every workflow
+			// the issuer will sign for, which on a public OIDC issuer is everyone.
+			name: "matchOIDCIdentity entry with a blank subject is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        matchOIDCIdentity:
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+            subject: ''
+`,
+			wantErr: "constrains no signer",
+		},
+		{
+			// One usable entry is enough. A commented-out or half-written sibling
+			// must not veto a block that does constrain a signer, or the gate
+			// starts failing correct configs.
+			name: "one complete matcher among incomplete ones validates",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        matchOIDCIdentity:
+          - issuer: ''
+            subject: ''
+          - issuer: '^https://token\.actions\.githubusercontent\.com$'
+            subject: '^https://github\.com/devantler-tech/platform/.+$'
+`,
+		},
+		{
+			// Keyed verification constrains the signer without OIDC matchers, so
+			// this is a legitimately complete block and must pass. Rejecting it
+			// would push a future keyed setup into disabling the gate.
+			name: "secretRef-only block validates",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        secretRef:
+          name: cosign-public-key
+`,
+		},
+		{
+			// Same reasoning as secretRef: a pinned trusted root constrains who
+			// may sign.
+			name: "trustedRootSecretRef-only block validates",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        trustedRootSecretRef:
+          name: cosign-trusted-root
+`,
+		},
+		{
+			// A secretRef that names nothing constrains nothing — the same
+			// presence-is-not-the-assertion rule applied to the keyed branch.
+			name: "secretRef with a blank name is rejected",
+			config: `
+spec:
+  workload:
+    flux:
+      verify:
+        provider: cosign
+        secretRef:
+          name: '  '
+`,
+			wantErr: "constrains no signer",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The gate that proves our Flux signature verification is switched on could pass a configuration that trusts **anyone**. It checked that the verify block sits where KSail reads it and that verification is on — but not *who* we are willing to trust. A block reduced to `provider: cosign` satisfies both and accepts any signed artifact from any signer on the platform's root source, which is the path every controller, policy and tenant arrives through.

**This is not a live exposure** — production already pins three specific GitHub workflow identities, verified. The value is regression cover: today a future edit that empties those matchers would flip the root source from "only our CI may publish this" to "anyone may", and every check would stay green. A gate that reports a stronger guarantee than the config delivers is worse than no gate on that dimension, because it is trusted.

It is the same failure this gate was written for after a three-week outage — configured, in effect, guaranteeing nothing — one level further in.

## What

The gate now also requires the verify block to name who it trusts, and rejects blocks that only *look* constrained (an empty matcher list, or matchers with a blank issuer or subject). Keyed setups remain valid on their own, so nobody is pushed into switching the gate off to ship one.

Production config passes unchanged.

Fixes #2948
Part of #2627
