### PR TITLE
fix(ci): give the merge-queue publication gate its own job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,13 +39,8 @@ jobs:
           go test ./scripts/validate-merge-group-heal
           go run ./scripts/validate-merge-group-heal .github/workflows/ci.yaml
 
-      - name: 🖋️ Validate DR signing contract
-        run: |
-          go test ./scripts/validate-dr-signing
-          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml
-
-      # The DR contract above checks WHAT the verify block allows. This checks
-      # that the block is in effect at all: it ran at spec.cluster.verify for
+      # The DR contract runs in its own dedicated job (below). This checks that
+      # the verify block is in effect at all: it ran at spec.cluster.verify for
       # ~3 weeks, where KSail discards it, and every text-based check passed
       # throughout (#2920).
       - name: 🔐 Validate Flux verification is in effect
@@ -151,6 +146,37 @@ jobs:
               - 'talos/**'
               - 'talos-local/**'
               - '.github/workflows/ci.yaml'
+
+  validate-publication-contract:
+    name: 🖋️ Validate Publication Contract
+    # A DEDICATED job, mirroring cd.yaml's, and that is the point rather than a
+    # style choice. The runner's $GITHUB_ENV and $GITHUB_PATH bridges carry
+    # across steps, so any step sharing a job with this validator could shadow
+    # `go` for it while the validator step itself still read as correct. Keeping
+    # the job to nothing but its own validator is what the contract's
+    # gateJobRunsOnlyItsValidator rule asserts, and it can only hold here.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout repository
+    steps:
+      - name: 📑 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: 🖋️ Validate DR signing contract
+        # Identical invocation to cd.yaml's, deliberately: the two routes to
+        # production must be gated by the same check, or they drift and the
+        # weaker one becomes the real policy.
+        run: |
+          go test ./scripts/validate-dr-signing
+          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml
 
   validate-eks-authorization:
     name: 🔐 Validate EKS Authorization
@@ -769,7 +795,7 @@ jobs:
 
   deploy-prod:
     name: 🚀 Deploy to Prod
-    needs: [changes, validate-eks-authorization]
+    needs: [changes, validate-eks-authorization, validate-publication-contract]
     if: github.event_name == 'merge_group' && needs.changes.outputs.k8s == 'true'
     runs-on: ubuntu-latest
     environment: prod
@@ -808,7 +834,7 @@ jobs:
 
   heal-prod-on-failure:
     name: 🩹 Heal Prod (restore main after unsuccessful merge-group deploy)
-    needs: [changes, deploy-prod]
+    needs: [changes, deploy-prod, validate-publication-contract]
     # The deploy above runs on the SPECULATIVE merge ref, before the PR lands on
     # `main`. When it fails the merge group is ejected — but the OCI `latest` tag
     # (and the prod cluster reconciling it) is left pointing at that ejected
@@ -877,6 +903,7 @@ jobs:
     needs:
       [
         changes,
+        validate-publication-contract,
         validate-eks-authorization,
         validate,
         naming,
@@ -891,6 +918,7 @@ jobs:
         with:
           job-results: >-
             ${{ needs.changes.result }}
+            ${{ needs.validate-publication-contract.result }}
             ${{ needs.validate-eks-authorization.result }}
             ${{ needs.validate.result }}
             ${{ needs.naming.result }}

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -45,12 +45,15 @@ const cdContractGateJob = "validate-publication-contract"
 // mergeQueueContractGateJob is the ci.yaml job that carries this validator on
 // the merge-queue production path.
 //
-// Unlike cdContractGateJob this is NOT a dedicated gate job: `changes` also
-// detects changed paths and runs the other contract validators. That difference
-// is why the gate-job rule that constrains what else may run beside the
-// validator (gateJobRunsOnlyItsValidator) is deliberately NOT applied here —
-// every OTHER rule is, because none of them depends on the job being dedicated.
-const mergeQueueContractGateJob = "changes"
+// It is a DEDICATED gate job, exactly like cdContractGateJob, so both routes
+// carry the identical rule set. It previously rode along in `changes`, which
+// also detects changed paths and runs the other contract validators — and a
+// shared job cannot satisfy gateJobRunsOnlyItsValidator, because that rule
+// exists to assert the job runs nothing BUT its validator. Leaving the rule off
+// left the runner's $GITHUB_ENV/$GITHUB_PATH bridges open on this route: a step
+// earlier in the shared job could shadow `go` for the validator step while that
+// step's own run block still read as correct.
+const mergeQueueContractGateJob = "validate-publication-contract"
 
 // mergeQueueProductionJob is a ci.yaml job that reaches production, together
 // with whether its PURPOSE requires it to survive a failed dependency.
@@ -428,6 +431,12 @@ func validateMergeQueueContractGate(documents map[string]any, jobs map[string]an
 	if err := runBlockRunsOnlyAllowedCommands(
 		documents, gate, step, mergeQueueContractGateJob, gateRunBlockCommands,
 	); err != nil {
+		return err
+	}
+	// Constraining the validator step says nothing about what ran BEFORE it in
+	// the same job, and the runner's env/path bridges carry across steps. This
+	// is the rule the shared-job arrangement could not carry.
+	if err := gateJobRunsOnlyItsValidator(gate, mergeQueueContractGateJob, gateStepActions); err != nil {
 		return err
 	}
 	// The job is the same question one level up: a skipped or failure-suppressed

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -1004,9 +1004,9 @@ func TestMergeQueueContractGateIsEnforced(t *testing.T) {
 		stepName      = "      - name: \U0001F58B️ Validate DR signing contract\n"
 		validatorLine = "          go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml\n"
 		testLine      = "          go test ./scripts/validate-dr-signing\n"
-		gateJobHeader = "  changes:\n"
-		deployNeeds   = "    needs: [changes, validate-eks-authorization]"
-		healNeeds     = "    needs: [changes, deploy-prod]"
+		gateJobHeader = "  validate-publication-contract:\n"
+		deployNeeds   = "    needs: [changes, validate-eks-authorization, validate-publication-contract]"
+		healNeeds     = "    needs: [changes, deploy-prod, validate-publication-contract]"
 	)
 
 	for name, arm := range map[string]struct {
@@ -1078,21 +1078,56 @@ func TestMergeQueueContractGateIsEnforced(t *testing.T) {
 		// are not redundant.
 		"deploy-prod no longer requires the gate job": {
 			func(s string) string {
-				return strings.Replace(s, deployNeeds, "    needs: [validate-eks-authorization]", 1)
+				return strings.Replace(s, deployNeeds, "    needs: [changes, validate-eks-authorization]", 1)
 			},
-			"does not require changes",
+			"does not require validate-publication-contract",
 		},
 		"heal-prod-on-failure no longer requires the gate job": {
 			func(s string) string {
-				return strings.Replace(s, healNeeds, "    needs: [deploy-prod]", 1)
+				return strings.Replace(s, healNeeds, "    needs: [changes, deploy-prod]", 1)
 			},
-			"does not require changes",
+			"does not require validate-publication-contract",
 		},
 		// The gate job itself moving or vanishing must fail rather than pass by
 		// finding nothing to check.
 		"gate job is renamed, so the validator has no home": {
-			func(s string) string { return strings.Replace(s, gateJobHeader, "  changes-renamed:\n", 1) },
-			"missing the changes job",
+			func(s string) string {
+				return strings.Replace(s, gateJobHeader, "  validate-publication-contract-renamed:\n", 1)
+			},
+			"missing the validate-publication-contract job",
+		},
+		// The rule the shared-job arrangement could not carry (#2950). The
+		// runner's $GITHUB_ENV/$GITHUB_PATH bridges apply to every LATER step, so
+		// a step earlier in this job can shadow `go` for the validator while the
+		// validator step stays byte-for-byte correct. Both arms leave the
+		// validator step untouched, which is exactly why every other rule above
+		// still passes on them — the poison is only visible at job scope.
+		//
+		// 🔴 Anchored on the validator step, which is unique to this job. The
+		// obvious anchor (the Setup Go step) occurs in FOUR jobs, so a
+		// first-occurrence replace lands in `changes` and the arm silently tests
+		// a job the contract no longer gates — an ablation that changes the file
+		// without changing the thing under test, which the changed-nothing guard
+		// cannot catch.
+		"gate job runs a second command step before the validator": {
+			func(s string) string {
+				return strings.Replace(
+					s, stepName,
+					"      - name: \U0001F4A5 Poison\n        run: echo 'PATH=/tmp/shadow:$PATH' >> \"$GITHUB_ENV\"\n\n"+stepName,
+					1,
+				)
+			},
+			"runs more than one command step",
+		},
+		"gate job runs an unlisted action that could write the bridges": {
+			func(s string) string {
+				return strings.Replace(
+					s, stepName,
+					"      - name: \U0001F4A5 Poison\n        uses: some-org/writes-github-env@v1\n\n"+stepName,
+					1,
+				)
+			},
+			"which is not one of the setup actions this gate may contain",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/scripts/validate-merge-group-heal/main.go
+++ b/scripts/validate-merge-group-heal/main.go
@@ -38,7 +38,15 @@ func validateWorkflowContract(workflow string) error {
 		line        string
 		description string
 	}{
-		{line: "    needs: [changes, deploy-prod]", description: "deploy dependencies"},
+		// validate-publication-contract is required by the DR signing contract:
+		// every ci.yaml job that reaches production must WAIT for the publication
+		// gate, and this job re-deploys main's artifact. Pinned as an exact line
+		// here so the two contracts cannot drift into asserting different
+		// dependency sets over the same job.
+		{
+			line:        "    needs: [changes, deploy-prod, validate-publication-contract]",
+			description: "deploy dependencies",
+		},
 		{line: "      group: prod-deploy", description: "shared production lock"},
 		{line: "      cancel-in-progress: false", description: "non-preempting production lock"},
 		{line: "          ref: main", description: "current-main checkout"},

--- a/scripts/validate-merge-group-heal/main_test.go
+++ b/scripts/validate-merge-group-heal/main_test.go
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
   heal-prod-on-failure:
-    needs: [changes, deploy-prod]
+    needs: [changes, deploy-prod, validate-publication-contract]
     concurrency:
       group: prod-deploy
       cancel-in-progress: false
@@ -63,7 +63,7 @@ func TestValidateWorkflowContractRejectsBrokenHealContracts(t *testing.T) {
 		},
 		{
 			name:        "missing deploy dependencies",
-			old:         "    needs: [changes, deploy-prod]",
+			old:         "    needs: [changes, deploy-prod, validate-publication-contract]",
 			replacement: "    needs: [changes]",
 			wantError:   "missing deploy dependencies",
 		},


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The merge-queue route is the normal way changes reach production, and its publication-contract gate was riding along inside a shared job. That job runs several other validators first, and anything running earlier in a job can quietly change the environment the later steps see — so an earlier step could have neutered the gate while the gate's own definition still looked perfectly correct.

The direct-push route already refuses this. The merge-queue route could not, because the rule that refuses it only makes sense for a job dedicated to the gate.

## What

Gives the merge-queue gate its own job, the same shape the direct-push route already uses, so both routes are now held to the identical rule set rather than the weaker one deciding policy. Production jobs and the required-checks aggregate wait on it.

Costs one extra CI job per run.

Fixes #2950
