### PR TITLE
fix(k8s): activate the Headlamp user-namespace mapping probe

### DIFF
--- a/k8s/providers/hetzner/apps/kustomization.yaml
+++ b/k8s/providers/hetzner/apps/kustomization.yaml
@@ -20,18 +20,19 @@ resources:
   # capture the completed Job's logs, then remove it again so its generic
   # ephemeral PVC and Longhorn volume are garbage-collected.
   # - userns-longhorn-smoke/
-  # Default-off disposable measurement of the subordinate UID/GID mapping a
-  # user-namespaced pod receives in the headlamp namespace (#2651, acceptance
-  # criterion 5). Staged exactly like userns-longhorn-smoke above, and for a
-  # reason that applies to EVERY Job reconciled here: this Flux Kustomization
-  # runs `wait: true` with no explicit healthChecks, so kstatus evaluates every
-  # applied resource and a Job that reports Failed — whether from a real
-  # negative result, an unschedulable pod, or a pull error — takes the whole
-  # apps layer not-Ready and can fail the merge-queue deploy. A probe must never
-  # be able to wedge the layer it is measuring, so activation is a deliberate,
-  # watched act: uncomment this resource in a short-lived PR, capture the
-  # completed Job's logs onto #2651, then remove the component again (#2858).
-  # - userns-headlamp-mapping-probe/
+  # ACTIVE for one short-lived PR: disposable measurement of the subordinate
+  # UID/GID mapping a user-namespaced pod receives in the headlamp namespace
+  # (#2651, acceptance criterion 5 — the last one open). Once the completed
+  # Job's log is recorded on #2651, this entry and the component are removed
+  # together (#2858); nothing here is meant to survive.
+  #
+  # This Flux Kustomization runs `wait: true` with no explicit healthChecks, so
+  # kstatus evaluates every applied resource and a Job that reports Failed takes
+  # the whole apps layer not-Ready. The probe therefore reports its reading as a
+  # `USERNS-PROBE-VERDICT=` log line and always exits 0 (#2954), so its own
+  # negative result — the identity map, which is precisely what it is here to
+  # detect — can no longer wedge the layer it is measuring.
+  - userns-headlamp-mapping-probe/
   # Prod-only Coroot Postgres integration for the platform-owned CNPG DBs:
   # additive CiliumNetworkPolicies that let the observability cluster-agent
   # scrape each on 5432 (the Cluster patches below stamp the

--- a/scripts/tests/test-userns-headlamp-mapping-probe.sh
+++ b/scripts/tests/test-userns-headlamp-mapping-probe.sh
@@ -270,23 +270,32 @@ else
   bad "probe container declares no envFrom" "found envFrom on the probe container: ${env_from}"
 fi
 
-# The probe is a disposable diagnostic: it must stay out of the parent
-# kustomization until a deliberate activation PR.
+# THIS IS THE ACTIVATION PR. The component is deliberately referenced by the
+# parent kustomization for exactly as long as it takes the merge-queue deploy to
+# run the Job once and put its log on #2651; #2858 then deletes the component,
+# this test file, and the parent's resource entry together.
+#
+# So the arm is inverted rather than deleted. Its job either way is to make the
+# component's activation state an ASSERTED fact instead of an incidental one: a
+# commented-out entry here would mean the merge deploys nothing and the Job never
+# runs, which is indistinguishable at the CI level from a successful activation —
+# a green run over a measurement that was never taken. Deleting the arm for the
+# duration would give exactly that silence.
 #
 # Fail closed on the file itself first. `grep` exits 2 for an unreadable or
 # missing ${parent} and 1 for no match, and BOTH land in the else branch — so a
-# renamed or deleted kustomization would report "staged" without anything having
-# been checked. The pattern also normalises the optional `./` prefix, which
-# kustomize accepts and the previous pattern did not match: an active component
-# written `- ./userns-headlamp-mapping-probe/` read as absent.
+# renamed or deleted kustomization would satisfy the check without anything
+# having been read. The pattern normalises the optional `./` prefix, which
+# kustomize accepts: an active component written
+# `- ./userns-headlamp-mapping-probe/` must not read as absent.
 if [ ! -r "${parent}" ]; then
-  bad "probe stays staged (commented out) in the apps kustomization" \
+  bad "probe is active in the apps kustomization for this activation PR" \
     "cannot read ${parent}, so the component's activation state was never established"
 elif grep -qE '^[[:space:]]*-[[:space:]]+\.?/?userns-headlamp-mapping-probe/?([[:space:]]|$)' "${parent}"; then
-  bad "probe stays staged (commented out) in the apps kustomization" \
-    "the component is active in ${parent}; it must be activated only by a short-lived PR and removed after (#2858)"
+  ok "probe is active in the apps kustomization for this activation PR"
 else
-  ok "probe stays staged (commented out) in the apps kustomization"
+  bad "probe is active in the apps kustomization for this activation PR" \
+    "the component is not referenced in ${parent}, so the merge-queue deploy would apply nothing and the criterion-5 reading would never be taken"
 fi
 
 # backoffLimit 0 keeps a single reading rather than retrying a measurement.

--- a/scripts/tests/test-userns-headlamp-mapping-probe.sh
+++ b/scripts/tests/test-userns-headlamp-mapping-probe.sh
@@ -288,10 +288,16 @@ fi
 # having been read. The pattern normalises the optional `./` prefix, which
 # kustomize accepts: an active component written
 # `- ./userns-headlamp-mapping-probe/` must not read as absent.
+#
+# `(\./)?` and not `\.?/?`: the latter is three optional forms, not two, so it
+# also accepted `- .userns-headlamp-mapping-probe/` (a differently-named hidden
+# directory) and `- /userns-headlamp-mapping-probe/` (an absolute path kustomize
+# rejects). Either would satisfy this arm without the intended local component
+# being referenced at all.
 if [ ! -r "${parent}" ]; then
   bad "probe is active in the apps kustomization for this activation PR" \
     "cannot read ${parent}, so the component's activation state was never established"
-elif grep -qE '^[[:space:]]*-[[:space:]]+\.?/?userns-headlamp-mapping-probe/?([[:space:]]|$)' "${parent}"; then
+elif grep -qE '^[[:space:]]*-[[:space:]]+(\./)?userns-headlamp-mapping-probe/?([[:space:]]|$)' "${parent}"; then
   ok "probe is active in the apps kustomization for this activation PR"
 else
   bad "probe is active in the apps kustomization for this activation PR" \


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Headlamp has been running with user namespaces enabled in production since 28 July, and every acceptance criterion on #2651 has been verified live **except one**: that the pod actually receives a non-identity subordinate UID/GID mapping. That is the criterion the whole pilot exists to answer — whether this cluster's kubelet honours the setting at all, or silently leaves the pod in the host user namespace.

It has been parked since 15 July for a reason that is now gone. Taking the reading needs a probe Job, and a failing Job used to take the entire `apps` layer not-Ready — including when it failed for the *right* reason, by reporting the identity map it was sent to look for. That made activation a "watched act", and no scheduled run is watched, so it was never going to happen.

#2954 removed that: the probe now reports its reading as a log line and always exits successfully, so it can no longer wedge the layer it is measuring.

## What

Turns the probe on for one deploy. The merge-queue deploy runs the Job once, its log is recorded on #2651, and then #2858 removes the component again — nothing here is meant to survive.

The test that used to insist the probe stay off is inverted rather than deleted, so the activation is checked rather than assumed. Left out, a mistakenly-still-disabled probe would deploy nothing while CI stayed green: a passing run over a measurement that was never taken.

**Operational note for the merge:** this deploys a short-lived Job into the `headlamp` namespace. Headlamp itself is untouched — no chart, values, or volume change.

Part of #2651. Follow-up cleanup: #2858.