### PR TITLE
fix(deploy): make rollout-gate suppression of machine-config sync visible and bounded

### DIFF
--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -245,8 +245,10 @@ runs:
     - name: 📣 Report suppressed machine-config sync
       # The step above is the pipeline's ONLY Talos machine-config sync, and the
       # rollout gate skips it. A skipped step inside a green deploy reads as
-      # ordinary conditional behaviour, so the suppression was invisible for ten
-      # days and misdirected the diagnosis of two unrelated issues (#2951).
+      # ordinary conditional behaviour, so the suppression went unnoticed for
+      # over a week and misdirected the diagnosis of two unrelated issues
+      # (#2951). The elapsed count belongs in the report, not in this comment,
+      # where it would be stale the day after it was written.
       # Surface it in the job summary, and warn once it outruns the rollout's
       # intended window. always(), so an earlier failure cannot hide it.
       if: >-

--- a/.github/actions/deploy-prod/action.yml
+++ b/.github/actions/deploy-prod/action.yml
@@ -242,6 +242,22 @@ runs:
         WG_SERVER_PRIVATE_KEY: ${{ inputs.wg-server-private-key }}
       run: ./scripts/run-ksail-prod-with-pull-auth.sh cluster update
 
+    - name: 📣 Report suppressed machine-config sync
+      # The step above is the pipeline's ONLY Talos machine-config sync, and the
+      # rollout gate skips it. A skipped step inside a green deploy reads as
+      # ordinary conditional behaviour, so the suppression was invisible for ten
+      # days and misdirected the diagnosis of two unrelated issues (#2951).
+      # Surface it in the job summary, and warn once it outruns the rollout's
+      # intended window. always(), so an earlier failure cannot hide it.
+      if: >-
+        always() && steps.cilium_rollout_gate.outputs.active == 'true'
+      shell: bash
+      env:
+        # Take the gate state from the gate itself — re-deriving it here would
+        # let the two drift apart silently, which is the original defect.
+        CILIUM_ROLLOUT_GATE_ACTIVE: ${{ steps.cilium_rollout_gate.outputs.active }}
+      run: ./scripts/report-cilium-rollout-gate-suppression.sh
+
     - name: 🛡️ Reassert or release the Cilium rollout gate
       # Reassert the suspension after delivery while OnDelete is active.
       # A later, reviewed rollout-completion or rollback artifact removes the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,10 @@ jobs:
               - 'scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh'
               - 'scripts/tests/test-cilium-homogeneous-devices-flux-wait.sh'
               - 'scripts/guard-cilium-homogeneous-device-rollout.sh'
+              # Both halves, so editing the reporter alone — or its test alone —
+              # still runs the check that covers it.
+              - 'scripts/report-cilium-rollout-gate-suppression.sh'
+              - 'scripts/tests/test-cilium-rollout-gate-suppression-signal.sh'
               - 'scripts/wait-for-platform-flux-revision.sh'
               - 'scripts/tests/test-opencost-usage-scraper.sh'
               # Both halves, so editing the guard alone — or its test alone —
@@ -343,6 +347,14 @@ jobs:
           bash scripts/tests/test-cilium-homogeneous-devices-activation.sh
           bash scripts/tests/test-cilium-homogeneous-devices-autoscaler-gate.sh
           bash scripts/tests/test-cilium-homogeneous-devices-flux-wait.sh
+
+      - name: 📣 Validate the rollout gate cannot suppress sync silently
+        if: needs.changes.outputs.k8s == 'true'
+        # The gate skips the pipeline's only Talos machine-config sync. Pin that
+        # it can never do so without a job-summary notice, that the suppression
+        # carries a declared start date, and that the bound past which it warns
+        # is real — a skipped step in a green deploy is otherwise invisible.
+        run: bash scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
 
       - name: 📊 Validate OpenCost usage metrics path
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
+++ b/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml
@@ -82,6 +82,13 @@ components:
   # the roll pod-by-pod per the component's runbook (verify each node keeps a
   # private primary address before the next). Rollback = re-comment (stepped
   # nodes roll back automatically under the restored RollingUpdate).
+  #
+  # While this reference is active the deploy skips `ksail cluster update` — the
+  # pipeline's only Talos machine-config sync. The date below is what makes that
+  # suppression measurable: the deploy reports it in its job summary and warns
+  # once it outruns the rollout's intended window. Set it when activating, and
+  # remove it in the same diff that re-comments the reference.
+  # platform.devantler.tech/rollout-gate-activated: 2026-07-26
   - cilium/components/homogeneous-devices/
   # Default-off Cilium bandwidth-manager + host-only BBR staging component
   # (#2607). It is not activation-ready: #2609 must prove pod-BBR datapath

--- a/scripts/report-cilium-rollout-gate-suppression.sh
+++ b/scripts/report-cilium-rollout-gate-suppression.sh
@@ -45,7 +45,9 @@ if [[ -n "${ROLLOUT_GATE_ACTIVATED_OVERRIDE:-}" ]]; then
 else
   [[ -f "${controllers_kustomization}" ]] ||
     fail "cannot read ${controllers_kustomization} to date the rollout gate"
-  marker_line="$(grep -F "${activation_marker}" "${controllers_kustomization}" || true)"
+  # head -1: the marker is prose-adjacent, so take the first declaration rather
+  # than letting a second mention of it anywhere in the file change the answer.
+  marker_line="$(grep -F "${activation_marker}" "${controllers_kustomization}" | head -1 || true)"
   [[ -n "${marker_line}" ]] ||
     fail "the rollout gate is active but ${activation_marker} <YYYY-MM-DD> is not declared beside the component reference"
   # Parameter expansion, not sed: the marker contains '/', which would collide
@@ -72,6 +74,12 @@ activated_epoch="$(to_epoch "${activated}")" ||
 now_epoch="$(date -u +%s)"
 elapsed_days=$(((now_epoch - activated_epoch) / 86400))
 readonly activated_epoch now_epoch elapsed_days
+
+# A future activation date is a typo, and it would silently buy the rollout
+# unlimited extra time — the elapsed count goes negative and never trips the
+# bound. Fail closed rather than report a suppression as fresh forever.
+((elapsed_days >= 0)) ||
+  fail "the rollout gate activation date is in the future: '${activated}' (${elapsed_days} days)"
 
 summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 

--- a/scripts/report-cilium-rollout-gate-suppression.sh
+++ b/scripts/report-cilium-rollout-gate-suppression.sh
@@ -45,11 +45,16 @@ if [[ -n "${ROLLOUT_GATE_ACTIVATED_OVERRIDE:-}" ]]; then
 else
   [[ -f "${controllers_kustomization}" ]] ||
     fail "cannot read ${controllers_kustomization} to date the rollout gate"
-  # head -1: the marker is prose-adjacent, so take the first declaration rather
-  # than letting a second mention of it anywhere in the file change the answer.
-  marker_line="$(grep -F "${activation_marker}" "${controllers_kustomization}" | head -1 || true)"
-  [[ -n "${marker_line}" ]] ||
+  # Require EXACTLY one declaration. Silently taking the first would let a second
+  # marker — a stale one left behind by a previous rollout, say — sit in the file
+  # while the reporter quietly dates the suppression from whichever came first.
+  marker_lines="$(grep -F "${activation_marker}" "${controllers_kustomization}" || true)"
+  marker_count="$(printf '%s' "${marker_lines}" | grep -c . || true)"
+  [[ "${marker_count}" -ge 1 ]] ||
     fail "the rollout gate is active but ${activation_marker} <YYYY-MM-DD> is not declared beside the component reference"
+  [[ "${marker_count}" -eq 1 ]] ||
+    fail "the rollout gate activation date is declared ${marker_count} times; exactly one ${activation_marker} is required"
+  marker_line="${marker_lines}"
   # Parameter expansion, not sed: the marker contains '/', which would collide
   # with sed's substitution delimiter.
   activated="${marker_line##*"${activation_marker}"}"
@@ -61,25 +66,36 @@ readonly activated
 [[ "${activated}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
   fail "the rollout gate activation date is not an ISO date: '${activated}'"
 
-# GNU and BSD date disagree on parsing; support both so this behaves the same on
-# a runner and on a maintainer's Mac.
-to_epoch() {
-  date -u -d "$1" +%s 2>/dev/null || date -u -j -f '%Y-%m-%d' "$1" +%s 2>/dev/null
+# Resolve a YYYY-MM-DD to its UTC MIDNIGHT epoch, on both GNU and BSD date.
+#
+# The explicit 00:00:00 is load-bearing, not decoration. BSD `date -j -f
+# '%Y-%m-%d'` fills unspecified fields from the CURRENT time, so a bare date
+# parses as that date at the present time-of-day, while GNU `date -d` parses it
+# as midnight. Left implicit, the same marker yields day counts that differ by
+# one between a maintainer's Mac and the Linux runner. Anchoring both sides to
+# midnight makes the elapsed count an exact whole-day difference everywhere.
+to_utc_midnight_epoch() {
+  date -u -d "$1T00:00:00Z" +%s 2>/dev/null ||
+    date -u -j -f '%Y-%m-%d %H:%M:%S' "$1 00:00:00" +%s 2>/dev/null
 }
 
-activated_epoch="$(to_epoch "${activated}")" ||
+activated_epoch="$(to_utc_midnight_epoch "${activated}")" ||
   fail "could not parse the rollout gate activation date: '${activated}'"
 [[ -n "${activated_epoch}" ]] ||
   fail "could not parse the rollout gate activation date: '${activated}'"
-now_epoch="$(date -u +%s)"
-elapsed_days=$(((now_epoch - activated_epoch) / 86400))
-readonly activated_epoch now_epoch elapsed_days
+today_epoch="$(to_utc_midnight_epoch "$(date -u +%Y-%m-%d)")"
+[[ -n "${today_epoch}" ]] || fail 'could not resolve the current UTC date'
+readonly activated_epoch today_epoch
 
-# A future activation date is a typo, and it would silently buy the rollout
-# unlimited extra time — the elapsed count goes negative and never trips the
-# bound. Fail closed rather than report a suppression as fresh forever.
-((elapsed_days >= 0)) ||
-  fail "the rollout gate activation date is in the future: '${activated}' (${elapsed_days} days)"
+# A future activation date is a typo, and it would silently buy the rollout extra
+# time. Compare the EPOCHS, before any division: bash truncates integer division
+# toward zero, so a date one day ahead would otherwise yield elapsed_days == 0 —
+# indistinguishable from "activated today".
+((today_epoch >= activated_epoch)) ||
+  fail "the rollout gate activation date is in the future: '${activated}'"
+
+elapsed_days=$(((today_epoch - activated_epoch) / 86400))
+readonly elapsed_days
 
 summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 
@@ -105,7 +121,10 @@ summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
   printf '`k8s/providers/hetzner/infrastructure/controllers/cilium/components/homogeneous-devices/kustomization.yaml`.\n'
 } >>"${summary}"
 
-if ((elapsed_days > warn_after_days)); then
+# >=, not >: warn_after_days=7 means "warn once this has run seven days", so the
+# warning belongs on day seven. A strict > would silently make the real bound
+# eight days, which is not what the constant says.
+if ((elapsed_days >= warn_after_days)); then
   printf '::warning::Talos machine-config sync has been suppressed by the Cilium rollout gate for %s days (threshold %s). Machine config in Git is diverging from the nodes, and platform#2922/#2938 are blocked behind it. Finish or roll back the rollout — see the component runbook.\n' \
     "${elapsed_days}" "${warn_after_days}"
 fi

--- a/scripts/report-cilium-rollout-gate-suppression.sh
+++ b/scripts/report-cilium-rollout-gate-suppression.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Report, in the deploy's own job summary, that the Cilium rollout gate has
+# suppressed the Talos machine-config sync — and warn once that suppression
+# outlives its intended window.
+#
+# The coupling itself is deliberate and stays: KSail owns Cluster Autoscaler and
+# could reconcile it back to one replica mid-rollout, racing a scale-up before
+# the first Cilium canary is verified. What is not acceptable is that it was
+# INVISIBLE. `cluster update` is the deploy's only Talos machine-config sync, and
+# a skipped step inside a green deploy is indistinguishable from a step that ran
+# and did nothing — so machine config in Git silently stopped being machine
+# config on the nodes, and the divergence grew with no signal anywhere
+# (platform#2951).
+#
+# Releasing the gate stays an operational judgement about the Cilium rollout, so
+# this never fails the deploy. It makes the suppression legible and bounded.
+
+set -euo pipefail
+
+root_dir="${PLATFORM_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+readonly root_dir
+readonly controllers_kustomization="${root_dir}/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml"
+readonly activation_marker='platform.devantler.tech/rollout-gate-activated:'
+
+# The component's runbook is "step nine nodes one at a time, verifying each, then
+# soak". A week is generous for that. Past it, the rollout is not progressing as
+# designed and the un-synced machine-config delta is the larger risk.
+readonly warn_after_days=7
+
+readonly gate_active="${CILIUM_ROLLOUT_GATE_ACTIVE:-false}"
+
+fail() {
+  printf '::error::%s\n' "$1"
+  exit 1
+}
+
+# Nothing was suppressed, so claim nothing. Staying silent here is what keeps
+# the notice meaningful when it does appear.
+[[ "${gate_active}" == true ]] || exit 0
+
+# The declared activation date lives beside the component reference, so it is
+# reviewed in the same diff that activates or releases the gate.
+if [[ -n "${ROLLOUT_GATE_ACTIVATED_OVERRIDE:-}" ]]; then
+  activated="${ROLLOUT_GATE_ACTIVATED_OVERRIDE}"
+else
+  [[ -f "${controllers_kustomization}" ]] ||
+    fail "cannot read ${controllers_kustomization} to date the rollout gate"
+  marker_line="$(grep -F "${activation_marker}" "${controllers_kustomization}" || true)"
+  [[ -n "${marker_line}" ]] ||
+    fail "the rollout gate is active but ${activation_marker} <YYYY-MM-DD> is not declared beside the component reference"
+  # Parameter expansion, not sed: the marker contains '/', which would collide
+  # with sed's substitution delimiter.
+  activated="${marker_line##*"${activation_marker}"}"
+  activated="${activated#"${activated%%[![:space:]]*}"}"
+  activated="${activated%%[[:space:]]*}"
+fi
+readonly activated
+
+[[ "${activated}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
+  fail "the rollout gate activation date is not an ISO date: '${activated}'"
+
+# GNU and BSD date disagree on parsing; support both so this behaves the same on
+# a runner and on a maintainer's Mac.
+to_epoch() {
+  date -u -d "$1" +%s 2>/dev/null || date -u -j -f '%Y-%m-%d' "$1" +%s 2>/dev/null
+}
+
+activated_epoch="$(to_epoch "${activated}")" ||
+  fail "could not parse the rollout gate activation date: '${activated}'"
+[[ -n "${activated_epoch}" ]] ||
+  fail "could not parse the rollout gate activation date: '${activated}'"
+now_epoch="$(date -u +%s)"
+elapsed_days=$(((now_epoch - activated_epoch) / 86400))
+readonly activated_epoch now_epoch elapsed_days
+
+summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+# The backticks below are Markdown code spans for the job summary, not command
+# substitution, so single quotes are deliberate — expanding them is exactly what
+# must not happen.
+# shellcheck disable=SC2016
+{
+  printf '## ⏸️ Talos machine-config sync was SUPPRESSED this deploy\n\n'
+  printf 'The Cilium homogeneous-device rollout gate is active, so '
+  printf '`ksail cluster update` — this deploy pipeline'"'"'s only Talos '
+  printf 'machine-config sync — did not run. **Machine config in Git is not '
+  printf 'necessarily machine config on the nodes.**\n\n'
+  printf '| | |\n|---|---|\n'
+  printf '| Gate active since | `%s` |\n' "${activated}"
+  printf '| Elapsed | **%s days** |\n' "${elapsed_days}"
+  printf '| Warn threshold | %s days |\n' "${warn_after_days}"
+  printf '\nThis also blocks anything that depends on `cluster update` applying '
+  printf 'configuration to the live cluster — including the root OCIRepository '
+  printf 'cosign `verify` block (platform#2922, platform#2938).\n\n'
+  printf 'Release is an operational judgement about the Cilium rollout, not '
+  printf 'something a deploy decides: follow step 4–5 of the runbook in '
+  printf '`k8s/providers/hetzner/infrastructure/controllers/cilium/components/homogeneous-devices/kustomization.yaml`.\n'
+} >>"${summary}"
+
+if ((elapsed_days > warn_after_days)); then
+  printf '::warning::Talos machine-config sync has been suppressed by the Cilium rollout gate for %s days (threshold %s). Machine config in Git is diverging from the nodes, and platform#2922/#2938 are blocked behind it. Finish or roll back the rollout — see the component runbook.\n' \
+    "${elapsed_days}" "${warn_after_days}"
+fi
+
+exit 0

--- a/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
+++ b/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
@@ -171,4 +171,71 @@ if run_reporter true "${future}"; then
 fi
 ok
 
+# The elapsed count must be an EXACT whole-day difference and identical on GNU
+# and BSD date. BSD `date -j -f '%Y-%m-%d'` fills unspecified fields from the
+# current time while GNU parses a bare date as midnight, so an implicit parse
+# makes this off by one between a Mac and the Linux runner.
+for probe_days in 1 3 9 40; do
+  probe_date="$(date -u -v-"${probe_days}"d +%Y-%m-%d 2>/dev/null || date -u -d "${probe_days} days ago" +%Y-%m-%d)"
+  run_reporter true "${probe_date}" || fail "reporter must exit 0 for a ${probe_days}-day-old gate"
+  grep -Fq "**${probe_days} days**" "${tmp}/summary" ||
+    fail "elapsed must be exactly ${probe_days} days for ${probe_date}, summary said otherwise"
+done
+ok
+
+# NEXT-DAY specifically: bash truncates integer division toward zero, so a date
+# one day ahead yields elapsed_days == 0 and reads as "activated today". The
+# 30-day case above does NOT cover this — the guard must compare epochs, not the
+# divided day count.
+tomorrow="$(date -u -v+1d +%Y-%m-%d 2>/dev/null || date -u -d '1 day' +%Y-%m-%d)"
+if run_reporter true "${tomorrow}"; then
+  fail 'an activation date one day ahead must fail closed (integer division hides it as 0 days)'
+fi
+ok
+
+# EXACT threshold: warn_after_days=7 means the warning belongs on day seven, not
+# day eight. A strict > would silently make the real bound one day longer.
+exactly_threshold="$(date -u -v-"${threshold}"d +%Y-%m-%d 2>/dev/null || date -u -d "${threshold} days ago" +%Y-%m-%d)"
+run_reporter true "${exactly_threshold}" ||
+  fail 'a suppression exactly at the threshold must still exit 0'
+grep -q '^::warning' "${tmp}/out" ||
+  fail 'the warning must fire ON the threshold day, not the day after'
+ok
+
+# One day INSIDE the bound must stay quiet, or the assertion above would pass
+# for a reporter that simply always warns.
+inside="$(date -u -v-"$((threshold - 1))"d +%Y-%m-%d 2>/dev/null || date -u -d "$((threshold - 1)) days ago" +%Y-%m-%d)"
+run_reporter true "${inside}" || fail 'an in-bound suppression must exit 0'
+! grep -q '^::warning' "${tmp}/out" ||
+  fail 'a suppression one day inside the bound must not warn'
+ok
+
+# Duplicate marker: the reporter must not silently date the suppression from
+# whichever declaration happens to come first.
+fixture_root="${tmp}/root"
+fixture_kustomization="${fixture_root}/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml"
+mkdir -p "$(dirname "${fixture_kustomization}")"
+{
+  printf '  # %s 2026-07-26\n' "${activation_marker}"
+  printf '  # %s 2026-01-01\n' "${activation_marker}"
+  printf '  - cilium/components/homogeneous-devices/\n'
+} >"${fixture_kustomization}"
+: >"${tmp}/summary"
+if CILIUM_ROLLOUT_GATE_ACTIVE=true PLATFORM_ROOT="${fixture_root}" \
+  GITHUB_STEP_SUMMARY="${tmp}/summary" "${report_script}" >"${tmp}/out" 2>&1; then
+  fail 'a duplicated activation marker must fail closed, not silently take the first'
+fi
+ok
+
+# Control for the fixture: with exactly one marker the same path succeeds, so the
+# assertion above is about duplication and not about the fixture being unreadable.
+printf '  # %s 2026-07-26\n' "${activation_marker}" >"${fixture_kustomization}"
+: >"${tmp}/summary"
+CILIUM_ROLLOUT_GATE_ACTIVE=true PLATFORM_ROOT="${fixture_root}" \
+  GITHUB_STEP_SUMMARY="${tmp}/summary" "${report_script}" >"${tmp}/out" 2>&1 ||
+  fail 'a single marker read from PLATFORM_ROOT must succeed'
+grep -Fq '2026-07-26' "${tmp}/summary" ||
+  fail 'the fixture summary must carry the declared date'
+ok
+
 printf 'passed: %s failed: 0\n' "${passed}"

--- a/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
+++ b/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# The Cilium rollout gate suppresses the deploy's only Talos machine-config
+# sync. That coupling is deliberate; its INVISIBILITY was not. A skipped step
+# inside a green deploy is indistinguishable from a step that ran and did
+# nothing, which is how the suppression survived ten days unnoticed and
+# misdirected the diagnosis of two unrelated issues (platform#2951).
+#
+# These assertions pin that the gate can never suppress machine-config sync
+# without saying so, and that the suppression is bounded rather than open-ended.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly report_script="${root_dir}/scripts/report-cilium-rollout-gate-suppression.sh"
+readonly deploy_action="${root_dir}/.github/actions/deploy-prod/action.yml"
+readonly controllers_kustomization="${root_dir}/k8s/providers/hetzner/infrastructure/controllers/kustomization.yaml"
+readonly component_kustomization="${root_dir}/k8s/providers/hetzner/infrastructure/controllers/cilium/components/homogeneous-devices/kustomization.yaml"
+readonly activation_marker='platform.devantler.tech/rollout-gate-activated:'
+
+passed=0
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+ok() {
+  passed=$((passed + 1))
+}
+
+line_of() {
+  grep -nF -- "$2" "$1" | head -1 | cut -d: -f1
+}
+
+# --- the reporter exists and is wired into the deploy -----------------------
+
+[[ -x "${report_script}" ]] ||
+  fail 'the gate-suppression reporter must be an executable script'
+ok
+
+grep -Fq './scripts/report-cilium-rollout-gate-suppression.sh' "${deploy_action}" ||
+  fail 'the deploy action must invoke the gate-suppression reporter'
+ok
+
+# It must report AFTER the step it describes, or it would announce a
+# suppression before the deploy has actually reached that decision.
+report_line="$(line_of "${deploy_action}" './scripts/report-cilium-rollout-gate-suppression.sh')"
+cluster_update_line="$(line_of "${deploy_action}" 'run: ./scripts/run-ksail-prod-with-pull-auth.sh cluster update')"
+readonly report_line cluster_update_line
+[[ -n "${report_line}" && -n "${cluster_update_line}" ]] ||
+  fail 'could not locate both the reporter and the cluster update step'
+((cluster_update_line < report_line)) ||
+  fail 'the reporter must run after the cluster update step it reports on'
+ok
+
+# The gate's own output is the single source of truth for "is it active".
+# Re-deriving it in the reporter would let the two drift apart silently.
+# shellcheck disable=SC2016
+grep -Fq 'CILIUM_ROLLOUT_GATE_ACTIVE: ${{ steps.cilium_rollout_gate.outputs.active }}' "${deploy_action}" ||
+  fail 'the reporter must take the gate state from the gate step output'
+ok
+
+# always(): a failure earlier in the deploy must not be able to hide the fact
+# that machine-config sync was suppressed.
+grep -Fq 'always() && steps.cilium_rollout_gate.outputs.active' "${deploy_action}" ||
+  fail 'the reporter must run under always() so an earlier failure cannot hide the suppression'
+ok
+
+# --- the activation marker exists while the gate is active ------------------
+
+component_referenced=false
+if grep -Eq '^[[:space:]]*-[[:space:]]*cilium/components/homogeneous-devices/?[[:space:]]*(#.*)?$' \
+  "${controllers_kustomization}"; then
+  component_referenced=true
+fi
+on_delete=false
+if grep -Eq '^[[:space:]]*type:[[:space:]]*OnDelete[[:space:]]*(#.*)?$' "${component_kustomization}"; then
+  on_delete=true
+fi
+
+if [[ "${component_referenced}" == true && "${on_delete}" == true ]]; then
+  marker_line="$(grep -F "${activation_marker}" "${controllers_kustomization}" || true)"
+  [[ -n "${marker_line}" ]] ||
+    fail "the rollout gate is ACTIVE, so ${activation_marker} <YYYY-MM-DD> must be declared beside the component reference"
+  ok
+  # Parameter expansion, not sed: the marker contains '/'.
+  declared_date="${marker_line##*"${activation_marker}"}"
+  declared_date="${declared_date#"${declared_date%%[![:space:]]*}"}"
+  declared_date="${declared_date%%[[:space:]]*}"
+  [[ "${declared_date}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
+    fail "the activation marker must be an ISO date, got: '${declared_date}'"
+  ok
+else
+  # Gate inactive: the marker must NOT be left behind claiming an active
+  # rollout, or the next activation inherits a stale start date.
+  ! grep -Fq "${activation_marker}" "${controllers_kustomization}" ||
+    fail 'the rollout gate is inactive, so the activation marker must be removed'
+  ok
+  ok
+fi
+
+# --- the bound is real and enforced ----------------------------------------
+
+grep -Eq '^readonly warn_after_days=[0-9]+$' "${report_script}" ||
+  fail 'the reporter must declare an explicit warn_after_days threshold'
+ok
+
+threshold="$(sed -nE 's/^readonly warn_after_days=([0-9]+)$/\1/p' "${report_script}")"
+readonly threshold
+[[ -n "${threshold}" && "${threshold}" -gt 0 && "${threshold}" -le 30 ]] ||
+  fail "the threshold must be a bound in (0,30] days, got: '${threshold}'"
+ok
+
+# --- behaviour: the reporter itself --------------------------------------
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+run_reporter() {
+  # $1 active, $2 declared date; emits summary to $tmp/summary, stdout captured
+  : >"${tmp}/summary"
+  CILIUM_ROLLOUT_GATE_ACTIVE="$1" \
+    ROLLOUT_GATE_ACTIVATED_OVERRIDE="$2" \
+    GITHUB_STEP_SUMMARY="${tmp}/summary" \
+    "${report_script}" >"${tmp}/out" 2>"${tmp}/err"
+}
+
+today="$(date -u +%Y-%m-%d)"
+long_ago="$(date -u -v-90d +%Y-%m-%d 2>/dev/null || date -u -d '90 days ago' +%Y-%m-%d)"
+
+# Inactive gate: nothing suppressed, so nothing claimed.
+run_reporter false "${today}" || fail 'reporter must exit 0 when the gate is inactive'
+[[ ! -s "${tmp}/summary" ]] ||
+  fail 'an inactive gate must not write a suppression notice'
+ok
+
+# Active + fresh: must still announce the suppression in the job summary.
+run_reporter true "${today}" || fail 'reporter must exit 0 for an active, in-bound gate'
+grep -Fq 'machine-config sync' "${tmp}/summary" ||
+  fail 'an active gate must name the suppressed sync in the job summary'
+ok
+grep -Fq "${today}" "${tmp}/summary" ||
+  fail 'the summary must state when the suppression began'
+ok
+# In-bound: informative, but NOT a warning annotation.
+! grep -q '^::warning' "${tmp}/out" ||
+  fail 'an in-bound suppression must not emit a warning annotation'
+ok
+
+# Active + long overdue: must warn loudly, and still exit 0 (releasing the
+# gate is an operational judgement, not something a deploy may decide).
+run_reporter true "${long_ago}" || fail 'an over-threshold gate must warn, not fail the deploy'
+grep -q '^::warning' "${tmp}/out" ||
+  fail 'a suppression past the threshold must emit a ::warning:: annotation'
+ok
+grep -Fq '90' "${tmp}/summary" ||
+  fail 'the summary must state the elapsed day count'
+ok
+
+# Fail closed: an active gate with an unreadable start date must NOT pass
+# silently — that is exactly the invisible-suppression class this guards.
+if run_reporter true 'not-a-date'; then
+  fail 'an active gate with an unparseable activation date must fail closed'
+fi
+ok
+
+printf 'passed: %s failed: 0\n' "${passed}"

--- a/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
+++ b/scripts/tests/test-cilium-rollout-gate-suppression-signal.sh
@@ -163,4 +163,12 @@ if run_reporter true 'not-a-date'; then
 fi
 ok
 
+# A future date would make elapsed negative, so the bound could never trip and
+# the gate would buy itself unlimited time from a single typo.
+future="$(date -u -v+30d +%Y-%m-%d 2>/dev/null || date -u -d '30 days' +%Y-%m-%d)"
+if run_reporter true "${future}"; then
+  fail 'an activation date in the future must fail closed, not read as perpetually fresh'
+fi
+ok
+
 printf 'passed: %s failed: 0\n' "${passed}"


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Cilium rollout gate skips the deploy pipeline's **only** Talos machine-config sync. That coupling
is deliberate and stays — what was not deliberate is that it happened silently, because a skipped
step inside a green deploy looks exactly like a step that ran and did nothing.

So machine config in Git quietly stopped being machine config on the nodes for **nine days** with no
signal anywhere, and it misdirected the diagnosis of two unrelated issues along the way.

## What

The deploy now says so in its job summary — what was skipped, since when, and what else is blocked
behind it — and warns loudly once the suppression outruns the rollout's intended one-week window.
Releasing the gate stays your operational call, so this never fails a deploy.

On today's state it fires immediately: 9 days elapsed against a 7-day bound.

The decision it records — keep the coupling, bound it — and the evidence are on #2951.

Fixes #2951
