### PR TITLE
fix(security): pin cosign subject refs at the image-verification layer

### DIFF
--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -109,8 +109,8 @@ spec:
         .all(e, e > 0)
       message: >-
         first-party app image is not signed by the publish-app release
-        pipeline (keyless cosign, actions/reusable-workflows publish-app.yaml
-        identity)
+        pipeline (keyless cosign, actions publish-app.yaml identity, pinned by
+        commit SHA or release tag)
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)
         .filter(image, image.startsWith('ghcr.io/devantler-tech/provider-upjet-'))
@@ -118,7 +118,7 @@ spec:
         .all(e, e > 0)
       message: >-
         provider-upjet package image is not signed by its repo's
-        publish-provider-package workflow (keyless cosign)
+        publish-provider-package workflow on main (keyless cosign)
     - expression: >-
         (images.containers + images.initContainers + images.ephemeralContainers)
         .filter(image, image.startsWith('ghcr.io/devantler-tech/ksail'))

--- a/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
+++ b/k8s/bases/infrastructure/cluster-policies/best-practices/verify-app-images.yaml
@@ -56,23 +56,22 @@ spec:
     - name: publishapp
       cosign:
         keyless:
-          # The publish-app workflow moved from reusable-workflows into the
-          # actions monorepo (reusable-workflows is being archived); both
-          # identities are accepted during the transition via ONE identity
-          # whose subjectRegExp alternates the repo — the same shape as the
-          # tenants' Flux OCIRepository verify blocks. Do NOT list a second
-          # identity entry instead: the IVPOL engine verifies cosign v3
-          # bundles through sigstore-go, which rejects more than one identity
-          # per verification ("unsupported: multiple identities are not
-          # supported at this time" — sigstore/cosign pkg/cosign/verify.go),
-          # so a second entry fail-closes EVERY image this attestor gates
-          # (observed live 2026-07-04: wedding-app v1.14.1 denied at
-          # admission for hours, wedging the whole merge queue). Narrow the
-          # alternation to actions-only once every first-party app image in
-          # prod ships actions-signed.
+          # publish-app.yaml lives in the actions monorepo. Callers pin that
+          # reusable workflow either by commit SHA or by release tag, so the
+          # ref alternation admits exactly those two forms and rejects a
+          # mutable ref such as @main — the same shape as the tenants' Flux
+          # OCIRepository verify blocks. Keep this to exactly ONE identity
+          # entry: the IVPOL engine verifies cosign v3 bundles through
+          # sigstore-go, which rejects more than one identity per verification
+          # ("unsupported: multiple identities are not supported at this
+          # time" — sigstore/cosign pkg/cosign/verify.go), so a second entry
+          # fail-closes EVERY image this attestor gates (observed live
+          # 2026-07-04: wedding-app v1.14.1 denied at admission for hours,
+          # wedging the whole merge queue). Express any additional accepted
+          # form as an alternation inside this one regex.
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/(actions|reusable-workflows)/\.github/workflows/publish-app\.yaml@.+$
+              subjectRegExp: ^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$
     # Crossplane provider packages (provider-upjet-*): the crossplane-contrib
     # reusable publish workflow they use cannot sign, so each provider repo
     # attaches the keyless signature in its own publish-provider-package.yml
@@ -86,12 +85,16 @@ spec:
     # publishapp would let a provider-workflow signature satisfy
     # verification for ANY app image (identities within one attestor are
     # OR'd per image).
+    # The ref is pinned to the default branch: publish-provider-package.yml is
+    # workflow_dispatch-only and publishes from main, so main is the sole
+    # legitimate signing ref. Pinning it rejects a package signed from an
+    # arbitrary feature branch, which an unconstrained ref accepts.
     - name: publishprovider
       cosign:
         keyless:
           identities:
             - issuer: https://token.actions.githubusercontent.com
-              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
+              subjectRegExp: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/heads/main$
     - name: ksailcd
       cosign:
         keyless:

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -8,17 +8,18 @@
 # pods, a compromised registry serving a tampered image).
 #
 # Scope: FIRST-PARTY images (ghcr.io/devantler-tech/*). All are keyless-cosign
-# signed, but by TWO different signing identities, so they need two rules:
+# signed, but by THREE different signing identities, so they need three rules:
 #   1. ghcr.io/devantler-tech/ksail — the ksail-operator image — is signed by
 #      ksail's OWN release pipeline (devantler-tech/ksail .github/workflows/
-#      cd.yaml; see that repo's GoReleaser `docker_signs` step).
-#   2. the app images (wedding-app, ascoachingogvaner, …) are signed by the
-#      shared publish-app.yaml workflow — now in devantler-tech/actions
-#      (moved from reusable-workflows, actions#425); both identities stay
-#      accepted until every app has published a fresh actions-signed image —
-#      the SAME transition alternation their Flux OCIRepository verify blocks
-#      and the verify-app-images ImageValidatingPolicy already pin.
-# Talos evaluates rules in order, first match wins, so the specific ksail rule
+#      cd.yaml; see that repo's GoReleaser `docker_signs` step), at a release tag.
+#   2. ghcr.io/devantler-tech/provider-upjet-* — the Crossplane provider packages
+#      — are signed by each provider repo's own publish-provider-package.yml, on
+#      its default branch (that workflow is workflow_dispatch-only).
+#   3. the app images (wedding-app, ascoachingogvaner, …) are signed by the
+#      shared publish-app.yaml workflow in devantler-tech/actions, pinned by
+#      commit SHA or release tag — the SAME form their Flux OCIRepository verify
+#      blocks and the verify-app-images ImageValidatingPolicy pin.
+# Talos evaluates rules in order, first match wins, so the two specific rules
 # MUST precede the ghcr.io/devantler-tech/* catch-all.
 #
 # FAIL-OPEN by design for everything else: an image matching NO rule is pulled

--- a/talos/cluster/verify-first-party-images.yaml
+++ b/talos/cluster/verify-first-party-images.yaml
@@ -58,20 +58,20 @@ rules:
   # Mirrors the verify-app-images ImageValidatingPolicy provider-upjet-*
   # attestor (#2382). MUST precede the catch-all below (first-match-wins) or the
   # catch-all's publish-app.yaml identity rejects these (ImagePullBackOff).
+  # The ref is pinned to the default branch: publish-provider-package.yml is
+  # workflow_dispatch-only and publishes from main, so main is the sole
+  # legitimate signing ref. Pinning it rejects a package signed from an
+  # arbitrary feature branch, which an unconstrained ref accepts.
   - image: ghcr.io/devantler-tech/provider-upjet-*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@.+$
-  # First-party APP images signed by the shared publish-app.yaml workflow.
-  # publish-app.yaml moved from devantler-tech/reusable-workflows into
-  # devantler-tech/actions (actions#425): images published after the move
-  # carry the actions identity, which this rule's old reusable-workflows-only
-  # regex rejected at the node pull layer (ImagePullBackOff on every new app
-  # release). Accept BOTH identities until every app has published a fresh
-  # actions-signed image, then narrow to actions-only — the same transition
-  # alternation as the apps' Flux OCIRepository verify blocks and the
-  # verify-app-images ImageValidatingPolicy.
+      subjectRegex: ^https://github\.com/devantler-tech/provider-upjet-[a-z0-9-]+/\.github/workflows/publish-provider-package\.yml@refs/heads/main$
+  # First-party APP images signed by the shared publish-app.yaml workflow in
+  # devantler-tech/actions. Callers pin that reusable workflow either by commit
+  # SHA or by release tag, so the ref alternation admits exactly those two forms
+  # and rejects a mutable ref such as @main. Same shape as the apps' Flux
+  # OCIRepository verify blocks and the verify-app-images ImageValidatingPolicy.
   - image: ghcr.io/devantler-tech/*
     keyless:
       issuer: https://token.actions.githubusercontent.com
-      subjectRegex: ^https://github\.com/devantler-tech/(actions|reusable-workflows)/\.github/workflows/publish-app\.yaml@.+$
+      subjectRegex: ^https://github\.com/devantler-tech/actions/\.github/workflows/publish-app\.yaml@([0-9a-f]{40}|refs/tags/v.+)$


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The cluster checks that first-party container images are signed by us before it will run them. That check was accepting a signature made from **any branch** of the signing repository, so an image built from a throwaway feature branch would have passed as genuine. This is not hypothetical — a provider package was published and signed from an agent feature branch in June. The app rule also still trusted a signing identity that was retired when that repository was archived in July.

## What

Both image-verification layers now accept only the signing refs that real releases actually come from, so a signature from an unofficial branch is rejected. The equivalent tightening was already applied to the manifest artifacts in #2402; this closes the same gap for images.

**Merge note:** the two rules deliberately pin *different* refs, because the two publishing pipelines genuinely differ. Applying one rule's form to the other would deny a currently-running workload at admission — so please keep them distinct if this is ever refactored.

Verified against the real published signatures rather than by inspection: each rule accepts the image it governs and rejects the other one's.

Fixes #2815
