### PR TITLE
fix(ci): prove every publication step's failure stops the run

### DIFF
--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -180,7 +180,62 @@ func validatePublicationAction(action string) error {
 		return errors.New("publication action must verify latest resolves to the staged digest")
 	}
 
+	return publicationStepsAreEnforced(action)
+}
+
+// publicationStepsAreEnforced proves every publication step's failure actually
+// stops the run.
+//
+// 🔴 THE FIFTH SITE OF THE requireEnforcedStep MISTAKE, and the one the checks
+// above cannot reach. Everything before this point is positional: it proves a
+// step EXISTS and sits in the right place in the chain. Position says nothing
+// about whether the step's verdict is honoured. `continue-on-error: true` on
+// `verify_evidence` keeps the gate present, correctly ordered, invoked with the
+// resolved digest and reading ENFORCE=true — so the ordering chain here, the
+// wiring assertions in test-verify-published-evidence.sh, and the enforcement
+// ratchet all still pass — while the gate's failure is discarded and
+// `promote_latest` moves the mutable tag onto bytes with no usable evidence.
+// That is precisely the state root verification exists to make impossible.
+//
+// Every step is covered rather than a named subset: this action's whole purpose
+// is producing bytes production will trust, so a step whose failure does not
+// stop it has no place in the chain, and an allowlist would need extending each
+// time a step is added — the omission this file has already made four times.
+func publicationStepsAreEnforced(action string) error {
+	document, err := decodeWorkflow(action)
+	if err != nil {
+		return fmt.Errorf("publication action is unreadable, so its steps cannot be proven enforced: %w", err)
+	}
+	runs, ok := document["runs"].(map[string]any)
+	if !ok {
+		return errors.New("publication action has no runs mapping, so its steps cannot be proven enforced")
+	}
+	steps, ok := runs["steps"].([]any)
+	if !ok || len(steps) == 0 {
+		return errors.New("publication action declares no steps, so nothing can be proven enforced")
+	}
+	for index, raw := range steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("publication action step %d is not a mapping, so it cannot be proven enforced", index)
+		}
+		if err := enforcesFailure(step, describePublicationStep(step, index)); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// describePublicationStep names a step the way its author will recognise it, so
+// the failure points at the line to change rather than an index to count to.
+func describePublicationStep(step map[string]any, index int) string {
+	if id, ok := step["id"].(string); ok && id != "" {
+		return fmt.Sprintf("publication action step %q", id)
+	}
+	if name, ok := step["name"].(string); ok && name != "" {
+		return fmt.Sprintf("publication action step %q", name)
+	}
+	return fmt.Sprintf("publication action step %d", index)
 }
 
 func validateVerifyAllowList(config string) error {

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -912,6 +913,79 @@ func TestPublicationActionRejectsEachAblation(t *testing.T) {
 			err := validatePublicationAction(ablated)
 			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
 				t.Fatalf("wrong result: got %v, want error mentioning %q", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+// TestPublicationActionRejectsSuppressedPublicationSteps pins the half of the
+// contract that ordering cannot see.
+//
+// 🔴 THE SAME CLASS AS enforcesFailure's job-level check, ONE LEVEL FURTHER
+// DOWN — inside the composite action's own steps, where every existing check
+// was blind. `continue-on-error: true` on `verify_evidence` leaves the step
+// present, in the right place, invoked with the right digest, reading
+// ENFORCE=true — so the ordering chain, the wiring test, and the enforcement
+// ratchet all still pass — while the gate's verdict is discarded and
+// `promote_latest` moves the mutable tag onto bytes carrying no usable
+// evidence. Position proves a step is reached; it says nothing about whether
+// its failure stops the run.
+func TestPublicationActionRejectsSuppressedPublicationSteps(t *testing.T) {
+	t.Parallel()
+
+	publisher := repoFile(t, ".github/actions/deploy-prod/publish-platform-manifests/action.yml")
+	cases := []struct {
+		name     string
+		stepID   string
+		injected string
+		wantErr  string
+	}{
+		{
+			name:     "a discarded evidence verdict promotes unevidenced bytes",
+			stepID:   "verify_evidence",
+			injected: "      continue-on-error: true",
+			wantErr:  "continue-on-error",
+		},
+		{
+			name:     "a suppressed signature failure promotes unsigned bytes",
+			stepID:   "cosign_sign",
+			injected: "      continue-on-error: true",
+			wantErr:  "continue-on-error",
+		},
+		{
+			name:     "a suppressed provenance failure promotes bytes lacking evidence",
+			stepID:   "attest_provenance",
+			injected: "      continue-on-error: true",
+			wantErr:  "continue-on-error",
+		},
+		{
+			name:     "a conditional gate can be skipped while the action still reads as gated",
+			stepID:   "verify_evidence",
+			injected: "      if: always()",
+			wantErr:  "condition",
+		},
+		{
+			name:     "a conditional promotion can run on a path the contract never checked",
+			stepID:   "promote_latest",
+			injected: "      if: always()",
+			wantErr:  "condition",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			anchor := "      id: " + testCase.stepID
+			ablated := strings.Replace(publisher, anchor, anchor+"\n"+testCase.injected, 1)
+			if ablated == publisher {
+				t.Fatalf("ablation changed nothing — no step carries id %q", testCase.stepID)
+			}
+			err := validatePublicationAction(ablated)
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("wrong result: got %v, want error mentioning %q", err, testCase.wantErr)
+			}
+			if !strings.Contains(fmt.Sprint(err), testCase.stepID) {
+				t.Fatalf("error does not name the offending step %q: %v", testCase.stepID, err)
 			}
 		})
 	}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Production trusts whatever arrives through the root OCI artifact, and one step — `verify_evidence` — is the last check between "attestations were requested" and "production starts following these bytes". That gate could be switched off by a single line while CI still reported the publication contract as fully enforced, because every existing check proved only that steps exist in the right *order*, never that a step's failure actually stops the run.

## What

Every step in the publication action must now prove its failure is fatal, reusing the check this repository already applies to workflow-level steps. The shipped action passes unchanged; the suppressed one is refused by name, so the failure points at the line to change.

Fixes #2967
Part of #2627
