### PR TITLE
docs(ci): correct where Kubescape exceptions are actually applied

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -500,12 +500,18 @@ jobs:
         #
         # The scan consumes the platform's justified exceptions: the
         # ClusterSecurityException CRs (k8s/bases/infrastructure/
-        # cluster-security-exceptions/ — the single source of truth, also
-        # consumed in-cluster by the kubescape-operator) are converted at scan
-        # time into Kubescape's native exceptions format by
+        # cluster-security-exceptions/ — the single source of truth) are
+        # converted at scan time into Kubescape's native exceptions format by
         # scripts/generate-kubescape-exceptions (#2264). With runtime-
         # enforced and except-only findings suppressed, the threshold gates the
         # residual REAL posture instead of sitting ~15 points under it.
+        #
+        # Two surfaces apply these exceptions: this scan, and the Headlamp view
+        # via the generated headlamp-exceptions ConfigMap. The kubescape-operator's
+        # stored scan resources (workloadconfigurationscans and the two summary
+        # kinds) do NOT — their appliedIgnoreRules is empty, so they carry
+        # pre-exception verdicts. Never read a posture number off those to judge
+        # an exception's effect; use this scan's output (#2823).
         #
         # The threshold is a regression FLOOR, not the live score. The
         # Kubescape compliance score has historically been environment-


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A comment in the CI workflow told readers that the security exceptions are applied by the
in-cluster scanner as well as by CI. They are not. Anyone checking whether an exception is
working — which is exactly what two open security issues are about — would look at the
in-cluster numbers, see the finding still listed, and conclude the exception is broken when
it is fine.

That misread already cost a run: the in-cluster numbers quoted on #2823 are pre-exception
figures, and a fix verified against them could never show an effect either way.

## What

Corrects the comment to say where exceptions actually take effect (the CI scan and the
Headlamp view), and warns off using the in-cluster scanner's stored results to judge an
exception. Comment-only — no behaviour change.

Part of #2823
