### PR TITLE
fix(ci): retry the cordon claim when an unrelated Node write breaks its CAS test

### DIFF
--- a/scripts/refresh-flux-ghcr-auth-safety.sh
+++ b/scripts/refresh-flux-ghcr-auth-safety.sh
@@ -63,6 +63,46 @@ select_talos_node_targets() {
   rm -f "${unsorted_targets}"
 }
 
+# Validate that an unclaimed node is still exactly what the capturing read saw,
+# so a rejected atomic claim can be retried against a fresh resourceVersion.
+# A Node object has several independent writers (kubelet status heartbeats, the
+# cloud controller manager, the CNI operator), and any of their writes rejects
+# the claim's resourceVersion test without changing anything relevant to drain
+# safety. Retrying is only sound while every fact the caller captured still
+# holds: same node identity, not being deleted, still unowned by this bridge,
+# and unchanged scheduling intent. A concurrent cordon, ownership grab, taint
+# edit, or node replacement therefore still refuses instead of retrying.
+node_claim_preconditions_still_hold() {
+  local state_file="$1"
+  local initial_node_uid="$2"
+  local was_cordoned="$3"
+  local initial_node_taints="$4"
+
+  jq -e \
+    --arg owner_annotation \
+    "platform.devantler.tech/ghcr-auth-drain-owner" \
+    --arg recovery_annotation \
+    "platform.devantler.tech/ghcr-auth-drain-recovery" \
+    --arg uid "${initial_node_uid}" \
+    --argjson was_cordoned "${was_cordoned}" \
+    --argjson initial_taints "${initial_node_taints}" '
+    .metadata.uid == $uid
+    and .metadata.deletionTimestamp == null
+    and ((.metadata.annotations[$owner_annotation] // "") == "")
+    and ((.metadata.annotations[$recovery_annotation] // "") == "")
+    and ((if (.spec.unschedulable // false) then 1 else 0 end)
+      == $was_cordoned)
+    and (((.spec.taints // [])
+      | map(select((
+          .key == "node.kubernetes.io/unschedulable"
+          and .effect == "NoSchedule"
+          and (.value // "") == ""
+        ) | not))
+      | sort_by([.key, .effect, (.value // ""), (.timeAdded // "")]))
+      == $initial_taints)
+  ' "${state_file}" >/dev/null
+}
+
 # Validate the scheduling state captured immediately before a Talos reboot.
 # The bridge must still own its serialization annotation while the node stays
 # cordoned; neither a bridge-created nor a pre-existing cordon may proceed after

--- a/scripts/refresh-flux-ghcr-auth.sh
+++ b/scripts/refresh-flux-ghcr-auth.sh
@@ -921,6 +921,53 @@ verify_bootstrap_quarantine_covers_unproved_destinations() {
 claim_node_cordon_ownership() {
   local node_name="$1" owner_token="$2" state_file="$3" result_file="$4"
   local recovery_record="${5:-}"
+  local was_cordoned="${6:-}" initial_taints="${7:-}"
+  local resource_version node_uid initial_node_uid
+  local attempt=1
+  local max_attempts="${CORDON_CLAIM_MAX_ATTEMPTS:-5}"
+
+  initial_node_uid="$(jq -er '.metadata.uid' "${state_file}")"
+
+  while :; do
+    build_and_apply_cordon_claim \
+      "${node_name}" "${owner_token}" "${state_file}" "${result_file}" \
+      "${recovery_record}" && return 0
+
+    # Only a conflict against a still-conforming node is retryable, and only
+    # when the caller supplied the scheduling facts needed to re-verify that.
+    if [[ -z "${was_cordoned}" || -z "${initial_taints}" ]] ||
+      ((attempt >= max_attempts)); then
+      break
+    fi
+
+    if ! kubectl \
+      --context "${KUBE_CONTEXT}" \
+      get node "${node_name}" \
+      --output json \
+      >"${state_file}" 2>"${result_file}"; then
+      break
+    fi
+
+    if ! node_claim_preconditions_still_hold \
+      "${state_file}" "${initial_node_uid}" \
+      "${was_cordoned}" "${initial_taints}"; then
+      break
+    fi
+
+    attempt=$((attempt + 1))
+  done
+
+  echo "::error::Could not atomically claim and cordon Talos node ${node_name}; refusing to drain it."
+  emit_safe_operation_output "cordon-claim" "${result_file}"
+  return 1
+}
+
+# Render the claim patch from the current captured state and apply it. Split out
+# so a rejected claim can be rebuilt against a re-read resourceVersion without
+# duplicating the patch shape.
+build_and_apply_cordon_claim() {
+  local node_name="$1" owner_token="$2" state_file="$3" result_file="$4"
+  local recovery_record="${5:-}"
   local resource_version node_uid
   resource_version="$(jq -er '.metadata.resourceVersion' "${state_file}")"
   node_uid="$(jq -er '.metadata.uid' "${state_file}")"
@@ -978,16 +1025,12 @@ claim_node_cordon_ownership() {
     ' >"${cordon_claim_patch_file}"
   fi
 
-  if ! kubectl \
+  kubectl \
     --context "${KUBE_CONTEXT}" \
     patch node "${node_name}" \
     --type=json \
     --patch-file="${cordon_claim_patch_file}" \
-    >"${result_file}" 2>&1; then
-    echo "::error::Could not atomically claim and cordon Talos node ${node_name}; refusing to drain it."
-    emit_safe_operation_output "cordon-claim" "${result_file}"
-    return 1
-  fi
+    >"${result_file}" 2>&1
 }
 
 # The atomic claim cordons the node before kubectl drain. Restore schedulability
@@ -1734,7 +1777,7 @@ prepare_runtime_bootstrap_roll() {
     if ! claim_node_cordon_ownership \
       "${node_name}" "${owner_token}" \
       "${cordon_state_file}" "${drain_result_file}" \
-      "${recovery_record}"; then
+      "${recovery_record}" "${was_cordoned}" "${initial_taints}"; then
       return 1
     fi
     assert_sync_lease_held || return 1
@@ -2061,7 +2104,8 @@ process_talos_node_target() {
     assert_sync_lease_held || return 1
     claim_node_cordon_ownership \
       "${node_name}" "${cordon_owner_token}" \
-      "${cordon_state_file}" "${drain_result_file}" || return 1
+      "${cordon_state_file}" "${drain_result_file}" \
+      "" "${was_cordoned}" "${initial_node_taints}" || return 1
   fi
 
   # A node resourceVersion fences only the claim itself. Renew after the claim

--- a/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/fake_kubectl_test.go
@@ -1477,6 +1477,23 @@ func fakeKubectlPatchNode(args []string, patchFile string) int {
 			appendEnvFile("OPERATION_LOG", "operator-cordon:"+nodeName+"\n")
 			return commandFailure(56, "resourceVersion test failed after concurrent cordon")
 		}
+		// A conflict that never clears, so the bounded retry budget runs out
+		// and the claim must still refuse rather than drain.
+		if nodeName == os.Getenv("FAKE_CLAIM_FAIL_NODE") {
+			setMarkerContent("resource-version-"+nodeName, incrementDecimal(currentResourceVersion))
+			return commandFailure(56, "resourceVersion test failed")
+		}
+		// An unrelated writer (a kubelet status heartbeat, the cloud
+		// controller manager) bumps resourceVersion between the capturing
+		// read and this patch, so the CAS test fails while nothing relevant
+		// to drain safety changed. Fires once, so a re-read then succeeds.
+		if nodeName == os.Getenv("FAKE_UNRELATED_NODE_WRITE_BEFORE_CLAIM_NODE") &&
+			!markerExists("unrelated-write-"+nodeName) {
+			touchMarker("unrelated-write-" + nodeName)
+			setMarkerContent("resource-version-"+nodeName, incrementDecimal(currentResourceVersion))
+			appendEnvFile("OPERATION_LOG", "unrelated-node-write:"+nodeName+"\n")
+			return commandFailure(56, "resourceVersion test failed")
+		}
 		owner := patchValueString(patch, "add", "/metadata/annotations/platform.devantler.tech~1ghcr-auth-drain-owner")
 		if owner == "" || markerExists("cordon-owner-"+nodeName) ||
 			len(patch) == 0 || patch[0].Operation != "test" ||

--- a/scripts/tests/refresh-flux-ghcr-auth/rollout_core_test.go
+++ b/scripts/tests/refresh-flux-ghcr-auth/rollout_core_test.go
@@ -333,6 +333,40 @@ func TestSchedulableNodeIsClaimedAndCordonedAtomically(t *testing.T) {
 	requireNoLine(t, operations, "node-claim:prod-worker-1")
 }
 
+func TestUnrelatedNodeWriteBeforeAtomicClaimIsRetried(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_UNRELATED_NODE_WRITE_BEFORE_CLAIM_NODE": "prod-worker-1",
+	})
+	requireSuccessResult(t, result)
+	operations := readLines(f.operationLog)
+	// The conflict really happened, and the claim still landed after it.
+	requireLine(t, operations, "unrelated-node-write:prod-worker-1")
+	claim := lineIndex(t, operations, "node-claim-cordon:prod-worker-1")
+	drain := lineIndex(t, operations, "node-drain:prod-worker-1")
+	if claim >= drain {
+		t.Errorf("claim index %d is not before drain index %d", claim, drain)
+	}
+}
+
+func TestRetriedClaimStillRefusesWhenTheRetryBudgetIsExhausted(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	result := f.runHelper(validConfig(), nil, map[string]string{
+		"FAKE_CLAIM_FAIL_NODE": "prod-worker-1",
+	})
+	requireFailureResult(t, result)
+	requireContains(t, result.stdout+result.stderr, "Could not atomically claim and cordon")
+	operations := readLines(f.operationLog)
+	for _, unexpected := range []string{"node-claim-cordon:prod-worker-1", "node-drain:prod-worker-1", "talos-reboot:10.0.0.2", "root-patch"} {
+		requireNoLine(t, operations, unexpected)
+	}
+	if pathExists(filepath.Join(f.syncStateDir, "cordon-owner-prod-worker-1")) {
+		t.Error("exhausted claim retries left an owner marker")
+	}
+}
+
 func TestConcurrentCordonBeforeAtomicClaimStopsTheRoll(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The production deploy has been failing intermittently and evicting PRs from the merge queue — 4 evictions today alone, interleaved with 8 clean runs on unchanged code. The cause is a safety check that is stricter than it needs to be: before draining a node, the deploy claims it with a patch that asserts *nothing at all* has changed on that node since it was read. But a Kubernetes node is written by several background controllers, so a routine kubelet heartbeat — nothing to do with whether the node is safe to drain — was enough to abort the whole deploy.

Because the trigger is unrelated background activity, re-queuing an evicted PR is a coin flip rather than a fix.

## What

The claim now retries against a fresh read instead of giving up on the first conflict — but only while every fact it originally relied on still holds. A genuine conflict (someone else cordoning the node, taking ownership, changing its taints, or the node being replaced) still refuses to drain, exactly as before, and running out of retries still fails closed with the same refusal.

Fixes #2976

⚠️ This touches the path that drains production nodes, so the safety behaviour is pinned by tests in both directions: a benign conflict must now succeed, and a persistent or genuine conflict must still refuse.
