### PR TITLE
fix(observability): alert on a degraded CNPG cluster instead of only wedging the merge queue

### DIFF
--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -86,6 +86,19 @@ stays quiet by design, exactly as the old Alertmanager did.
   and **cert-expiry** checks are not Flux resources, so they need a scan-safe
   synthetic check (e.g. per-CronJob dead-man pings like the heartbeat below, tied
   to the silent vault snapshot in #1970) and are still TODO.
+- **Degraded CNPG clusters alert on their own, not via the merge-queue gate.**
+  A database losing a replica used to reach Slack only through the gate
+  described above — as a *Flux* error naming a Kustomization, 20 minutes late,
+  after `apps` had already timed out and evicted every PR from the merge queue.
+  That happened twice in three weeks (coroot-db 2026-07-14, umami-db
+  2026-08-05, the latter degraded for over five hours with no alert). Coroot's
+  inspections cover crashloops, but the 07-14 case was a pod that stayed
+  Running, never Ready, with zero restarts.
+  `bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded.yaml` now
+  checks every CNPG `Cluster` every 30 minutes and posts to the same Slack
+  webhook when one has been degraded past a 15-minute grace. It is deliberately
+  independent of any Flux health gate, so relaxing that gate cannot silently
+  remove this coverage.
 - **kube-apiserver audit logs are searchable in Coroot again.** Coroot's
   node-agent ingests container logs/traces, not host audit-log files, so the
   previous alloy-audit → Loki pipeline was removed with the migration. The

--- a/docs/dr/alerting.md
+++ b/docs/dr/alerting.md
@@ -94,7 +94,7 @@ stays quiet by design, exactly as the old Alertmanager did.
   2026-08-05, the latter degraded for over five hours with no alert). Coroot's
   inspections cover crashloops, but the 07-14 case was a pod that stayed
   Running, never Ready, with zero restarts.
-  `bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded.yaml` now
+  `bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml` now
   checks every CNPG `Cluster` every 30 minutes and posts to the same Slack
   webhook when one has been degraded past a 15-minute grace. It is deliberately
   independent of any Flux health gate, so relaxing that gate cannot silently

--- a/k8s/bases/infrastructure/cluster-security-exceptions/gitops-managed-cronjobs.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/gitops-managed-cronjobs.yaml
@@ -16,6 +16,8 @@
 #   * longhorn-system/longhorn-stale-node-cleanup — prunes stale Longhorn node objects for gone
 #                                                   autoscaled nodes (platform)
 #   * observability/cluster-heartbeat             — external-uptime heartbeat ping (platform)
+#   * observability/cnpg-degraded-alert           — alerts on a CNPG cluster degraded past its
+#                                                   grace period (platform)
 #   * observability/coroot-alert-autosuppressor   — re-asserts by-design Coroot alert suppressions (platform)
 #   * observability/coroot-custom-cloud-pricing   — applies Hetzner per-unit pricing to Coroot (platform)
 #   * openbao/vault-snapshot                      — OpenBao raft-snapshot backup (platform)
@@ -42,8 +44,9 @@ spec:
     All CronJobs on this cluster are GitOps-managed platform components delivered
     by Flux after PR review (the review is the approval): Cilium Hubble cert
     rotation, the Kubescape scan schedulers, Longhorn stale-node cleanup, the
-    observability heartbeat / Coroot alert-autosuppressor / Coroot cloud-pricing
-    jobs, the OpenBao raft-snapshot backup, and Umami tenant provisioning.
+    observability heartbeat / CNPG degraded-cluster alert / Coroot
+    alert-autosuppressor / Coroot cloud-pricing jobs, the OpenBao raft-snapshot
+    backup, and Umami tenant provisioning.
     Namespace-scoped to the infrastructure namespaces that run these, so a CronJob
     in any unexpected namespace still surfaces for review.
   posture:

--- a/k8s/bases/infrastructure/controllers/coroot/cluster-role-binding-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cluster-role-binding-cnpg-degraded-alert.yaml
@@ -1,0 +1,15 @@
+# Grants the cnpg-degraded-alert ServiceAccount its list-only view of CNPG
+# Clusters. See cluster-role-cnpg-degraded-alert.yaml for the scope rationale.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cnpg-degraded-alert
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnpg-degraded-alert
+subjects:
+  - kind: ServiceAccount
+    name: cnpg-degraded-alert
+    namespace: observability

--- a/k8s/bases/infrastructure/controllers/coroot/cluster-role-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cluster-role-cnpg-degraded-alert.yaml
@@ -1,0 +1,18 @@
+# What the cnpg-degraded-alert CronJob may read.
+#
+# Read-only, and ONLY the CNPG Cluster CR. The check has to see clusters in every
+# namespace that runs one (umami, wedding-app, backstage, observability), so it is
+# cluster-scoped by necessity — but it is list-only on a single resource type,
+# which is the least privilege that satisfies that.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cnpg-degraded-alert
+rules:
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - list

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -51,58 +51,6 @@
 # unset (local/CI) it defaults to an invalid URL so the alert reaches nowhere and
 # local/CI stays quiet by design, exactly as cluster-heartbeat does.
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cnpg-degraded-alert
-  namespace: observability
----
-# The webhook goes in a Secret rather than inline in the CronJob's env, matching
-# flux-notifications/secret.yaml and alertmanager/secret.yaml (the two other
-# consumers of this same URL). An inline env value is readable from the CronJob
-# spec itself by anyone who can `get cronjob`, and would lean on the C-0012
-# exception the observability namespace already carries — reusing an exception to
-# hold a weaker pattern in place is not the same as not needing one.
-# The inline default keeps `ksail workload validate` (no SOPS access) building and
-# leaves local/CI inert.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cnpg-degraded-alert-webhook
-  namespace: observability
-type: Opaque
-stringData:
-  url: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cnpg-degraded-alert
-rules:
-  # Read-only, and ONLY the CNPG Cluster CR. The check needs to see clusters in
-  # every namespace (umami, wedding-app, backstage, observability), so this is
-  # cluster-scoped by necessity — but it is list-only on a single resource type,
-  # which is the least privilege that satisfies that.
-  - apiGroups:
-      - postgresql.cnpg.io
-    resources:
-      - clusters
-    verbs:
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cnpg-degraded-alert
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cnpg-degraded-alert
-subjects:
-  - kind: ServiceAccount
-    name: cnpg-degraded-alert
-    namespace: observability
----
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded-alert.yaml
@@ -47,9 +47,11 @@
 # kube-apiserver, hooks.slack.com:443 and DNS egress. It does not depend on
 # Coroot itself.
 #
-# The webhook is injected by Flux substitution from the per-cluster SOPS secret;
-# unset (local/CI) it defaults to an invalid URL so the alert reaches nowhere and
-# local/CI stays quiet by design, exactly as cluster-heartbeat does.
+# The webhook is injected by Flux substitution from the per-cluster SOPS secret.
+# Unset (local/CI) it defaults to the reserved example.invalid host, which the
+# script matches explicitly and skips, so local/CI stays quiet by design. Every
+# OTHER delivery failure fails the Job: nothing outside this Job would notice a
+# silently dropped alert.
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -150,11 +152,28 @@ spec:
                     "$degraded" "${GRACE_SECONDS}")
                   jq -n --arg t "$text" '{text: $t}' > /tmp/payload.json
 
+                  # Only the known placeholder host is allowed to skip delivery.
+                  # example.invalid is RFC 2606 reserved, so it can never be a
+                  # real endpoint — matching it explicitly keeps local/CI inert
+                  # without also swallowing a REAL prod delivery failure.
+                  case "$WEBHOOK_URL" in
+                    https://example.invalid/*)
+                      echo "No Slack webhook configured; alert not delivered."
+                      exit 0
+                      ;;
+                  esac
+
+                  # No `|| true` here, deliberately. Unlike cluster-heartbeat --
+                  # a dead-man's-switch whose MISSING ping is what the external
+                  # monitor alerts on -- nothing outside this Job notices if the
+                  # POST fails. Swallowing that would record a successful run
+                  # having sent nothing: the same silent-zero failure the API
+                  # read above is guarded against, at the other end of the check.
                   curl -sf --max-time 15 \
                     --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused \
                     -H 'Content-Type: application/json' \
                     --data @/tmp/payload.json \
-                    "$WEBHOOK_URL" || echo "WARN: could not deliver alert to webhook" >&2
+                    "$WEBHOOK_URL"
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded.yaml
@@ -57,6 +57,23 @@ metadata:
   name: cnpg-degraded-alert
   namespace: observability
 ---
+# The webhook goes in a Secret rather than inline in the CronJob's env, matching
+# flux-notifications/secret.yaml and alertmanager/secret.yaml (the two other
+# consumers of this same URL). An inline env value is readable from the CronJob
+# spec itself by anyone who can `get cronjob`, and would lean on the C-0012
+# exception the observability namespace already carries — reusing an exception to
+# hold a weaker pattern in place is not the same as not needing one.
+# The inline default keeps `ksail workload validate` (no SOPS access) building and
+# leaves local/CI inert.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cnpg-degraded-alert-webhook
+  namespace: observability
+type: Opaque
+stringData:
+  url: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -126,7 +143,10 @@ spec:
                 - name: GRACE_SECONDS
                   value: "900"
                 - name: WEBHOOK_URL
-                  value: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-degraded-alert-webhook
+                      key: url
               command:
                 - /bin/sh
                 - -c

--- a/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/cron-job-cnpg-degraded.yaml
@@ -1,0 +1,215 @@
+# Alerts on a CloudNativePG `Cluster` that has been degraded past a grace period.
+#
+# WHY THIS EXISTS AS A SEPARATE CHECK
+#
+# Until now the ONLY signal for a degraded database was the merge-queue gate.
+# docs/dr/alerting.md states the design: the four top-level Kustomizations
+# `wait: true` on their children, "so a failed controller / app / HelmRelease
+# surfaces here as its parent going NotReady". A degraded CNPG replica therefore
+# reached Slack as a *Flux* error naming a Kustomization — 20 minutes late, after
+# `apps` had already timed out and evicted every PR from the merge queue.
+#
+# That happened twice in three weeks: coroot-db on 2026-07-14, and umami-db on
+# 2026-08-05, whose third replica sat Ready=False for over five hours while
+# nothing alerted (the cluster kept SERVING the whole time — primary healthy,
+# archiving and backups green). Coroot's auto-inspections cover crashloops, so
+# the umami pod's restart loop was visible on that path, but the coroot-db case
+# was a pod that stayed Running, never Ready, with ZERO restarts — which no
+# Coroot inspection covers.
+#
+# This check is deliberately independent of any Flux health gate, so that
+# relaxing that gate (platform#2639 direction 1) does not silently remove the
+# only coverage this class has.
+#
+# GRACE PERIOD — WHY `lastTransitionTime` IS SAFE HERE
+#
+# The grace period keys on the Ready condition's `lastTransitionTime`. That was
+# VERIFIED, not assumed: sampled 45s apart on prod, every cluster's
+# `lastTransitionTime` was byte-identical, so CNPG writes it only on an actual
+# transition. (Crossplane's `Synced` condition behaves the OPPOSITE way — it is
+# rewritten every reconcile, which would make a grace period silently
+# unreachable and the check a permanent no-op. Do not copy this pattern to a
+# Crossplane resource without re-measuring.)
+#
+# One rule covers both degradation shapes, because the timestamp means the right
+# thing in each: a cluster short of instances that only just became Ready is
+# still scaling up and stays quiet inside the grace; one that has been "Ready"
+# for hours while short a replica is a persistent degradation and alerts.
+#
+# REPEATS ARE DELIBERATE. A plain webhook has no notification-controller-style
+# dedupe, so a cluster still degraded on the next tick alerts again. That is
+# intended — a degraded production database should keep paging until it is
+# fixed — and it is strictly QUIETER than the signal it replaces, which fired
+# every ~20 minutes as a merge_group failure.
+#
+# Lives in the observability namespace to reuse the allow-coroot
+# CiliumNetworkPolicy (endpointSelector: {}), which already permits
+# kube-apiserver, hooks.slack.com:443 and DNS egress. It does not depend on
+# Coroot itself.
+#
+# The webhook is injected by Flux substitution from the per-cluster SOPS secret;
+# unset (local/CI) it defaults to an invalid URL so the alert reaches nowhere and
+# local/CI stays quiet by design, exactly as cluster-heartbeat does.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cnpg-degraded-alert
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cnpg-degraded-alert
+rules:
+  # Read-only, and ONLY the CNPG Cluster CR. The check needs to see clusters in
+  # every namespace (umami, wedding-app, backstage, observability), so this is
+  # cluster-scoped by necessity — but it is list-only on a single resource type,
+  # which is the least privilege that satisfies that.
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cnpg-degraded-alert
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cnpg-degraded-alert
+subjects:
+  - kind: ServiceAccount
+    name: cnpg-degraded-alert
+    namespace: observability
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cnpg-degraded-alert
+  namespace: observability
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      # Headroom for pod scheduling + the L7 DNS proxy resolving hooks.slack.com
+      # + curl's retry budget, well below the */30 schedule.
+      activeDeadlineSeconds: 180
+      template:
+        metadata:
+          labels:
+            app: cnpg-degraded-alert
+        spec:
+          restartPolicy: Never
+          serviceAccountName: cnpg-degraded-alert
+          # This check DOES call the Kubernetes API, so unlike cluster-heartbeat
+          # it needs its token. C-0034 is already excepted for the observability
+          # namespace (cluster-security-exceptions/service-account-tokens.yaml).
+          automountServiceAccountToken: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: check
+              image: docker.io/badouralix/curl-jq:latest@sha256:1e7c0284e24572ace7170df9fc91f15fd3b79ebf056d4dde17244d5d74bbfabc
+              env:
+                - name: GRACE_SECONDS
+                  value: "900"
+                - name: WEBHOOK_URL
+                  value: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  API=https://kubernetes.default.svc
+                  SA=/var/run/secrets/kubernetes.io/serviceaccount
+
+                  # A non-2xx or unparseable response must NOT be reported as
+                  # "no degraded clusters" — that is the silent-zero failure
+                  # mode where a broken check and a healthy cluster look
+                  # identical. Fail loudly to the Job log instead.
+                  code=$(curl -sS -o /tmp/body -w '%{http_code}' \
+                    --cacert "$SA/ca.crt" \
+                    -H "Authorization: Bearer $(cat "$SA/token")" \
+                    "$API/apis/postgresql.cnpg.io/v1/clusters")
+                  if [ "$code" = "404" ]; then
+                    echo "CNPG CRD not installed on this cluster; nothing to check."
+                    exit 0
+                  fi
+                  if [ "$code" != "200" ]; then
+                    echo "ERROR: kube API returned HTTP $code listing CNPG clusters" >&2
+                    exit 1
+                  fi
+                  if ! jq -e 'has("items")' /tmp/body >/dev/null; then
+                    echo "ERROR: unexpected response shape from kube API" >&2
+                    exit 1
+                  fi
+
+                  total=$(jq -r '.items | length' /tmp/body)
+                  degraded=$(jq -r --argjson grace "${GRACE_SECONDS}" \
+                                   --argjson now "$(date -u +%s)" '
+                    .items[]
+                    | . as $c
+                    | (($c.status.conditions // []) | map(select(.type == "Ready")) | first) as $ready
+                    | ($c.status.readyInstances // 0) as $r
+                    | ($c.spec.instances // 0) as $d
+                    | select($r < $d or (($ready.status // "Unknown") != "True"))
+                    | select($ready.lastTransitionTime != null)
+                    | select(($now - ($ready.lastTransitionTime | fromdate)) >= $grace)
+                    | "• `\($c.metadata.namespace)/\($c.metadata.name)` — \($r)/\($d) instances ready, Ready=\($ready.status // "Unknown") since \($ready.lastTransitionTime)"
+                  ' /tmp/body)
+
+                  if [ -z "$degraded" ]; then
+                    echo "Checked $total CNPG cluster(s); none degraded beyond ${GRACE_SECONDS}s."
+                    exit 0
+                  fi
+
+                  echo "Degraded CNPG cluster(s) detected:"
+                  echo "$degraded"
+
+                  text=$(printf '*Degraded CloudNativePG cluster(s)*\n\n%s\n\n_A replica has been down longer than %ss. The primary may still be serving — check before assuming an outage. A replica that cannot self-heal needs its PVC + pod deleted so CNPG re-clones it from the primary (docs/dr/runbook.md)._' \
+                    "$degraded" "${GRACE_SECONDS}")
+                  jq -n --arg t "$text" '{text: $t}' > /tmp/payload.json
+
+                  curl -sf --max-time 15 \
+                    --retry 3 --retry-delay 2 --retry-all-errors --retry-connrefused \
+                    -H 'Content-Type: application/json' \
+                    --data @/tmp/payload.json \
+                    "$WEBHOOK_URL" || echo "WARN: could not deliver alert to webhook" >&2
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+                runAsGroup: 65532
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                # readOnlyRootFilesystem: true, so give the script a writable
+                # scratch dir for the API response and the webhook payload.
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 5m
+                  memory: 32Mi
+                limits:
+                  # CPU limit set for kubescape C-0270; generous so the
+                  # short-lived curl+jq never throttles.
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - http-route.yaml
   - cilium-network-policy.yaml
   - cron-job.yaml
+  - cron-job-cnpg-degraded.yaml

--- a/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/kustomization.yaml
@@ -13,4 +13,9 @@ resources:
   - http-route.yaml
   - cilium-network-policy.yaml
   - cron-job.yaml
-  - cron-job-cnpg-degraded.yaml
+  # Degraded-CNPG-cluster alert (one resource per file, per the naming convention):
+  - service-account-cnpg-degraded-alert.yaml
+  - secret-cnpg-degraded-alert.yaml
+  - cluster-role-cnpg-degraded-alert.yaml
+  - cluster-role-binding-cnpg-degraded-alert.yaml
+  - cron-job-cnpg-degraded-alert.yaml

--- a/k8s/bases/infrastructure/controllers/coroot/secret-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/secret-cnpg-degraded-alert.yaml
@@ -1,0 +1,24 @@
+# Slack incoming-webhook for the cnpg-degraded-alert CronJob. It is the SAME
+# webhook Coroot, flux-notifications and alertmanager post to
+# (${alertmanager_webhook_url}, injected by Flux from the per-cluster
+# variables-cluster Secret), so degraded-database alerts land in the same channel
+# as everything else and there is no new secret to provision.
+#
+# The URL lives in a Secret rather than inline in the CronJob's env, matching
+# flux-notifications/secret.yaml and alertmanager/secret.yaml (the two other
+# consumers of this URL). An inline env value is readable straight off the
+# CronJob spec by anyone who can `get cronjob`, and would lean on the C-0012
+# exception the observability namespace already carries — reusing an exception to
+# hold a weaker pattern in place is not the same as not needing one.
+#
+# The inline default keeps `ksail workload validate` (which has no SOPS access)
+# building and leaves local/CI inert.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cnpg-degraded-alert-webhook
+  namespace: observability
+type: Opaque
+stringData:
+  url: ${alertmanager_webhook_url:=https://example.invalid/no-slack-configured}

--- a/k8s/bases/infrastructure/controllers/coroot/service-account-cnpg-degraded-alert.yaml
+++ b/k8s/bases/infrastructure/controllers/coroot/service-account-cnpg-degraded-alert.yaml
@@ -1,0 +1,9 @@
+# Identity for the cnpg-degraded-alert CronJob, which needs to list CNPG Clusters
+# across every namespace. See cron-job-cnpg-degraded-alert.yaml for why the check
+# exists; cluster-role-cnpg-degraded-alert.yaml for what it may read.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cnpg-degraded-alert
+  namespace: observability

--- a/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/config-map-headlamp-exceptions.yaml
@@ -464,7 +464,7 @@ data:
             "controlID": "^C-0026$"
           }
         ],
-        "reason": "C-0026 lists every CronJob for manual approval and has no hardening remedy. All CronJobs on this cluster are GitOps-managed platform components delivered by Flux after PR review (the review is the approval): Cilium Hubble cert rotation, the Kubescape scan schedulers, Longhorn stale-node cleanup, the observability heartbeat / Coroot alert-autosuppressor / Coroot cloud-pricing jobs, the OpenBao raft-snapshot backup, and Umami tenant provisioning. Namespace-scoped to the infrastructure namespaces that run these, so a CronJob in any unexpected namespace still surfaces for review."
+        "reason": "C-0026 lists every CronJob for manual approval and has no hardening remedy. All CronJobs on this cluster are GitOps-managed platform components delivered by Flux after PR review (the review is the approval): Cilium Hubble cert rotation, the Kubescape scan schedulers, Longhorn stale-node cleanup, the observability heartbeat / CNPG degraded-cluster alert / Coroot alert-autosuppressor / Coroot cloud-pricing jobs, the OpenBao raft-snapshot backup, and Umami tenant provisioning. Namespace-scoped to the infrastructure namespaces that run these, so a CronJob in any unexpected namespace still surfaces for review."
       },
       {
         "name": "health-probes",

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -133,6 +133,38 @@ const (
 // trees, so nothing granted to the aws/aws service account this validator
 // exists to protect is touched.
 //
+// Measured against main 875f5dc3 before approving THIS value: the rendered
+// surface moves from 514 -> 519 documents, purely additive. Membership was
+// proven by set difference in BOTH directions over apiVersion|kind|namespace|name
+// (not by count, which cannot see a rename): zero removed, zero renamed, and the
+// five additions are exactly the degraded-CNPG-cluster alert —
+//
+//	v1                          ServiceAccount      observability/cnpg-degraded-alert
+//	v1                          Secret              observability/cnpg-degraded-alert-webhook
+//	rbac.authorization.k8s.io/v1 ClusterRole        cnpg-degraded-alert
+//	rbac.authorization.k8s.io/v1 ClusterRoleBinding cnpg-degraded-alert
+//	batch/v1                    CronJob             observability/cnpg-degraded-alert
+//
+// Grant-bearing objects DID move here, additively: 64 -> 67 Role / ClusterRole /
+// RoleBinding / ClusterRoleBinding / ServiceAccount documents, being the three
+// above. That is the same shape as the OpenCost usage-scraper approval below —
+// one dedicated ServiceAccount, one narrow ClusterRole, one binding between
+// exactly those two identities. The ClusterRole is list-only on a single resource
+// type (`clusters.postgresql.cnpg.io`); it is cluster-scoped only because the
+// check must see databases in every namespace that runs one.
+//
+// Exactly ONE existing entry's content moved:
+//
+//	kubescape.io/v1beta1  ClusterSecurityException  gitops-managed-cronjobs
+//
+// and its rendered delta is one prose sentence in `reason`, naming the new
+// CronJob in the enumeration that field already carries. Its `match` scope is
+// unchanged, so the exception grants nothing new.
+//
+// Every `aws`-bearing line in the rendered surface is byte-identical across the
+// two trees (116 on both sides), so nothing granted to the aws/aws service
+// account this validator exists to protect is touched.
+//
 // Measured against main fa041449 before approving the previous value: the
 // production infrastructure overlay moves from 204 -> 210 documents, with
 // exactly six additive OpenCost usage-scraper resources and no existing
@@ -195,7 +227,7 @@ const (
 // kubectl render diff — render k8s/providers/hetzner/{apps,infrastructure,
 // infrastructure/controllers} plus k8s/clusters/prod/{bootstrap,} for both
 // trees and diff them.
-const expectedRenderedSurfaceSHA = "fef511d40d44624fcd81d26a7c09b84c7a08ebb25eae7d643cfacd9519146927"
+const expectedRenderedSurfaceSHA = "6af27989825d60e4139a4d8754ff6e4be4ed5e20b75181dacade8653c14cc5aa"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

When a database loses a replica, nothing tells us. The first sign is the platform
**merge queue jamming** — every PR gets evicted, 20 minutes at a time — because the only
thing watching database health is the deploy gate.

That has now happened twice in three weeks. Today `umami-db` sat degraded for **over five
hours** with no alert, while still serving traffic normally, and took the merge queue down
with it.

## What

A small scheduled check that looks at every Postgres cluster every 30 minutes and posts to
the existing Slack alert channel when one has been degraded for more than 15 minutes.

It watches the databases directly rather than inferring their health from a deploy failure,
so we hear about a lost replica in minutes instead of discovering it when shipping stops.
It is also the prerequisite for the real fix in #2639 — stopping a degraded-but-serving
database from blocking merges at all — which cannot land until this coverage exists, or it
would remove the only signal we have.

No new always-on workload, and it reuses the alerting and network paths already in place.

Fixes #2978
Part of #2639
