### PR TITLE
fix(lint): skip trivy KSV-0039, a per-file artifact hiding 29 HIGH/CRITICAL findings

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -143,7 +143,7 @@ DISABLE_ERRORS_LINTERS:
   # exact commands this job runs, so a slice can show the number moved without a CI round trip.
   #
   # ⚠️ Read trivy's number from that script, NOT from the MegaLinter summary. MegaLinter reports
-  # this trivy scan as "1 non blocking error" while the scan actually fails 612 checks across 457
+  # this trivy scan as "1 non blocking error" while the scan actually fails 164 checks across 73
   # targets; the 1 is an artifact of how MegaLinter counts trivy's output. checkov's number is a
   # genuine sum of "Failed checks:" and needs no such caveat.
   #

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -83,8 +83,14 @@ DISABLE_ERRORS_LINTERS:
   # does not fail the build while a tracked backlog is worked off. Nothing is thresholded, no
   # path is hidden, and each entry names the issue that removes it.
   #
-  # checkov (15) and trivy (612): Kubernetes misconfiguration in k8s/, which the section above
+  # checkov (15) and trivy (164): Kubernetes misconfiguration in k8s/, which the section above
   # explains is NOT covered elsewhere. Tracked by #2787.
+  #
+  # trivy was 614 until KSV-0039 ("limit range usage") was skipped in .trivyignore — 450 of those
+  # 614 were that one LOW check, evaluated per-file against objects that cannot carry a LimitRange
+  # (HelmRepository, HTTPRoute, PodDisruptionBudget) and against the LimitRange manifests
+  # themselves. See .trivyignore for the reason and #2988 for the measurement. The residual 164 is
+  # real: 29 of it is HIGH/CRITICAL, mostly RBAC breadth.
   #
   # checkov's 15 are all `kubernetes` framework, and 4 of them are CKV_K8S_40, at exactly these
   # sites: the two vault-backup jobs, the userns-longhorn-smoke probe, and the vault-config Job.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,30 @@
+# Trivy misconfiguration checks skipped on this repository, with the reason each one is skipped.
+#
+# The bar here is the same one .mega-linter.yml applies: a skip names a technical reason that
+# survives checking, and nothing is hidden merely because it is noisy. Anything that describes real
+# state stays enabled and gets fixed at the manifest instead — see #2787, which tracks driving
+# checkov and trivy to zero on k8s/ so both can leave DISABLE_ERRORS_LINTERS.
+
+# KSV-0039 "limit range usage" — 450 of trivy's 614 findings on this tree (73%), all LOW.
+#
+# The check is evaluated per FILE, but a LimitRange is a namespace-scoped object that this
+# repository deliberately keeps in its own base (k8s/bases/infrastructure/limit-ranges/, plus the
+# longhorn overlay). So the check asks every file whether it contains a LimitRange, and every file
+# that is not one answers no. That includes objects which cannot carry a LimitRange at all — the
+# firing set is 46 helm-release.yaml, 46 cilium-network-policy.yaml, 42 helm-repository.yaml,
+# 23 pod-disruption-budget.yaml, 14 http-route.yaml, 13 external-secret.yaml, 8 network-policy.yaml,
+# 6 flux-kustomization.yaml.
+#
+# It also fires on the LimitRange manifests themselves — limit-ranges/kube-system.yaml,
+# limit-ranges/kyverno.yaml and controllers/longhorn/limit-range.yaml. A check reporting "limit
+# range usage" against a LimitRange is reading file contents rather than namespace state, and no
+# per-file edit can satisfy it.
+#
+# Skipping it is therefore not a threshold or a deferral: there is nothing to fix. It is also what
+# makes the rest of the scan readable — the residual 164 findings contain 29 HIGH/CRITICAL (RBAC
+# breadth: KSV-0114, KSV-0046, KSV-0041, KSV-0056) that were previously buried in a count of 614.
+#
+# Measured at 005761c0: with this entry trivy fails 164 checks, without it 614, and KSV-0039 drops
+# to 0 while no other check id changes. Re-derive with scripts/megalinter-scan-counts.sh rather than
+# trusting this number if it matters — every figure here is a measurement.
+KSV-0039


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

Trivy reports 614 Kubernetes misconfiguration findings on this repo, and **450 of them (73%) are a
single low-severity check that cannot be satisfied**. It asks each file whether it contains a
LimitRange — but LimitRanges are namespace objects kept in their own base here, so it fails every
file that is not one, including things that could never carry a LimitRange, and including the
LimitRange definitions themselves.

The cost is not noise, it is concealment: buried in that count of 614 are **29 HIGH and CRITICAL
findings** about over-broad cluster permissions that nobody can see at a glance today.

## What

Skips that one check, with the reason written down beside it, and corrects the finding counts
recorded in the lint config. Trivy now reports 164 — the findings that describe real state.

This does **not** re-arm trivy to fail the build; 164 real findings remain and #2787 still owns
getting them to zero.

Fixes #2988
Part of #2787
