### PR TITLE
ci: let the main-validation gate finish instead of cancelling it

### DIFF
--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -22,12 +22,15 @@ on:
 permissions: {}
 
 concurrency:
-  group: validate-main-${{ github.ref }}
-  # This workflow only ever runs on push to main, so every run shares one group
-  # key. Cancelling would let a second push evict the first push's gate result
-  # and leave main green on a check that never finished — reopening the exact
-  # hole described above, from the other side. Each push is its own subject and
-  # its result is its own record, so runs here are allowed to complete.
+  # Every push to main is its own subject and its gate result is its own record,
+  # so each run gets its own group and none of them can suppress another.
+  #
+  # Disabling cancellation is not enough on a shared key: a concurrency group
+  # holds one running plus one pending run, and a third push cancels the pending
+  # one. With a shared `github.ref` key the second push's gate would still be
+  # evicted while queued, leaving main green on a check that never finished —
+  # reopening the exact hole described above, from the other side.
+  group: validate-main-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/validate-main.yaml
+++ b/.github/workflows/validate-main.yaml
@@ -23,7 +23,12 @@ permissions: {}
 
 concurrency:
   group: validate-main-${{ github.ref }}
-  cancel-in-progress: true
+  # This workflow only ever runs on push to main, so every run shares one group
+  # key. Cancelling would let a second push evict the first push's gate result
+  # and leave main green on a check that never finished — reopening the exact
+  # hole described above, from the other side. Each push is its own subject and
+  # its result is its own record, so runs here are allowed to complete.
+  cancel-in-progress: false
 
 jobs:
   validate-eks-authorization:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`validate-main.yaml` exists to catch one specific failure: a direct push to `main` fires neither `ci.yaml`'s nor `cd.yaml`'s authorization gate, so `main` could carry a broken authorization surface while all of its own checks show green. Its header records that happening once already, invisible for two days.

The workflow currently cancels its own in-progress runs. Since it only ever runs on push to `main`, every run shares one concurrency key — so a second push evicts the first push's gate before it finishes, and a cancelled check is not a failed check. That reopens the very hole the workflow was written to close, from the other side.

## What

Runs of the gate are allowed to complete, so each push to `main` gets its own verification record. This matches the "non-preempting production lock" the repo already applies to its other production-critical workflow.

No behaviour changes for pull requests — this workflow does not run on them.

Part of devantler-tech/monorepo#2690
