### PR TITLE
feat(coroot): export Crossplane managed-resource conditions as metrics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
               - 'scripts/tests/test-cilium-rollout-gate-suppression-signal.sh'
               - 'scripts/wait-for-platform-flux-revision.sh'
               - 'scripts/tests/test-opencost-usage-scraper.sh'
+              - 'scripts/tests/test-crossplane-sync-exporter.sh'
               # Both halves, so editing the guard alone — or its test alone —
               # still runs the check that covers it.
               - 'scripts/dr-rebuild-supersession-guard.sh'
@@ -362,6 +363,14 @@ jobs:
         # Render the full component contract so the cAdvisor scrape and its
         # least-privilege delivery path cannot silently disappear.
         run: bash scripts/tests/test-opencost-usage-scraper.sh
+
+      - name: 🔄 Validate Crossplane sync exporter metrics path
+        if: needs.changes.outputs.k8s == 'true'
+        # A wrong GVK, a renamed series, or a scrape target that drifts from the
+        # kube-state-metrics listen address all export nothing — and no series
+        # reads exactly like a fleet with nothing wrong. Schema validation cannot
+        # see any of it, so render the component contract instead.
+        run: bash scripts/tests/test-crossplane-sync-exporter.sh
 
       - name: 🧭 Validate the DR rebuild supersession gate
         if: needs.changes.outputs.k8s == 'true'

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role-binding.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-sync-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-sync-exporter
+subjects:
+  - kind: ServiceAccount
+    name: crossplane-sync-exporter
+    namespace: observability

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/cluster-role.yaml
@@ -1,0 +1,17 @@
+# Read-only, and scoped to the one managed-resource kind this exporter reads.
+# It is deliberately not `apiGroups: ["*"]`: a metrics exporter that could read
+# every custom resource in the cluster would also be able to read the spec of
+# resources that carry provider configuration.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-sync-exporter
+rules:
+  - apiGroups:
+      - repo.github.m.upbound.io
+    resources:
+      - repositories
+    verbs:
+      - get
+      - list
+      - watch

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/config-map.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/config-map.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: crossplane-sync-exporter
+  namespace: observability
+data:
+  # kube-state-metrics has no built-in knowledge of Crossplane managed
+  # resources, so their conditions are described here as custom resource state.
+  #
+  # Every condition is exported, not just Synced. That is deliberate: the defect
+  # this exporter exists to surface is a resource reporting Ready=True while
+  # Synced=False, and an alert can only express that pair if both series exist.
+  #
+  # groupVersionKind is exact — CustomResourceStateMetrics accepts no wildcard
+  # and no `categories: managed` selector — so each managed-resource kind must be
+  # listed. This component starts with Repository alone, which is the kind that
+  # carries the observed failure and therefore both a positive and a negative
+  # fixture. Extending the list to the remaining managed kinds is tracked
+  # separately; until then the exporter's coverage is explicitly partial.
+  custom-resource-state.yaml: |
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+        - groupVersionKind:
+            group: repo.github.m.upbound.io
+            version: v1alpha1
+            kind: Repository
+          metricNamePrefix: crossplane
+          labelsFromPath:
+            name: [metadata, name]
+            namespace: [metadata, namespace]
+          metrics:
+            - name: managed_resource_condition
+              help: "Crossplane managed resource condition status (1 = True, 0 = False)."
+              each:
+                type: Gauge
+                gauge:
+                  path: [status, conditions]
+                  labelsFromPath:
+                    condition: [type]
+                    reason: [reason]
+                  valueFrom: [status]
+
+  # The agent scrapes its own pod over loopback, so kube-state-metrics needs no
+  # Service and no ingress. Remote-write is the only ingest path Coroot's bundled
+  # Prometheus exposes (spec.prometheus carries no scrape configuration and there
+  # is no prometheus-operator), which is the same reason the opencost
+  # usage-scraper is shaped this way.
+  prometheus.yml: |
+    global:
+      scrape_interval: 1m
+      scrape_timeout: 10s
+
+    remote_write:
+      - url: http://coroot-prometheus.observability.svc.cluster.local:9090/api/v1/write
+
+    scrape_configs:
+      - job_name: crossplane-sync-exporter
+        static_configs:
+          - targets:
+              - 127.0.0.1:8080
+        metric_relabel_configs:
+          # Ship only the condition series. kube-state-metrics also emits its own
+          # build and self-telemetry metrics, which Coroot already has.
+          - source_labels:
+              - __name__
+            regex: crossplane_managed_resource_condition
+            action: keep

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/config-map.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/config-map.yaml
@@ -62,6 +62,15 @@ data:
         metric_relabel_configs:
           # Ship only the condition series. kube-state-metrics also emits its own
           # build and self-telemetry metrics, which Coroot already has.
+          #
+          # This `keep` does NOT drop `up`: metric relabeling excludes
+          # automatically generated timeseries, so `up{job="crossplane-sync-exporter"}`
+          # is still delivered. That matters more here than it looks — without it,
+          # "no condition series" would be ambiguous between a healthy fleet and a
+          # dead exporter, which is the same silent-sensor failure this component
+          # exists to surface. An alert on the condition series should gate on `up`
+          # for exactly that reason. Do not add `up` to this regex: it is already
+          # exempt, and listing it would imply the others are too.
           - source_labels:
               - __name__
             regex: crossplane_managed_resource_condition

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crossplane-sync-exporter
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: crossplane-sync-exporter
+    app.kubernetes.io/part-of: coroot
+    app.kubernetes.io/component: metrics-exporter
+    platform.devantler.tech/replica-floor: exempt
+spec:
+  # A second replica would export identical series and race them into the
+  # remote-write receiver. Recreate avoids an overlapping rollout; the agent's
+  # WAL is disposable because Prometheus is the durable store.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: crossplane-sync-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: crossplane-sync-exporter
+        app.kubernetes.io/part-of: coroot
+        app.kubernetes.io/component: metrics-exporter
+    spec:
+      serviceAccountName: crossplane-sync-exporter
+      # kube-state-metrics reads the managed resources through the API server.
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kube-state-metrics
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:2bbc915567334b13632bf62c0a97084aff72a36e13c4dabd5f2f11c898c5bacd
+          imagePullPolicy: IfNotPresent
+          args:
+            - --custom-resource-state-config-file=/etc/kube-state-metrics/custom-resource-state.yaml
+            # Built-in resources stay off: Coroot's cluster agent already
+            # supplies kube-state metrics, and a second copy would double-count.
+            - --custom-resource-state-only=true
+            # Loopback only — the agent scrapes this from inside the pod, so
+            # nothing needs to reach it from the network.
+            - --host=127.0.0.1
+            - --port=8080
+            - --telemetry-host=127.0.0.1
+            - --telemetry-port=8081
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kube-state-metrics
+              readOnly: true
+        - name: prometheus-agent
+          image: ghcr.io/coroot/prometheus:2.55.1-ubi9-0@sha256:c2a4f92f728411b834b7abd07764cf587e28749c377b157443569dea4f81f833
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --enable-feature=agent
+            - --storage.agent.path=/prometheus
+            - --web.listen-address=127.0.0.1:9090
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 20m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: crossplane-sync-exporter
+        - name: data
+          emptyDir:
+            sizeLimit: 1Gi

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/part-of: coroot
     app.kubernetes.io/component: metrics-exporter
     platform.devantler.tech/replica-floor: exempt
+  annotations:
+    checkov.io/skip1: CKV_K8S_38=kube-state-metrics reads the managed resources it exports through the API server
 spec:
   # A second replica would export identical series and race them into the
   # remote-write receiver. Recreate avoids an overlapping rollout; the agent's

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/kustomization.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+# Default-off component for platform#2820.
+#
+# A Crossplane managed resource can report Ready=True while Synced=False, which
+# means no declared setting is reaching the provider while every health check
+# keyed on Ready reads the fleet as healthy. Nothing in the cluster observes the
+# Synced condition today, so that state is silent.
+#
+# This component supplies the missing metric, which is the prerequisite for the
+# alerting rule — the rule cannot be written before the series exists. It does
+# not alert; delivery is a separate change, and so is extending coverage beyond
+# Repository to the remaining managed-resource kinds.
+#
+# No CiliumNetworkPolicy is included: the base `allow-coroot` policy
+# (controllers/coroot/cilium-network-policy.yaml, endpointSelector: {}) already
+# grants every observability pod egress to the kube-apiserver, intra-namespace
+# traffic to coroot-prometheus, and DNS — which is the whole of what this pod
+# needs.
+#
+# Keep the component unreferenced until a separate activation change can deploy,
+# observe, and roll it back independently.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - service-account.yaml
+  - cluster-role.yaml
+  - cluster-role-binding.yaml
+  - config-map.yaml
+  - deployment.yaml

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/service-account.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-sync-exporter
+  namespace: observability
+automountServiceAccountToken: false

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -33,6 +33,29 @@ require_text() {
   grep -Fq -- "$needle" <<<"${haystack}" || fail "${description}"
 }
 
+# Exact-value assertion. A substring match is wrong for every value below,
+# because the failure being guarded against is a RENAME — and a renamed value is
+# usually a LONGER one (`crossplane` -> `crossplane_mr`), which a substring match
+# accepts. Anchoring to the whole line is what makes the assertion mean what it
+# says.
+require_line() {
+  local haystack="$1"
+  local value="$2"
+  local description="$3"
+  local line
+
+  # Exact string comparison on the trimmed line, deliberately not a regex: every
+  # value here contains `.`, `[`, `-` or `/`, and escaping them for grep is both
+  # error-prone and easy to get subtly wrong in the permissive direction.
+  while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ "${line}" = "${value}" ] && return 0
+  done <<<"${haystack}"
+
+  fail "${description}"
+}
+
 reject_text() {
   local haystack="$1"
   local needle="$2"
@@ -123,23 +146,23 @@ config_map="$(
 
 # Coroot's bundled Prometheus exposes no scrape configuration, so remote-write is
 # the only ingest path into the store the alerting rule will query.
-require_text \
+require_line \
   "${config_map}" \
-  'url: http://coroot-prometheus.observability.svc.cluster.local:9090/api/v1/write' \
+  '- url: http://coroot-prometheus.observability.svc.cluster.local:9090/api/v1/write' \
   'the exporter must remote-write into the Prometheus Coroot queries'
 
 # The GVK is matched exactly by CustomResourceStateMetrics — there is no wildcard
 # and no `categories: managed` selector — so a drifted group or version silently
 # exports nothing at all.
-require_text \
+require_line \
   "${config_map}" \
   'group: repo.github.m.upbound.io' \
   'the exporter must target the GitHub repository managed-resource group'
-require_text \
+require_line \
   "${config_map}" \
   'version: v1alpha1' \
   'the exporter must target the served Repository version'
-require_text \
+require_line \
   "${config_map}" \
   'kind: Repository' \
   'the exporter must target the Repository kind'
@@ -147,37 +170,37 @@ require_text \
 # The emitted series name is metricNamePrefix + name. The scrape config filters on
 # the joined result, so renaming either half without the other drops every series
 # while both files still look individually correct. This assertion is the coupling.
-require_text \
+require_line \
   "${config_map}" \
   'metricNamePrefix: crossplane' \
   'the exported series must carry the crossplane prefix the scrape filter expects'
-require_text \
+require_line \
   "${config_map}" \
-  'name: managed_resource_condition' \
+  '- name: managed_resource_condition' \
   'the exported series must carry the name the scrape filter expects'
-require_text \
+require_line \
   "${config_map}" \
   'regex: crossplane_managed_resource_condition' \
   'the scrape filter must keep exactly the series the exporter emits'
 
 # Ready is exported alongside Synced deliberately: the defect being detected is
 # the PAIR, so a rule cannot express it if the conditions are filtered apart.
-require_text \
+require_line \
   "${config_map}" \
   'path: [status, conditions]' \
   'the exporter must read every condition, not a single hard-coded one'
-require_text \
+require_line \
   "${config_map}" \
   'valueFrom: [status]' \
   'the condition status must supply the gauge value'
-require_text \
+require_line \
   "${config_map}" \
   'condition: [type]' \
   'each series must be labelled with its condition type'
 
 # The agent scrapes kube-state-metrics inside the pod, so this target must stay
 # equal to the kube-state-metrics listen address asserted on the Deployment below.
-require_text \
+require_line \
   "${config_map}" \
   '- 127.0.0.1:8080' \
   'the agent must scrape kube-state-metrics over loopback'
@@ -185,7 +208,7 @@ require_text \
 deployment="$(
   extract_resource Deployment crossplane-sync-exporter <<<"${rendered}"
 )" || fail 'the component must render the exporter Deployment'
-require_text \
+require_line \
   "${deployment}" \
   'serviceAccountName: crossplane-sync-exporter' \
   'the exporter must use its dedicated service account'
@@ -197,30 +220,30 @@ require_text \
   "${deployment}" \
   'ghcr.io/coroot/prometheus:2.55.1-ubi9-0@sha256:' \
   'the agent image must be immutable and match the deployed Coroot Prometheus line'
-require_text \
+require_line \
   "${deployment}" \
-  '--enable-feature=agent' \
+  '- --enable-feature=agent' \
   'the scraper must run Prometheus in lightweight agent mode'
 
 # Built-in kube-state metrics would duplicate what Coroot's cluster agent already
 # sends, so the exporter must stay restricted to the custom resource state.
-require_text \
+require_line \
   "${deployment}" \
-  '--custom-resource-state-only=true' \
+  '- --custom-resource-state-only=true' \
   'the exporter must not emit a second copy of the built-in kube-state metrics'
-require_text \
+require_line \
   "${deployment}" \
-  '--host=127.0.0.1' \
+  '- --host=127.0.0.1' \
   'kube-state-metrics must not be reachable from outside the pod'
-require_text \
+require_line \
   "${deployment}" \
-  '--port=8080' \
+  '- --port=8080' \
   'the kube-state-metrics port must match the loopback scrape target'
-require_text \
+require_line \
   "${deployment}" \
   'platform.devantler.tech/replica-floor: exempt' \
   'the intentionally singleton exporter must document its replica-floor exemption'
-require_text \
+require_line \
   "${deployment}" \
   'readOnlyRootFilesystem: true' \
   'the exporter must keep its root filesystem immutable'
@@ -232,11 +255,11 @@ require_text \
 cluster_role="$(
   extract_resource ClusterRole crossplane-sync-exporter <<<"${rendered}"
 )" || fail 'the component must render the exporter ClusterRole'
-require_text \
+require_line \
   "${cluster_role}" \
   '- repo.github.m.upbound.io' \
   'the exporter must be limited to the managed-resource group it exports'
-require_text \
+require_line \
   "${cluster_role}" \
   '- repositories' \
   'the exporter must be limited to the resource it exports'

--- a/scripts/tests/test-crossplane-sync-exporter.sh
+++ b/scripts/tests/test-crossplane-sync-exporter.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+
+# Contract for the default-off Crossplane sync exporter (#2986).
+#
+# The failure this component exists to prevent is a silent one: a managed
+# resource reporting Ready=True while Synced=False, which every Ready-keyed
+# health check reads as healthy. The exporter has the same failure shape itself
+# — a wrong GVK, a renamed metric, or a scrape target that no longer matches the
+# kube-state-metrics listen address all yield ZERO series, and an empty result
+# is indistinguishable from a healthy cluster. None of those would fail a schema
+# validation, so they are asserted here instead.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly root_dir
+readonly coroot_dir="${root_dir}/k8s/bases/infrastructure/coroot"
+readonly exporter_component="${coroot_dir}/components/crossplane-sync-exporter"
+readonly local_cluster="${root_dir}/k8s/clusters/local"
+readonly prod_cluster="${root_dir}/k8s/clusters/prod"
+readonly ci_workflow="${root_dir}/.github/workflows/ci.yaml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+require_text() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+
+  grep -Fq -- "$needle" <<<"${haystack}" || fail "${description}"
+}
+
+reject_text() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+
+  if grep -Fq -- "$needle" <<<"${haystack}"; then
+    fail "${description}"
+  fi
+}
+
+extract_resource() {
+  local kind="$1"
+  local name="$2"
+
+  awk -v wanted_kind="${kind}" -v wanted_name="${name}" '
+    function reset_document() {
+      document = ""
+      resource_kind = ""
+      resource_name = ""
+      in_metadata = 0
+    }
+
+    function emit_if_match() {
+      if (!found && resource_kind == wanted_kind && resource_name == wanted_name) {
+        printf "%s", document
+        found = 1
+      }
+      reset_document()
+    }
+
+    BEGIN { reset_document() }
+    /^---[[:space:]]*$/ { emit_if_match(); next }
+    {
+      if (!found) {
+        document = document $0 ORS
+        if ($0 ~ /^kind:[[:space:]]*/) {
+          resource_kind = $0
+          sub(/^kind:[[:space:]]*/, "", resource_kind)
+        } else if ($0 ~ /^metadata:[[:space:]]*$/) {
+          in_metadata = 1
+        } else if ($0 ~ /^[^[:space:]]/ && $0 !~ /^metadata:/) {
+          in_metadata = 0
+        } else if (in_metadata && $0 ~ /^  name:[[:space:]]*/) {
+          resource_name = $0
+          sub(/^  name:[[:space:]]*/, "", resource_name)
+        }
+      }
+    }
+    END {
+      if (!found) {
+        emit_if_match()
+      }
+      if (!found) {
+        exit 1
+      }
+    }
+  '
+}
+
+grep -Fq \
+  "'scripts/tests/test-crossplane-sync-exporter.sh'" \
+  "${ci_workflow}" ||
+  fail 'the Crossplane sync exporter contract must trigger manifest validation'
+
+grep -Fq \
+  'run: bash scripts/tests/test-crossplane-sync-exporter.sh' \
+  "${ci_workflow}" ||
+  fail 'CI must execute the Crossplane sync exporter contract'
+
+# Default-off: the exporter must not appear anywhere it has not been explicitly
+# activated. A component is only reachable through a `components:` reference, so
+# an accidental reference is the way this ships before its activation change.
+for surface in "${coroot_dir}" "${local_cluster}" "${prod_cluster}"; do
+  surface_rendered="$(kubectl kustomize "${surface}")" ||
+    fail "the ${surface} surface must render"
+  reject_text \
+    "${surface_rendered}" \
+    'crossplane-sync-exporter' \
+    "the exporter must remain default-off until an activation change enables it (${surface})"
+done
+
+rendered="$(kubectl kustomize "${exporter_component}")" ||
+  fail 'the default-off Crossplane sync-exporter component must render'
+
+config_map="$(
+  extract_resource ConfigMap crossplane-sync-exporter <<<"${rendered}"
+)" || fail 'the component must render the exporter ConfigMap'
+
+# Coroot's bundled Prometheus exposes no scrape configuration, so remote-write is
+# the only ingest path into the store the alerting rule will query.
+require_text \
+  "${config_map}" \
+  'url: http://coroot-prometheus.observability.svc.cluster.local:9090/api/v1/write' \
+  'the exporter must remote-write into the Prometheus Coroot queries'
+
+# The GVK is matched exactly by CustomResourceStateMetrics — there is no wildcard
+# and no `categories: managed` selector — so a drifted group or version silently
+# exports nothing at all.
+require_text \
+  "${config_map}" \
+  'group: repo.github.m.upbound.io' \
+  'the exporter must target the GitHub repository managed-resource group'
+require_text \
+  "${config_map}" \
+  'version: v1alpha1' \
+  'the exporter must target the served Repository version'
+require_text \
+  "${config_map}" \
+  'kind: Repository' \
+  'the exporter must target the Repository kind'
+
+# The emitted series name is metricNamePrefix + name. The scrape config filters on
+# the joined result, so renaming either half without the other drops every series
+# while both files still look individually correct. This assertion is the coupling.
+require_text \
+  "${config_map}" \
+  'metricNamePrefix: crossplane' \
+  'the exported series must carry the crossplane prefix the scrape filter expects'
+require_text \
+  "${config_map}" \
+  'name: managed_resource_condition' \
+  'the exported series must carry the name the scrape filter expects'
+require_text \
+  "${config_map}" \
+  'regex: crossplane_managed_resource_condition' \
+  'the scrape filter must keep exactly the series the exporter emits'
+
+# Ready is exported alongside Synced deliberately: the defect being detected is
+# the PAIR, so a rule cannot express it if the conditions are filtered apart.
+require_text \
+  "${config_map}" \
+  'path: [status, conditions]' \
+  'the exporter must read every condition, not a single hard-coded one'
+require_text \
+  "${config_map}" \
+  'valueFrom: [status]' \
+  'the condition status must supply the gauge value'
+require_text \
+  "${config_map}" \
+  'condition: [type]' \
+  'each series must be labelled with its condition type'
+
+# The agent scrapes kube-state-metrics inside the pod, so this target must stay
+# equal to the kube-state-metrics listen address asserted on the Deployment below.
+require_text \
+  "${config_map}" \
+  '- 127.0.0.1:8080' \
+  'the agent must scrape kube-state-metrics over loopback'
+
+deployment="$(
+  extract_resource Deployment crossplane-sync-exporter <<<"${rendered}"
+)" || fail 'the component must render the exporter Deployment'
+require_text \
+  "${deployment}" \
+  'serviceAccountName: crossplane-sync-exporter' \
+  'the exporter must use its dedicated service account'
+require_text \
+  "${deployment}" \
+  'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0@sha256:' \
+  'the kube-state-metrics image must be immutable'
+require_text \
+  "${deployment}" \
+  'ghcr.io/coroot/prometheus:2.55.1-ubi9-0@sha256:' \
+  'the agent image must be immutable and match the deployed Coroot Prometheus line'
+require_text \
+  "${deployment}" \
+  '--enable-feature=agent' \
+  'the scraper must run Prometheus in lightweight agent mode'
+
+# Built-in kube-state metrics would duplicate what Coroot's cluster agent already
+# sends, so the exporter must stay restricted to the custom resource state.
+require_text \
+  "${deployment}" \
+  '--custom-resource-state-only=true' \
+  'the exporter must not emit a second copy of the built-in kube-state metrics'
+require_text \
+  "${deployment}" \
+  '--host=127.0.0.1' \
+  'kube-state-metrics must not be reachable from outside the pod'
+require_text \
+  "${deployment}" \
+  '--port=8080' \
+  'the kube-state-metrics port must match the loopback scrape target'
+require_text \
+  "${deployment}" \
+  'platform.devantler.tech/replica-floor: exempt' \
+  'the intentionally singleton exporter must document its replica-floor exemption'
+require_text \
+  "${deployment}" \
+  'readOnlyRootFilesystem: true' \
+  'the exporter must keep its root filesystem immutable'
+require_text \
+  "${deployment}" \
+  'CKV_K8S_38=' \
+  'the service-account token mount must carry its documented justification'
+
+cluster_role="$(
+  extract_resource ClusterRole crossplane-sync-exporter <<<"${rendered}"
+)" || fail 'the component must render the exporter ClusterRole'
+require_text \
+  "${cluster_role}" \
+  '- repo.github.m.upbound.io' \
+  'the exporter must be limited to the managed-resource group it exports'
+require_text \
+  "${cluster_role}" \
+  '- repositories' \
+  'the exporter must be limited to the resource it exports'
+
+# A metrics exporter able to read every custom resource could also read provider
+# configuration it has no need for.
+reject_text \
+  "${cluster_role}" \
+  "- '*'" \
+  'the exporter must not receive wildcard API access'
+for verb in create update patch delete deletecollection; do
+  reject_text \
+    "${cluster_role}" \
+    "- ${verb}" \
+    "the exporter must stay read-only (found ${verb})"
+done
+
+extract_resource \
+  ClusterRoleBinding \
+  crossplane-sync-exporter <<<"${rendered}" >/dev/null ||
+  fail 'the component must bind the exporter ClusterRole'
+extract_resource \
+  ServiceAccount \
+  crossplane-sync-exporter <<<"${rendered}" >/dev/null ||
+  fail 'the component must render the exporter ServiceAccount'
+
+printf 'PASS: the default-off Crossplane sync exporter keeps its least-privilege metric contract\n'


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A Crossplane managed resource can sit with `Ready=True` while `Synced=False`. In that
state nothing we declare is actually reaching the provider, but every health check
keyed on `Ready` reads the fleet as healthy — so the control is voided silently while
the config file still reads as the truth. **3 of 20 repository resources are in exactly
that state on the cluster right now.** Nothing today would surface it.

## What

Adds the missing metric, which is the prerequisite for alerting on it — the rule cannot
be written before the series exists. Off-the-shelf images, no bespoke code: it follows
the same shape as the existing opencost usage-scraper.

Both `Synced` and `Ready` are exported, so the misleading pair can be caught in one
query rather than inferred.

**Ships default-off** (the component is unreferenced), so turning it on is a separate,
independently reversible change — as is the alert itself and extending coverage beyond
repository resources to the other managed-resource kinds.

Fixes #2986
Part of #2820
