### PR TITLE
security(ci): parse the DR publisher step instead of scanning workflow text

### DIFF
--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -97,37 +97,164 @@ const (
 	validatorCommand      = "go run ./scripts/validate-dr-signing .github/workflows/dr-rebuild.yaml ksail.prod.yaml"
 )
 
+// drRebuildJob is the dr-rebuild.yaml job that reaches production.
+const drRebuildJob = "rebuild"
+
+// drRequiredPermission is a job-level grant the rebuild job must carry, together
+// with what stops working without it.
+type drRequiredPermission struct {
+	name string
+	// consequence completes "so …", naming what the DR rebuild cannot do.
+	consequence string
+}
+
+// drRequiredPermissions are the three write grants the publication transaction
+// needs. Matched on the PARSED key and value, so the trailing comment on each
+// line is documentation rather than part of the contract.
+var drRequiredPermissions = []drRequiredPermission{
+	{"id-token", "keyless cosign signing cannot mint a Fulcio certificate"},
+	{"packages", "the publication transaction cannot update GHCR"},
+	{"attestations", "the SBOM and provenance cannot be recorded"},
+}
+
+// drPublisherCredential is an input the publisher step must receive, and the
+// exact expression it must receive it from.
+type drPublisherCredential struct {
+	input      string
+	expression string
+}
+
+// drPublisherCredentials are the two secrets the shared publication action needs.
+// Asserted on the publisher STEP's `with` mapping, not anywhere in the job.
+var drPublisherCredentials = []drPublisherCredential{
+	{"ghcr-token", "${{ secrets.GHCR_TOKEN }}"},
+	{"hcloud-token", "${{ secrets.HCLOUD_TOKEN }}"},
+}
+
+// validateDRWorkflow checks that the disaster-recovery route publishes through
+// the same checked action as every other route, with the grants and credentials
+// that action needs.
+//
+// 🔴 THE WORKFLOW IS PARSED, NOT SCANNED — the third route, and the last one to
+// be converted. The two production routes were parsed in #2939; this one still
+// asked `containsLine`, which is satisfied by the expected text appearing
+// ANYWHERE in the job's text. Five ways that said "wired" about a DR route that
+// was not, each reproduced as an ablation and each returning nil against the
+// scanning version:
+//
+//  1. The `uses:` line survives as a COMMENT while the step invokes a different
+//     action. A comment runs nothing, so the gate certified a publisher that is
+//     not called.
+//  2. The same text inside a BLOCK SCALAR — an `echo` in a run block — with no
+//     `uses:` step anywhere.
+//  3. The credentials named on a DIFFERENT step. A scan over the job text cannot
+//     tell which step receives them, so the publisher could be invoked with none.
+//  4. The publisher step carries `if: false`, so it never runs while the workflow
+//     reads as correct.
+//  5. The publisher step carries `continue-on-error: true`, so it runs, fails,
+//     and the rebuild continues to promote the mutable tag anyway.
+//
+// (4) and (5) are the requireEnforcedStep class this file has now fixed at six
+// sites; matching and enforcing are inseparable there for exactly this reason.
+// A DR publish that silently skipped its evidence is unrecoverable by hand at
+// the one moment nobody can afford to debug it.
 func validateDRWorkflow(workflow string) error {
-	job, ok := extractJob(workflow, "  rebuild:")
+	document, err := decodeWorkflow(workflow)
+	if err != nil {
+		return fmt.Errorf(
+			"disaster-recovery workflow does not parse, so its publication wiring cannot be established: %w", err,
+		)
+	}
+	jobs, ok := document["jobs"].(map[string]any)
+	if !ok {
+		return errors.New("disaster-recovery workflow has no jobs mapping")
+	}
+	job, ok := jobs[drRebuildJob].(map[string]any)
 	if !ok {
 		return errors.New("missing rebuild job")
 	}
 
-	if !containsExactLine(job, "      id-token: write # keyless cosign signing (Fulcio OIDC)") {
-		return errors.New(
-			"rebuild job is missing `id-token: write`, so keyless cosign signing cannot mint a Fulcio certificate",
-		)
+	if err := requireJobPermissions(job); err != nil {
+		return err
 	}
-	if !containsExactLine(job, "      packages: write # push OCI artifacts to GHCR") {
-		return errors.New(
-			"rebuild job is missing `packages: write`, so the publication transaction cannot update GHCR",
-		)
-	}
-	if !containsExactLine(job, "      attestations: write # write SBOM + SLSA provenance attestations") {
-		return errors.New(
-			"rebuild job is missing `attestations: write`, so the SBOM and provenance cannot be recorded",
-		)
-	}
-	if !containsLine(job, "uses: ./.github/actions/deploy-prod/publish-platform-manifests") {
-		return errors.New(
+
+	// The rebuild JOB legitimately carries `if:` — the supersession gate — so the
+	// job-level condition is deliberately NOT refused here, unlike cd.yaml's
+	// deploy-prod. What must hold is that the publisher STEP is neither skipped
+	// nor failure-suppressed, which is requireEnforcedStep's whole contract.
+	step, err := requireEnforcedStep(
+		job, usesAction(nestedPublisherAction),
+		errors.New(
 			"rebuild job must use the shared publication action so normal and disaster-recovery delivery cannot drift",
+		),
+		"the publisher step in the DR rebuild job",
+	)
+	if err != nil {
+		return err
+	}
+
+	return requirePublisherCredentials(step)
+}
+
+// requireJobPermissions proves the rebuild job grants each required permission
+// as `write`, read from the parsed mapping.
+//
+// A `permissions` value this cannot read is REFUSED rather than skipped, for the
+// reason every other shape check in this file gives: it decides whether a
+// disaster-recovery publish is trusted, so a grant that cannot be established
+// must not fall through to accepted. That includes the blanket `write-all`
+// scalar — which does grant enough, but names none of these three, so a later
+// narrowing could drop one silently while this check kept passing.
+func requireJobPermissions(job map[string]any) error {
+	raw, present := job["permissions"]
+	if !present {
+		return errors.New(
+			"rebuild job declares no permissions, so it grants none of the writes the publication transaction needs",
 		)
 	}
-	if !containsLine(job, "ghcr-token: ${{ secrets.GHCR_TOKEN }}") ||
-		!containsLine(job, "hcloud-token: ${{ secrets.HCLOUD_TOKEN }}") {
-		return errors.New("rebuild job does not pass the required publication credentials to the shared action")
+	permissions, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf(
+			"rebuild job declares permissions in a shape this check cannot read (%v); each of %s must be granted "+
+				"explicitly as `write`, so a later narrowing cannot drop one silently",
+			raw, drRequiredPermissionNames(),
+		)
+	}
+	for _, required := range drRequiredPermissions {
+		if value, _ := permissions[required.name].(string); strings.TrimSpace(value) != "write" {
+			return fmt.Errorf(
+				"rebuild job does not grant `%s: write`, so %s",
+				required.name, required.consequence,
+			)
+		}
 	}
 	return nil
+}
+
+// requirePublisherCredentials proves the publisher step itself receives both
+// secrets. Asserted on the step's own `with` mapping: the scanning version read
+// them from anywhere in the job, so credentials on an unrelated step satisfied
+// it while the publisher was invoked with none.
+func requirePublisherCredentials(step map[string]any) error {
+	with, _ := step["with"].(map[string]any)
+	for _, credential := range drPublisherCredentials {
+		if value, _ := with[credential.input].(string); strings.TrimSpace(value) != credential.expression {
+			return fmt.Errorf(
+				"the publisher step in the DR rebuild job does not pass %s: %s, so it cannot complete the "+
+					"publication credentials the shared action requires",
+				credential.input, credential.expression,
+			)
+		}
+	}
+	return nil
+}
+
+func drRequiredPermissionNames() string {
+	names := make([]string, 0, len(drRequiredPermissions))
+	for _, required := range drRequiredPermissions {
+		names = append(names, required.name)
+	}
+	return strings.Join(names, ", ")
 }
 
 func validatePublicationAction(action string) error {
@@ -985,42 +1112,6 @@ func stringListContains(value any, want string) bool {
 			if name, ok := item.(string); ok && strings.TrimSpace(name) == want {
 				return true
 			}
-		}
-	}
-	return false
-}
-
-func extractJob(workflow string, header string) (string, bool) {
-	lines := strings.Split(workflow, "\n")
-	start := -1
-	for i, line := range lines {
-		if line == header {
-			start = i + 1
-			break
-		}
-	}
-	if start < 0 {
-		return "", false
-	}
-
-	end := len(lines)
-	for i := start; i < len(lines); i++ {
-		line := lines[i]
-		if strings.HasPrefix(line, "  ") &&
-			!strings.HasPrefix(line, "   ") &&
-			strings.HasSuffix(line, ":") {
-			end = i
-			break
-		}
-	}
-
-	return strings.Join(lines[start:end], "\n"), true
-}
-
-func containsExactLine(block string, want string) bool {
-	for _, line := range strings.Split(block, "\n") {
-		if line == want {
-			return true
 		}
 	}
 	return false

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -784,6 +784,20 @@ func TestParsedHelpersFailClosedOnShapesTheyCannotRead(t *testing.T) {
 	}
 }
 
+// drPublisherStep is the DR rebuild's publisher step, byte-exact. The ablations
+// below replace this whole block so each one MOVES the mechanism rather than
+// deleting it: the text the old scanning check looked for survives somewhere the
+// workflow does not execute it, which is the only shape that separates a scan
+// from a parse. An ablation that merely deleted the step would be refused by
+// both implementations and would prove nothing.
+const drPublisherStep = `      - name: 📦 Publish evidenced manifests to GHCR
+        id: publish_platform_manifest
+        uses: ./.github/actions/deploy-prod/publish-platform-manifests
+        with:
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
+          hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
+`
+
 func TestDRWorkflowContractRejectsEachAblation(t *testing.T) {
 	t.Parallel()
 
@@ -810,10 +824,92 @@ func TestDRWorkflowContractRejectsEachAblation(t *testing.T) {
 			wantErr: "attestations: write",
 		},
 		{
+			name:    "a permission granted as read does not authorise the transaction",
+			old:     "      packages: write # push OCI artifacts to GHCR\n",
+			new:     "      packages: read # push OCI artifacts to GHCR\n",
+			wantErr: "packages: write",
+		},
+		{
 			name:    "without the shared action DR can drift from normal deploy",
 			old:     "uses: ./.github/actions/deploy-prod/publish-platform-manifests",
 			new:     "uses: ./.github/actions/other-publisher",
 			wantErr: "shared publication action",
+		},
+		{
+			name: "the publisher text survives in a COMMENT while another action runs",
+			old:  drPublisherStep,
+			new: `      - name: 📦 Publish evidenced manifests to GHCR
+        id: publish_platform_manifest
+        # uses: ./.github/actions/deploy-prod/publish-platform-manifests
+        uses: ./.github/actions/other-publisher
+        with:
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
+          hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
+`,
+			wantErr: "shared publication action",
+		},
+		{
+			name: "the publisher text survives in a BLOCK SCALAR while nothing invokes it",
+			old:  drPublisherStep,
+			new: `      - name: 📦 Publish evidenced manifests to GHCR
+        id: publish_platform_manifest
+        run: |
+          echo "uses: ./.github/actions/deploy-prod/publish-platform-manifests"
+          echo "ghcr-token: ${{ secrets.GHCR_TOKEN }}"
+          echo "hcloud-token: ${{ secrets.HCLOUD_TOKEN }}"
+`,
+			wantErr: "shared publication action",
+		},
+		{
+			name: "credentials named on a DIFFERENT step never reach the publisher",
+			old:  drPublisherStep,
+			new: `      - name: 📦 Publish evidenced manifests to GHCR
+        id: publish_platform_manifest
+        uses: ./.github/actions/deploy-prod/publish-platform-manifests
+
+      - name: 🔑 Unrelated step that merely names the credentials
+        run: |
+          echo "ghcr-token: ${{ secrets.GHCR_TOKEN }}"
+          echo "hcloud-token: ${{ secrets.HCLOUD_TOKEN }}"
+`,
+			wantErr: "publication credentials",
+		},
+		{
+			name: "one credential present and the other missing is still unpublishable",
+			old:  drPublisherStep,
+			new: `      - name: 📦 Publish evidenced manifests to GHCR
+        id: publish_platform_manifest
+        uses: ./.github/actions/deploy-prod/publish-platform-manifests
+        with:
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
+`,
+			wantErr: "hcloud-token",
+		},
+		{
+			name: "a SKIPPED publisher step leaves the workflow reading as correct",
+			old:  drPublisherStep,
+			new: `      - name: 📦 Publish evidenced manifests to GHCR
+        id: publish_platform_manifest
+        if: false
+        uses: ./.github/actions/deploy-prod/publish-platform-manifests
+        with:
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
+          hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
+`,
+			wantErr: "declares a condition",
+		},
+		{
+			name: "a FAILURE-SUPPRESSED publisher step discards its own verdict",
+			old:  drPublisherStep,
+			new: `      - name: 📦 Publish evidenced manifests to GHCR
+        id: publish_platform_manifest
+        continue-on-error: true
+        uses: ./.github/actions/deploy-prod/publish-platform-manifests
+        with:
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}
+          hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
+`,
+			wantErr: "continue-on-error",
 		},
 		{
 			name:    "a renamed rebuild job hides the whole contract",
@@ -829,6 +925,74 @@ func TestDRWorkflowContractRejectsEachAblation(t *testing.T) {
 			ablated := strings.ReplaceAll(workflow, testCase.old, testCase.new)
 			if ablated == workflow {
 				t.Fatalf("ablation changed nothing — the control does not target a real line")
+			}
+			err := validateDRWorkflow(ablated)
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("wrong result: got %v, want error mentioning %q", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+// TestDRPermissionsAreReadFromTheParsedGrantNotItsComment pins the direction the
+// scanning check got wrong in the SAFE-looking way: it compared each permission
+// against a whole line INCLUDING its trailing comment, so rewording the comment
+// broke the gate while the grant itself was untouched. A contract that fails on
+// a documentation edit trains people to weaken it.
+func TestDRPermissionsAreReadFromTheParsedGrantNotItsComment(t *testing.T) {
+	t.Parallel()
+
+	workflow := repoFile(t, ".github/workflows/dr-rebuild.yaml")
+	reworded := strings.ReplaceAll(
+		workflow,
+		"      id-token: write # keyless cosign signing (Fulcio OIDC)",
+		"      id-token: write # mints the Fulcio certificate for keyless signing",
+	)
+	if reworded == workflow {
+		t.Fatal("ablation changed nothing — the control does not target a real line")
+	}
+	if err := validateDRWorkflow(reworded); err != nil {
+		t.Fatalf("rewording a permission's comment must not break the contract: %v", err)
+	}
+}
+
+// TestDRWorkflowFailsClosedOnShapesItCannotRead covers the shapes a parser can
+// meet that a scanner never did. Each must be REFUSED rather than skipped: this
+// decides whether a disaster-recovery publish is trusted, so a grant this cannot
+// read must not fall through to accepted.
+func TestDRWorkflowFailsClosedOnShapesItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	workflow := repoFile(t, ".github/workflows/dr-rebuild.yaml")
+	for _, testCase := range []struct {
+		name    string
+		old     string
+		new     string
+		wantErr string
+	}{
+		{
+			name: "permissions collapsed to a blanket scalar names no specific grant",
+			old: `    permissions:
+      contents: read # checkout repository
+      packages: write # push OCI artifacts to GHCR
+      id-token: write # keyless cosign signing (Fulcio OIDC)
+      attestations: write # write SBOM + SLSA provenance attestations
+`,
+			new:     "    permissions: write-all\n",
+			wantErr: "permissions",
+		},
+		{
+			name:    "a workflow that does not parse cannot establish anything",
+			old:     "\n  rebuild:\n",
+			new:     "\n  rebuild:\n    : : :\n",
+			wantErr: "does not parse",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ablated := strings.ReplaceAll(workflow, testCase.old, testCase.new)
+			if ablated == workflow {
+				t.Fatal("ablation changed nothing — the control does not target a real line")
 			}
 			err := validateDRWorkflow(ablated)
 			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The disaster-recovery rebuild is the one route to production that runs when the cluster is gone —
the moment nobody can afford to debug a supply-chain policy by hand. Its publication wiring was the
last of the three routes still established by **scanning the workflow's text** rather than reading
it, and a scan cannot tell the difference between a step that runs and a string that merely appears.

Five ways the gate said "wired" about a DR route that was not — each one reproduced, and each one
**accepted by the old check**: the publisher named only in a comment, or inside an `echo`, with its
credentials sitting on an unrelated step, or with the step switched off entirely so its failure is
skipped or discarded. In every case the workflow reads correct and the contract reports success.

Not reachable by an outside contributor — it needs a workflow edit — so this hardens a gate that
already exists rather than closing a live exposure.

## What

The DR route is now parsed like the other two: the publisher is located as a real step whose action
matches exactly, proven to be neither skipped nor failure-suppressed, and its two credentials are
asserted on **that step** instead of anywhere in the job.

The three permission grants move to parsed lookups as well. The old check compared each against a
whole line *including its trailing comment*, so rewording a comment broke the gate while the grant
itself was untouched — a contract that fails on a documentation edit is one people learn to weaken.

Shipped configuration passes unchanged; no workflow or cluster config is modified.

Fixes #2941
Part of #2627
