### PR TITLE
fix(ci): accept the shared cosign matcher in the DR publication contract

### DIFF
--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -41,6 +42,87 @@ const drIdentitySubject = `^https://github\.com/devantler-tech/platform/\.github
 // identity on the issuer/subject PAIR, so a correct subject under a different
 // issuer does not admit the DR signature and must not satisfy this gate.
 const drIdentityIssuer = `^https://token\.actions\.githubusercontent\.com$`
+
+// drIdentityIssuerLiteral and drIdentitySubjectLiteral are the CONCRETE strings
+// Fulcio puts in the DR rebuild's certificate — the values cosign actually
+// matches the allow-list regexes against.
+//
+// They exist because the allow-list can no longer carry the DR identity as its
+// own entry. cosign rejects a multi-entry matchOIDCIdentity outright, so all
+// three trusted signers (ci.yaml on the merge-queue ref, cd.yaml on main, and
+// dr-rebuild.yaml on main) have to share ONE entry, and that entry is therefore
+// an alternation which can never be string-equal to any single identity.
+// Comparing regex text to regex text is the wrong question; the right one is
+// whether the shipped matcher ADMITS this certificate, so the check evaluates
+// the matcher against these literals instead.
+const (
+	drIdentityIssuerLiteral  = `https://token.actions.githubusercontent.com`
+	drIdentitySubjectLiteral = `https://github.com/devantler-tech/platform/.github/workflows/dr-rebuild.yaml@refs/heads/main`
+)
+
+// drIdentitySharedSubject is the ONE subject regex that carries all three
+// trusted signers: ci.yaml on the merge-queue ref, cd.yaml on main, and
+// dr-rebuild.yaml on main. cosign accepts exactly one matchOIDCIdentity entry,
+// so trusting three signers means one entry whose alternation is INSIDE the
+// subject — there is nowhere else to put it.
+const drIdentitySharedSubject = `^https://github\.com/devantler-tech/platform/\.github/workflows/(ci\.yaml@refs/heads/gh-readonly-queue/main/.+|(cd|dr-rebuild)\.yaml@refs/heads/main)$`
+
+// permittedSubjects are the only subject regexes production may ship, compared
+// EXACTLY.
+//
+// Exact comparison is deliberate and is the property this file refuses to give
+// up. Evaluating the regex against the DR identity alone cannot replace it: a
+// widened matcher such as `<real>|^https://github\.com/attacker/…$` still admits
+// the DR identity, so every match-based check passes while a second signer has
+// been let in. Only string equality is blind to nothing in the lengthening
+// direction. What the single-entry cosign limit changed is not whether to
+// compare exactly, but WHAT to compare against — a list of one identity was
+// never satisfiable once three signers had to share one entry.
+//
+// Adding or removing a trusted signer is therefore a deliberate edit here, on a
+// pull request, which is the review point a supply-chain allow-list should have.
+var permittedSubjects = []string{
+	// The three-signer form production ships.
+	drIdentitySharedSubject,
+	// The DR identity alone — the correct shape for a cluster whose only
+	// publisher is the DR rebuild, and the narrowest thing that can satisfy
+	// this contract.
+	drIdentitySubject,
+}
+
+// untrustedSubjects are certificate subjects a permitted matcher must REFUSE.
+//
+// These do not replace the exact comparison above; they guard the constants
+// themselves. A typo in drIdentitySharedSubject — a dot left unescaped, a
+// missing anchor — would be copied verbatim into permittedSubjects and compare
+// equal to itself forever, so the allow-list would be wrong and the gate would
+// still pass. Evaluating the permitted form against known-bad subjects is what
+// catches that. Each entry varies exactly one field of the real subject —
+// owner, repo, workflow, ref — plus the two boundary escapes an unanchored or
+// partially-anchored regex lets through.
+var untrustedSubjects = []string{
+	// A different owner, including one that merely extends the real one — the
+	// case an unescaped `.` or a missing anchor waves through.
+	`https://github.com/attacker/platform/.github/workflows/dr-rebuild.yaml@refs/heads/main`,
+	`https://github.com/devantler-tech-attacker/platform/.github/workflows/dr-rebuild.yaml@refs/heads/main`,
+	// A different repository under the real owner.
+	`https://github.com/devantler-tech/attacker/.github/workflows/dr-rebuild.yaml@refs/heads/main`,
+	// A different workflow in the real repository: any workflow that can be
+	// added by a PR must not be able to sign a production artifact.
+	`https://github.com/devantler-tech/platform/.github/workflows/attacker.yaml@refs/heads/main`,
+	// The real workflow at a ref an outside contributor controls.
+	`https://github.com/devantler-tech/platform/.github/workflows/dr-rebuild.yaml@refs/heads/attacker`,
+	`https://github.com/devantler-tech/platform/.github/workflows/dr-rebuild.yaml@refs/pull/1/merge`,
+	// Boundary escapes: an unanchored regex matches these because the real
+	// subject is a substring of each.
+	`https://attacker.example/https://github.com/devantler-tech/platform/.github/workflows/dr-rebuild.yaml@refs/heads/main`,
+	`https://github.com/devantler-tech/platform/.github/workflows/dr-rebuild.yaml@refs/heads/main.attacker`,
+}
+
+// untrustedIssuer stands in for the wrong-issuer half of the pair. cosign
+// matches issuer AND subject, so an allow-list that admits any issuer admits a
+// signature minted somewhere other than GitHub's OIDC provider.
+const untrustedIssuer = `https://attacker.example`
 
 // cdContractGateJob is the cd.yaml job that runs this validator on the
 // direct-push production path. Named once so the wiring check and the workflow
@@ -444,17 +526,65 @@ func validateVerifyAllowList(config string) error {
 	}
 
 	for _, entry := range entries {
-		if entry.Issuer == drIdentityIssuer && entry.Subject == drIdentitySubject {
-			return nil
+		if entry.Issuer != drIdentityIssuer || !slices.Contains(permittedSubjects, entry.Subject) {
+			continue
 		}
+
+		// The entry is one of the permitted forms. Prove that form is actually
+		// correct rather than merely familiar: it must admit the DR rebuild's
+		// real certificate and refuse every known-bad subject. This is what
+		// catches a typo baked into the constant, which equality alone cannot
+		// see because a wrong constant still equals itself.
+		if err := verifyPermittedSubject(entry.Subject); err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	return fmt.Errorf(
-		"cosign matchOIDCIdentity at spec.workload.flux.verify has %d entries but none is exactly the DR rebuild "+
-			"identity, so a DR-published artifact stays unverifiable; add an entry with issuer %s and subject %s "+
-			"(both compared exactly — a wider regex containing this one is not accepted)",
-		len(entries), drIdentityIssuer, drIdentitySubject,
+		"cosign matchOIDCIdentity at spec.workload.flux.verify has %d entries but none is exactly a permitted DR "+
+			"rebuild matcher, so a DR-published artifact stays unverifiable; use issuer %s with subject %s (the "+
+			"three-signer form) or %s (DR alone), each compared exactly — a wider regex that merely contains one of "+
+			"them is not accepted. cosign supports exactly ONE entry, so a second signer belongs in the alternation "+
+			"inside the subject, never in a second entry",
+		len(entries), drIdentityIssuer, drIdentitySharedSubject, drIdentitySubject,
 	)
+}
+
+// verifyPermittedSubject checks a permitted subject regex against the DR
+// rebuild's real certificate subject and against the known-bad subjects.
+//
+// It guards the CONSTANTS, not the config: an allow-list entry that compares
+// equal to a mistyped permitted form is accepted by the equality check and
+// still admits the wrong signers, and that mistake would survive review
+// precisely because the file and the constant agree with each other.
+func verifyPermittedSubject(subject string) error {
+	compiled, err := regexp.Compile(subject)
+	if err != nil {
+		return fmt.Errorf(
+			"permitted subject %s is not a valid regular expression, so cosign cannot evaluate it and it admits "+
+				"nothing: %w", subject, err,
+		)
+	}
+
+	if !compiled.MatchString(drIdentitySubjectLiteral) {
+		return fmt.Errorf(
+			"permitted subject %s does not match the DR rebuild's certificate subject %s, so a DR-published "+
+				"artifact stays unverifiable", subject, drIdentitySubjectLiteral,
+		)
+	}
+
+	for _, untrusted := range untrustedSubjects {
+		if compiled.MatchString(untrusted) {
+			return fmt.Errorf(
+				"permitted subject %s also admits %s, so a signer we do not trust could publish an artifact Flux "+
+					"accepts; anchor the expression with ^…$ and escape every dot", subject, untrusted,
+			)
+		}
+	}
+
+	return nil
 }
 
 // validateCDWiring checks that the direct-push production path cannot deploy

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -525,6 +525,24 @@ func validateVerifyAllowList(config string) error {
 		)
 	}
 
+	// cosign refuses a multi-entry matchOIDCIdentity outright — "unsupported:
+	// multiple identities are not supported at this time" — and it fails CLOSED
+	// for the whole list, so a second entry does not add a signer, it removes
+	// every one of them. Finding a correct entry somewhere in a longer list
+	// therefore says nothing about whether a DR artifact verifies, which is the
+	// only question this contract asks. validate-flux-verify refuses the same
+	// shape; it is repeated here because this gate is what stands between a
+	// disaster recovery and an artifact production will not accept.
+	if len(entries) > 1 {
+		return fmt.Errorf(
+			"cosign matchOIDCIdentity at spec.workload.flux.verify has %d entries, and cosign supports exactly ONE: "+
+				"it rejects a multi-entry list for the whole set, so a DR-published artifact stays unverifiable even "+
+				"though a correct entry is present; express several trusted signers as an alternation inside one "+
+				"entry's subject regex",
+			len(entries),
+		)
+	}
+
 	for _, entry := range entries {
 		if entry.Issuer != drIdentityIssuer || !slices.Contains(permittedSubjects, entry.Subject) {
 			continue

--- a/scripts/validate-dr-signing/main.go
+++ b/scripts/validate-dr-signing/main.go
@@ -532,9 +532,17 @@ func validateVerifyAllowList(config string) error {
 
 		// The entry is one of the permitted forms. Prove that form is actually
 		// correct rather than merely familiar: it must admit the DR rebuild's
-		// real certificate and refuse every known-bad subject. This is what
-		// catches a typo baked into the constant, which equality alone cannot
-		// see because a wrong constant still equals itself.
+		// real certificate and refuse every known-bad value. This is what
+		// catches a typo baked into a constant, which equality alone cannot see
+		// because a wrong constant still equals itself.
+		//
+		// Both halves are checked because cosign matches on the PAIR: an
+		// over-broad issuer admits a signature minted outside GitHub's OIDC
+		// provider however tight the subject is.
+		if err := verifyPermittedIssuer(entry.Issuer); err != nil {
+			return err
+		}
+
 		if err := verifyPermittedSubject(entry.Subject); err != nil {
 			return err
 		}
@@ -550,6 +558,38 @@ func validateVerifyAllowList(config string) error {
 			"inside the subject, never in a second entry",
 		len(entries), drIdentityIssuer, drIdentitySharedSubject, drIdentitySubject,
 	)
+}
+
+// verifyPermittedIssuer checks the permitted issuer regex against GitHub's real
+// OIDC issuer and against an issuer we must never trust.
+//
+// It guards the constant for the same reason verifyPermittedSubject does, and
+// it matters independently: cosign matches the issuer/subject PAIR, so an
+// issuer that admits anyone makes the subject's precision irrelevant.
+func verifyPermittedIssuer(issuer string) error {
+	compiled, err := regexp.Compile(issuer)
+	if err != nil {
+		return fmt.Errorf(
+			"permitted issuer %s is not a valid regular expression, so cosign cannot evaluate it and it admits "+
+				"nothing: %w", issuer, err,
+		)
+	}
+
+	if !compiled.MatchString(drIdentityIssuerLiteral) {
+		return fmt.Errorf(
+			"permitted issuer %s does not match GitHub's OIDC issuer %s, so no GitHub-signed artifact verifies",
+			issuer, drIdentityIssuerLiteral,
+		)
+	}
+
+	if compiled.MatchString(untrustedIssuer) {
+		return fmt.Errorf(
+			"permitted issuer %s also admits %s, so a signature minted outside GitHub's OIDC provider would "+
+				"verify; anchor the expression with ^…$ and escape every dot", issuer, untrustedIssuer,
+		)
+	}
+
+	return nil
 }
 
 // verifyPermittedSubject checks a permitted subject regex against the DR

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -1251,14 +1251,36 @@ func TestPublicationActionRejectsPromotionBeforeEvidence(t *testing.T) {
 	}
 }
 
+// ablateShippedMatcher replaces whichever permitted subject the shipped config
+// carries with the given replacement.
+//
+// The ablations below must not name one permitted form directly. The config
+// legitimately ships either the three-signer alternation or the DR identity
+// alone, so a test pinned to one of them silently stops ablating anything the
+// day the other is adopted — which is exactly what happened when the allow-list
+// collapsed to a single shared entry: the substitution matched nothing, the
+// ablation became a no-op, and it was the "changed nothing" guard rather than
+// the assertion that caught it. Failing loudly when no permitted form is
+// present keeps that guard.
+func ablateShippedMatcher(t *testing.T, config string, replacement string) string {
+	t.Helper()
+
+	for _, permitted := range permittedSubjects {
+		if strings.Contains(config, permitted) {
+			return strings.ReplaceAll(config, permitted, replacement)
+		}
+	}
+
+	t.Fatal("ablation changed nothing — the shipped config carries no permitted DR matcher to remove")
+
+	return ""
+}
+
 func TestVerifyAllowListRejectsAMissingDRIdentity(t *testing.T) {
 	t.Parallel()
 
 	config := repoFile(t, "ksail.prod.yaml")
-	ablated := strings.ReplaceAll(config, drIdentitySubject, `^https://example\.invalid$`)
-	if ablated == config {
-		t.Fatal("ablation changed nothing — the DR identity is not present to remove")
-	}
+	ablated := ablateShippedMatcher(t, config, `^https://example\.invalid$`)
 	if err := validateVerifyAllowList(ablated); err == nil {
 		t.Fatal("allow-list without the DR identity was accepted")
 	}
@@ -1301,11 +1323,8 @@ func TestVerifyAllowListRejectsACommentedDRIdentity(t *testing.T) {
 	t.Parallel()
 
 	config := repoFile(t, "ksail.prod.yaml")
-	removed := strings.ReplaceAll(config, drIdentitySubject, `^https://example\.invalid$`)
-	if removed == config {
-		t.Fatal("ablation changed nothing — the DR identity is not present to remove")
-	}
-	bypassed := removed + "\n# " + drIdentitySubject + "\n"
+	removed := ablateShippedMatcher(t, config, `^https://example\.invalid$`)
+	bypassed := removed + "\n# " + drIdentitySharedSubject + "\n"
 	if err := validateVerifyAllowList(bypassed); err == nil {
 		t.Fatal("a commented-out DR identity was accepted as an allow-list entry")
 	}
@@ -1339,6 +1358,71 @@ func TestVerifyAllowListRejectsASubjectThatMerelyContainsTheDRIdentity(t *testin
 	config := allowListConfig("spec.workload.flux.verify", drIdentityIssuer, widened)
 	if err := validateVerifyAllowList(config); err == nil {
 		t.Fatal("a widened subject regex that merely contains the DR identity was accepted")
+	}
+}
+
+// The lengthening attack, aimed at the form production actually ships. The test
+// above widens the DR-only matcher; this one widens the three-signer
+// alternation, which is the entry a pull request would really be editing. A
+// check that evaluated the regex against the DR identity would pass here — the
+// widened expression still admits the DR rebuild — which is why the comparison
+// stayed exact.
+func TestVerifyAllowListRejectsAWidenedSharedMatcher(t *testing.T) {
+	t.Parallel()
+
+	widened := strings.TrimSuffix(drIdentitySharedSubject, `$`) +
+		`|^https://github\.com/attacker/repo/\.github/workflows/x\.yaml@refs/heads/main$`
+	config := allowListConfig("spec.workload.flux.verify", drIdentityIssuer, widened)
+
+	err := validateVerifyAllowList(config)
+	if err == nil {
+		t.Fatal("a widened three-signer matcher admitting an extra signer was accepted")
+	}
+	// Rejected for the RIGHT reason: the exact comparison, not a parse failure.
+	if !strings.Contains(err.Error(), "is exactly a permitted DR") {
+		t.Fatalf("rejected for the wrong reason — expected the exact-match refusal, got: %v", err)
+	}
+}
+
+// The constants themselves are the remaining single point of failure: a
+// permitted form is compared against the shipped config, so a mistake baked
+// into the constant agrees with itself forever and the gate keeps passing.
+// verifyPermittedSubject is what notices, so assert it on every permitted form
+// rather than only the one production happens to ship.
+func TestPermittedSubjectsAdmitTheDRIdentityAndRefuseUntrustedSigners(t *testing.T) {
+	t.Parallel()
+
+	if len(permittedSubjects) == 0 {
+		t.Fatal("no permitted subjects to check — the allow-list contract would admit nothing")
+	}
+
+	for _, permitted := range permittedSubjects {
+		if err := verifyPermittedSubject(permitted); err != nil {
+			t.Errorf("permitted subject %s is not a correct matcher: %v", permitted, err)
+		}
+	}
+}
+
+// The positive control for the test above: it passes only because the untrusted
+// subjects are genuinely refused, not because the list is empty or the matcher
+// refuses everything. A matcher that admitted nothing would also "refuse" them.
+func TestUntrustedSubjectsAreDistinguishedFromTheRealOne(t *testing.T) {
+	t.Parallel()
+
+	if len(untrustedSubjects) == 0 {
+		t.Fatal("no untrusted subjects — the over-breadth guard would assert nothing")
+	}
+
+	for _, untrusted := range untrustedSubjects {
+		if untrusted == drIdentitySubjectLiteral {
+			t.Errorf("untrusted subject %s IS the real DR identity, so the guard contradicts itself", untrusted)
+		}
+	}
+
+	// An anchored `.*` admits everything, so it must fail — proving the guard
+	// can fail at all, rather than passing because nothing exercises it.
+	if err := verifyPermittedSubject(`^.*$`); err == nil {
+		t.Fatal("a catch-all subject was accepted, so the over-breadth guard never fires")
 	}
 }
 

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -1401,6 +1401,25 @@ func TestPermittedSubjectsAdmitTheDRIdentityAndRefuseUntrustedSigners(t *testing
 			t.Errorf("permitted subject %s is not a correct matcher: %v", permitted, err)
 		}
 	}
+
+	if err := verifyPermittedIssuer(drIdentityIssuer); err != nil {
+		t.Errorf("permitted issuer %s is not a correct matcher: %v", drIdentityIssuer, err)
+	}
+}
+
+// The issuer half of the pair, with the same two ablations the subject guard
+// gets: a matcher that admits nobody, and one that admits everybody. Without
+// these the issuer guard could pass while asserting nothing.
+func TestPermittedIssuerGuardFiresInBothDirections(t *testing.T) {
+	t.Parallel()
+
+	if err := verifyPermittedIssuer(`^https://example\.invalid$`); err == nil {
+		t.Fatal("an issuer that does not match GitHub's OIDC provider was accepted")
+	}
+
+	if err := verifyPermittedIssuer(`^.*$`); err == nil {
+		t.Fatal("a catch-all issuer was accepted, so the issuer over-breadth guard never fires")
+	}
 }
 
 // The positive control for the test above: it passes only because the untrusted

--- a/scripts/validate-dr-signing/main_test.go
+++ b/scripts/validate-dr-signing/main_test.go
@@ -1407,6 +1407,37 @@ func TestPermittedSubjectsAdmitTheDRIdentityAndRefuseUntrustedSigners(t *testing
 	}
 }
 
+// A correct entry buried in a longer list. cosign fails CLOSED on a multi-entry
+// matchOIDCIdentity, so the second entry does not add a signer — it removes
+// every one of them, and the DR artifact stops verifying. A check that returned
+// as soon as it found a permitted entry would call this configuration fine.
+func TestVerifyAllowListRejectsAPermittedEntryAmongSeveral(t *testing.T) {
+	t.Parallel()
+
+	single := allowListConfig("spec.workload.flux.verify", drIdentityIssuer, drIdentitySharedSubject)
+	// Positive control: the same entry ALONE must pass, so the rejection below
+	// is attributable to the extra entry and not to the synthetic YAML.
+	if err := validateVerifyAllowList(single); err != nil {
+		t.Fatalf("the permitted entry alone was rejected, so this test proves nothing: %v", err)
+	}
+
+	// allowListConfig indents two spaces per path segment, so a four-segment
+	// path puts the list items ten spaces in. Derive it rather than hard-coding
+	// the depth, or this test breaks the day the path changes.
+	itemIndent := strings.Repeat("  ", len(strings.Split("spec.workload.flux.verify", "."))+1)
+	twoEntries := single +
+		itemIndent + "- issuer: '" + drIdentityIssuer + "'\n" +
+		itemIndent + "  subject: '" + drIdentitySubject + "'\n"
+
+	err := validateVerifyAllowList(twoEntries)
+	if err == nil {
+		t.Fatal("a permitted entry alongside a second entry was accepted, but cosign verifies neither")
+	}
+	if !strings.Contains(err.Error(), "supports exactly ONE") {
+		t.Fatalf("rejected for the wrong reason — expected the multi-entry refusal, got: %v", err)
+	}
+}
+
 // The issuer half of the pair, with the same two ablations the subject guard
 // gets: a matcher that admits nobody, and one that admits everybody. Without
 // these the issuer guard could pass while asserting nothing.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

`main` currently fails its own production publication contract, and nothing has said so — the
`Validate Main` workflow never ran on the commit that introduced it, so it landed silently.

Two guards now demand incompatible things. One requires the cluster's cosign allow-list to hold
**exactly one** signer entry, because cosign refuses a multi-entry list outright and would verify
nothing. The other required an entry **exactly equal** to the disaster-recovery signer. Three
signers have to be trusted, so the single entry must list them as alternatives — and an entry
listing three alternatives can never be equal to one of them. The two rules cannot both be
satisfied.

The practical cost is larger than one red check: this contract runs on the merge queue, so **no
pull request can reach production while it fails**, including the ones that would deploy the fix.

## What

Compares the allow-list against the **permitted forms** of the matcher rather than against a single
identity, so trusting several signers is expressible again.

The exact comparison is deliberately kept. A widened matcher still admits the DR signer, so a check
that merely asked "does this admit disaster recovery?" would wave through an extra signer — the one
direction this contract exists to refuse. Adding or removing a trusted signer stays a deliberate,
reviewed edit.

A new guard checks each permitted form against the real DR certificate and a battery of untrusted
ones, so a typo in the definition is caught rather than agreeing with itself forever.

Fixes #3009


---

> [!IMPORTANT]
> **Merge order — this PR first, then #3004.**
>
> This one changes only `scripts/validate-dr-signing/`, which is **not** in the `k8s` change filter,
> so its merge-queue run will **not** deploy. It unblocks the queue; it does not touch the cluster.
>
> Production delivery is separately halted (#3005): the live root source declares three cosign
> matchers against `main`'s one, so it fails verification and `infrastructure` /
> `infrastructure-controllers` are stalled. Workloads are serving throughout — a stalled pipeline,
> not an outage.
>
> #3004 *does* change `k8s/`, so merging it **after** this lands runs `ksail cluster update` in the
> merge queue and applies the corrected matcher directly, outside the broken channel — which is what
> heals production. Nothing here should be merged in the other order.
