### PR TITLE
fix(kubescape): require a cluster-wide posture exception to declare itself

### DIFF
--- a/k8s/bases/infrastructure/cluster-security-exceptions/admission-controllers.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/admission-controllers.yaml
@@ -6,6 +6,12 @@ apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: admission-controllers
+  annotations:
+    # Cluster-wide on purpose: the webhook configurations these controls scan
+    # are installed by upstream charts across every controller namespace, and
+    # the platform sets none of them, so there is no narrower scope that is
+    # also complete.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     Admission webhook timeouts are configured by upstream Helm charts

--- a/k8s/bases/infrastructure/cluster-security-exceptions/cilium-network-policies.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/cilium-network-policies.yaml
@@ -7,6 +7,12 @@ apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: cilium-network-policies
+  annotations:
+    # Cluster-wide on purpose: Cilium is the CNI for the whole cluster, so
+    # every namespace is segmented by CiliumNetworkPolicy rather than by the
+    # NetworkPolicy objects these controls look for. Scoping this would only
+    # make the controls fail somewhere Cilium is still the enforcement point.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     Platform uses CiliumNetworkPolicies for all network segmentation.

--- a/k8s/bases/infrastructure/cluster-security-exceptions/helm-chart-metadata.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/helm-chart-metadata.yaml
@@ -7,6 +7,11 @@ apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: helm-chart-metadata
+  annotations:
+    # Cluster-wide on purpose: the recommended-label conventions these controls
+    # check are set by whichever upstream chart rendered the object, in every
+    # namespace that runs one. The platform authors none of them.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     Third-party Helm charts use their own label conventions. Adding all

--- a/k8s/bases/infrastructure/cluster-security-exceptions/image-verification.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/image-verification.yaml
@@ -11,6 +11,12 @@ apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: image-verification
+  annotations:
+    # Cluster-wide on purpose: C-0237 scans every workload image reference, and
+    # unsigned third-party chart images are spread across every namespace. The
+    # narrower posture is tracked as first-party pull enforcement (#2856), not
+    # as a scope on this exception.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     First-party images (ghcr.io/devantler-tech/*) are cosign-signed and

--- a/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/pod-security-mutations.yaml
@@ -15,6 +15,19 @@ apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: pod-security-mutations
+  annotations:
+    # Cluster-wide, and KNOWN to be wider than its own rationale (#2824). The
+    # compensating mutation named below excludes twelve namespaces —
+    # kube-system, kube-public, kube-node-lease, flux-system, longhorn-system,
+    # local-path-storage, kubescape, kubevirt, cdi, observability, velero,
+    # chaos-mesh — so in exactly those namespaces this exception suppresses
+    # C-0013/C-0016/C-0055/C-0211 with nothing injecting them. Six of the twelve
+    # are separately and deliberately excepted for C-0013/C-0016/C-0055 in
+    # infrastructure-privileged.yaml; C-0211 and the other six are not covered
+    # anywhere. Narrowing it needs a scope the CSE designators cannot yet spell
+    # (an In-list would fail every newly-onboarded namespace), which is why this
+    # is declared rather than fixed here.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     Kyverno mutate policy "add-security-context" injects these controls

--- a/k8s/bases/infrastructure/cluster-security-exceptions/talos-cis-control-plane-false-positives.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/talos-cis-control-plane-false-positives.yaml
@@ -37,6 +37,10 @@ metadata:
     # cluster-wide `kind: ".*"` designator for it, which the plugin would apply
     # to every workload in the cluster.
     platform.devantler.tech/headlamp-mirror: exclude
+    # Cluster-wide on purpose: every control here is a host-scanner finding on
+    # the control-plane node, which has no workload, namespace or kind to scope
+    # against. See the NO-`match:` note above.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     CIS control-plane checks that are false positives on Talos Linux, matching

--- a/k8s/bases/infrastructure/cluster-security-exceptions/talos-cis-worker-false-positives.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/talos-cis-worker-false-positives.yaml
@@ -40,6 +40,10 @@ metadata:
     # emit a cluster-wide `kind: ".*"` designator for it, which the plugin would
     # apply to every workload in the cluster.
     platform.devantler.tech/headlamp-mirror: exclude
+    # Cluster-wide on purpose: every control here is a host-scanner finding on
+    # the worker node, which has no workload, namespace or kind to scope
+    # against. See the NO-`match:` note above.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     CIS worker-node checks that are false positives on Talos Linux, matching Sidero's

--- a/k8s/bases/infrastructure/cluster-security-exceptions/upstream-chart-defaults.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/upstream-chart-defaults.yaml
@@ -9,6 +9,12 @@ apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: upstream-chart-defaults
+  annotations:
+    # Cluster-wide on purpose: C-0258 is an etcd-level property of the Talos
+    # control plane with no workload scope at all, and the remaining three are
+    # properties of upstream chart images and operator hostPath usage that
+    # appear wherever those charts are installed.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     These controls flag behaviors defined by upstream Helm charts or the

--- a/k8s/bases/infrastructure/cluster-security-exceptions/vpa-managed-resources.yaml
+++ b/k8s/bases/infrastructure/cluster-security-exceptions/vpa-managed-resources.yaml
@@ -9,6 +9,13 @@ apiVersion: kubescape.io/v1beta1
 kind: ClusterSecurityException
 metadata:
   name: vpa-managed-resources
+  annotations:
+    # Cluster-wide, and KNOWN to be wider than its own rationale: the reason
+    # below holds only where a VPA object actually right-sizes the workload,
+    # which is not every namespace. Narrowing it to the workloads VPA manages
+    # is tracked in #2824 alongside the same defect in pod-security-mutations.
+    # Declared here so the scope is a recorded decision rather than an omission.
+    platform.devantler.tech/cluster-wide: declared
 spec:
   reason: >-
     VPA manages resource requests and limits at pod admission time.

--- a/scripts/generate-kubescape-exceptions/main.go
+++ b/scripts/generate-kubescape-exceptions/main.go
@@ -60,6 +60,20 @@ const (
 	// cluster-wide designator would except that control for every workload.
 	mirrorExclude = "exclude"
 
+	// clusterWideAnnotation declares that an exception is MEANT to suppress its
+	// controls for every workload in the cluster. An omitted `spec.match` is
+	// what produces that scope, so without this marker the widest exception the
+	// repository can express is also the one written by typing the least, and a
+	// forgotten scope is indistinguishable from a deliberate one. Suppression is
+	// silent — an excepted workload that genuinely violates a control reads
+	// exactly like a compliant one — so the scope has to be stated, not inferred
+	// from an absence.
+	clusterWideAnnotation = "platform.devantler.tech/cluster-wide"
+	// clusterWideDeclared is the only accepted clusterWideAnnotation value. As
+	// with mirrorExclude, any other value fails closed rather than being read as
+	// a declaration: a typo must not grant cluster-wide suppression.
+	clusterWideDeclared = "declared"
+
 	formatKubescape = "kubescape"
 	formatConfigMap = "headlamp-configmap"
 
@@ -362,6 +376,42 @@ func resolveMirrorExclusion(metadata map[string]any, path, name string) (bool, e
 	return true, nil
 }
 
+// resolveClusterWideDeclaration reads the CR's cluster-wide scope marker.
+//
+// Absent annotation => not declared, which is the safe default: an exception
+// that forgot to scope itself then fails closed at conversion instead of
+// silently excepting its controls for every workload in the cluster.
+func resolveClusterWideDeclaration(metadata map[string]any, path, name string) (bool, error) {
+	rawAnnotations, present := metadata["annotations"]
+	if !present || rawAnnotations == nil {
+		return false, nil
+	}
+
+	// Same fail-closed reasoning as resolveMirrorExclusion: a malformed
+	// annotations block must not be read as "no marker", because here that
+	// reading is the permissive one.
+	annotations, ok := rawAnnotations.(map[string]any)
+	if !ok {
+		return false, cseErrorf(path, name, "metadata.annotations must be a mapping, got %v", rawAnnotations)
+	}
+
+	raw, ok := annotations[clusterWideAnnotation]
+	if !ok {
+		return false, nil
+	}
+
+	value, ok := raw.(string)
+	if !ok {
+		return false, cseErrorf(path, name, "%s must be a string, got %v", clusterWideAnnotation, raw)
+	}
+
+	if value != clusterWideDeclared {
+		return false, cseErrorf(path, name, "unsupported %s value %q (only %q is recognised)", clusterWideAnnotation, value, clusterWideDeclared)
+	}
+
+	return true, nil
+}
+
 // convertDocument converts one ClusterSecurityException document; nil for other kinds.
 func convertDocument(doc any, path string) (*policy, error) {
 	document, ok := doc.(map[string]any)
@@ -436,6 +486,22 @@ func convertDocument(doc any, path string) (*policy, error) {
 		}
 
 		match = parsed
+	}
+
+	clusterWide, err := resolveClusterWideDeclaration(metadata, path, name)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case len(match) == 0 && !clusterWide:
+		return nil, cseErrorf(path, name,
+			"no spec.match, which excepts these controls for EVERY workload; scope it, or declare the scope with the %s: %s annotation",
+			clusterWideAnnotation, clusterWideDeclared)
+	case len(match) > 0 && clusterWide:
+		return nil, cseErrorf(path, name,
+			"declares %s: %s but also sets spec.match; the marker would claim a scope the exception does not have",
+			clusterWideAnnotation, clusterWideDeclared)
 	}
 
 	resources, err := resolveMatch(match, path, name)

--- a/scripts/generate-kubescape-exceptions/main_test.go
+++ b/scripts/generate-kubescape-exceptions/main_test.go
@@ -113,13 +113,16 @@ spec:
 	}
 }
 
-// TestGenerateNoMatchIsClusterWide verifies an omitted match targets every
-// resource, including cluster-scoped resources that have no namespace.
+// TestGenerateNoMatchIsClusterWide verifies a DECLARED cluster-wide exception
+// targets every resource, including cluster-scoped resources that have no
+// namespace.
 func TestGenerateNoMatchIsClusterWide(t *testing.T) {
 	dir := writeCSE(t, `
 kind: ClusterSecurityException
 metadata:
   name: cluster-wide
+  annotations:
+    platform.devantler.tech/cluster-wide: declared
 spec:
   posture:
     - controlID: C-0034
@@ -141,6 +144,88 @@ spec:
 	}
 }
 
+// TestUndeclaredClusterWideScopeFailsClosed is the guard: an exception with no
+// spec.match suppresses its controls for EVERY workload, and until this fired
+// that scope was reached by writing nothing at all. An author who forgot to
+// scope an exception and one who deliberately chose cluster-wide produced byte
+// for byte the same CR, so review had no signal to catch the first.
+func TestUndeclaredClusterWideScopeFailsClosed(t *testing.T) {
+	_, err := generate(writeCSE(t, `
+kind: ClusterSecurityException
+metadata:
+  name: undeclared
+spec:
+  posture:
+    - controlID: C-0013
+      action: ignore
+`))
+	if err == nil {
+		t.Fatal("undeclared cluster-wide scope must fail closed, got nil error")
+	}
+
+	if !strings.Contains(err.Error(), clusterWideAnnotation) {
+		t.Errorf("error %q must name %s so the fix is obvious", err, clusterWideAnnotation)
+	}
+}
+
+// TestClusterWideAnnotationFailsClosed covers the marker's own malformed
+// shapes. A typo'd value must not be read as a declaration.
+func TestClusterWideAnnotationFailsClosed(t *testing.T) {
+	for name, annotation := range map[string]string{
+		"wrong value":  `platform.devantler.tech/cluster-wide: "true"`,
+		"empty value":  `platform.devantler.tech/cluster-wide: ""`,
+		"non-string":   `platform.devantler.tech/cluster-wide: true`,
+		"capitalised":  `platform.devantler.tech/cluster-wide: Declared`,
+		"padded value": `platform.devantler.tech/cluster-wide: " declared "`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := generate(writeCSE(t, `
+kind: ClusterSecurityException
+metadata:
+  name: malformed-marker
+  annotations:
+    `+annotation+`
+spec:
+  posture:
+    - controlID: C-0013
+      action: ignore
+`))
+			if err == nil {
+				t.Fatal("malformed cluster-wide marker must fail closed, got nil error")
+			}
+		})
+	}
+}
+
+// TestDeclaredClusterWideWithMatchFailsClosed rejects a CR that both declares
+// cluster-wide scope and scopes itself. The two statements contradict, and
+// silently honouring the match would leave a marker on file claiming a scope
+// the generated exception does not have — the same invisible-scope problem one
+// level up.
+func TestDeclaredClusterWideWithMatchFailsClosed(t *testing.T) {
+	_, err := generate(writeCSE(t, `
+kind: ClusterSecurityException
+metadata:
+  name: contradictory
+  annotations:
+    platform.devantler.tech/cluster-wide: declared
+spec:
+  posture:
+    - controlID: C-0013
+      action: ignore
+  match:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - flux-system
+`))
+	if err == nil {
+		t.Fatal("declaring cluster-wide scope alongside a match must fail closed, got nil error")
+	}
+}
+
 // TestGenerateFrameworkScopedPosture verifies a CSE framework constraint is
 // preserved in Kubescape's native posture policy instead of being widened.
 func TestGenerateFrameworkScopedPosture(t *testing.T) {
@@ -148,6 +233,8 @@ func TestGenerateFrameworkScopedPosture(t *testing.T) {
 kind: ClusterSecurityException
 metadata:
   name: nsa-only
+  annotations:
+    platform.devantler.tech/cluster-wide: declared
 spec:
   posture:
     - frameworkName: NSA
@@ -187,6 +274,8 @@ metadata:
 kind: ClusterSecurityException
 metadata:
   name: zzz-last
+  annotations:
+    platform.devantler.tech/cluster-wide: declared
 spec:
   posture:
     - controlID: C-0002
@@ -195,6 +284,8 @@ spec:
 kind: ClusterSecurityException
 metadata:
   name: aaa-first
+  annotations:
+    platform.devantler.tech/cluster-wide: declared
 spec:
   posture:
     - controlID: C-0002
@@ -362,11 +453,13 @@ func TestGenerateRejectsDuplicateNames(t *testing.T) {
 kind: ClusterSecurityException
 metadata: {name: dupe}
 spec:
+  match: {namespaceSelector: {matchExpressions: [{key: kubernetes.io/metadata.name, operator: In, values: [flux-system]}]}}
   posture: [{controlID: C-0002, action: ignore}]
 ---
 kind: ClusterSecurityException
 metadata: {name: dupe}
 spec:
+  match: {namespaceSelector: {matchExpressions: [{key: kubernetes.io/metadata.name, operator: In, values: [flux-system]}]}}
   posture: [{controlID: C-0013, action: ignore}]
 `)
 
@@ -411,6 +504,7 @@ metadata:
   name: host-only
   annotations:
     platform.devantler.tech/headlamp-mirror: exclude
+    platform.devantler.tech/cluster-wide: declared
 spec:
   posture: [{controlID: C-0092, action: ignore}]
 ---
@@ -418,6 +512,7 @@ kind: ClusterSecurityException
 metadata:
   name: workload-scoped
 spec:
+  match: {namespaceSelector: {matchExpressions: [{key: kubernetes.io/metadata.name, operator: In, values: [flux-system]}]}}
   posture: [{controlID: C-0002, action: ignore}]
 `)
 
@@ -445,6 +540,7 @@ func TestMirrorDefaultsToIncluded(t *testing.T) {
 kind: ClusterSecurityException
 metadata: {name: no-annotations}
 spec:
+  match: {namespaceSelector: {matchExpressions: [{key: kubernetes.io/metadata.name, operator: In, values: [flux-system]}]}}
   posture: [{controlID: C-0002, action: ignore}]
 `)
 
@@ -522,6 +618,7 @@ metadata:
   name: empty-annotations
   annotations:
 spec:
+  match: {namespaceSelector: {matchExpressions: [{key: kubernetes.io/metadata.name, operator: In, values: [flux-system]}]}}
   posture: [{controlID: C-0002, action: ignore}]
 `)
 
@@ -539,6 +636,7 @@ metadata:
   name: host-only
   annotations:
     platform.devantler.tech/headlamp-mirror: exclude
+    platform.devantler.tech/cluster-wide: declared
 spec:
   posture: [{controlID: C-0092, action: ignore}]
 `)

--- a/scripts/generate-kubescape-exceptions/main_test.go
+++ b/scripts/generate-kubescape-exceptions/main_test.go
@@ -170,13 +170,36 @@ spec:
 
 // TestClusterWideAnnotationFailsClosed covers the marker's own malformed
 // shapes. A typo'd value must not be read as a declaration.
+//
+// Each case asserts WHICH error it got, not merely that it got one. Every
+// fixture here also has no spec.match, so a regression that ignored this
+// annotation entirely would still be rejected — by the undeclared-scope guard —
+// and a bare `err != nil` check would stay green while the marker did nothing.
 func TestClusterWideAnnotationFailsClosed(t *testing.T) {
-	for name, annotation := range map[string]string{
-		"wrong value":  `platform.devantler.tech/cluster-wide: "true"`,
-		"empty value":  `platform.devantler.tech/cluster-wide: ""`,
-		"non-string":   `platform.devantler.tech/cluster-wide: true`,
-		"capitalised":  `platform.devantler.tech/cluster-wide: Declared`,
-		"padded value": `platform.devantler.tech/cluster-wide: " declared "`,
+	for name, tc := range map[string]struct {
+		annotation string
+		want       string
+	}{
+		"wrong value": {
+			annotation: `platform.devantler.tech/cluster-wide: "true"`,
+			want:       `unsupported platform.devantler.tech/cluster-wide value "true"`,
+		},
+		"empty value": {
+			annotation: `platform.devantler.tech/cluster-wide: ""`,
+			want:       `unsupported platform.devantler.tech/cluster-wide value ""`,
+		},
+		"non-string": {
+			annotation: `platform.devantler.tech/cluster-wide: true`,
+			want:       "platform.devantler.tech/cluster-wide must be a string",
+		},
+		"capitalised": {
+			annotation: `platform.devantler.tech/cluster-wide: Declared`,
+			want:       `unsupported platform.devantler.tech/cluster-wide value "Declared"`,
+		},
+		"padded value": {
+			annotation: `platform.devantler.tech/cluster-wide: " declared "`,
+			want:       `unsupported platform.devantler.tech/cluster-wide value " declared "`,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, err := generate(writeCSE(t, `
@@ -184,14 +207,18 @@ kind: ClusterSecurityException
 metadata:
   name: malformed-marker
   annotations:
-    `+annotation+`
+    `+tc.annotation+`
 spec:
   posture:
     - controlID: C-0013
       action: ignore
 `))
 			if err == nil {
-				t.Fatal("malformed cluster-wide marker must fail closed, got nil error")
+				t.Fatalf("malformed cluster-wide marker must fail closed, want an error containing %q, got none", tc.want)
+			}
+
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

A security exception that names no scope silently applies to **every workload in the cluster** — and that is the scope you get by writing the least. So an exception whose author forgot to scope it looks exactly like one that was deliberately made cluster-wide, and nobody reviewing it can tell which they are reading. Nine of our twenty exceptions were in that state, including the one #2824 was filed about, which suppresses four pod-security controls in twelve namespaces where the thing meant to compensate for it does not run.

Suppression is invisible: a workload that genuinely violates a control reads the same as a compliant one. That is why this is worth a guard rather than a comment.

## What

A cluster-wide exception now has to say so, in one annotation. Anything that forgot is rejected at build time with a message naming the fix. Every existing cluster-wide exception now records *why* it is cluster-wide — and for the two whose scope is knowingly too wide, that it is too wide and where that is tracked.

Nothing the cluster consumes changes; this is a rule about how the exceptions are written.

Part of #2824