### PR TITLE
fix(security): disposition the six unreachable-probe checkov findings

### DIFF
--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -13,10 +13,10 @@ metadata:
     # Both containers bind 127.0.0.1 only (--host/--telemetry-host and --web.listen-address
     # below), because the agent scrapes kube-state-metrics from inside the pod and nothing
     # reaches either port from the network. A kubelet httpGet/tcpSocket probe dials the POD IP,
-    # so it cannot reach a loopback listener; the pod carries no Service for the same reason.
-    # An exec probe is not available either — kube-state-metrics ships distroless, with no shell
-    # or HTTP client. Exposing a port purely to satisfy the check would widen the attack surface
-    # this design deliberately closes, so the workload is dispositioned rather than changed.
+    # so it cannot reach a loopback listener; this component ships no Service for the same
+    # reason. Binding either port to the pod network purely to satisfy the check would widen
+    # the attack surface this design deliberately closes, so the workload is dispositioned
+    # rather than changed.
     checkov.io/skip2: CKV_K8S_8=loopback-only listeners are unreachable from a kubelet probe; see the note above
     checkov.io/skip3: CKV_K8S_9=loopback-only listeners are unreachable from a kubelet probe; see the note above
 spec:

--- a/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
+++ b/k8s/bases/infrastructure/coroot/components/crossplane-sync-exporter/deployment.yaml
@@ -10,6 +10,15 @@ metadata:
     platform.devantler.tech/replica-floor: exempt
   annotations:
     checkov.io/skip1: CKV_K8S_38=kube-state-metrics reads the managed resources it exports through the API server
+    # Both containers bind 127.0.0.1 only (--host/--telemetry-host and --web.listen-address
+    # below), because the agent scrapes kube-state-metrics from inside the pod and nothing
+    # reaches either port from the network. A kubelet httpGet/tcpSocket probe dials the POD IP,
+    # so it cannot reach a loopback listener; the pod carries no Service for the same reason.
+    # An exec probe is not available either — kube-state-metrics ships distroless, with no shell
+    # or HTTP client. Exposing a port purely to satisfy the check would widen the attack surface
+    # this design deliberately closes, so the workload is dispositioned rather than changed.
+    checkov.io/skip2: CKV_K8S_8=loopback-only listeners are unreachable from a kubelet probe; see the note above
+    checkov.io/skip3: CKV_K8S_9=loopback-only listeners are unreachable from a kubelet probe; see the note above
 spec:
   # A second replica would export identical series and race them into the
   # remote-write receiver. Recreate avoids an overlapping rollout; the agent's

--- a/k8s/bases/infrastructure/opencost/components/usage-scraper/deployment.yaml
+++ b/k8s/bases/infrastructure/opencost/components/usage-scraper/deployment.yaml
@@ -10,6 +10,13 @@ metadata:
     platform.devantler.tech/replica-floor: exempt
   annotations:
     checkov.io/skip1: CKV_K8S_38=Prometheus kubernetes_sd and authenticated kubelet scraping both need the token
+    # The agent binds 127.0.0.1:9090 (--web.listen-address below) and pushes via remote_write to
+    # coroot-prometheus; nothing scrapes it, and no Service selects this pod. A kubelet
+    # httpGet/tcpSocket probe dials the POD IP, so it cannot reach a loopback listener. Opening
+    # 9090 to the pod network purely to satisfy the check would expose an admin endpoint that has
+    # no consumer, so the workload is dispositioned rather than changed.
+    checkov.io/skip2: CKV_K8S_8=loopback-only listener is unreachable from a kubelet probe; see the note above
+    checkov.io/skip3: CKV_K8S_9=loopback-only listener is unreachable from a kubelet probe; see the note above
 spec:
   # Two replicas would scrape identical node series and race them into the
   # remote-write receiver. Recreate avoids an overlapping rollout; the WAL is

--- a/k8s/providers/hetzner/infrastructure/overprovisioning/pod-template.yaml
+++ b/k8s/providers/hetzner/infrastructure/overprovisioning/pod-template.yaml
@@ -35,6 +35,13 @@ metadata:
     app.kubernetes.io/name: overprovisioning
     app.kubernetes.io/component: cluster-buffer
     app.kubernetes.io/part-of: platform
+  annotations:
+    # The buffer chunks are VIRTUAL: the capacity-buffer controller injects pods of this shape
+    # into the autoscaler's in-memory scheduling simulation and never creates them, so the
+    # overprovisioning namespace holds zero pods (verified against prod). A probe on a pod that
+    # is never instantiated can never execute, and the pause image serves nothing to probe.
+    checkov.io/skip1: CKV_K8S_8=virtual scheduling placeholder, never instantiated; see the note above
+    checkov.io/skip2: CKV_K8S_9=virtual scheduling placeholder, never instantiated; see the note above
 template:
   metadata:
     labels:


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The Kubernetes misconfiguration backlog (#2787) is what keeps checkov and trivy reporting without
failing the build. Three of its workloads are flagged for missing liveness and readiness probes,
and **none of them can be probed at all**: two Prometheus agents listen on loopback only and are
scraped from inside their own pod, and the autoscaler capacity buffer's pods are virtual — the
controller simulates them and never creates one.

Adding a probe to any of the three would mean opening an admin port to the pod network that has no
consumer. That trades real attack surface for a green scanner line, which is the wrong direction.

## What

Each of the three carries a scoped `checkov.io/skip` annotation naming its specific constraint —
never a disabled check. A new workload that genuinely forgets a probe is still flagged.

Backlog moves **18 → 12** on the repository's own CI-equivalent scan.

Part of #2787
