### PR TITLE
fix(kubescape): let the posture scanner fetch its policy artifacts

### DIFF
--- a/k8s/bases/infrastructure/controllers/kubescape/cilium-network-policy.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/cilium-network-policy.yaml
@@ -32,11 +32,12 @@ spec:
     #   vestigial under offline mode, kept harmless — its failure mode is a
     #   skipped version check, not an outage).
     #   NOTE: report.armo.cloud (ARMO posture-report ingestion) is deliberately
-    #   NOT allowed — the operator runs OFFLINE (capabilities.kubescapeOffline:
-    #   enable, see helm-release.yaml), so config-scan results persist to the
-    #   in-cluster storage component instead of being POSTed to ARMO. There is
-    #   no ARMO account, so the submit only ever 400'd "missing account id" and
-    #   aborted the scan; offline mode removes that dependency entirely.
+    #   NOT allowed. The scheduled scan runs local-only via scanV1.keepLocal
+    #   (see kubescapeScheduler.requestBody in helm-release.yaml), so config-scan
+    #   results persist to the in-cluster storage component instead of being
+    #   POSTed to ARMO. There is no ARMO account, so the submit only ever 400'd
+    #   "missing account id" and aborted the scan. Omitting the host here is the
+    #   second, independent guard on that path — keep it out of this list.
     # - github.com + CDNs             — regolibrary / controls artifacts
     # If scan components log download failures, extend this list with the
     # missing host (failure mode is stale scan data, not an outage).

--- a/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
+++ b/k8s/bases/infrastructure/controllers/kubescape/helm-release.yaml
@@ -94,40 +94,43 @@ spec:
       # the CRs are deployed and schema-valid. Exemptions stay a LAST RESORT behind real
       # fixes — keep the cluster-security-exceptions set minimal and irreducible.
       riskAcceptance: enable
-      # Run posture/config scanning OFFLINE (air-gapped). This cluster has no
-      # ARMO SaaS account, but the chart defaults to submit-mode: the scanner
-      # POSTs each posture report to report.armo.cloud and treats the submit as
-      # a terminal step. With no account that submit fails ("400 missing account
-      # id"), which ABORTS the scan before results are written — so NO
-      # config-scan CRs (workloadconfigurationscansummaries /
-      # configurationscansummaries) ever persist and the cluster compliance
-      # score stays 0. Offline mode skips the cloud submit and persists results
-      # straight to the in-cluster storage component (storage:true,
-      # keepLocal:true are already set), restoring posture scanning + findings.
-      # Vulnerability scanning (kubevuln) is unaffected — it never gated on the
-      # cloud submit.
+      # DISABLED deliberately — this flag does NOT mean "do not call the cloud",
+      # it means "do not use the network at all", and the posture scanner needs
+      # the network for one thing it cannot work without: its policy artifacts.
       #
-      # IMPORTANT: capabilities.kubescapeOffline ALONE does NOT keep the posture
-      # SCAN local on chart 1.40.2. This flag only (a) toggles the scanner's
-      # config.json mountPath and (b) sets clusterData.keepLocal — neither of
-      # which reaches the scanner's per-scan Submit path. The scanner still
-      # resolves a cloud report URL (api.armosec.io) and, with an empty account,
-      # forces Submit=true, so every scheduled scan tries to generate+write an
-      # account ID to /home/nonroot/.kubescape/config.json. On chart 1.40.2 that
-      # path is an emptyDir subPath the kubelet materialises as a DIRECTORY (an
-      # upstream mount bug), so the write fails "is a directory" and the scan
-      # ABORTS before persisting fresh WorkloadConfigurationScan CRs — freezing
-      # the Kubescape dashboard on stale results (surfaced under scanner v4.0.9,
-      # which treats the account-ID write as terminal). Upstream fixes this by
-      # injecting scanV1.keepLocal:true into the scan-scheduler request body for
-      # offline installs (helm-charts#857 / PR #862, merged, UNRELEASED — chart
-      # is still 1.40.2). We apply that same fix now via the request-body
-      # override below; keepLocal makes the scanner run local-only (Submit=false,
-      # no cloud call, no account-ID write, no config.json touch), so the scan
-      # completes and persists CRs each run — and the config.json mount bug is
-      # never reached. Drop the override once the chart releases the fix past
-      # 1.40.2.
-      kubescapeOffline: enable
+      # What the chart does with it (1.40.3, templates/kubescape/deployment.yaml
+      # and templates/_common.tpl):
+      #   - `enable` is the ONLY thing that sets `KS_OFFLINE=true` on the
+      #     scanner. With that set, the scanner does not fetch the Regolibrary
+      #     controls/frameworks bundle, and nothing else in the chart supplies
+      #     it: `/home/nonroot/.kubescape` is an emptyDir with no init container
+      #     or ConfigMap behind it, so it is empty on every pod start. The
+      #     scanner then logs `failed to list frameworks` and every scan aborts
+      #     with `open /home/nonroot/.kubescape/{security,allcontrols}.json: no
+      #     such file or directory`, persisting nothing.
+      #   - it also force-injects `scanV1.keepLocal: true` into the scheduler
+      #     request body — which is why `kubescapeScheduler.requestBody` below
+      #     sets that explicitly and MUST keep doing so while this is disabled.
+      #   - it also ORs into `clusterData.keepLocal`. That value is
+      #     `or (offline) (not serviceDiscovery.enabled)`, and serviceDiscovery
+      #     is false here, so it stays `true` either way. Disabling this flag
+      #     does not change it.
+      #
+      # Cloud submit is prevented by `keepLocal`, not by this flag. keepLocal
+      # makes the scanner run local-only (Submit=false), so there is no report
+      # POST to report.armo.cloud, no cloud account-ID generation, and no write
+      # to `/home/nonroot/.kubescape/config.json` — which matters because that
+      # path is an emptyDir subPath the kubelet materialises as a directory, so
+      # a write there fails and takes the scan down with it. There is no ARMO
+      # account, and report.armo.cloud is not in the egress allow-list, so the
+      # submit path stays closed by construction as well.
+      #
+      # The artifact fetch this re-enables is already allowed by
+      # cilium-network-policy.yaml (github.com + release-assets.githubusercontent.com,
+      # added for exactly this download). Results still persist to the in-cluster
+      # storage component (storage:true, keepLocal:true). Vulnerability scanning
+      # (kubevuln) is unaffected either way — it never gated on the cloud submit.
+      kubescapeOffline: disable
     hostScanner:
       enabled: true
     nodeAgent:
@@ -179,17 +182,18 @@ spec:
         # the scanner to >= v4.0.10 AND grants it the securityexceptions RBAC. (Same
         # component-image-ahead-of-chart pattern as the nodeAgent override above.)
         tag: v4.0.10
-    # Force the scheduled posture scan to run LOCAL-ONLY. Chart 1.40.2 renders
-    # the scan-scheduler ConfigMap request-body verbatim from this value, and
-    # the scanner maps scanV1.keepLocal -> scanInfo.Local, which forces
-    # Submit=false (no cloud submit, no account-ID generation, no config.json
-    # write). This is what actually unblocks in-cluster persistence under
-    # kubescapeOffline (see the long note on capabilities.kubescapeOffline
-    # above) and it mirrors upstream helm-charts PR #862 exactly. The rest of
-    # this block reproduces the chart 1.40.2 default request-body unchanged
-    # (this value fully replaces the default, so it must be complete). Drop the
-    # whole override once the chart releases the offline keepLocal fix past
-    # 1.40.2.
+    # Force the scheduled posture scan to run LOCAL-ONLY. REQUIRED — this is the
+    # only thing keeping the scan off the cloud-submit path now that
+    # capabilities.kubescapeOffline is disabled (see the note there). The chart
+    # renders the scan-scheduler ConfigMap request-body from this value, and the
+    # scanner maps scanV1.keepLocal -> scanInfo.Local, forcing Submit=false: no
+    # cloud submit, no account-ID generation, no config.json write.
+    #
+    # The chart force-injects the same keepLocal ONLY when kubescapeOffline is
+    # enabled, so do NOT drop this override as redundant — with offline disabled
+    # the chart injects nothing and removing it would restore Submit=true, whose
+    # failure mode is a scan that aborts before persisting results. This value
+    # fully replaces the chart default, so it must stay complete.
     kubescapeScheduler:
       requestBody:
         commands:

--- a/scripts/validate-eks-ci-role-policy/main.go
+++ b/scripts/validate-eks-ci-role-policy/main.go
@@ -245,7 +245,32 @@ const (
 // kubectl render diff — render k8s/providers/hetzner/{apps,infrastructure,
 // infrastructure/controllers} plus k8s/clusters/prod/{bootstrap,} for both
 // trees and diff them.
-const expectedRenderedSurfaceSHA = "e28f84558cdc773eafbde8d04a819e1623b839ea4e743625e875f6bc3790cae2"
+//
+// Measured against base 0ca55381 while re-enabling the Kubescape posture
+// scanner's policy-artifact fetch: 514 rendered documents on both sides across
+// all five roots (122 apps, 209 infrastructure, 176 controllers, 4 bootstrap,
+// 3 prod), with membership IDENTICAL — zero added, removed, or renamed. Four of
+// the five roots are byte-identical. Exactly ONE line moves in the whole
+// production render:
+//
+//	helm.toolkit.fluxcd.io/v2  HelmRelease  kubescape/kubescape
+//	  values.capabilities.kubescapeOffline: enable -> disable
+//
+// That field decides one thing in the chart: whether KS_OFFLINE=true is set on
+// the scanner container. It reaches no identity, binding, policy document, or
+// service account. Its only other chart use ORs into clusterData.keepLocal,
+// which is `or (offline) (not serviceDiscovery.enabled)` — serviceDiscovery is
+// false here, so that value stays true either way and does not move. The
+// accompanying cilium-network-policy.yaml edit is comment-only and renders to
+// nothing, which the byte-identical infrastructure root confirms.
+//
+// All Role / ClusterRole / RoleBinding / ClusterRoleBinding / ServiceAccount
+// documents are byte-identical, as is every `aws`-bearing line — trivially so,
+// since a single non-RBAC line differs across the entire surface.
+//
+// The fingerprint itself was read from the required job's own output on the
+// approved renderer, because the local toolchain is refused as unapproved.
+const expectedRenderedSurfaceSHA = "cb575e34b191a662da108421fdff7c67f0cc00bf3c9b2b7cf0c5a4e49b46fc52"
 
 // authorizationOverlayPaths lists every independently reconciled production
 // layer where an object can grant privileges to the aws/aws service account.


### PR DESCRIPTION
> 🤖 Generated by the Agentic Engineer

## Why

The cluster's security posture scanning has not run for days, and nothing said so. The scanner needs a policy bundle to check anything against; it was configured never to fetch one, and nothing else provided it — so every scheduled run gave up before evaluating a single control.

The dangerous part is how that looks from outside: a scanner that checks nothing and a cluster with nothing wrong produce the same answer. The CI gate stayed green the whole time.

## What

Lets the scanner fetch its policy bundle again, by turning off the "never use the network" setting that was blocking it.

That setting was not what kept posture reports from being sent to the vendor's cloud — a separate, explicit setting does that, and it stays exactly as it was. Two independent guards keep that path closed, and both are untouched: the scan runs local-only, and the vendor's ingestion host is not in the firewall allow-list. The hosts the bundle is downloaded from were already permitted.

`Fixes #3023` · `Part of #2933`

**Not closing #2933**, deliberately. Its most valuable requirement is that a failure like this should be loud instead of silent, and this change does not do that — it repairs the outage without making the next one visible. That half is filed as #3024 and is worth more than this fix.

⚠️ **Verification is only partly possible before merge.** The change was validated against both overlays and checked against the pinned chart's own templates, but the thing that ultimately matters — a scan completing — can only be observed once this is deployed. That check is recorded as an acceptance criterion on #3023 and will be done after merge, not assumed.
